### PR TITLE
DM-12974: Add structlog-based route logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,6 @@ kubernetes/keeper-config-staging.yaml
 kubernetes/cloudsql-secrets-prod.yaml
 kubernetes/keeper-secrets-prod.yaml
 kubernetes/ssl-proxy-secrets-prod.yaml
+kubernetes/keeper-tls-secrets.yaml
 kubernetes/keeper-config-prod.yaml
 kubernetes/dhparam.pem

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,25 @@
 Change log
 ##########
 
+1.8.0 (2017-12-13)
+==================
+
+Adds logging with `structlog <http://www.structlog.org/en/stable/>`__.
+Structlog is configured to generate key-value log strings in test/development and JSON-formatted strings in production.
+The ``@log_route`` decorator creates a new logger and binds metadata about a request, such as a unique request ID, method and path.
+It also logs the response latency and status when the route returns.
+The auth decorators bind the username once the user is known.
+
+`DM-12974 <https://jira.lsstcorp.org/browse/DM-12974>`__.
+
 1.7.0 (2017-12-13)
 ==================
 
 In this version we've dropped the ``nginx-ssl-proxy`` pod that we've used thus far and adopted the standard Kubernetes Ingress resources for TLS termination instead.
 This means that the Keeper service is now a NodePort-type service.
 The advantage of using Ingress is that we can rely on Google to maintain that resource and ensure that the TLS-terminating proxy is updated with new security patches.
+
+`DM-12923 <https://jira.lsstcorp.org/browse/DM-12923>`__.
 
 1.6.0 (2017-12-13)
 ==================

--- a/keeper/__init__.py
+++ b/keeper/__init__.py
@@ -12,6 +12,7 @@ from flask.ext.sqlalchemy import SQLAlchemy
 
 from .config import config
 from .version import get_version
+from .logutils import log_route
 
 db = SQLAlchemy()
 
@@ -40,6 +41,7 @@ def create_app(profile='production'):
 
     # authentication token route
     @app.route('/token')
+    @log_route()
     @password_auth.login_required
     def get_auth_token():
         """Obtain a token for API users.

--- a/keeper/api_v1/builds.py
+++ b/keeper/api_v1/builds.py
@@ -8,10 +8,12 @@ from .. import db
 from ..auth import token_auth, permission_required, is_authorized
 from ..models import Product, Build, Edition, Permission
 from ..utils import auto_slugify_edition
+from ..logutils import log_route
 from ..dasher import build_dashboard_safely
 
 
 @api.route('/products/<slug>/builds/', methods=['POST'])
+@log_route()
 @token_auth.login_required
 @permission_required(Permission.UPLOAD_BUILD)
 def new_build(slug):
@@ -157,6 +159,7 @@ def new_build(slug):
 
 
 @api.route('/builds/<int:id>', methods=['PATCH'])
+@log_route()
 @token_auth.login_required
 @permission_required(Permission.UPLOAD_BUILD)
 def patch_build(id):
@@ -219,6 +222,7 @@ def patch_build(id):
 
 
 @api.route('/builds/<int:id>', methods=['DELETE'])
+@log_route()
 @token_auth.login_required
 @permission_required(Permission.DEPRECATE_BUILD)
 def deprecate_build(id):
@@ -267,6 +271,7 @@ def deprecate_build(id):
 
 
 @api.route('/products/<slug>/builds/', methods=['GET'])
+@log_route()
 def get_product_builds(slug):
     """List all builds for a product.
 
@@ -309,6 +314,7 @@ def get_product_builds(slug):
 
 
 @api.route('/builds/<int:id>', methods=['GET'])
