### PR TITLE
Enable ltd-mason in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,28 @@ language: python
 python:
   - '3.5'
   - '3.5-dev'
+matrix:
+  allow_failures:
+    - python: "3.5-dev"
+  include:
+    # This is the ltd-mason documentation deployment build
+    - python: "3.5"
+      env: LTD_MASON_BUILD=true
 install:
   - pip install -r requirements.txt
+  - pip install ltd-mason==0.2.0rc0
 script:
   - 'py.test --flake8 --cov=app'
-  - cd docs && make html
+  # NOTE: don't use nit-picky mode with httpdomain. Lots of false positives.
+  - 'sphinx-build -b html -a -W -d docs/_build/doctree docs docs/_build/html'
+after_success:
+  # ltd-mason is a no-op for regular builds with LTD_MASON_BUILD=false
+  - ltd-mason-travis --html-dir docs/_build/html --verbose
+env:
+  global:
+    - LTD_MASON_BUILD=false  # disable builds in regular text matrix
+    - LTD_MASON_PRODUCT="ltd-keeper"
+    # travis encrypt "LTD_MASON_AWS_ID=... LTD_MASON_AWS_SECRET=...
+    - secure: "QoOaiKnEkCsjpBO5bB//pJP8RdbL/6oddNRUae6xmWmDq+ntdHUQBg3fvsYh5zcqkH8IfBSr+hVBgMd+nps3qVyV/HkKGwKBAMFk8nKqTDNUAfozBQtjBYDqxzP0ig8h4Qu+nmKIhGOVzFtkH6yiK42lbI5m6sXDRo8WwR6fvGqTX+2gtFY5daVZzxmtsKJ0bV0R2qkflE6TrGMi02Qj3liDZo4AU+MfqajHF2Egfi8wbAMyUJVGIFtGA9KiN5PbNR0eAFRMpLr98KO5/Vw0uMVElDif9oYHteqGwC9slxYu/rdIirpqmCxjAFvdVUTe3mk8/jUq9ANcGIAyBe5xbfkYCAv8n6UDTPj7IBcVF/DtYgbcB+n4t8zRk1t+4IOmF1RMG7E2g0nbQoS0VwOd9t1ZsUJSJIm2buTwA395KgJfJZQUQm+gY66/BA2WckxUuOgzYRzLVj3x9rWcKje+4MIA60ZqCiWGq2AFcFmr+ULqQOSQk8TcfGLl3iL1S6RfoDmy0AFtFXVthLHU/EER5Au0ukC1DitKrHve+Bq3qR2pXGPCdrwlCDde6qmarMWkf893zXjHpgNyaZ+3tqUOOkf4842w/688g5B6mMtRqsCylHn9b4GJM8J8XCeBKU5QDU/BHZbafnanbP8A6jvlYaISaiG5JJBwjikZCu+BiFc="
+    # travis encrypt "LTD_KEEPER_URL=... LTD_KEEPER_USER=... LTD_KEEPER_PASSWORD=..." --add env.global 
+    - secure: "Fz0VPGtPIWG4D9GcW88ZwXucDJwx2HFnRidEOraZx1e3NBzd4rE5UoEOgCB68MQlKLozlDD9RnBGuV/d2+PbB6tczMBugVlptApP2Wd0BA8JOqnsAgaRuB2Fw+euuRUoaN+NGPta3MS5v44gvto25WNnkU8yGFiiGbH/KAZT3MH2pm7Fa7BnFexvAyXRY33klXRHZ5wLH+e/RrMwsqk9aqiF0JFn5iS+XP32imBdkgVnJDOwp6ptLTYXQdQ7pm5zjNi3M6EA/bIOMsyG3kwWU8WkXuZSThrseYD4UnSEooQHZhowNklZ2V69iUo3t5QhbU7NelMcxJSThK39EuIW95ayYUl8t71c9G97LIK8yEOvAJN80jVPvAHrhv/9c5P6GykzwVDECTVZqOxT7YoO5mmXgpfsZmSy2cxsv/mZys3pEbl83//EYc/kDWrV6yIZogchkxYF3V4A3SHURilG8WwqQP/zOrEXdiYbR0lVdcydepywOacqdqH5YfhkC7Q56Eb2tfvtbqgPedmFROTWzNRQGjBibfnCt9mRFeAblXnFco8wOMKbdN4laApXrbdSyJ3aSuzFUuGVe+4OltAer49xOa927DUUePm3QOQfFy+m6gFVt1Ee3f4kWID1LIfu86Vq56KD1U0VBwRPSMCeQdwR/xJ+y8yCbR/Y4IhVXEg="

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,8 +5,8 @@ import sys
 import os
 
 # Add the app to the Python path for autodoc
-sys.path.insert(0, os.path.abspath('..'))
-print(sys.path)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '../')))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
This enables continuous documentation deployment to LSST the Docs under the ltd-keeper product name.