### PR TITLE
DM-12356: Support the LSST DM document release procedure

### DIFF
--- a/app/api_v1/editions.py
+++ b/app/api_v1/editions.py
@@ -37,7 +37,7 @@ def new_edition(slug):
            "build_url": "http://localhost:5000/builds/1",
            "slug": "latest",
            "title": "Latest",
-           "mode:": 1,
+           "mode:": "git_refs",
            "tracked_refs": [
                "master"
            ]
@@ -63,13 +63,12 @@ def new_edition(slug):
     :<json string build_url: URL of the build entity this Edition uses.
     :<json string slug: URL-safe name for edition.
     :<json string title: Human-readable name for edition.
-    :<json int mode: Tracking mode.
-       ``1``: track the Git ref specified by ``tracked_refs``.
-       ``2``: track LSST document version tags.
+    :<json str mode: Tracking mode.
+       ``git_refs``: track the Git ref specified by ``tracked_refs``.
+       ``lsst_doc``: track LSST document version tags.
     :<json array tracked_refs: Git ref(s) that describe the version of the
-        Product that this this Edition is intended to point to. For
-        multi-package documentation builds this is a list of Git refs that
-        are checked out, in order of priority, for each component repository.
+        Product that this this Edition is intended to point to when using
+        the ``git_refs`` tracking mode.
 
     :resheader Location: URL of the created Edition resource.
 
@@ -207,7 +206,7 @@ def get_edition(id):
            "date_created": "2016-03-01T11:50:18.196724Z",
            "date_ended": null,
            "date_rebuilt": "2016-03-01T11:50:18.196706Z",
-           "mode": 1,
+           "mode": "git_refs",
            "product_url": "http://localhost:5000/products/lsst_apps",
            "published_url": "pipelines.lsst.io",
            "self_url": "http://localhost:5000/editions/1",
@@ -227,9 +226,9 @@ def get_edition(id):
         will be ``null`` for editions that are *not deprecated*.
     :>json string date_rebuilt: UTC date time when the edition last re-pointed
         to a different build.
-    :<json int mode: Tracking mode.
-       ``1``: track the Git ref specified by ``tracked_refs``.
-       ``2``: track LSST document version tags.
+    :>json str mode: Tracking mode.
+       ``git_refs``: track the Git ref specified by ``tracked_refs``.
+       ``lsst_doc``: track LSST document version tags.
     :>json string product_url: URL of parent product entity.
     :>json string published_url: Full URL where this edition is published.
     :>json string self_url: URL of this Edition entity.
@@ -299,7 +298,7 @@ def edit_edition(id):
            "date_created": "2016-03-01T10:21:29.017615Z",
            "date_ended": null,
            "date_rebuilt": "2016-03-01T10:21:29.590839Z",
-           "mode": 1,
+           "mode": "git_refs",
            "product_url": "http://localhost:5000/products/lsst_apps",
            "published_url": "pipelines.lsst.io",
            "self_url": "http://localhost:5000/editions/1",
@@ -320,9 +319,9 @@ def edit_edition(id):
     :<json string title: Human-readable name for edition (optional).
     :<json string slug: URL-safe name for edition (optinal). Changing the slug
         dynamically updates the ``published_url``.
-    :<json int mode: Tracking mode.
-       ``1``: track the Git ref specified by ``tracked_refs``.
-       ``2``: track LSST document version tags.
+    :<json str mode: Tracking mode.
+       ``git_refs``: track the Git ref specified by ``tracked_refs``.
+       ``lsst_doc``: track LSST document version tags.
     :<json array tracked_refs: Git ref(s) that this Edition points to.
         For multi-package documentation builds this is a list of Git refs that
         are checked out, in order of priority, for each component repository
@@ -334,9 +333,9 @@ def edit_edition(id):
         will be ``null`` for editions that are *not deprecated*.
     :>json string date_rebuilt: UTC date time when the edition last re-pointed
         to a different build.
-    :>json int mode: Tracking mode.
-       ``1``: track the Git ref specified by ``tracked_refs``.
-       ``2``: track LSST document version tags.
+    :>json str mode: Tracking mode.
+       ``git_refs``: track the Git ref specified by ``tracked_refs``.
+       ``lsst_doc``: track LSST document version tags.
     :>json string product_url: URL of parent product entity.
     :>json string published_url: Full URL where this edition is published.
     :>json string self_url: URL of this Edition entity.
