### PR TITLE
DM-14772: Allow . and _ in edition slugs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Change log
 ##########
 
+1.10.0 (2018-06-12)
+===================
+
+Both ``.`` and ``_`` characters can now appear in edition slugs.
+Previously these characters were automatically converted to ``-`` characters in edition names, but this prevented editions from being named after semantic version tags or EUPS tags.
+
+`DM-14772 <https://jira.lsstcorp.org/browse/DM-14772>`__.
+
 1.9.0 (2018-05-03)
 ==================
 

--- a/docs/gke-update.rst
+++ b/docs/gke-update.rst
@@ -23,17 +23,19 @@ Procedure
    Travis CI pushes a new Docker image to Docker Hub.
    See :doc:`docker-image`.
 
-3. Update the :file:`keeper-deployment.yaml` and update the name of the ``uwsgi`` container's ``image`` to the new Docker image: ``lsstsqre/ltd-keeper:X.Y.Z``.
+3. In :file:`keeper-deployment.yaml`, :file:`keeper-deployment.yaml`, and :file:`keeper-mgmt-pod.yaml` update the name of the ``uwsgi`` container's ``image`` to the new Docker image: ``lsstsqre/ltd-keeper:X.Y.Z``.
 
 4. Apply the new deployment configuration:
 
    .. code-block:: bash
 
       kubectl apply -f keeper-deployment.yaml
+      kubectl apply -f keeper-worker-deployment.yaml
    
    To follow the upgrade, use these commands:
 
    .. code-block:: bash
 
       kubectl describe deployment keeper-deployment
+      kubectl describe deployment keeper-worker-deployment
       kubectl get pods

--- a/keeper/utils.py
+++ b/keeper/utils.py
@@ -21,7 +21,7 @@ from .exceptions import ValidationError
 PRODUCT_SLUG_PATTERN = re.compile('^[a-z]+[-a-z0-9]*[a-z0-9]+$')
 
 # Regular expression to validate url-safe slugs for editions/builds
-PATH_SLUG_PATTERN = re.compile('^[a-zA-Z0-9-]+$')
+PATH_SLUG_PATTERN = re.compile('^[a-zA-Z0-9-\._]+$')
 
 # Regular expression for DM ticket branches (to auto-build slugs)
 TICKET_BRANCH_PATTERN = re.compile('^tickets/([A-Z]+-[0-9]+)$')
@@ -88,8 +88,6 @@ def auto_slugify_edition(git_refs):
         return m.group(1)
 
     slug = slug.replace('/', '-')
-    slug = slug.replace('_', '-')
-    slug = slug.replace('.', '-')
     return slug
 
 

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.9.0"
+          image: "lsstsqre/ltd-keeper:1.10.0"
           ports:
             - containerPort: 3031
               name: keeper

--- a/kubernetes/keeper-mgmt-pod.yaml
+++ b/kubernetes/keeper-mgmt-pod.yaml
@@ -34,7 +34,7 @@ spec:
         mountPath: /etc/ssl/certs
 
     - name: uwsgi
-      image: "lsstsqre/ltd-keeper:1.9.0"
+      image: "lsstsqre/ltd-keeper:1.10.0"
       imagePullPolicy: "Always"
       # Container should do nothing on start; let the user access it
       # http://kubernetes.io/docs/user-guide/containers/#how-docker-handles-command-and-arguments

--- a/kubernetes/keeper-worker-deployment.yaml
+++ b/kubernetes/keeper-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 
         - name: keeper-worker
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.9.0"
+          image: "lsstsqre/ltd-keeper:1.10.0"
           command: ["/bin/bash"]
           args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
           volumeMounts:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,9 +9,12 @@ from keeper.utils import (auto_slugify_edition, validate_path_slug,
     [(['tickets/DM-1234'], 'DM-1234'),
      (['tickets/LCR-758'], 'LCR-758'),
      (['master'], 'master'),
-     (['u/rowen/r12_patch1'], 'u-rowen-r12-patch1'),
+     (['u/rowen/r12_patch1'], 'u-rowen-r12_patch1'),
      (['tickets/DM-1234', 'tickets/DM-5678'],
-      'tickets-DM-1234-tickets-DM-5678')])
+      'tickets-DM-1234-tickets-DM-5678'),
+     (['v15_0'], 'v15_0'),
+     (['w_2018_01'], 'w_2018_01'),
+     (['1.0.0'], '1.0.0')])
 def test_auto_slugify_edition(git_refs, expected):
     assert expected == auto_slugify_edition(git_refs)
     assert validate_path_slug(auto_slugify_edition(git_refs))


### PR DESCRIPTION
This is necessary to support semantic versions (`1.0.0`) as edition names and EUPS tags (v15_0 or `w_2018_01`) as edition names as well.

Fixes #32