+@log_route()
 def get_build(id):
     """Show metadata for a single build.
 

--- a/keeper/api_v1/editions.py
+++ b/keeper/api_v1/editions.py
@@ -6,10 +6,12 @@ from . import api
 from .. import db
 from ..auth import token_auth, permission_required
 from ..models import Product, Edition, Permission
+from ..logutils import log_route
 from ..dasher import build_dashboard_safely
 
 
 @api.route('/products/<slug>/editions/', methods=['POST'])
+@log_route()
 @token_auth.login_required
 @permission_required(Permission.ADMIN_EDITION)
 def new_edition(slug):
@@ -89,6 +91,7 @@ def new_edition(slug):
 
 
 @api.route('/editions/<int:id>', methods=['DELETE'])
+@log_route()
 @token_auth.login_required
 @permission_required(Permission.ADMIN_EDITION)
 def deprecate_edition(id):
@@ -141,6 +144,7 @@ def deprecate_edition(id):
 
 
 @api.route('/products/<slug>/editions/', methods=['GET'])
+@log_route()
 def get_product_editions(slug):
     """List all editions published for a Product.
 
@@ -182,6 +186,7 @@ def get_product_editions(slug):
 
 
 @api.route('/editions/<int:id>', methods=['GET'])
+@log_route()
 def get_edition(id):
     """Show metadata for an Edition.
 
@@ -248,6 +253,7 @@ def get_edition(id):
 
 
 @api.route('/editions/<int:id>', methods=['PATCH'])
+@log_route()
 @token_auth.login_required
 @permission_required(Permission.ADMIN_EDITION)
 def edit_edition(id):

--- a/keeper/api_v1/errorhandlers.py
+++ b/keeper/api_v1/errorhandlers.py
@@ -15,6 +15,9 @@ from . import api
 @api.errorhandler(ValidationError)
 def bad_request(e):
     """Handler for ValidationError exceptions."""
+    logger = structlog.get_logger()
+    logger.error(status=400, message=e.args[0])
+
     response = jsonify({'status': 400, 'error': 'bad request',
                         'message': e.args[0]})
     response.status_code = 400
@@ -24,6 +27,9 @@ def bad_request(e):
 @api.app_errorhandler(404)
 def not_found(e):
     """App-wide handler for HTTP 404 errors."""
+    logger = structlog.get_logger()
+    logger.error(status=400)
+
     response = jsonify({'status': 404, 'error': 'not found',
                         'message': 'invalid resource URI'})
     response.status_code = 404
@@ -33,6 +39,9 @@ def not_found(e):
 @api.errorhandler(405)
 def method_not_supported(e):
     """Handler for HTTP 405 exceptions."""
+    logger = structlog.get_logger()
+    logger.error(status=405)
+
     response = jsonify({'status': 405, 'error': 'method not supported',
                         'message': 'the method is not supported'})
     response.status_code = 405

--- a/keeper/api_v1/errorhandlers.py
+++ b/keeper/api_v1/errorhandlers.py
@@ -6,6 +6,8 @@ than the default HMTL header response.
 """
 
 from flask import jsonify
+import structlog
+
 from ..exceptions import ValidationError
 from . import api
 
@@ -40,6 +42,9 @@ def method_not_supported(e):
 @api.app_errorhandler(500)
 def internal_server_error(e):
     """App-wide handler for HTTP 500 errors."""
+    logger = structlog.get_logger()
+    logger.error(status=500, message=e.args[0])
+
     response = jsonify({'status': 500, 'error': 'internal server error',
                         'message': e.args[0]})
     response.status_code = 500

--- a/keeper/api_v1/products.py
+++ b/keeper/api_v1/products.py
@@ -5,10 +5,12 @@ from . import api
 from .. import db
 from ..auth import token_auth, permission_required
 from ..models import Product, Permission, Edition
+from ..logutils import log_route
 from ..dasher import build_dashboard_safely, build_dashboards
 
 
 @api.route('/products/', methods=['GET'])
+@log_route()
 def get_products():
     """List all documentation products (anonymous access allowed).
 
@@ -44,6 +46,7 @@ def get_products():
 
 
 @api.route('/products/<slug>', methods=['GET'])
+@log_route()
 def get_product(slug):
     """Get the record of a single documentation product (anonymous access
     allowed).
@@ -114,6 +117,7 @@ def get_product(slug):
 
 
 @api.route('/products/', methods=['POST'])
+@log_route()
 @token_auth.login_required
 @permission_required(Permission.ADMIN_PRODUCT)
 def new_product():
@@ -218,6 +222,7 @@ def new_product():
 
 
 @api.route('/products/<slug>', methods=['PATCH'])
