### PR TITLE
DM-5645: Add fine-grained authorization to ltd-keeper users

### DIFF
--- a/app/api_v1/builds.py
+++ b/app/api_v1/builds.py
@@ -4,19 +4,24 @@ from flask import jsonify, request
 
 from . import api
 from .. import db
-from ..auth import token_auth
-from ..models import Product, Build
+from ..auth import token_auth, permission_required
+from ..models import Product, Build, Permission
 
 
 @api.route('/products/<slug>/builds/', methods=['POST'])
+@permission_required(Permission.UPLOAD_BUILD)
 @token_auth.login_required
 def new_build(slug):
-    """Add a new build for a product (token required).
+    """Add a new build for a product.
 
     This method only adds a record for the build and specifies where the build
     should be uploaded. The client is reponsible for uploading the build.
     Once the documentation is uploaded, send
     :http:patch:`/builds/(int:id)` to set the 'uploaded' field to ``True``.
+
+    **Authorization**
+
+    User must be authenticated and have ``upload_build`` permissions.
 
     **Example request**
 
@@ -118,12 +123,17 @@ def new_build(slug):
 
 
 @api.route('/builds/<int:id>', methods=['PATCH'])
+@permission_required(Permission.UPLOAD_BUILD)
 @token_auth.login_required
 def patch_build(id):
-    """Mark a build as uploaded (token required).
+    """Mark a build as uploaded.
 
     This method should be called when the documentation has been successfully
     uploaded to the S3 bucket, setting the 'uploaded' field to ``True``.
+
+    **Authorization**
+
+    User must be authenticated and have ``upload_build`` permissions.
 
     **Example request**
 
@@ -174,9 +184,14 @@ def patch_build(id):
 
 
 @api.route('/builds/<int:id>', methods=['DELETE'])
+@permission_required(Permission.DEPRECATE_BUILD)
 @token_auth.login_required
 def deprecate_build(id):
-    """Mark a build as deprecated (token required).
+    """Mark a build as deprecated.
+
+    **Authorization**
+
+    User must be authenticated and have ``deprecate_build`` permissions.
 
     **Example request**
 

--- a/app/api_v1/editions.py
+++ b/app/api_v1/editions.py
@@ -4,14 +4,19 @@ from flask import jsonify, request
 
 from . import api
 from .. import db
-from ..auth import token_auth
-from ..models import Product, Edition
+from ..auth import token_auth, permission_required
+from ..models import Product, Edition, Permission
 
 
 @api.route('/products/<slug>/editions/', methods=['POST'])
+@permission_required(Permission.ADMIN_EDITION)
 @token_auth.login_required
 def new_edition(slug):
-    """Create a new Edition for a Product (token required).
+    """Create a new Edition for a Product.
+
+    **Authorization**
+
+    User must be authenticated and have ``admin_edition`` permissions.
 
     **Example request**
 
@@ -81,14 +86,19 @@ def new_edition(slug):
 
 
 @api.route('/editions/<int:id>', methods=['DELETE'])
+@permission_required(Permission.ADMIN_EDITION)
 @token_auth.login_required
 def deprecate_edition(id):
-    """Deprecate an Edition of a Product (token required).
+    """Deprecate an Edition of a Product.
 
     When an Edition is deprecated, the current time is added to the
     Edition's ``date_ended`` field. Any Edition record with a non-``null``
     ``date_ended`` field will be garbage-collected by LTD Keeper (the
     deletion does not occur immediately upon API request).
+
+    **Authorization**
+
+    User must be authenticated and have ``admin_edition`` permissions.
 
     **Example request**
 
@@ -224,9 +234,10 @@ def get_edition(id):
 
 
 @api.route('/editions/<int:id>', methods=['PATCH'])
+@permission_required(Permission.ADMIN_EDITION)
 @token_auth.login_required
 def edit_edition(id):
-    """Edit an Edition (token required).
+    """Edit an Edition.
 
     This PATCH method allows you to specify a subset of JSON fields to replace
     existing fields in the Edition resource. Not all fields in an Edition are
@@ -237,6 +248,10 @@ def edit_edition(id):
     Use :http:delete:`/editions/(int:id)` to deprecate an edition.
 
     The full resource record is returned.