@@ -345,9 +344,10 @@ def edit_edition(id):
         ``x-amz-meta-surrogate-control`` header of any the edition's S3
         objects to control Fastly caching.
     :>json string title: Human-readable name for edition.
-    :>json string tracked_refs: Git ref that this Edition points to. For multi-
-        repository builds, this can be a comma-separated list of refs to use,
-        in order of priority.
+    :>json string tracked_refs: Git ref that this Edition points to, for use
+        with the ``git_refs`` tricking mode. For multi-repository products,
+        this can be a comma-separated list of refs to use, in order of
+        priority.
 
     :statuscode 200: No errors.
     :statuscode 404: Edition resource not found.

--- a/app/api_v1/editions.py
+++ b/app/api_v1/editions.py
@@ -37,6 +37,7 @@ def new_edition(slug):
            "build_url": "http://localhost:5000/builds/1",
            "slug": "latest",
            "title": "Latest",
+           "mode:": 1,
            "tracked_refs": [
                "master"
            ]
@@ -62,6 +63,9 @@ def new_edition(slug):
     :<json string build_url: URL of the build entity this Edition uses.
     :<json string slug: URL-safe name for edition.
     :<json string title: Human-readable name for edition.
+    :<json int mode: Tracking mode.
+       ``1``: track the Git ref specified by ``tracked_refs``.
+       ``2``: track LSST document version tags.
     :<json array tracked_refs: Git ref(s) that describe the version of the
         Product that this this Edition is intended to point to. For
         multi-package documentation builds this is a list of Git refs that
@@ -203,6 +207,7 @@ def get_edition(id):
            "date_created": "2016-03-01T11:50:18.196724Z",
            "date_ended": null,
            "date_rebuilt": "2016-03-01T11:50:18.196706Z",
+           "mode": 1,
            "product_url": "http://localhost:5000/products/lsst_apps",
            "published_url": "pipelines.lsst.io",
            "self_url": "http://localhost:5000/editions/1",
@@ -222,6 +227,9 @@ def get_edition(id):
         will be ``null`` for editions that are *not deprecated*.
     :>json string date_rebuilt: UTC date time when the edition last re-pointed
         to a different build.
+    :<json int mode: Tracking mode.
+       ``1``: track the Git ref specified by ``tracked_refs``.
+       ``2``: track LSST document version tags.
     :>json string product_url: URL of parent product entity.
     :>json string published_url: Full URL where this edition is published.
     :>json string self_url: URL of this Edition entity.
@@ -291,6 +299,7 @@ def edit_edition(id):
            "date_created": "2016-03-01T10:21:29.017615Z",
            "date_ended": null,
            "date_rebuilt": "2016-03-01T10:21:29.590839Z",
+           "mode": 1,
            "product_url": "http://localhost:5000/products/lsst_apps",
            "published_url": "pipelines.lsst.io",
            "self_url": "http://localhost:5000/editions/1",
@@ -311,6 +320,9 @@ def edit_edition(id):
     :<json string title: Human-readable name for edition (optional).
     :<json string slug: URL-safe name for edition (optinal). Changing the slug
         dynamically updates the ``published_url``.
+    :<json int mode: Tracking mode.
+       ``1``: track the Git ref specified by ``tracked_refs``.
+       ``2``: track LSST document version tags.
     :<json array tracked_refs: Git ref(s) that this Edition points to.
         For multi-package documentation builds this is a list of Git refs that
         are checked out, in order of priority, for each component repository
@@ -322,6 +334,9 @@ def edit_edition(id):
         will be ``null`` for editions that are *not deprecated*.
     :>json string date_rebuilt: UTC date time when the edition last re-pointed
         to a different build.
+    :>json int mode: Tracking mode.
+       ``1``: track the Git ref specified by ``tracked_refs``.
+       ``2``: track LSST document version tags.
     :>json string product_url: URL of parent product entity.
     :>json string published_url: Full URL where this edition is published.
     :>json string self_url: URL of this Edition entity.

--- a/app/api_v1/products.py
+++ b/app/api_v1/products.py
@@ -4,7 +4,7 @@ from flask import jsonify, request, current_app
 from . import api
 from .. import db
 from ..auth import token_auth, permission_required
-from ..models import Product, Permission, Edition, EditionMode
+from ..models import Product, Permission, Edition
 from ..dasher import build_dashboard_safely, build_dashboards
 
 
