### PR TITLE
DM-6111: Edition rebuild changes Cache-Control to no-cache for Browsers

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -539,7 +539,11 @@ class Edition(db.Model):
                 dest_path=self.bucket_root_dirname,
                 aws_access_key_id=AWS_ID,
                 aws_secret_access_key=AWS_SECRET,
-                surrogate_key=self.surrogate_key)
+                surrogate_key=self.surrogate_key,
+                # Force Fastly to cache the edition for 1 year
+                surrogate_control='max-age=31536000',
+                # Force browsers to revalidate their local cache using ETags.
+                cache_control='no-cache')
 
         if FASTLY_SERVICE_ID is not None and FASTLY_KEY is not None:
             fastly_service = fastly.FastlyService(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -116,7 +116,9 @@ def test_copy_directory(request):
         dest_path=bucket_root + 'a/',
         aws_access_key_id=os.getenv('LTD_KEEPER_TEST_AWS_ID'),
         aws_secret_access_key=os.getenv('LTD_KEEPER_TEST_AWS_SECRET'),
-        surrogate_key='new-key')
+        surrogate_key='new-key',
+        surrogate_control='max-age=31536000',
+        cache_control='no-cache')
 
     # Test files in the a/ directory are from b/
     for obj in bucket.objects.filter(Prefix=bucket_root + 'a/'):
@@ -126,9 +128,10 @@ def test_copy_directory(request):
         head = s3.meta.client.head_object(
             Bucket=os.getenv('LTD_KEEPER_TEST_BUCKET'),
             Key=obj.key)
-        assert head['CacheControl'] == 'max-age=3600'
+        assert head['CacheControl'] == 'no-cache'
         assert head['ContentType'] == 'text/plain'
         assert head['Metadata']['surrogate-key'] == 'new-key'
+        assert head['Metadata']['surrogate-control'] == 'max-age=31536000'
 
 
 def test_copy_dir_src_in_dest():


### PR DESCRIPTION
When an edition is rebuild the following headers are set:

```
Surrogate-Control: max-age=31536000
Cache-Control: no-cache
```

This ensures that Fastly caches the content in its POPs for a year, while also telling browsers to check with Fastly whether a client-side cache is stale based on ETag hashes.

See
https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching
for more information.

In the future it may be a good idea to create more nuanced client-side caching rules based on content types. For example, CSS and JavaScript can probably be cached for at least a day without requiring the browser to re-validate that cache.