+
+    **Authorization**
+
+    User must be authenticated and have ``admin_edition`` permissions.
 
     **Example request**
 

--- a/app/api_v1/products.py
+++ b/app/api_v1/products.py
@@ -3,8 +3,8 @@
 from flask import jsonify, request
 from . import api
 from .. import db
-from ..auth import token_auth
-from ..models import Product
+from ..auth import token_auth, permission_required
+from ..models import Product, Permission
 
 
 @api.route('/products/', methods=['GET'])
@@ -92,9 +92,14 @@ def get_product(slug):
 
 
 @api.route('/products/', methods=['POST'])
+@permission_required(Permission.ADMIN_PRODUCT)
 @token_auth.login_required
 def new_product():
-    """Create a new documentation product (token required).
+    """Create a new documentation product.
+
+    **Authorization**
+
+    User must be authenticated and have ``admin_product`` permissions.
 
     **Example request**
 
@@ -159,13 +164,18 @@ def new_product():
 
 
 @api.route('/products/<slug>', methods=['PATCH'])
+@permission_required(Permission.ADMIN_PRODUCT)
 @token_auth.login_required
 def edit_product(slug):
-    """Update a product (token required).
+    """Update a product.
 
     Not all fields can be updated: in particular ``'slug'``, ``'domain'``, and
     ``'bucket-name'``. Support for updating these Product attributes may be
     added later.
+
+    **Authorization**
+
+    User must be authenticated and have ``admin_product`` permissions.
 
     **Example request**
 