@@ -171,9 +171,9 @@ def new_product():
     :<json string bucket_name: Name of the S3 bucket hosting builds.
     :<json string doc_repo: URL of the Git documentation repo (i.e., on
        GitHub).
-    :<json int main_mode: Tracking mode for the main (default) edition.
-       ``1``: track the ``master`` Git ref. ``2``: track LSST document version
-       tags.
+    :<json str main_mode: Tracking mode for the main (default) edition.
+       ``git_refs``: track the ``master`` branch.
+       ``lsst_doc``: track LSST document version tags.
     :<json string root_domain: Root domain name where documentation for
        this LSST the Docs installation is served from. (e.g., ``lsst.io``).
     :<json string root_fastly_domain: Root domain name for Fastly CDN used
@@ -201,7 +201,7 @@ def new_product():
             edition_data['mode'] = request_json['main_mode']
         else:
             # Default tracking mode
-            edition_data['mode'] = EditionMode.GIT_REFS
+            edition_data['mode'] = 'git_refs'
 
         edition = Edition(product=product)
         edition.import_data(edition_data)

--- a/app/api_v1/products.py
+++ b/app/api_v1/products.py
@@ -4,7 +4,7 @@ from flask import jsonify, request, current_app
 from . import api
 from .. import db
 from ..auth import token_auth, permission_required
-from ..models import Product, Permission, Edition
+from ..models import Product, Permission, Edition, EditionMode
 from ..dasher import build_dashboard_safely, build_dashboards
 
 
@@ -171,6 +171,9 @@ def new_product():
     :<json string bucket_name: Name of the S3 bucket hosting builds.
     :<json string doc_repo: URL of the Git documentation repo (i.e., on
        GitHub).
+    :<json int main_mode: Tracking mode for the main (default) edition.
+       ``1``: track the ``master`` Git ref. ``2``: track LSST document version
+       tags.
     :<json string root_domain: Root domain name where documentation for
        this LSST the Docs installation is served from. (e.g., ``lsst.io``).
     :<json string root_fastly_domain: Root domain name for Fastly CDN used
@@ -186,14 +189,22 @@ def new_product():
     """
     product = Product()
     try:
-        product.import_data(request.json)
+        request_json = request.json
+        product.import_data(request_json)
         db.session.add(product)
 
         # Create a default edition for the product
+        edition_data = {'tracked_refs': ['master'],
+                        'slug': 'main',
+                        'title': 'Latest'}
+        if 'main_mode' in request_json:
+            edition_data['mode'] = request_json['main_mode']
+        else:
+            # Default tracking mode
+            edition_data['mode'] = EditionMode.GIT_REFS
+
         edition = Edition(product=product)
-        edition.import_data({'tracked_refs': ['master'],
-                             'slug': 'main',
-                             'title': 'Latest'})
+        edition.import_data(edition_data)
         db.session.add(edition)
 
         db.session.commit()

--- a/app/gitrefutils.py
+++ b/app/gitrefutils.py
@@ -1,0 +1,72 @@
+"""Utilities for parsing Git refs according to LSST format."""
+
+__all__ = ['DOCUSHARE_PATTERN', 'LSST_DOC_V_TAG', 'LsstDocVersionTag']
+
+import re
+
+
+# The RFC-401 format for tagged docushare releases.
+DOCUSHARE_PATTERN = re.compile(r'docushare-v(?P<version>[\d\.]+)')
+
+# The RFC-405/LPM-51 format for LSST semantic document versions.
+# v<minor>.<major>
+LSST_DOC_V_TAG = re.compile(r'^v(?P<major>[\d+])\.(?P<minor>[\d+])$')
+
+
+class LsstDocVersionTag(object):
+    """Represent and compare LSST document (``v<major>.<minor>``) version
+    tags.
+
+    These semantic version tags are defined in LPM-51.
+
+    Parameters
+    ----------
+    version_str : `str`
+        Tag name. To be parsed successfully, the tag must be formatted as
+        ``'v<major>.<minor>'``.
+
+    Raises
+    ------
+    ValueError
+        Raised if the ``version_str`` argument cannot be parsed (it doesn't
+        match the LPM-51 standard).
+    """
+
+    def __init__(self, version_str):
+        super(LsstDocVersionTag, self).__init__()
+        self.version_str = version_str
+        match = LSST_DOC_V_TAG.match(version_str)
+        if match is None:
+            raise ValueError(
+                '{:r} is not a LSST document version tag'.format(version_str))
+        self.major = int(match.group('major'))
+        self.minor = int(match.group('minor'))
+
+    def __repr__(self):
+        return 'LsstDocVersion({:r})'.format(self.version_str)
+
+    def __str__(self):
+        return '{0:d}.{1:d}'.format(self.major, self.minor)
+
+    def __eq__(self, other):
+        return self.major == other.major and self.minor == other.minor
+
+    def __ne__(self, other):
+        return self.__eq__(other) is False
+
+    def __gt__(self, other):
+        if self.major > other.major:
+            return True
+        elif self.major == other.major:
+            return self.minor > other.minor
+        else:
+            return False
+
+    def __lt__(self, other):
+        return (self.__eq__(other) is False) and (self.__gt__(other) is False)
+
+    def __ge__(self, other):
+        return (self.__eq__(other) is True) or (self.__gt__(other) is True)
+
+    def __le__(self, other):
+        return (self.__eq__(other) is True) or (self.__gt__(other) is False)

--- a/app/models.py
+++ b/app/models.py
@@ -388,14 +388,13 @@ class Build(db.Model):
         """Hook for when a build has been uploaded."""
         self.uploaded = True
 
-        # Rebuild any edition that tracks this build's git refs
         editions = Edition.query.autoflush(False)\
             .filter(Edition.product == self.product)\
-            .filter(Edition.tracked_refs == self.git_refs)\
             .all()
 
         for edition in editions:
-            edition.rebuild(self.get_url())
+            if edition.should_rebuild(build=self):
+                edition.rebuild(build=self)
 
     def deprecate_build(self):
         """Trigger a build deprecation.

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -6,7 +6,7 @@ In LTD Keeper, a Build is created every time a Sphinx repository is compiled and
 LTD Keeper doesn't touch objects in S3 directly; LTD Mason uploads documentation sites to S3 and then registers the build with  LTD Keeper.
 
 New builds added using the :http:post:`/products/(slug)/builds/` method.
