### PR TITLE
DM-6638: Auto slug for edition paths deals with underscores

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -88,6 +88,7 @@ def auto_slugify_edition(git_refs):
         return m.group(1)
 
     slug = slug.replace('/', '-')
+    slug = slug.replace('_', '-')
     slug = slug.replace('.', '-')
     return slug
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from app.utils import (auto_slugify_edition, validate_path_slug,
     'git_refs,expected',
     [(['tickets/DM-1234'], 'DM-1234'),
      (['master'], 'master'),
+     (['u/rowen/r12_patch1'], 'u-rowen-r12-patch1'),
      (['tickets/DM-1234', 'tickets/DM-5678'],
       'tickets-DM-1234-tickets-DM-5678')])
 def test_auto_slugify_edition(git_refs, expected):


### PR DESCRIPTION
Had a bug where `utils.auto_slugify_edition` did not replace underscores with a dash, and therefore `failed utils.validate_path_slug`.

Adds this replacement code and adds a test for such a case.