--- a/app/models.py
+++ b/app/models.py
@@ -17,6 +17,24 @@ from .utils import split_url, format_utc_datetime, \
 class Permission(object):
     """User permission definitions.
 
+    These permissions can be added to the ``permissions`` column of a
+    :class:`User`. For example, to give a user permission to both
+    administer products *and* editions::
+
+        p = Permission
+        user = User(username='test-user',
+                    permissions=p.ADMIN_PRODUCT | p.ADMIN_EDITION)
+
+    You can give a user permission to do everything with the
+    :meth:`User.full_permissions` helper method:
+
+        p = Permission
+        user = User(username='admin-user',
+                    permission=p.full_permissions())
+
+    See :class:`User.has_permission` for how to use these permission
+    bits to test user authorization.
+
     Attributes
     ----------
     ADMIN_USER
@@ -40,6 +58,13 @@ class Permission(object):
 
     @classmethod
     def full_permissions(self):
+        """Helper method to create a bit mask with all permissions enabled.
+
+        Returns
+        -------
+        permissions : int
+            Bit mask with all permissions enabled.
+        """
         return self.ADMIN_USER | self.ADMIN_PRODUCT | self.ADMIN_EDITION \
             | self.UPLOAD_BUILD | self.DEPRECATE_BUILD
 

--- a/run.py
+++ b/run.py
@@ -17,7 +17,7 @@ See config/{development.py, production.py} for associated configuration.
 import argparse
 
 from app import create_app, db
-from app.models import User
+from app.models import User, Permission
 
 
 if __name__ == '__main__':
@@ -36,7 +36,8 @@ if __name__ == '__main__':
         db.create_all()
         # bootstrap a user
         if User.query.get(1) is None:
-            u = User(username=app.config['DEFAULT_USER'])
+            u = User(username=app.config['DEFAULT_USER'],
+                     permissions=Permission.full_permissions())
             u.set_password(app.config['DEFAULT_PASSWORD'])
             db.session.add(u)
             db.session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,18 @@
 import pytest
 
 from app import create_app, db
-from app.models import User
+from app.models import User, Permission
 from app.testutils import TestClient
 
 
 DEFAULT_USERNAME = 'hipster'
 DEFAULT_PASSWORD = 'pug'
+
+# additional usernames with specific roles
+PRODUCT_ADMIN_USERNAME = 'product_admin'
+EDITION_ADMIN_USERNAME = 'edition_admin'
+BUILD_UPLOADER_USERNAME = 'build_uploader'
+BUILD_DEPRECATOR_USERNAME = 'build_deprecator'
 
 
 @pytest.fixture
@@ -19,9 +25,33 @@ def empty_app(request):
     ctx.push()
     db.drop_all()
     db.create_all()
-    u = User(username=DEFAULT_USERNAME)
+
+    # Creates users with each of the permissions
+    u = User(username=DEFAULT_USERNAME,
+             permissions=Permission.full_permissions())
     u.set_password(DEFAULT_PASSWORD)
     db.session.add(u)
+
+    u = User(username=PRODUCT_ADMIN_USERNAME,
+             permissions=Permission.ADMIN_PRODUCT)
+    u.set_password(DEFAULT_PASSWORD)
+    db.session.add(u)
+
+    u = User(username=EDITION_ADMIN_USERNAME,
+             permissions=Permission.ADMIN_EDITION)
+    u.set_password(DEFAULT_PASSWORD)
+    db.session.add(u)
+
+    u = User(username=BUILD_UPLOADER_USERNAME,
+             permissions=Permission.UPLOAD_BUILD)
+    u.set_password(DEFAULT_PASSWORD)
+    db.session.add(u)
+
+    u = User(username=BUILD_DEPRECATOR_USERNAME,
+             permissions=Permission.DEPRECATE_BUILD)
+    u.set_password(DEFAULT_PASSWORD)
+    db.session.add(u)
+
     db.session.commit()
 
     def fin():
@@ -44,6 +74,49 @@ def basic_client(empty_app):
 def client(empty_app):
     """Client with token-based auth, using the `app` application."""
     _c = TestClient(empty_app, DEFAULT_USERNAME, DEFAULT_PASSWORD)
+    r = _c.get('/token')
+    client = TestClient(empty_app, r.json['token'])
+    return client
+
+
+@pytest.fixture
+def anon_client(empty_app):
+    """Anonymous client."""
+    client = TestClient(empty_app, '', '')
+    return client
+
+
+@pytest.fixture
+def product_client(empty_app):
+    """Client with token-based auth with ADMIN_PRODUCT permissions."""
+    _c = TestClient(empty_app, PRODUCT_ADMIN_USERNAME, DEFAULT_PASSWORD)
+    r = _c.get('/token')
+    client = TestClient(empty_app, r.json['token'])
+    return client
+
+
+@pytest.fixture
+def edition_client(empty_app):
+    """Client with token-based auth with ADMIN_EDITION permissions."""
+    _c = TestClient(empty_app, EDITION_ADMIN_USERNAME, DEFAULT_PASSWORD)
+    r = _c.get('/token')
+    client = TestClient(empty_app, r.json['token'])
+    return client
+
+
+@pytest.fixture
+def upload_build_client(empty_app):
+    """Client with token-based auth with UPLOAD_BUILD permissions."""
+    _c = TestClient(empty_app, BUILD_UPLOADER_USERNAME, DEFAULT_PASSWORD)
+    r = _c.get('/token')
+    client = TestClient(empty_app, r.json['token'])
+    return client
+
+
+@pytest.fixture
+def deprecate_build_client(empty_app):
+    """Client with token-based auth with DEPRECATE_BUILD permissions."""
+    _c = TestClient(empty_app, BUILD_DEPRECATOR_USERNAME, DEFAULT_PASSWORD)
     r = _c.get('/token')
     client = TestClient(empty_app, r.json['token'])
     return client

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -1,7 +1,7 @@
 """Tests for the builds API."""
 
 import pytest
-
+from werkzeug.exceptions import NotFound
 from app.exceptions import ValidationError
 
 
@@ -92,3 +92,90 @@ def test_builds(client):
           'git_refs': 'master'}
     with pytest.raises(ValidationError):
         r = client.post('/products/lsst_apps/builds/', b5)
+
+
+# Authorizion tests: POST /products/<slug>/builds/ ===========================
+# Only the build-upload auth'd client should get in
+
+
+def test_post_build_auth_anon(anon_client):
+    r = anon_client.post('/products/test/builds/', {'foo': 'bar'})
+    assert r.status == 401
+
+
+def test_post_build_auth_product_client(product_client):
+    r = product_client.post('/products/test/builds/', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_post_build_auth_edition_client(edition_client):
+    r = edition_client.post('/products/test/builds/', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_post_build_auth_builduploader_client(upload_build_client):
+    with pytest.raises(NotFound):
+        upload_build_client.post('/products/test/builds/', {'foo': 'bar'})
+
+
+def test_post_build_auth_builddeprecator_client(deprecate_build_client):
+    r = deprecate_build_client.post('/products/test/builds/', {'foo': 'bar'})
+    assert r.status == 403
+
+
+# Authorizion tests: PATCH /products/<slug>/builds/ ==========================
+# Only the build-upload auth'd client should get in
+
+
+def test_patch_build_auth_anon(anon_client):
+    r = anon_client.patch('/builds/1', {'foo': 'bar'})
+    assert r.status == 401
+
+
+def test_patch_build_auth_product_client(product_client):
+    r = product_client.patch('/builds/1', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_patch_build_auth_edition_client(edition_client):
+    r = edition_client.patch('/builds/1', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_patch_build_auth_builduploader_client(upload_build_client):
+    with pytest.raises(NotFound):
+        upload_build_client.patch('/builds/1', {'foo': 'bar'})
+
+
+def test_patch_build_auth_builddeprecator_client(deprecate_build_client):
+    r = deprecate_build_client.patch('/builds/1', {'foo': 'bar'})
+    assert r.status == 403
+
+
+# Authorizion tests: DELETE /products/<slug>/builds/ =========================
+# Only the build-deprecator auth'd client should get in
+
+
+def test_delete_build_auth_anon(anon_client):
+    r = anon_client.delete('/builds/1')
+    assert r.status == 401
+
+
+def test_delete_build_auth_product_client(product_client):
+    r = product_client.delete('/builds/1')
+    assert r.status == 403
+
+
+def test_delete_build_auth_edition_client(edition_client):
+    r = edition_client.delete('/builds/1')
+    assert r.status == 403
+
+
+def test_delete_build_auth_builduploader_client(upload_build_client):
+    r = upload_build_client.delete('/builds/1')
+    assert r.status == 403
+
+
+def test_delete_build_auth_builddeprecator_client(deprecate_build_client):
+    with pytest.raises(NotFound):
+        deprecate_build_client.delete('/builds/1', {'foo': 'bar'})

--- a/tests/test_editions.py
+++ b/tests/test_editions.py
@@ -1,5 +1,8 @@
 """Tests for the editions API."""
 
+import pytest
+from werkzeug.exceptions import NotFound
+
 
 def test_editions(client):
     # Add a sample product
@@ -70,3 +73,90 @@ def test_editions(client):
     r = client.get(product_url + '/editions/')
     assert r.status == 200
     assert len(r.json['editions']) == 0
+
+
+# Authorizion tests: POST /products/<slug>/editions/ =========================
+# Only the full admin client and the edition-authorized client should get in
+
+
+def test_post_edition_auth_anon(anon_client):
+    r = anon_client.post('/products/test/editions/', {'foo': 'bar'})
+    assert r.status == 401
+
+
+def test_post_edition_auth_product_client(product_client):
+    r = product_client.post('/products/test/editions/', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_post_edition_auth_edition_client(edition_client):
+    with pytest.raises(NotFound):
+        edition_client.post('/products/test/editions/', {'foo': 'bar'})
+
+
+def test_post_edition_auth_builduploader_client(upload_build_client):
+    r = upload_build_client.post('/products/test/editions/', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_post_edition_auth_builddeprecator_client(deprecate_build_client):
+    r = deprecate_build_client.post('/products/test/editions/', {'foo': 'bar'})
+    assert r.status == 403
+
+
+# Authorizion tests: PATCH /editions/<slug>/editions/ =========================
+# Only the full admin client and the edition-authorized client should get in
+
+
+def test_patch_edition_auth_anon(anon_client):
+    r = anon_client.patch('/editions/1', {'foo': 'bar'})
+    assert r.status == 401
+
+
+def test_patch_edition_auth_product_client(product_client):
+    r = product_client.patch('/editions/1', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_patch_edition_auth_edition_client(edition_client):
+    with pytest.raises(NotFound):
+        edition_client.patch('/editions/1', {'foo': 'bar'})
+
+
+def test_patch_edition_auth_builduploader_client(upload_build_client):
+    r = upload_build_client.patch('/editions/1', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_patch_edition_auth_builddeprecator_client(deprecate_build_client):
+    r = deprecate_build_client.patch('/editions/1', {'foo': 'bar'})
+    assert r.status == 403
+
+
+# Authorizion tests: DELETE /editions/<slug> =================================
+# Only the full admin client and the edition-authorized client should get in
+
+
+def test_delete_edition_auth_anon(anon_client):
+    r = anon_client.delete('/editions/1')
+    assert r.status == 401
+
+
+def test_delete_edition_auth_product_client(product_client):
+    r = product_client.delete('/editions/1')
+    assert r.status == 403
+
+
+def test_delete_edition_auth_edition_client(edition_client):
+    with pytest.raises(NotFound):
+        edition_client.delete('/editions/1')
+
+
+def test_delete_edition_auth_builduploader_client(upload_build_client):
+    r = upload_build_client.delete('/editions/1')
+    assert r.status == 403
+
+
+def test_delete_edition_auth_builddeprecator_client(deprecate_build_client):
+    r = deprecate_build_client.delete('/editions/1')
+    assert r.status == 403

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,5 +1,9 @@
 """Tests for the product API."""
 
+import pytest
+from werkzeug.exceptions import NotFound
+from app.exceptions import ValidationError
+
 
 def test_products(client):
     r = client.get('/products/')
@@ -56,3 +60,61 @@ def test_products(client):
     print(r.json)
     for k, v in p2v2.items():
         assert r.json[k] == v
+
+
+# Authorizion tests: POST /products/ =========================================
+# Only the full admin client and the product-authorized client should get in
+
+
+def test_post_product_auth_anon(anon_client):
+    r = anon_client.post('/products/', {'foo': 'bar'})
+    assert r.status == 401
+
+
+def test_post_product_auth_product_client(product_client):
+    with pytest.raises(ValidationError):
+        product_client.post('/products/', {'foo': 'bar'})
+
+
+def test_post_product_auth_edition_client(edition_client):
+    r = edition_client.post('/products/', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_post_product_auth_builduploader_client(upload_build_client):
+    r = upload_build_client.post('/products/', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_post_product_auth_builddeprecator_client(upload_build_client):
+    r = upload_build_client.post('/products/', {'foo': 'bar'})
+    assert r.status == 403
+
+
+# Authorizion tests: PATCH /products/<slug> ==================================
+# Only the full admin client and the product-authorized client should get in
+
+
+def test_patch_product_auth_anon(anon_client):
+    r = anon_client.patch('/products/test', {'foo': 'bar'})
+    assert r.status == 401
+
+
+def test_patch_product_auth_product_client(product_client):
+    with pytest.raises(NotFound):
+        product_client.patch('/products/test', {'foo': 'bar'})
+
+
+def test_patch_product_auth_edition_client(edition_client):
+    r = edition_client.patch('/products/test', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_patch_product_auth_builduploader_client(upload_build_client):
+    r = upload_build_client.patch('/products/test', {'foo': 'bar'})
+    assert r.status == 403
+
+
+def test_patch_product_auth_builddeprecator_client(upload_build_client):
+    r = upload_build_client.patch('/products/test', {'foo': 'bar'})
+    assert r.status == 403


### PR DESCRIPTION
The initial MVP of ltd-keeper had all-or-nothing authentication; any user was effectively an admin user. This adds fine-grained roles that each API user could have (for example, one API user might be able to add a build, but not create an edition or product or add another user).

- [x] Define a set of permissions
- [x] Add permissions bits to the User model with a helper method to validate that a user has the correct permissions
- [x] Create a decorator that can be added to routes to declare required permissions
- [x] Apply that decorator throughout the codebase
- [x] Test authorization of all secured endpoints
- [x] Add documentation to the individual routes. More general docs may have to wait for a `PUT /users/` route to be added. → [DM-5678](https://jira.lsstcorp.org/browse/DM-5678)
- Deferred: ~~Make it possible for some routes to be semi-opened. For example, a user who administers a Product might see 'private' infrastructural details about the Product that an anonymous user would not see. A way to do this is described in https://github.com/miguelgrinberg/Flask-HTTPAuth/issues/17#issuecomment-76668519~~ → [DM-5679](https://jira.lsstcorp.org/browse/DM-5679)