-The methods listed on this page allow you to list maintain builds (such as showing or deprecating them).
+The other methods listed on this page allow you to list and maintain Builds (such as showing or deprecating them).
 
 Methods
 =======
@@ -19,9 +19,9 @@ Methods
 
 *See also:*
 
-- :http:post:`/products/(slug)/builds/` --- create a new build for a product.
+- :http:post:`/products/(slug)/builds/` --- create a new build for a :doc:`Product <products>`.
 
-- :http:get:`/products/(slug)/builds/` --- list all builds for a product.
+- :http:get:`/products/(slug)/builds/` --- list all builds for a :doc:`Product <products>`.
 
 Reference
 =========

--- a/docs/editions.rst
+++ b/docs/editions.rst
@@ -2,26 +2,28 @@
 Editions - `/editions/`
 #######################
 
-An Edition is a publication of a Product's documentation.
+An Edition is a publication of a :doc:`Product <products>`\ ’s documentation.
 Editions allow products to have multiple versions of documentation published at once, from separate URLs.
-For example, the 'latest' documentation might be published to ``docs.project.org``, but documentation for the tagged 'v1' might be published to ``v1.docs.project.org``.
+For example, the 'latest' documentation might be published to ``docs.project.org``, but documentation for the tagged 'v1' release might be published to ``docs.project.org/v/v1``.
 
-Editions are merely pointers to a Build; an Edition is updated by pointing to a newer build (see :http:patch:`/editions/(int:id)`).
+Editions are merely pointers to a :doc:`Build <builds>`; an Edition is updated by pointing to a newer :doc:`Build <builds>` (see :http:patch:`/editions/(int:id)`).
 
 Methods
 =======
 
-- :http:get:`/editions/(int:id)` --- show a single edition.
+- :http:get:`/editions/(int:id)` --- show a single Edition.
 
-- :http:patch:`/editions/(int:id)` --- update an edition.
+- :http:patch:`/editions/(int:id)` --- update an Edition.
 
-- :http:delete:`/editions/(int:id)` --- deprecate an edition.
-
-
+- :http:delete:`/editions/(int:id)` --- deprecate an Edition.
 
 *See also:*
 
-- :doc:`/products/ <products>` for creating a new edition associated with a product.
+- :http:post:`/products/(slug)/editions/` --- create a new Edition for a Product.
+
+- :http:get:`/products/(slug)/editions/` --- list all Edition for a Product.
+
+- :http:get:`/products/(slug)/editions/` --- list all Edition for a Product.
 
 Reference
 =========