+@log_route()
 @token_auth.login_required
 @permission_required(Permission.ADMIN_PRODUCT)
 def edit_product(slug):
@@ -290,6 +295,7 @@ def edit_product(slug):
 
 
 @api.route('/products/<slug>/dashboard', methods=['POST'])
+@log_route()
 @token_auth.login_required
 @permission_required(Permission.ADMIN_PRODUCT)
 def rebuild_product_dashboard(slug):

--- a/keeper/api_v1/root.py
+++ b/keeper/api_v1/root.py
@@ -4,9 +4,11 @@
 from flask import jsonify, url_for
 from . import api
 from ..version import get_version
+from ..logutils import log_route
 
 
 @api.route('/', methods=['GET'])
+@log_route()
 def get_root():
     """Root API route.
     """

--- a/keeper/config.py
+++ b/keeper/config.py
@@ -1,7 +1,11 @@
 """ltd-keeper configuration and environment profiles."""
 
 import abc
+import logging
 import os
+import sys
+
+import structlog
 
 BASEDIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -43,7 +47,30 @@ class DevelopmentConfig(Config):
     @classmethod
     def init_app(cls, app):
         """Initialization hook called during create_app."""
-        pass
+        logging.basicConfig(
+            format="%(message)s",
+            stream=sys.stdout,
+            level=logging.INFO,
+        )
+
+        structlog.configure(
+            processors=[
+                structlog.stdlib.filter_by_level,
+                structlog.stdlib.add_logger_name,
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.PositionalArgumentsFormatter(),
+                structlog.processors.StackInfoRenderer(),
+                structlog.processors.format_exc_info,
+                structlog.processors.UnicodeDecoder(),
+                # structlog.stdlib.render_to_log_kwargs,
+                structlog.processors.KeyValueRenderer(
+                    key_order=["event", "method", "path", "request_id"],
+                ),
+            ],
+            context_class=structlog.threadlocal.wrap_dict(dict),
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            cache_logger_on_first_use=True,
+        )
 
 
 class TestConfig(Config):
@@ -56,7 +83,30 @@ class TestConfig(Config):
     @classmethod
     def init_app(cls, app):
         """Initialization hook called during create_app."""
-        pass
+        logging.basicConfig(
+            format="%(message)s",
+            stream=sys.stdout,
+            level=logging.INFO,
+        )
+
+        structlog.configure(
+            processors=[
+                structlog.stdlib.filter_by_level,
+                structlog.stdlib.add_logger_name,
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.PositionalArgumentsFormatter(),
+                structlog.processors.StackInfoRenderer(),
+                structlog.processors.format_exc_info,
+                structlog.processors.UnicodeDecoder(),
+                # structlog.stdlib.render_to_log_kwargs,
+                structlog.processors.KeyValueRenderer(
+                    key_order=["event", "method", "path", "request_id"],
+                ),
+            ],
+            context_class=structlog.threadlocal.wrap_dict(dict),
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            cache_logger_on_first_use=True,
+        )
 
 
 class ProductionConfig(Config):
@@ -71,7 +121,27 @@ class ProductionConfig(Config):
     @classmethod
     def init_app(cls, app):
         """Initialization hook called during create_app."""
