### PR TITLE
DM-9021: Add hooks to trigger LTD Dasher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 sudo: false
 language: python
 python:
-  - '3.5'
-  - '3.5-dev'
+  - '3.6'
 matrix:
   allow_failures:
-    - python: "3.5-dev"
+    - python: "3.6"
   include:
     # This is the ltd-mason documentation deployment build
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       env: LTD_MASON_BUILD=true
 install:
   - pip install -r requirements.txt
-  - pip install ltd-mason==0.2.0rc0
+  - pip install ltd-mason==0.2.2
 script:
   - 'py.test --cov=app'
   # - 'py.test --flake8 --cov=app'  # flake8 currently broken

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ install:
   - pip install -r requirements.txt
   - pip install ltd-mason==0.2.2
 script:
-  - 'py.test --cov=app'
-  # - 'py.test --flake8 --cov=app'  # flake8 currently broken
+  - 'py.test --flake8 --cov=app'
   # NOTE: don't use nit-picky mode with httpdomain. Lots of false positives.
   - 'sphinx-build -b html -a -W -d docs/_build/doctree docs docs/_build/html'
 after_success:

--- a/app/api_v1/__init__.py
+++ b/app/api_v1/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 api = Blueprint('api', __name__)
 
-from . import products, builds, editions, errorhandlers  # NOQA
+from . import products, builds, editions, dashboards, errorhandlers  # NOQA

--- a/app/api_v1/builds.py
+++ b/app/api_v1/builds.py
@@ -1,13 +1,14 @@
 """API v1 routes for builds."""
 
 import uuid
-from flask import jsonify, request
+from flask import jsonify, request, current_app
 
 from . import api
 from .. import db
 from ..auth import token_auth, permission_required, is_authorized
 from ..models import Product, Build, Edition, Permission
 from ..utils import auto_slugify_edition
+from ..dasher import build_dashboard_safely
 
 
 @api.route('/products/<slug>/builds/', methods=['POST'])
@@ -213,6 +214,7 @@ def patch_build(id):
     build = Build.query.get_or_404(id)
     build.patch_data(request.json)
     db.session.commit()
+    build_dashboard_safely(current_app, request, build.product)
     return jsonify({}), 200, {'Location': build.get_url()}
 
 

--- a/app/api_v1/dashboards.py
+++ b/app/api_v1/dashboards.py
@@ -1,0 +1,33 @@
+"""API v1 route for dashboard building."""
+
+from flask import jsonify, current_app
+from . import api
+from ..auth import token_auth, permission_required
+from ..models import Product, Permission
+from ..dasher import build_dashboards
+
+
+@api.route('/dashboards', methods=['POST'])
+@token_auth.login_required
+@permission_required(Permission.ADMIN_PRODUCT)
+def rebuild_all_dashboards():
+    """Rebuild the LTD Dasher dashboards for all products.
+
+    Note that dashboards are built asynchronously.
+
+    **Authorization**
+
+    User must be authenticated and have ``admin_product`` permissions.
+
+    :statuscode 202: Dashboard rebuild trigger sent.
+
+    **See also**
+
+    - :http:post:`/products/(slug)/dashboard` for single-product dashboard
+      rebuilds.
+    """
+    build_dashboards(
+        [product.get_url() for product in Product.query.all()],
+        current_app.config['LTD_DASHER_URL'],
+        current_app.logger)
+    return jsonify({}), 202, {}

--- a/app/api_v1/editions.py
+++ b/app/api_v1/editions.py
@@ -204,6 +204,7 @@ def get_edition(id):
            "published_url": "pipelines.lsst.io",
            "self_url": "http://localhost:5000/editions/1",
            "slug": "latest",