--- a/docs/editions.rst
+++ b/docs/editions.rst
@@ -12,43 +12,43 @@ Tracking modes
 ==============
 
 Editions track :doc:`Builds <builds>`.
-This means that when a new :doc:`Build <builds>` is uploaded, any edition for that :doc:`Product <products>` that tracks that *kind* of build will be updated.
-An Edition's tracking mode is given with the ``mode`` field of :http:get:`/editions/(int:id)`, and can either be set initially (:http:post:`/products/(slug)/editions/`) or updated on an existing Edition (:http:patch:`/editions/(int:id)`).
+This means that when a new :doc:`Build <builds>` is uploaded, any Edition for that :doc:`Product <products>` that tracks that *kind* of Build will be updated.
+An Edition's tracking mode is given with the ``mode`` field, and can either be set initially (:http:post:`/products/(slug)/editions/`) or updated on an existing Edition (:http:patch:`/editions/(int:id)`).
 There are two tracking modes, currently:
 
-======== =============
-``mode`` Description
-======== =============
-1        Git ref
-2        LSST document
-======== =============
+============ =================================
+mode field   Tracking behavior
+============ =================================
+``git_refs`` Git branches and tags
+``lsst_doc`` Latest LSST document version tags
+============ =================================
 
-Git reference mode (default)
-----------------------------
+Git reference mode (``git_refs``, default)
+------------------------------------------
 
 This mode tracks Builds with a specific Git ref (branch name or tag).
 
-To use this mode, the ``mode`` field of the Edition must have a value of ``1``.
-Then ``tracked_refs`` field is an array of Git ref strings that determine the value of ``git_refs`` a :doc:`Build <builds>` needs to be published as the Edition.
+Enable this mode by setting the Edition's ``mode`` field to ``git_refs``.
+Then set the ``tracked_refs`` field with array of Git ref strings that determine the value of ``git_refs`` a :doc:`Build <builds>` needs to be published as the Edition.
 
 As an example, an Edition has these fields:
 
 .. code-block:: json
 
    {
-     "mode": 1,
+     "mode": "git_refs",
      "tracked_refs": ["master"]
    }
 
 Then a :doc:`Build <builds>` with ``{"git_refs": ["master"]}`` will be published by the Edition.
 
-LSST document mode
-------------------
+LSST document mode (``lsst_doc``)
+---------------------------------
 
 This mode makes the Edition track the :doc:`Build <builds>` with the most recent LSST document semantic version tag.
 LSST document semantic version tags are formatted as ``v<Major>.<Minor>``.
 
-The Edition's mode field must have a value of ``2`` to use this mode.
+Enable this mode by setting the Edition's ``mode`` field to ``lsst_doc``.
 
 Note that until the first :doc:`Build <builds>` with a semantic version tag is published, an Edition with this mode will track the ``master`` Git ref.
 
@@ -65,9 +65,7 @@ Methods
 
 - :http:post:`/products/(slug)/editions/` --- create a new Edition for a Product.
 
-- :http:get:`/products/(slug)/editions/` --- list all Edition for a Product.
-
-- :http:get:`/products/(slug)/editions/` --- list all Edition for a Product.
+- :http:get:`/products/(slug)/editions/` --- list all Editions for a Product.
 
 Reference
 =========

--- a/docs/editions.rst
+++ b/docs/editions.rst
@@ -8,6 +8,50 @@ For example, the 'latest' documentation might be published to ``docs.project.org
 
 Editions are merely pointers to a :doc:`Build <builds>`; an Edition is updated by pointing to a newer :doc:`Build <builds>` (see :http:patch:`/editions/(int:id)`).
 