-        pass
+        logging.basicConfig(
+            format="%(message)s",
+            stream=sys.stdout,
+            level=logging.INFO,
+        )
+
+        structlog.configure(
+            processors=[
+                structlog.stdlib.filter_by_level,
+                structlog.stdlib.add_logger_name,
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.PositionalArgumentsFormatter(),
+                structlog.processors.StackInfoRenderer(),
+                structlog.processors.format_exc_info,
+                structlog.processors.UnicodeDecoder(),
+                structlog.processors.JSONRenderer(),
+            ],
+            context_class=structlog.threadlocal.wrap_dict(dict),
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            cache_logger_on_first_use=True,
+        )
 
 
 config = {

--- a/keeper/logutils.py
+++ b/keeper/logutils.py
@@ -1,0 +1,47 @@
+"""Logging helpers and utilities.
+"""
+
+__all__ = ['log_route']
+
+from functools import wraps
+from timeit import default_timer as timer
+import uuid
+
+from flask import request, make_response
+import structlog
+
+
+def log_route():
+    """Route decorator to initialize a thread-local logger for a route.
+    """
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            # Initialize a timer to capture the response time
+            # This is for convenience, in addition to route monitoring.
+            start_time = timer()
+
+            # Initialize a new thread-local logger and add a unique request
+            # ID to its context.
+            # http://www.structlog.org/en/stable/examples.html
+            logger = structlog.get_logger()
+            log = logger.new(
+                request_id=str(uuid.uuid4()),
+                path=request.path,
+                method=request.method,
+            )
+
+            # Pass through route
+            response = f(*args, **kwargs)
+            response = make_response(response)
+
+            # Close out the logger
+            end_time = timer()
+            log.info(
+                status=response.status_code,
+                response_time=end_time - start_time)
+
+            return response
+
+        return decorated_function
+    return decorator

--- a/keeper/models.py
+++ b/keeper/models.py
@@ -556,7 +556,7 @@ class Edition(db.Model):
             'self_url': self.get_url(),
             'product_url': self.product.get_url(),
             'build_url': build_url,
-            'mode': EditionMode.id_to_name(self.mode),
+            'mode': self.mode_name,
             'tracked_refs': self.tracked_refs,
             'slug': self.slug,
             'title': self.title,
@@ -588,7 +588,7 @@ class Edition(db.Model):
             self.set_mode(data['mode'])
         else:
             # Set default
-            self.set_mode('git_refs')
+            self.set_mode(self.default_mode_name)
 
         # Validate the slug
         self._validate_slug(data['slug'])
@@ -779,6 +779,31 @@ class Edition(db.Model):
         self.mode = EditionMode.name_to_id(mode)
 
         # TODO set tracked_refs to None if mode is LSST_DOC.
+
+    @property
+    def default_mode_name(self):
+        """Default tracking mode name if ``Edition.mode`` is `None` (`str`).
+        """
+        return 'git_refs'
+
+    @property
+    def default_mode_id(self):
+        """Default tracking mode ID if ``Edition.mode`` is `None` (`int`).
+        """
+        return EditionMode.name_to_id(self.default_mode_name)
+
+    @property
+    def mode_name(self):
+        """Name of the mode (`str`).
+
+        See also
+        --------
+        EditionMode
+        """
+        if self.mode is not None:
+            return EditionMode.id_to_name(self.mode)
+        else:
+            return self.default_mode_name
 
     def update_slug(self, new_slug):
         """Update the edition's slug by migrating files on S3."""

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:tickets-DM-12923"
+          image: "lsstsqre/ltd-keeper:tickets-DM-12974"
           ports:
             - containerPort: 3031
               name: keeper

--- a/kubernetes/keeper-mgmt-pod.yaml
+++ b/kubernetes/keeper-mgmt-pod.yaml
@@ -34,7 +34,7 @@ spec:
         mountPath: /etc/ssl/certs
 
     - name: uwsgi
-      image: "lsstsqre/ltd-keeper:tickets-DM-12923"
+      image: "lsstsqre/ltd-keeper:tickets-DM-12974"
       imagePullPolicy: "Always"
       # Container should do nothing on start; let the user access it
       # http://kubernetes.io/docs/user-guide/containers/#how-docker-handles-command-and-arguments

--- a/kubernetes/ltd-prod-namespace.yaml
+++ b/kubernetes/ltd-prod-namespace.yaml
@@ -1,0 +1,8 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: "ltd-prod"
+  labels:
+    name: "ltd-prod"
+    env: "prod"
+    project: "lsst-the-docs"

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'python-dateutil==2.4.2',
         'boto3==1.2.3',
         'requests==2.10.0',
+        'structlog==17.2.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
- Add structlog as a dependency.
- Configure structlog to output key-value strings in test/development and JSON-formatted strings in production.
- Add a `@log_route` decorator that creates a new logger and binds metadata about a request, such as a unique request ID, method and path. It also logs the response latency and status when the route returns.
- The auth decorators bind the username once the user is known.