### PR TITLE
DM-7439: Support non-DM tickets for special edition routes

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -24,7 +24,7 @@ PRODUCT_SLUG_PATTERN = re.compile('^[a-z]+[-a-z0-9]*[a-z0-9]+$')
 PATH_SLUG_PATTERN = re.compile('^[a-zA-Z0-9-]+$')
 
 # Regular expression for DM ticket branches (to auto-build slugs)
-TICKET_BRANCH_PATTERN = re.compile('^tickets/(DM-[0-9]+)$')
+TICKET_BRANCH_PATTERN = re.compile('^tickets/([A-Z]+-[0-9]+)$')
 
 
 def split_url(url, method='GET'):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ from app.utils import (auto_slugify_edition, validate_path_slug,
 @pytest.mark.parametrize(
     'git_refs,expected',
     [(['tickets/DM-1234'], 'DM-1234'),
+     (['tickets/LCR-758'], 'LCR-758'),
      (['master'], 'master'),
      (['u/rowen/r12_patch1'], 'u-rowen-r12-patch1'),
      (['tickets/DM-1234', 'tickets/DM-5678'],


### PR DESCRIPTION
Previously only tickets/DM-NNNN tickets got editions with /v/DM-NNNN
paths. The regex now works with any ticket type, e.g. tickets/LCR-NNNN.