+Tracking modes
+==============
+
+Editions track :doc:`Builds <builds>`.
+This means that when a new :doc:`Build <builds>` is uploaded, any edition for that :doc:`Product <products>` that tracks that *kind* of build will be updated.
+An Edition's tracking mode is given with the ``mode`` field of :http:get:`/editions/(int:id)`, and can either be set initially (:http:post:`/products/(slug)/editions/`) or updated on an existing Edition (:http:patch:`/editions/(int:id)`).
+There are two tracking modes, currently:
+
+======== =============
+``mode`` Description
+======== =============
+1        Git ref
+2        LSST document
+======== =============
+
+Git reference mode (default)
+----------------------------
+
+This mode tracks Builds with a specific Git ref (branch name or tag).
+
+To use this mode, the ``mode`` field of the Edition must have a value of ``1``.
+Then ``tracked_refs`` field is an array of Git ref strings that determine the value of ``git_refs`` a :doc:`Build <builds>` needs to be published as the Edition.
+
+As an example, an Edition has these fields:
+
+.. code-block:: json
+
+   {
+     "mode": 1,
+     "tracked_refs": ["master"]
+   }
+
+Then a :doc:`Build <builds>` with ``{"git_refs": ["master"]}`` will be published by the Edition.
+
+LSST document mode
+------------------
+
+This mode makes the Edition track the :doc:`Build <builds>` with the most recent LSST document semantic version tag.
+LSST document semantic version tags are formatted as ``v<Major>.<Minor>``.
+
+The Edition's mode field must have a value of ``2`` to use this mode.
+
+Note that until the first :doc:`Build <builds>` with a semantic version tag is published, an Edition with this mode will track the ``master`` Git ref.
+
 Methods
 =======
 

--- a/docs/products.rst
+++ b/docs/products.rst
@@ -2,14 +2,14 @@
 Products - `/products`
 ######################
 
-The ``/products/`` API allows you to list products, create new products, and update products (including adding new builds and editions).
+The ``/products/`` API allows you to list Products, create new Products, and update Products (including adding new :doc:`Builds <builds>` and :doc:`Editions <editions>`).
 
 In LTD Keeper, a Product is the root entity associated with a documentation project.
 Generally, a single Sphinx documentation repository maps to a Product.
 LTD Keeper can host documentation for several products.
 
-The actual documentation associated with a Product is manifested by **builds**.
-In turn, builds are the source of **editions**, which are published versions of the Product's documentation.
+The actual documentation associated with a Product is manifested by :doc:`Builds <builds>`.
+In turn, :doc:`Builds <builds>` are the source of :doc:`Editions <editions>`, which are published versions of the Product's documentation.
 
 Method summary
 ==============
@@ -36,9 +36,9 @@ Method summary
 
 *See also:*
 
-- :doc:`/builds/ <builds>` for editing or deleting a build.
+- :doc:`/builds/ <builds>`
 
-- :doc:`/editions/ <editions>` for editing or deleting an edition.
+- :doc:`/editions/ <editions>`
 
 Reference
 =========

--- a/docs/products.rst
+++ b/docs/products.rst
@@ -28,9 +28,7 @@ Method summary
 
 - :http:post:`/products/(slug)/editions/` --- create a new edition for a product.
 
-- :http:get:`/products/(slug)/editions/` --- list all edition for a product.
-
-- :http:get:`/products/(slug)/editions/` --- list all edition for a product.
+- :http:get:`/products/(slug)/editions/` --- list all editions for a product.
 
 - :http:post:`/products/(slug)/dashboard` --- manually rebuild the dashboards for a product.
 

--- a/migrations/versions/aae44dcdaf52_add_edition_mode_column.py
+++ b/migrations/versions/aae44dcdaf52_add_edition_mode_column.py
@@ -1,0 +1,23 @@
+"""Add Edition.mode column
+
+Revision ID: aae44dcdaf52
+Revises: ffdd80058eed
+Create Date: 2017-11-17 11:12:43.148696
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'aae44dcdaf52'
+down_revision = 'ffdd80058eed'
+
+
+def upgrade():
+    with op.batch_alter_table('editions', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('mode', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('editions', schema=None) as batch_op:
+        batch_op.drop_column('mode')

--- a/tests/test_gitrefutils.py
+++ b/tests/test_gitrefutils.py
@@ -1,0 +1,18 @@
+"""Tests for the app.gitrefutils module.
+"""
+
+import pytest
+
+from app.gitrefutils import LsstDocVersionTag
+
+
+def test_lsst_doc_tag():
+    version = LsstDocVersionTag('v1.2')
+
+    assert version.major == 1
+    assert version.minor == 2
+
+
+def test_invalid_lsst_doc_tag():
+    with pytest.raises(ValueError):
+        LsstDocVersionTag('1.2')

--- a/tests/test_patch_edition_mode.py
+++ b/tests/test_patch_edition_mode.py
@@ -1,5 +1,5 @@
 """Tests for PATCHing an edition to change the tracking mode from