+           "surrogate_key": "2a5f38f27e3c46258fd9b0e69afe54fd",
            "title": "Development master",
            "tracked_refs": [
                "master"
@@ -222,6 +223,9 @@ def get_edition(id):
     :>json string published_url: Full URL where this edition is published.
     :>json string self_url: URL of this Edition entity.
     :>json string slug: URL-safe name for edition.
+    :>json string surrogate_key: Surrogate key that should be used in the
+        ``x-amz-meta-surrogate-control`` header of any the edition's S3
+        objects to control Fastly caching.
     :>json string title: Human-readable name for edition.
     :>json string tracked_refs: Git ref that this Edition points to. For multi-
         repository builds, this can be a comma-separated list of refs to use,
@@ -288,6 +292,7 @@ def edit_edition(id):
            "published_url": "pipelines.lsst.io",
            "self_url": "http://localhost:5000/editions/1",
            "slug": "latest",
+           "surrogate_key": "2a5f38f27e3c46258fd9b0e69afe54fd",
            "title": "Development master",
            "tracked_refs": [
                "master"
@@ -318,6 +323,9 @@ def edit_edition(id):
     :>json string published_url: Full URL where this edition is published.
     :>json string self_url: URL of this Edition entity.
     :>json string slug: URL-safe name for edition.
+    :>json string surrogate_key: Surrogate key that should be used in the
+        ``x-amz-meta-surrogate-control`` header of any the edition's S3
+        objects to control Fastly caching.
     :>json string title: Human-readable name for edition.
     :>json string tracked_refs: Git ref that this Edition points to. For multi-
         repository builds, this can be a comma-separated list of refs to use,

--- a/app/api_v1/editions.py
+++ b/app/api_v1/editions.py
@@ -1,11 +1,12 @@
 """API v1 routes for Editions."""
 
-from flask import jsonify, request
+from flask import jsonify, request, current_app
 
 from . import api
 from .. import db
 from ..auth import token_auth, permission_required
 from ..models import Product, Edition, Permission
+from ..dasher import build_dashboard_safely
 
 
 @api.route('/products/<slug>/editions/', methods=['POST'])
@@ -80,6 +81,7 @@ def new_edition(slug):
     except Exception:
         db.session.rollback()
         raise
+    build_dashboard_safely(current_app, request, product)
     return jsonify({}), 201, {'Location': edition.get_url()}
 
 
@@ -131,6 +133,7 @@ def deprecate_edition(id):
     edition = Edition.query.get_or_404(id)
     edition.deprecate()
     db.session.commit()
+    build_dashboard_safely(current_app, request, edition.product)
     return jsonify({}), 200
 
 
@@ -342,4 +345,5 @@ def edit_edition(id):
     except Exception:
         db.session.rollback()
         raise
+    build_dashboard_safely(current_app, request, edition.product)
     return jsonify(edition.export_data())

--- a/app/api_v1/products.py
+++ b/app/api_v1/products.py
@@ -286,6 +286,10 @@ def rebuild_product_dashboard(slug):
     User must be authenticated and have ``admin_product`` permissions.
 
     :statuscode 202: Dashboard rebuild trigger sent.
+
+    **See also**
+
+    - :http:post:`/dashboards`
     """
     product = Product.query.filter_by(slug=slug).first_or_404()
     build_dashboards(product.get_url(),

--- a/app/api_v1/products.py
+++ b/app/api_v1/products.py
@@ -297,7 +297,7 @@ def rebuild_product_dashboard(slug):
     - :http:post:`/dashboards`
     """
     product = Product.query.filter_by(slug=slug).first_or_404()
-    build_dashboards(product.get_url(),
-                     current_app.config[''],
+    build_dashboards([product.get_url()],
+                     current_app.config['LTD_DASHER_URL'],
                      current_app.logger)
     return jsonify({}), 202, {}

--- a/app/api_v1/products.py
+++ b/app/api_v1/products.py
@@ -1,10 +1,11 @@
 """API v1 routes for products."""
 
-from flask import jsonify, request
+from flask import jsonify, request, current_app
 from . import api
 from .. import db
 from ..auth import token_auth, permission_required
 from ..models import Product, Permission, Edition
+from ..dasher import build_dashboard_safely
 
 
 @api.route('/products/', methods=['GET'])
@@ -194,6 +195,9 @@ def new_product():
     except Exception:
         db.session.rollback()
         raise
+
+    build_dashboard_safely(current_app, request, product)
+
     return jsonify({}), 201, {'Location': product.get_url()}
 
 
@@ -263,4 +267,7 @@ def edit_product(slug):
     except Exception:
         db.session.rollback()
         raise
+
+    build_dashboard_safely(current_app, request, product)
+
     return jsonify({}), 200, {'Location': product.get_url()}

--- a/app/api_v1/products.py
+++ b/app/api_v1/products.py
@@ -79,6 +79,7 @@ def get_product(slug):
            "root_fastly_domain": "global.ssl.fastly.net",
            "self_url": "http://localhost:5000/products/pipelines",
            "slug": "pipelines",
+           "surrogate_key": "2a5f38f27e3c46258fd9b0e69afe54fd",
            "title": "LSST Science Pipelines"
        }
 
@@ -100,6 +101,9 @@ def get_product(slug):
         the reader.
     :>json string self_url: URL of this Product resource.
     :>json string slug: URL/path-safe identifier for this product.
+    :>json string surrogate_key: Surrogate key that should be used in the
+        ``x-amz-meta-surrogate-control`` header of any product-level
+        dashboards to control Fastly caching.
     :>json string title: Human-readable product title.
 
     :statuscode 200: No error.
@@ -144,6 +148,7 @@ def new_product():
            "root_domain": "lsst.io",
            "root_fastly_domain": "global.ssl.fastly.net",
            "slug": "pipelines",
+           "surrogate_key": "2a5f38f27e3c46258fd9b0e69afe54fd",
            "title": "LSST Science Pipelines"
        }
 

--- a/app/dasher.py
+++ b/app/dasher.py
@@ -32,6 +32,7 @@ def build_dashboards(product_urls, dasher_url, logger):
 
     if dasher_url is None:
         # skip if not configured
+        print('LTD_DASHER_URL not set, skipping')
         logger.warning('LTD_DASHER_URL not set, skipping')
         return
 

--- a/app/dasher.py
+++ b/app/dasher.py
@@ -1,0 +1,40 @@
+"""Interaction with LTD Dasher microservices (for building static dashboards
+of product editions and builds.
+"""
+
+import requests
+
+from .exceptions import DasherError
+
+
+def build_dashboards(product_urls, dasher_url):
+    """Trigger ltd-dasher's POST /build endpoint to build dashboards for one
+    or more LTD products.
+
+    This function is a no-op if the LTD_DASHER_URL app config is ``None``.
+
+    Parameters
+    ----------
+    product_urls : `list` or `tuple` of `str`
+        Sequence of LTD Keeper product URLs for products whose dashboards
+        should be rebuilt.
+    dasher_url : `str`
+        Root URL of the dasher service in the Kubernetes cluster. Should be
+        the value of the ``LTD_DASHER_URL`` configuration.
+
+    Raises
+    ------
+    DasherError
+    """
+    assert isinstance(product_urls, (list, tuple))
+
+    if dasher_url is None:
+        # skip if not configured
+        return
+
+    dasher_build_url = '{0}/build'.format(dasher_url)
+    request_data = {'product_urls': product_urls}
+    r = requests.post(dasher_build_url, json=request_data)
+
+    if r.status_code != 202:
+        raise DasherError('Dasher error (status {0})'.format(r.status_code))

--- a/app/dasher.py
+++ b/app/dasher.py
@@ -7,7 +7,7 @@ import requests
 from .exceptions import DasherError
 
 
-def build_dashboards(product_urls, dasher_url):
+def build_dashboards(product_urls, dasher_url, logger):
     """Trigger ltd-dasher's POST /build endpoint to build dashboards for one
     or more LTD products.
 
@@ -21,6 +21,8 @@ def build_dashboards(product_urls, dasher_url):
     dasher_url : `str`
         Root URL of the dasher service in the Kubernetes cluster. Should be
         the value of the ``LTD_DASHER_URL`` configuration.
+    logger : `logging.Logger`
+        A logger provided by the application (``app.logger``).
 
     Raises
     ------
@@ -30,6 +32,7 @@ def build_dashboards(product_urls, dasher_url):
 
     if dasher_url is None:
         # skip if not configured
+        logger.warning('LTD_DASHER_URL not set, skipping')
         return
 
     dasher_build_url = '{0}/build'.format(dasher_url)
@@ -38,3 +41,31 @@ def build_dashboards(product_urls, dasher_url):
 
     if r.status_code != 202:
         raise DasherError('Dasher error (status {0})'.format(r.status_code))
+
+
+def build_dashboard_safely(app, request, product):
+    """Build a dashboard while catching any exceptions.
+
+    This function should be used by routes. Dashboard failures shouldn't block
+    a build uploard or an edition change, so this function logs errors, but
+    allows the route to return cleanly.
+
+    Parameters
+    ----------
+    app :
+        Flask application (from `flask.current_app`).
+    request :
+        Flask request instance.
+    product : `app.models.Product`
+        `~app.models.Product` instance whose dashboard is being updated.
+    """
+    try:
+        build_dashboards([product.get_url()],
+                         app.config['LTD_DASHER_URL'],
+                         app.logger)
+    except Exception:
+        app.logger.exception(
+            'LTD Dasher failed '
+            '{method} {url} {data}'.format(data=request.json,
+                                           method=request.method,
+                                           url=request.url))

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -21,3 +21,8 @@ class S3Error(Exception):
 class FastlyError(Exception):
     """"Errors related to Fastly API usage."""
     pass
+
+
+class DasherError(Exception):
+    """Errors related to LTD Dasher."""
+    pass

--- a/app/models.py
+++ b/app/models.py
@@ -359,6 +359,7 @@ class Build(db.Model):
             .filter(Edition.product == self.product)\
             .filter(Edition.tracked_refs == self.git_refs)\
             .all()
+
         for edition in editions:
             edition.rebuild(self.get_url())
 

--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ class Config(object):
     AWS_SECRET = os.environ.get('LTD_KEEPER_AWS_SECRET')
     FASTLY_KEY = os.environ.get('LTD_KEEPER_FASTLY_KEY')
     FASTLY_SERVICE_ID = os.environ.get('LTD_KEEPER_FASTLY_ID')
+    LTD_DASHER_URL = os.getenv('LTD_DASHER_URL', None)
 
     # Suppresses a warning until Flask-SQLAlchemy 3
     # See http://stackoverflow.com/a/33790196

--- a/docs/dashboards.rst
+++ b/docs/dashboards.rst
@@ -1,0 +1,21 @@
+##########################
+Dashboards - `/dashboards`
+##########################
+
+The ``/dashboards`` API allows you to update dashboards for products in bulk.
+
+Dashboards are normally rebuilt whenever a new build or edition are created or updated.
+But if the dashboard design changes, it is useful to trigger a rebuild of all dashboards.
+
+Dashboards are created by the `LTD Dasher <https://github.com/lsst-sqre/ltd-dasher>`_ microservice.
+
+Method Summary
+==============
+
+- :http:post:`/dashboards` --- rebuild all dashboards.
+
+Reference
+=========
+
+.. autoflask:: app:create_app(profile='development')
+   :endpoints: api.rebuild_all_dashboards

--- a/docs/dev-migrations.rst
+++ b/docs/dev-migrations.rst
@@ -34,6 +34,9 @@ The migration can be tested locally if you have a development DB running a previ
    ./run.py db upgrade
    ./run.py runserver
 
+With a :doc:`staging deployment <gke-staging-deployment-playbook>`, it is also possible to :doc:`test migrations <gke-migrations>` against a copy of the production database.
+This is now recommended practice.
+
 Coding for Migrations
 =====================
 

--- a/docs/docker-image.rst
+++ b/docs/docker-image.rst
@@ -15,7 +15,6 @@ Relevant images are:
 
 - ``lsstsqre/ltd-keeper:latest`` --- Created by the Dockerfile in this `github.com/lsst-sqre/ltd-keeper <https://github.com/lsst-sqre/ltd-keeper>`_ repository. This deploys LTD Keeper as a uWSGI application.
 - ``lsstsqre/nginx-python:compose`` --- An Nginx Proxy for LTD Keeper containers to be used in a Docker Compose environment (see :doc:`compose`). The related Dockerfile can be found in `github.com/lsst-sqre/nginx-python-docker <https://github.com/lsst-sqre/nginx-python-docker>`_.
-- ``lsstsqre/nginx-python:k8s`` --- An Nginx Proxy for LTD Keeper containers to be used in a Kubernetes environment (see :doc:`gke-deploy`). The related Dockerfile can be found in `github.com/lsst-sqre/nginx-python-docker <https://github.com/lsst-sqre/nginx-python-docker>`_.
 
 
 Building and Publishing the Keeper Docker Image

--- a/docs/gke-cloudsql.rst
+++ b/docs/gke-cloudsql.rst
@@ -38,6 +38,10 @@ You can also enable automated backups from the instance's page on the Google Clo
 Create a Service Account
 ========================
 
+.. note::
+
+   This step may not longer be necessary with Cloud SDK authentication and automatic service discovery.
+
 To authenticate to the Cloud SQL instance, we need to create a Google Cloud Service Account.
 
 Create a new Service Account from the IAM & Admin section of the Google Cloud console.
@@ -47,8 +51,10 @@ This JSON file will be used directly with the Cloud SQL proxy and also to build 
 
 See `Google's documentation for complete steps on creating a Service Account <https://cloud.google.com/sql/docs/sql-proxy#create-service-account>`__.
 
-Install the Cloud SQL Proxy
-===========================
+.. _gke-cloudsql-proxy:
+
+Install and Run the Cloud SQL Proxy
+===================================
 
 LTD operators should install the `Cloud SQL Proxy <https://cloud.google.com/sql/docs/sql-proxy>`_ locally to access and administer the Cloud SQL instance.
 
@@ -63,18 +69,30 @@ Create a convenient directory where a unix socket can be created:
 .. code-block:: bash
 
    mkdir cloudsql
+   sudo chmod 777
+
 
 And run the proxy:
 
 .. code-block:: bash
 
-   $GOPATH/bin/cloud_sql_proxy -dir=cloudsql -instances=PROJECT:REGION:ltd-sql-1 --credential_file=service_account.json
+   $GOPATH/bin/cloud_sql_proxy -dir=cloudsql
 
-Replace ``PROJECT`` and ``REGION`` with the Google Cloud project's name and default region (specified previously in :doc:`gke-setup`).
+.. note::
 
-``service_account.json`` is the path to the service account JSON credentials file that was downloaded previously.
+   Alternatively, a Service Account credential can be used:
+
+   .. code-block:: bash
+   
+      $GOPATH/bin/cloud_sql_proxy -dir=cloudsql -instances=PROJECT:REGION:ltd-sql-1 --credential_file=service_account.json
+   
+   Replace ``PROJECT`` and ``REGION`` with the Google Cloud project's name and default region (specified previously in :doc:`gke-setup`).
+
+   ``service_account.json`` is the path to the service account JSON credentials file that was downloaded previously.
 
 See the `github.com/GoogleCloudPlatform/cloudsql-proxy <https://github.com/GoogleCloudPlatform/cloudsql-proxy>`_ repository for further details.
+
+.. _gke-cloudsql-connect:
 
 Connect to the Cloud SQL Instance and Create a keeper Database
 ==============================================================

--- a/docs/gke-migrations.rst
+++ b/docs/gke-migrations.rst
@@ -71,3 +71,42 @@ Procedure
    .. code-block:: bash
 
       kubectl create -f keeper-deployment
+
+.. _gke-migrations-troubleshooting:
+
+Troubleshooting
+===============
+
+Unexpected branched state
+-------------------------
+
+It's possible for Alembic to get into an unexpected branching state, producing an error message during a ``run.py db upgrade`` like::
+
+   alembic.util.exc.CommandError: Requested revision 1ba709663f26 overlaps with other requested revisions 0c0c70d73d4b
+
+The ``run.py db heads`` and ``run.py db branches`` and ``run.py db current`` commands will show a normal, linear version history.
+A true validation is to inspect the ``alembic_version`` table in the database.
+
+Following :ref:`gke-cloudsql-connect`, log into the database and show the ``alembic_version`` table:
+
+.. code-block:: sql
+
+   use keeper;
+   select * from alembic_version;
+
+If more than one version row is present, then the table can be easily reset.
+First, drop the ``alembic_version`` table:
+
+.. code-block:: sql
+
+   drop table alembic_version;
+
+Then in the management pod, stamp the database version:
+
+.. code-block:: bash
+
+   ./run.py db stamp $VERSION
+
+where ``$VERSION`` is the ID of the known current migration.
+This creates a new ``alembic_version`` table with a single row specifying the current version.
+Now the database upgrade can be retried.

--- a/docs/gke-migrations.rst
+++ b/docs/gke-migrations.rst
@@ -20,7 +20,7 @@ Procedure
 
    .. code-block:: bash
 
-      kubectl delete keeper-deployment
+      kubectl delete deployment keeper-deployment
 
    Watch for the pods to be deleted with ``kubectl get pods``.
 

--- a/docs/gke-staging-deployment-playbook.rst
+++ b/docs/gke-staging-deployment-playbook.rst
@@ -1,0 +1,60 @@
+#######################################
+Creating and Using a Staging Deployment
+#######################################
+
+When working on LTD Keeper, it's sometimes useful to create a separate Kubernetes deployment for testing that's isolated from production.
+For example, a staging deployment can be used to test breaking changes like SQL migrations.
+Ideally this would be an automated integration test.
+But for now, this page gives a playbook for creating an isolated staging deployment.
+
+.. _gke-staging-db:
+
+Duplicating the production database
+===================================
+
+.. _gke-staging-db-create-instance:
+
+Creating the staging CloudSQL instance
+--------------------------------------
+
+Create a CloudSQL instance for staging called ``ltd-sql-staging``, if one is not already available.
+
+1. Visit the project's CloudSQL console dashboard, https://console.cloud.google.com/sql/, and click **Create instance**.
+2. Choose a second generation of CloudSQL.
+3. Configure to match the production CloudSQL instance:
+
+   - Name: ``ltd-sql-staging``.
+   - DB version: MySQL 5.6.
+   - Region: ``us-central1-b``.
+   - Type: ``db-g1-small``.
+   - Disk: 10 GB.
+   - Disable backups and binary logging (not needed for staging).
+
+.. note::
+
+   This staging DB inherits the credentials from the production database.
+   There's no need to create a new root user password.
+
+.. _gke-staging-db-restore:
+
+Restore the production DB backup to the staging DB
+--------------------------------------------------
+
+Follow `CloudSQL documentation on restoring to a different instance <https://cloud.google.com/sql/docs/mysql/backup-recovery/restoring#restorebackups-another-instance>`_.
+
+The **backup** should be a recent one from the production database.
+The **target instance** is ``ltd-sql-staging``.
+Since this is a temporary staging DB, it's safe to overwrite any existing data.
+
+You can connect to this staging database by following:
+
+1. :ref:`gke-cloudsql-proxy`.
+2. :ref:`gke-cloudsql-connect`.
+
+.. _gke-staging-db-further-reading:
+
+Further reading
+---------------
+
+- `Tips on restoring to a different instance <https://cloud.google.com/sql/docs/mysql/backup-recovery/restore#tips-restore-different-instance>`_.
+- `Tips on restoring with CloudSQL <https://cloud.google.com/sql/docs/mysql/backup-recovery/restore#tips-restore>`_.

--- a/docs/gke-staging-deployment-playbook.rst
+++ b/docs/gke-staging-deployment-playbook.rst
@@ -58,3 +58,107 @@ Further reading
 
 - `Tips on restoring to a different instance <https://cloud.google.com/sql/docs/mysql/backup-recovery/restore#tips-restore-different-instance>`_.
 - `Tips on restoring with CloudSQL <https://cloud.google.com/sql/docs/mysql/backup-recovery/restore#tips-restore>`_.
+
+.. _gke-staging-namespace:
+
+Creating and using a Kubernetes namespace for staging
+=====================================================
+
+Create a namespace
+------------------
+
+Check what namespaces currently exist in the cluster:
+
+.. code-block:: bash
+
+   kubectl get namespaces
+
+Currently, production is deployed to the ``default`` namespace; we use an ``ltd-staging`` (or similar) namespace for integration testing.
+To create the ``ltd-staging`` namespace using the :file:`kubernetes/ltd-staging-namespace.yaml` resource template in the Git repository:
+
+.. code-block:: bash
+
+   kubectl create -f ltd-staging-namespace.yaml
+
+Confirm that an ``ltd-staging`` namespace exists:
+
+.. code-block:: bash
+
+   kubectl get namespaces --show-labels
+
+Create the context
+------------------
+
+Contexts allow you to switch between clusters and namespaces when working with ``kubectl``.
+First, look at the existing contexts (these are configured locally):
+
+.. code-block:: bash
+
+   kubectl config get-contexts
+
+If there's only a context for the ``lsst-the-docs`` cluster and default namespace, then we can create a context for the ``ltd-staging`` namespace.
+
+.. code-block:: bash
+
+   kubectl config set-context ltd-staging --namespace=ltd-staging --cluster=$CLUSTER_NAME --user=$CLUSTER_NAME
+
+where ``$CLUSTER_NAME`` are the same as that for the existing default context.
+
+It's also convenient to create a name for the default namespace:
+
+.. code-block:: bash
+
+   kubectl config set-context ltd-default --cluster=$CLUSTER_NAME --user=$CLUSTER_NAME
+
+Switch to the staging context
+-----------------------------
+
+.. code-block:: bash
+
+   kubectl config use-context ltd-staging
+
+You can confirm what namespace you're working in with:
+
+.. code-block:: bash
+
+   kubectl config current-context
+
+Further reading
+---------------
+
+- `Kubernetes namespaces walkthrough <https://kubernetes.io/docs/admin/namespaces/walkthrough/>`_.
+
+.. gke-staging-deployment:
+
+Deploying to the staging namespace
+==================================
+
+LTD Keeper can be deployed into the ``ltd-staging`` namespace using the same pattern described in :doc:`gke-config` and :doc:`gke-deploy`.
+Some modifications, described below, are needed to re-configure the deployment for staging.
+
+Modifying configuration and secrets
+-----------------------------------
+
+Secrets and other resources need to be customized for the staging namespace:
+
+- Modifications to :file:`kubernetes/keeper-secrets-template.yaml`:
+
+  - ``db-url`` should point to the new ``ltd-sql-staging`` database.
+  - ``server-name`` should point to a staging URL, like ``keeper-staging.lsst.codes``.
+    Remember to create a new DNS record pointing to the ``nginx-ssl-proxy``.
+
+- In :file:`kubernetes/keeper-deployment.yaml` and :file:`kubernetes/keeper-mgmt-pod.yaml`, the ``cloudsql-proxy`` command should be updated:
+
+  .. code-block:: yaml
+
+     command: ["/cloud_sql_proxy", "-dir=/cloudsql", "-credential_file=/secret/file.json", "-instances=$PROJECTNAME:ltd-sql-staging"]
+
+  where ``$PROJECTNAME`` should be set to the Google Cloud Platform project name.
+
+.. note::
+
+   It may be necessary to update :file:`kubernetes/ssl-proxy-secrets.yaml` if you aren't using a wildcard cert.
+
+.. warning::
+
+   With the staging deployment, as currently implemented, the database is independent, but resources in the S3 bucket **are not**, since the S3 bucket is specified in DB tables that are replicated from the production DB.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,4 +41,5 @@ For more information about LSST the Docs, see `SQR-006: Documentation Deployment
    gke-deploy
    gke-update
    gke-migrations
+   gke-staging-deployment-playbook
    gke-troubleshooting

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ For more information about LSST the Docs, see `SQR-006: Documentation Deployment
    products
    builds
    editions
+   dashboards
 
 .. toctree::
    :caption: Development

--- a/docs/products.rst
+++ b/docs/products.rst
@@ -30,6 +30,10 @@ Method Summary
 
 - :http:get:`/products/(slug)/editions/` --- list all edition for a product.
 
+- :http:get:`/products/(slug)/editions/` --- list all edition for a product.
+
+- :http:post:`/products/(slug)/dashboard` --- manually rebuild the dashboards for a product.
+
 *See also:*
 
 - :doc:`/builds/ <builds>` for editing or deleting a build.
@@ -40,4 +44,4 @@ Reference
 =========
 
 .. autoflask:: app:create_app(profile='development')
-   :endpoints: api.get_products, api.get_product, api.new_product, api.edit_product, api.new_build, api.get_product_builds, api.new_edition, api.get_product_editions
+   :endpoints: api.get_products, api.get_product, api.new_product, api.edit_product, api.new_build, api.get_product_builds, api.new_edition, api.get_product_editions, api.rebuild_product_dashboard

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: production
             - name: LTD_KEEPER_URL_SCHEME
               value: https
+            - name: LTD_DASHER_URL
+              value: "http://dasher:3031"  # URL with cluster DNS to LTD Dasher - https://github.com/lsst-sqre/ltd-dasher
             - name: LTD_KEEPER_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/keeper-mgmt-pod.yaml
+++ b/kubernetes/keeper-mgmt-pod.yaml
@@ -51,6 +51,8 @@ spec:
           value: production
         - name: LTD_KEEPER_URL_SCHEME
           value: https
+        - name: LTD_DASHER_URL
+          value: "http://dasher:3031"  # URL with cluster DNS to LTD Dasher - https://github.com/lsst-sqre/ltd-dasher
         - name: LTD_KEEPER_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/kubernetes/ltd-staging-namespace.yaml
+++ b/kubernetes/ltd-staging-namespace.yaml
@@ -1,0 +1,8 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: "ltd-staging"
+  labels:
+    name: "ltd-staging"
+    env: "staging"
+    project: "lsst-the-docs"

--- a/migrations/versions/ffdd80058eed_add_surrogate_key_to_product.py
+++ b/migrations/versions/ffdd80058eed_add_surrogate_key_to_product.py
@@ -1,0 +1,26 @@
+"""Add surrogate_key to product
+
+Revision ID: ffdd80058eed
+Revises: 0c0c70d73d4b
+Create Date: 2017-01-25 16:59:17.456605
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ffdd80058eed'
+down_revision = '0c0c70d73d4b'
+
+
+def upgrade():
+    with op.batch_alter_table('products', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('surrogate_key',
+                                      sa.String(length=32),
+                                      nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('products', schema=None) as batch_op:
+        batch_op.drop_column('surrogate_key')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ Flask-Migrate==1.8.0
 python-dateutil==2.4.2
 boto3==1.2.3
 requests==2.10.0
-pytest==2.9.2
-pytest-cov==2.3.0
-pytest-flake8==0.6
+pytest==3.0.5
+pytest-cov==2.4.0
+pytest-flake8==0.8.1
 responses==0.5.1
 Sphinx==1.3.5
 sphinx-rtd-theme==0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pytest==3.0.5
 pytest-cov==2.4.0
 pytest-flake8==0.8.1
 responses==0.5.1
-Sphinx==1.3.5
+Sphinx==1.5.1
 sphinx-rtd-theme==0.1.9
 numpydoc==0.5
 sphinxcontrib-httpdomain==1.4.0

--- a/run.py
+++ b/run.py
@@ -135,5 +135,23 @@ def copydb():
     crossover.copy_data_in_transaction()
 
 
+@manager.command
+def initkeys():
+    """Temporary command to add surrogate keys to Products."""
+    import uuid
+    with keeper_app.app_context():
+        for product in models.Product.query.all():
+            if product.surrogate_key is None:
+                print('Adding surrogate key to {0}'.format(product.slug))
+                product.surrogate_key = uuid.uuid4().hex
+                try:
+                    db.session.add(product)
+                    db.session.commit()
+                except Exception:
+                    db.session.rollback()
+                    print('Failed to make surrogate key for {0}'.format(
+                        product.slug))
+
+
 if __name__ == '__main__':
     manager.run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 norecursedirs = venv
 flake8-ignore =
     docs/conf.py ALL

--- a/tests/test_dashboards.py
+++ b/tests/test_dashboards.py
@@ -1,0 +1,25 @@
+"""Tests for the dashboard API."""
+
+
+def test_rebuild_dashboards(client):
+    """Test dashboard rebuilds with full client."""
+    r = client.post('/dashboards', {})
+    assert r.status == 202
+
+
+def test_rebuild_dashboards_anon(anon_client):
+    """Test dashaboard rebuild with anonymous client."""
+    r = anon_client.post('/dashboards', {})
+    assert r.status == 401
+
+
+def test_rebuild_dashboards_edition(edition_client):
+    """Test dashaboard rebuild with edition client."""
+    r = edition_client.post('/dashboards', {})
+    assert r.status == 403
+
+
+def test_rebuild_dashboards_upload_build(upload_build_client):
+    """Test dashaboard rebuild with upload_build client."""
+    r = upload_build_client.post('/dashboards', {})
+    assert r.status == 403

--- a/tests/test_dasher.py
+++ b/tests/test_dasher.py
@@ -1,0 +1,66 @@
+"""Tests for dasher module (LTD Dasher dashboard builds)."""
+
+import json
+import responses
+import pytest
+
+from app.dasher import build_dashboards
+from app.exceptions import DasherError
+
+
+@responses.activate
+def test_build_dashboards():
+    """Verify a successful mocked call to ltd-dasher /build."""
+    product_urls = ['https://example.org/products/test-product']
+
+    dasher_url = 'http://test-dasher.local:80'
+    endpoint_url = dasher_url + '/build'
+
+    # Mock dasher api call
+    responses.add(responses.POST, endpoint_url, status=202)
+
+    # Run client function
+    build_dashboards(product_urls, dasher_url)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == endpoint_url
+
+    # I'm seeing Travis env think that request is a str, while my local
+    # machine things it's bytes. Rather odd :/
+    if isinstance(responses.calls[0].request.body, bytes):
+        request_json = json.loads(responses.calls[0].request.body.decode())
+    else:
+        request_json = json.loads(responses.calls[0].request.body)
+    assert request_json['product_urls'] == product_urls
+
+
+@responses.activate
+def test_skipped_build_dashboards():
+    """Check behaviour when LTD_DASHER_URL is not configured."""
+    product_urls = ['https://example.org/products/test-product']
+
+    dasher_url = None
+
+    # Run client function
+    build_dashboards(product_urls, dasher_url)
+
+    assert len(responses.calls) == 0
+
+
+@responses.activate
+def test_failed_build_dashboards():
+    """Verify a failed mocked call to ltd-dasher /build."""
+    product_urls = ['https://example.org/products/test-product']
+
+    dasher_url = 'http://test-dasher.local:80'
+    endpoint_url = dasher_url + '/build'
+
+    # Mock dasher api call
+    responses.add(responses.POST, endpoint_url, status=404)
+
+    # Run client function
+    with pytest.raises(DasherError):
+        build_dashboards(product_urls, dasher_url)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == endpoint_url

--- a/tests/test_dasher.py
+++ b/tests/test_dasher.py
@@ -1,6 +1,7 @@
 """Tests for dasher module (LTD Dasher dashboard builds)."""
 
 import json
+import logging
 import responses
 import pytest
 
@@ -20,7 +21,7 @@ def test_build_dashboards():
     responses.add(responses.POST, endpoint_url, status=202)
 
     # Run client function
-    build_dashboards(product_urls, dasher_url)
+    build_dashboards(product_urls, dasher_url, logging.getLogger(__name__))
 
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == endpoint_url
@@ -42,7 +43,7 @@ def test_skipped_build_dashboards():
     dasher_url = None
 
     # Run client function
-    build_dashboards(product_urls, dasher_url)
+    build_dashboards(product_urls, dasher_url, logging.getLogger(__name__))
 
     assert len(responses.calls) == 0
 
@@ -60,7 +61,7 @@ def test_failed_build_dashboards():
 
     # Run client function
     with pytest.raises(DasherError):
-        build_dashboards(product_urls, dasher_url)
+        build_dashboards(product_urls, dasher_url, logging.getLogger(__name__))
 
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == endpoint_url

--- a/tests/test_fastly.py
+++ b/tests/test_fastly.py
@@ -13,7 +13,7 @@ def test_purge_key():
     surrogate_key = uuid.uuid4().hex
 
     url = 'https://api.fastly.com/service/{0}/purge/{1}'.format(
-            service_id, surrogate_key)
+        service_id, surrogate_key)
 
     # Mock the API call and response
     responses.add(responses.POST, url, status=200)
@@ -34,7 +34,7 @@ def test_purge_key_fail():
     surrogate_key = uuid.uuid4().hex
 
     url = 'https://api.fastly.com/service/{0}/purge/{1}'.format(
-            service_id, surrogate_key)
+        service_id, surrogate_key)
 
     # Mock the API call and response
     responses.add(responses.POST, url, status=404)

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -164,3 +164,27 @@ def test_patch_product_auth_builduploader_client(upload_build_client):
 def test_patch_product_auth_builddeprecator_client(upload_build_client):
     r = upload_build_client.patch('/products/test', {'foo': 'bar'})
     assert r.status == 403
+
+
+# Authorizion tests: POST /products/<slug>/dashboard =========================
+# Only the full admin client and the product-authorized client should get in
+
+
+def test_post_dashboard_auth_anon(anon_client):
+    r = anon_client.post('/products/test/dashboard', {})
+    assert r.status == 401
+
+
+def test_post_dashboard_auth_product_client(product_client):
+    with pytest.raises(NotFound):
+        product_client.post('/products/test/dashboard', {})
+
+
+def test_post_dashboard_auth_edition_client(edition_client):
+    r = edition_client.post('/products/test/dashboard', {})
+    assert r.status == 403
+
+
+def test_post_dashboard_auth_builduploader_client(upload_build_client):
+    r = upload_build_client.post('/products/test/dashboard', {})
+    assert r.status == 403

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -81,6 +81,8 @@ def test_products(client):
     assert r.json['domain'] == 'pipelines.lsst.io'
     assert r.json['fastly_domain'] == 'global.ssl.fastly.net'
     assert r.json['published_url'] == 'https://pipelines.lsst.io'
+    # Test surrogate key
+    assert len(r.json['surrogate_key']) == 32
 
     r = client.get(p2_url)
     for k, v in p2.items():
@@ -89,6 +91,8 @@ def test_products(client):
     assert r.json['domain'] == 'qserv.lsst.io'
     assert r.json['fastly_domain'] == 'global.ssl.fastly.net'
     assert r.json['published_url'] == 'https://qserv.lsst.io'
+    # Test surrogate key
+    assert len(r.json['surrogate_key']) == 32
 
     p2v2 = dict(p2)
     p2v2['title'] = 'Qserve Data Access'

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -2,3 +2,5 @@
 socket = :3031
 module = run
 callable = keeper_app
+processes = 4
+threads = 2


### PR DESCRIPTION
This PR add hooks to the LTD Keeper server app that triggers an [LTD Dasher](https://github.com/lsst-sqre/ltd-dasher) Dashboard build whenever a build or edition gets updated (created, updated, deleted).

The Dasher server is automatically discovered with Kubernetes (i.e., Dasher has a `dasher` service, so its cluster URL is `http://dasher:3091`). If the Dasher config isn't set then dashboard builds are a no-op. This way Dasher is an optional extension to the LTD deployment.

There are two new routes dedicated to building dashboards, which are mostly intended to debugging and recovering from errors:

- [POST /dashboards](https://ltd-keeper.lsst.io/v/DM-9021/dashboards.html#post--dashboards)
- [POST /products/(slug)/dashboard](https://ltd-keeper.lsst.io/v/DM-9021/products.html#post--products-(slug)-dashboard)

There are client functions for LTD Dasher:

- `app.build_dashboards` is the core client function. This is used directly by the specialized routes for building dashboards, like [POST /dashboards](https://ltd-keeper.lsst.io/v/DM-9021/dashboards.html#post--dashboards) and [POST /products/(slug)/dashboard](https://ltd-keeper.lsst.io/v/DM-9021/products.html#post--products-(slug)-dashboard).
- `app.build_dashboards_safely` is a wrapper client that catches all exceptions. This is used by all routes where dashboard builds are incidental; I don't want a failure to build a dashboard to raise a 500 error.

In a future ticket I'll add logging and monitoring to help us identify when dashboards aren't being updated.

Product resources have a new `surrogate_key` DB field (which is also available from the `GET /products/(slug)` route). LTD Dasher uses this surrogate key to control Fastly caching of dashboards). However, the `surrogate_key` is still maintained by Keeper since Keeper handles all stateful metadata. There is a DB migration involved in adding this `surrogate_key`.

Other features packed into this PR:

- Instructions for deploying to a staging environment.
- Fix py.test and flake8/coverage versions.
- Make `uwsgi` work in a multi-threaded mode so that it doesn't block itself when talking with the Dasher microservice).

Draft docs: https://ltd-keeper.lsst.io/v/DM-9021