-GIT_REF to LSST_DOC.
+``git_refs`` to ``lsst_doc``.
 """
 
 
@@ -17,7 +17,7 @@ def test_pach_lsst_doc_edition(client):
     p1_data = {
         'slug': 'ldm-151',
         'doc_repo': 'https://github.com/lsst/LDM-151',
-        'main_mode': 1,  # default
+        'main_mode': 'git_refs',  # default
         'title': 'Applications Design',
         'root_domain': 'lsst.io',
         'root_fastly_domain': 'global.ssl.fastly.net',
@@ -58,7 +58,7 @@ def test_pach_lsst_doc_edition(client):
 
     # PATCH the tracking mode of the edition
     edition_patch_data = {
-        'mode': 2
+        'mode': 'lsst_doc'
     }
     r = client.patch(edition_url, edition_patch_data)
     assert r.status == 200

--- a/tests/test_patch_edition_mode.py
+++ b/tests/test_patch_edition_mode.py
@@ -1,0 +1,77 @@
+"""Tests for PATCHing an edition to change the tracking mode from
+GIT_REF to LSST_DOC.
+"""
+
+
+def test_pach_lsst_doc_edition(client):
+    """Test patching an edition from tracking a Git ref to an LSST doc.
+
+    1. Create a product with the default GIT_REF tracking mode for the
+       main edition.
+    2. Post a build on `master`; it is tracked.
+    3. Post a `v1.0` build; it is not tracked.
+    4. Patch the main edition to use the LSST_DOC tracking mode.
+    5. Post a `v1.1` build that is tracked.
+    """
+    # Add product
+    p1_data = {
+        'slug': 'ldm-151',
+        'doc_repo': 'https://github.com/lsst/LDM-151',
+        'main_mode': 1,  # default
+        'title': 'Applications Design',
+        'root_domain': 'lsst.io',
+        'root_fastly_domain': 'global.ssl.fastly.net',
+        'bucket_name': 'bucket-name'
+    }
+    r = client.post('/products/', p1_data)
+    assert r.status == 201
+
+    # Get the URL for the default edition
+    r = client.get('/products/ldm-151/editions/')
+    edition_url = r.json['editions'][0]
+
+    # Create a build on 'master'
+    b1_data = {
+        'slug': 'b1',
+        'github_requester': 'jonathansick',
+        'git_refs': ['master']
+    }
+    r = client.post('/products/ldm-151/builds/', b1_data)
+    b1_url = r.headers['Location']
+    r = client.patch(b1_url, {'uploaded': True})
+    # Test that the main edition updated.
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+
+    # Create a build with a semantic version tag.
+    b2_data = {
+        'slug': 'b2',
+        'github_requester': 'jonathansick',
+        'git_refs': ['v1.0']
+    }
+    r = client.post('/products/ldm-151/builds/', b2_data)
+    b2_url = r.headers['Location']
+    r = client.patch(b2_url, {'uploaded': True})
+    # Test that the main edition *did not* update
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+
+    # PATCH the tracking mode of the edition
+    edition_patch_data = {
+        'mode': 2
+    }
+    r = client.patch(edition_url, edition_patch_data)
+    assert r.status == 200
+
+    # Create another build with a semantic version tag.
+    b3_data = {
+        'slug': 'b3',
+        'github_requester': 'jonathansick',
+        'git_refs': ['v1.1']
+    }
+    r = client.post('/products/ldm-151/builds/', b3_data)
+    b3_url = r.headers['Location']
+    r = client.patch(b3_url, {'uploaded': True})
+    # Test that the main edition *did* update now
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url

--- a/tests/test_track_lsst_doc.py
+++ b/tests/test_track_lsst_doc.py
@@ -1,0 +1,121 @@
+"""Test an Edition that tracks LSST document releases (EditionMode.LSST_DOC).
+"""
+
+
+def test_lsst_doc_edition(client):
+    """Test an edition that tracks LSST Doc semantic versions.
+
+    1. Create a build on `master`; it should be tracked because the LSST_DOC
+       mode tracks master if a semantic version tag hasn't been pushed yet.
+    2. Create a ticket branch; it isn't tracked.
+    3. Create a v1.0 build; it is tracked.
+    4. Create another build on `master`; it isn't tracked because we already
+       have the v1.0 build.
+    5. Create a v0.9 build that is not tracked because it's older.
+    6. Create a v1.1 build that **is** tracked because it's newer.
+    """
+    # Add product
+    p1_data = {
+        'slug': 'ldm-151',
+        'doc_repo': 'https://github.com/lsst/LDM-151',
+        'main_mode': 2,
+        'title': 'Applications Design',
+        'root_domain': 'lsst.io',
+        'root_fastly_domain': 'global.ssl.fastly.net',
+        'bucket_name': 'bucket-name'
+    }
+    r = client.post('/products/', p1_data)
+    assert r.status == 201
+    # p1_url = r.headers['Location']
+
+    # Get the URL for the default edition
+    r = client.get('/products/ldm-151/editions/')
+    edition_url = r.json['editions'][0]
+
+    # Create a build on 'master'
+    b1_data = {
+        'slug': 'b1',
+        'github_requester': 'jonathansick',
+        'git_refs': ['master']
+    }
+    r = client.post('/products/ldm-151/builds/', b1_data)
+    b1_url = r.headers['Location']
+    r = client.patch(b1_url, {'uploaded': True})
+
+    # Test that the main edition updated because there are no builds yet
+    # with semantic versions
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+
+    # Create a ticket branch build
+    b2_data = {
+        'slug': 'b2',
+        'github_requester': 'jonathansick',
+        'git_refs': ['tickets/DM-1']
+    }
+    r = client.post('/products/ldm-151/builds/', b2_data)
+    b2_url = r.headers['Location']
+    r = client.patch(b2_url, {'uploaded': True})
+
+    # Test that the main edition *did not* update because this build is
+    # neither for master not a semantic version.
+    # with semantic versions
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+
+    # Create a build with a semantic version tag.
+    b3_data = {
+        'slug': 'b3',
+        'github_requester': 'jonathansick',
+        'git_refs': ['v1.0']
+    }
+    r = client.post('/products/ldm-151/builds/', b3_data)
+    b3_url = r.headers['Location']
+    r = client.patch(b3_url, {'uploaded': True})
+
+    # Test that the main edition updated
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url
+
+    # Create another build on 'master'
+    b4_data = {
+        'slug': 'b4',
+        'github_requester': 'jonathansick',
+        'git_refs': ['master']
+    }
+    r = client.post('/products/ldm-151/builds/', b4_data)
+    b4_url = r.headers['Location']
+    r = client.patch(b4_url, {'uploaded': True})
+
+    # Test that the main edition *did not* update because now it's sticking
+    # to only show semantic versions.
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url
+
+    # Create a build with a **older** semantic version tag.
+    b5_data = {
+        'slug': 'b5',
+        'github_requester': 'jonathansick',
+        'git_refs': ['v0.9']
+    }
+    r = client.post('/products/ldm-151/builds/', b5_data)
+    b5_url = r.headers['Location']
+    r = client.patch(b5_url, {'uploaded': True})
+
+    # Test that the main edition *did not* update b/c it's older
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url
+
+    # Create a build with a **newer** semantic version tag.
+    b6_data = {
+        'slug': 'b6',
+        'github_requester': 'jonathansick',
+        'git_refs': ['v1.1']
+    }
+    r = client.post('/products/ldm-151/builds/', b6_data)
+    b6_url = r.headers['Location']
+    r = client.patch(b6_url, {'uploaded': True})
+
+    # Test that the main edition updated
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b6_url

--- a/tests/test_track_lsst_doc.py
+++ b/tests/test_track_lsst_doc.py
@@ -1,4 +1,4 @@
-"""Test an Edition that tracks LSST document releases (EditionMode.LSST_DOC).
+"""Test an Edition that tracks LSST document releases (``lsst_doc).
 """
 
 
@@ -18,7 +18,7 @@ def test_lsst_doc_edition(client):
     p1_data = {
         'slug': 'ldm-151',
         'doc_repo': 'https://github.com/lsst/LDM-151',
-        'main_mode': 2,
+        'main_mode': 'lsst_doc',
         'title': 'Applications Design',
         'root_domain': 'lsst.io',
         'root_fastly_domain': 'global.ssl.fastly.net',


### PR DESCRIPTION
This PR adds the explicit idea of **tracking modes** to edition resources. This determines whether or not an edition is updated with a new build. The default tracking mode was to update if a build resource has the right git ref (a tag or branch name).

The new tracking mode allows an edition to watch for builds with git refs formatted as ``v<Major>.<Minor>`` and always publish the newest such tag. This supports the revised LSST DM document release procedure: https://developer.lsst.io/v/DM-11952/docs/change-controlled-docs.html

Draft documentation for the LTD Keeper API update is at: https://ltd-keeper.lsst.io/v/DM-12356/editions.html