### PR TITLE
DM-15016: Add EUPS tag tracking modes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Change log
 ##########
 
+1.11.0 (2018-07-09)
+===================
+
+This release improves and expands the system of edition tracking modes.
+
+There are three new tracking modes:
+
+- ``eups_major_release`` tracks an EUPS major release tag (``vX_Y``) and its Git variant (``X.Y``).
+- ``eups_weekly_release`` tracks an EUPS weekly release tag (``w_YYYY_WW``) and its Git variant (``w.YYYY.WW``).
+- ``eups_daily_release`` tracks an EUPS daily release tag (``d_YYYY_MM_DD``) and its Git variant (``d.YYYY.MM.DD``).
+
+In addition, the code for determining whether an edition should rebuild or not given the tracking mode has been refactored out of the ``Edition.should_rebuild`` model method and into a new ``keeper.editiontracking`` subpackage.
+Each tracking mode is now built around a uniform interface.
+
+`DM-15016 <https://jira.lsstcorp.org/browse/DM-15016>`__.
+
 1.10.0 (2018-06-12)
 ===================
 

--- a/docs/editions.rst
+++ b/docs/editions.rst
@@ -8,20 +8,30 @@ For example, the 'latest' documentation might be published to ``docs.project.org
 
 Editions are merely pointers to a :doc:`Build <builds>`; an Edition is updated by pointing to a newer :doc:`Build <builds>` (see :http:patch:`/editions/(int:id)`).
 
+.. _edition-tracking-modes:
+
 Tracking modes
 ==============
 
 Editions track :doc:`Builds <builds>`.
 This means that when a new :doc:`Build <builds>` is uploaded, any Edition for that :doc:`Product <products>` that tracks that *kind* of Build will be updated.
 An Edition's tracking mode is given with the ``mode`` field, and can either be set initially (:http:post:`/products/(slug)/editions/`) or updated on an existing Edition (:http:patch:`/editions/(int:id)`).
-There are two tracking modes, currently:
 
-============ =================================
-mode field   Tracking behavior
-============ =================================
-``git_refs`` Git branches and tags
-``lsst_doc`` Latest LSST document version tags
-============ =================================
+These are the available tracking modes:
+
+.. list-table::
+   :header-rows: 1
+   
+   * - ``mode`` field
+     - Tracking behavior
+
+   * - :ref:`git_refs <git_refs-tracking-mode>`
+     - Git branches and tags
+
+   * - :ref:`lsst_doc <lsst_doc-tracking-mode>`
+     - Latest LSST document version tags
+
+.. _git_refs-tracking-mode:
 
 Git reference mode (``git_refs``, default)
 ------------------------------------------
@@ -41,6 +51,8 @@ As an example, an Edition has these fields:
    }
 
 Then a :doc:`Build <builds>` with ``{"git_refs": ["master"]}`` will be published by the Edition.
+
+.. _lsst_doc-tracking-mode:
 
 LSST document mode (``lsst_doc``)
 ---------------------------------

--- a/docs/editions.rst
+++ b/docs/editions.rst
@@ -31,6 +31,15 @@ These are the available tracking modes:
    * - :ref:`lsst_doc <lsst_doc-tracking-mode>`
      - Latest LSST document version tags
 
+   * - :ref:`eups_major_release <eups_major_release-tracking-mode>`
+     - Latest EUPS major release tags
+
+   * - :ref:`eups_weekly_release <eups_weekly_release-tracking-mode>`
+     - Latest EUPS weekly release tags
+
+   * - :ref:`eups_daily_release <eups_daily_release-tracking-mode>`
+     - Latest EUPS daily release tags
+
 .. _git_refs-tracking-mode:
 
 Git reference mode (``git_refs``, default)
@@ -63,6 +72,48 @@ LSST document semantic version tags are formatted as ``v<Major>.<Minor>``.
 Enable this mode by setting the Edition's ``mode`` field to ``lsst_doc``.
 
 Note that until the first :doc:`Build <builds>` with a semantic version tag is published, an Edition with this mode will track the ``master`` Git ref.
+
+.. _eups_major_release-tracking-mode:
+
+EUPS major release tag (``eups_major_release``)
+-----------------------------------------------
+
+This mode makes the edition track the :doc:`Build <builds>` with the most recent EUPS major release tag.
+
+EUPS major release tags have two forms that are both treated interchangeably:
+
+- EUPS tag: ``vX_Y`` (as in ``v15_0``).
+- Git tag: ``X_Y`` (as in ``15.0``).
+
+Enable this mode by setting the Edition's ``mode`` field to ``eups_major_release``.
+
+.. _eups_weekly_release-tracking-mode:
+
+EUPS weekly release tag (``eups_weekly_release``)
+-------------------------------------------------
+
+This mode makes the edition track the :doc:`Build <builds>` with the most recent EUPS weekly release tag.
+
+EUPS weekly release tags have two forms that are both treated interchangeably:
+
+- EUPS tag: ``w_YYYY_WW`` (as in ``w_2018_01``).
+- Git tag: ``w.YYYY.WW`` (as in ``w.2018.01``).
+
+Enable this mode by setting the Edition's ``mode`` field to ``eups_weekly_release``.
+
+.. _eups_daily_release-tracking-mode:
+
+EUPS daily release tag (``eups_daily_release``)
+-----------------------------------------------
+
+This mode makes the edition track the :doc:`Build <builds>` with the most recent EUPS daily release tag.
+
+EUPS daily release tags have two forms that are both treated interchangeably:
+
+- EUPS tag: ``d_YYYY_MM_DD`` (as in ``d_2018_01_01``).
+- Git tag: ``d.YYYY.MM.DD`` (as in ``d.2018.01.01``).
+
+Enable this mode by setting the Edition's ``mode`` field to ``eups_daily_release``.
 
 Methods
 =======

--- a/keeper/editiontracking/__init__.py
+++ b/keeper/editiontracking/__init__.py
@@ -1,0 +1,1 @@
+from .trackingmodes import EditionTrackingModes

--- a/keeper/editiontracking/eupsdailymode.py
+++ b/keeper/editiontracking/eupsdailymode.py
@@ -1,0 +1,93 @@
+"""Implement the "eups_daily_release" Edition tracking mode.
+"""
+
+__all__ = ('EupsDailyReleaseTrackingMode',)
+
+import re
+from structlog import get_logger
+
+
+TAG_PATTERN = re.compile(r'^d_(?P<year>\d+)_(?P<month>\d+)_(?P<day>\d+)$')
+"""Regular expression for matching an EUPS daily release tag with the format
+``d_YYYY_MM_DD``.
+"""
+
+
+class EupsDailyReleaseTrackingMode:
+    """Tracking mode for the the newest EUPS daily release (``d_YYYY_MM_DD``).
+    """
+
+    @property
+    def name(self):
+        return 'eups_daily_release'
+
+    def should_update(self, edition, candidate_build):
+        # Does the build have the d_YYYY_MM_DD tag?
+        try:
+            candidate_version = DailyReleaseTag(
+                candidate_build.git_refs[0])
+        except ValueError:
+            return False
+
+        # Does the edition's current build have a daily release
+        # as its Git ref?
+        try:
+            current_version = DailyReleaseTag(
+                edition.build.git_refs[0])
+        except (ValueError, AttributeError):
+            # Attribute error if current build is None
+            # Not currently tracking a version, so automatically accept
+            # the candidate.
+            return True
+
+        # Is the candidate version newer than the existing version?
+        if candidate_version >= current_version:
+            # Accept >= in case a replacement of the same version is
+            # somehow required.
+            return True
+
+        return False
+
+
+class DailyReleaseTag:
+    """An EUPS tag for a daily release.
+    """
+
+    def __init__(self, tag):
+        self.logger = get_logger(__name__)
+
+        self.logger.debug('DailyReleaseTag', tag=tag)
+
+        self.tag = tag
+        match = TAG_PATTERN.search(tag)
+        if match is None:
+            raise ValueError(
+                '{!r} is not an EUPS daily release tag '.format(tag))
+        self.year = int(match.group('year'))
+        self.month = int(match.group('month'))
+        self.day = int(match.group('day'))
+
+        self.logger.debug('DailyReleaseTag',
+                          tag=tag, year=self.year, day=self.day)
+
+    @property
+    def parts(self):
+        return (self.year, self.month, self.day)
+
+    def __eq__(self, other):
+        return self.parts == other.parts
+
+    def __ne__(self, other):
+        return self.__eq__(other) is False
+
+    def __gt__(self, other):
+        return self.parts > other.parts
+
+    def __lt__(self, other):
+        return (self.__eq__(other) is False) and (self.__gt__(other) is False)
+
+    def __ge__(self, other):
+        return (self.__eq__(other) is True) or (self.__gt__(other) is True)
+
+    def __le__(self, other):
+        return (self.__eq__(other) is True) or (self.__gt__(other) is False)

--- a/keeper/editiontracking/eupsdailymode.py
+++ b/keeper/editiontracking/eupsdailymode.py
@@ -12,9 +12,16 @@ TAG_PATTERN = re.compile(r'^d_(?P<year>\d+)_(?P<month>\d+)_(?P<day>\d+)$')
 ``d_YYYY_MM_DD``.
 """
 
+GIT_TAG_PATTERN = re.compile(
+    r'^d\.(?P<year>\d+)\.(?P<month>\d+)\.(?P<day>\d+)$')
+"""Regular expression for matching the Git variant of an EUPS daily release tag
+with the format ``d.YYYY.MM.DD``.
+"""
+
 
 class EupsDailyReleaseTrackingMode:
-    """Tracking mode for the the newest EUPS daily release (``d_YYYY_MM_DD``).
+    """Tracking mode for the the newest EUPS daily release (``d_YYYY_MM_DD``
+    of ``d.YYYY.MM.DD``).
     """
 
     @property
@@ -22,7 +29,7 @@ class EupsDailyReleaseTrackingMode:
         return 'eups_daily_release'
 
     def should_update(self, edition, candidate_build):
-        # Does the build have the d_YYYY_MM_DD tag?
+        # Does the build have a daily release tag?
         try:
             candidate_version = DailyReleaseTag(
                 candidate_build.git_refs[0])
@@ -61,8 +68,11 @@ class DailyReleaseTag:
         self.tag = tag
         match = TAG_PATTERN.search(tag)
         if match is None:
-            raise ValueError(
-                '{!r} is not an EUPS daily release tag '.format(tag))
+            # Fall back to Git variant pattern
+            match = GIT_TAG_PATTERN.search(tag)
+            if match is None:
+                raise ValueError(
+                    '{!r} is not an EUPS daily release tag '.format(tag))
         self.year = int(match.group('year'))
         self.month = int(match.group('month'))
         self.day = int(match.group('day'))

--- a/keeper/editiontracking/eupsmajormode.py
+++ b/keeper/editiontracking/eupsmajormode.py
@@ -11,9 +11,15 @@ TAG_PATTERN = re.compile(r'^v(?P<major>\d+)_(?P<minor>\d+)$')
 ``vX_Y``.
 """
 
+GIT_TAG_PATTERN = re.compile(r'^(?P<major>\d+)\.(?P<minor>\d+)$')
+"""Regular expression for matching the Git-version of an EUPS major release tag
+with the format ``X.Y``.
+"""
+
 
 class EupsMajorReleaseTrackingMode:
-    """Tracking mode for the the newest EUPS major release (``vX_Y``).
+    """Tracking mode for the the newest EUPS major release (``vX_Y`` or
+    ``X.Y``).
     """
 
     @property
@@ -21,7 +27,7 @@ class EupsMajorReleaseTrackingMode:
         return 'eups_major_release'
 
     def should_update(self, edition, candidate_build):
-        # Does the build have the vN_M tag?
+        # Does the build have a major release tag?
         try:
             candidate_version = MajorReleaseTag(
                 candidate_build.git_refs[0])
@@ -56,8 +62,11 @@ class MajorReleaseTag:
         self.tag = tag
         match = TAG_PATTERN.search(tag)
         if match is None:
-            raise ValueError(
-                '{!r} is not an EUPS major release tag '.format(tag))
+            # Fall back to git variant
+            match = GIT_TAG_PATTERN.search(tag)
+            if match is None:
+                raise ValueError(
+                    '{!r} is not an EUPS major release tag '.format(tag))
         self.major = int(match.group('major'))
         self.minor = int(match.group('minor'))
 

--- a/keeper/editiontracking/eupsmajormode.py
+++ b/keeper/editiontracking/eupsmajormode.py
@@ -1,0 +1,84 @@
+"""Implement the "eups_major_release" Edition tracking mode.
+"""
+
+__all__ = ('EupsMajorReleaseTrackingMode',)
+
+import re
+
+
+TAG_PATTERN = re.compile(r'^v(?P<major>\d+)_(?P<minor>\d+)$')
+"""Regular expression for matching an EUPS major release tag with the format
+``vX_Y``.
+"""
+
+
+class EupsMajorReleaseTrackingMode:
+    """Tracking mode for the the newest EUPS major release (``vX_Y``).
+    """
+
+    @property
+    def name(self):
+        return 'eups_major_release'
+
+    def should_update(self, edition, candidate_build):
+        # Does the build have the vN_M tag?
+        try:
+            candidate_version = MajorReleaseTag(
+                candidate_build.git_refs[0])
+        except ValueError:
+            return False
+
+        # Does the edition's current build have a major release?
+        # as its Git ref?
+        try:
+            current_version = MajorReleaseTag(
+                edition.build.git_refs[0])
+        except (ValueError, AttributeError):
+            # Attribute error if current build is None
+            # Not currently tracking a version, so automatically accept
+            # the candidate.
+            return True
+
+        # Is the candidate version newer than the existing version?
+        if candidate_version >= current_version:
+            # Accept >= in case a replacement of the same version is
+            # somehow required.
+            return True
+
+        return False
+
+
+class MajorReleaseTag:
+    """An EUPS tag for a major release.
+    """
+
+    def __init__(self, tag):
+        self.tag = tag
+        match = TAG_PATTERN.search(tag)
+        if match is None:
+            raise ValueError(
+                '{!r} is not an EUPS major release tag '.format(tag))
+        self.major = int(match.group('major'))
+        self.minor = int(match.group('minor'))
+
+    @property
+    def parts(self):
+        return (self.major, self.minor)
+
+    def __eq__(self, other):
+        return self.parts == other.parts
+
+    def __ne__(self, other):
+        return self.__eq__(other) is False
+
+    def __gt__(self, other):
+        return self.parts > other.parts
+
+    def __lt__(self, other):
+        return (self.__eq__(other) is False) and (self.__gt__(other) is False)
+
+    def __ge__(self, other):
+        return (self.__eq__(other) is True) or (self.__gt__(other) is True)
+
+    def __le__(self, other):
+        return (self.__eq__(other) is True) or (self.__gt__(other) is False)

--- a/keeper/editiontracking/eupsweeklymode.py
+++ b/keeper/editiontracking/eupsweeklymode.py
@@ -1,0 +1,92 @@
+"""Implement the "eups_weekly_release" Edition tracking mode.
+"""
+
+__all__ = ('EupsWeeklyReleaseTrackingMode',)
+
+import re
+from structlog import get_logger
+
+
+TAG_PATTERN = re.compile(r'^w_(?P<year>\d+)_(?P<week>\d+)$')
+"""Regular expression for matching an EUPS weekly release tag with the format
+``w_YYYY_WW``.
+"""
+
+
+class EupsWeeklyReleaseTrackingMode:
+    """Tracking mode for the the newest EUPS weekly release (``w_YYYY_WW``).
+    """
+
+    @property
+    def name(self):
+        return 'eups_weekly_release'
+
+    def should_update(self, edition, candidate_build):
+        # Does the build have the w_YYYY_WW tag?
+        try:
+            candidate_version = WeeklyReleaseTag(
+                candidate_build.git_refs[0])
+        except ValueError:
+            return False
+
+        # Does the edition's current build have a weekly release
+        # as its Git ref?
+        try:
+            current_version = WeeklyReleaseTag(
+                edition.build.git_refs[0])
+        except (ValueError, AttributeError):
+            # Attribute error if current build is None
+            # Not currently tracking a version, so automatically accept
+            # the candidate.
+            return True
+
+        # Is the candidate version newer than the existing version?
+        if candidate_version >= current_version:
+            # Accept >= in case a replacement of the same version is
+            # somehow required.
+            return True
+
+        return False
+
+
+class WeeklyReleaseTag:
+    """An EUPS tag for a weekly release.
+    """
+
+    def __init__(self, tag):
+        self.logger = get_logger(__name__)
+
+        self.logger.debug('WeeklyReleaseTag', tag=tag)
+
+        self.tag = tag
+        match = TAG_PATTERN.search(tag)
+        if match is None:
+            raise ValueError(
+                '{!r} is not an EUPS weekly release tag '.format(tag))
+        self.year = int(match.group('year'))
+        self.week = int(match.group('week'))
+
+        self.logger.debug('WeeklyReleaseTag',
+                          tag=tag, year=self.year, week=self.week)
+
+    @property
+    def parts(self):
+        return (self.year, self.week)
+
+    def __eq__(self, other):
+        return self.parts == other.parts
+
+    def __ne__(self, other):
+        return self.__eq__(other) is False
+
+    def __gt__(self, other):
+        return self.parts > other.parts
+
+    def __lt__(self, other):
+        return (self.__eq__(other) is False) and (self.__gt__(other) is False)
+
+    def __ge__(self, other):
+        return (self.__eq__(other) is True) or (self.__gt__(other) is True)
+
+    def __le__(self, other):
+        return (self.__eq__(other) is True) or (self.__gt__(other) is False)

--- a/keeper/editiontracking/eupsweeklymode.py
+++ b/keeper/editiontracking/eupsweeklymode.py
@@ -12,9 +12,15 @@ TAG_PATTERN = re.compile(r'^w_(?P<year>\d+)_(?P<week>\d+)$')
 ``w_YYYY_WW``.
 """
 
+GIT_TAG_PATTERN = re.compile(r'^w\.(?P<year>\d+)\.(?P<week>\d+)$')
+"""Regular expression for matching the Git variant of an EUPS weekly release
+tag with the format ``w.YYYY.WW``.
+"""
+
 
 class EupsWeeklyReleaseTrackingMode:
-    """Tracking mode for the the newest EUPS weekly release (``w_YYYY_WW``).
+    """Tracking mode for the the newest EUPS weekly release (``w_YYYY_WW``
+    or ``w.YYYY.WW``).
     """
 
     @property
@@ -22,7 +28,7 @@ class EupsWeeklyReleaseTrackingMode:
         return 'eups_weekly_release'
 
     def should_update(self, edition, candidate_build):
-        # Does the build have the w_YYYY_WW tag?
+        # Does the build have the weekly release tag?
         try:
             candidate_version = WeeklyReleaseTag(
                 candidate_build.git_refs[0])
@@ -61,8 +67,11 @@ class WeeklyReleaseTag:
         self.tag = tag
         match = TAG_PATTERN.search(tag)
         if match is None:
-            raise ValueError(
-                '{!r} is not an EUPS weekly release tag '.format(tag))
+            # Fall back to Git tag variant
+            match = GIT_TAG_PATTERN.search(tag)
+            if match is None:
+                raise ValueError(
+                    '{!r} is not an EUPS weekly release tag '.format(tag))
         self.year = int(match.group('year'))
         self.week = int(match.group('week'))
 

--- a/keeper/editiontracking/gitrefmode.py
+++ b/keeper/editiontracking/gitrefmode.py
@@ -1,0 +1,25 @@
+"""Implements the ``git_ref`` tracking mode.
+"""
+
+__all__ = ('GitRefTrackingMode',)
+
+
+class GitRefTrackingMode:
+    """Default tracking mode where an edition tracks an array of Git refs.
+
+    This is the default mode if Edition.mode is None.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def name(self):
+        return 'git_refs'
+
+    def should_update(self, edition, candidate_build):
+        if (candidate_build.product == edition.product) \
+                and (candidate_build.git_refs == edition.tracked_refs):
+            return True
+        else:
+            return False

--- a/keeper/editiontracking/trackingmodes.py
+++ b/keeper/editiontracking/trackingmodes.py
@@ -3,6 +3,7 @@ __all__ = ('EditionTrackingModes',)
 from ..exceptions import ValidationError
 from .gitrefmode import GitRefTrackingMode
 from .lsstdocmode import LsstDocTrackingMode
+from .eupsmajormode import EupsMajorReleaseTrackingMode
 
 
 class EditionTrackingModes:
@@ -14,6 +15,7 @@ class EditionTrackingModes:
     _modes = {
         1: GitRefTrackingMode(),
         2: LsstDocTrackingMode(),
+        3: EupsMajorReleaseTrackingMode(),
     }
     """Map of tracking mode ID (an integer stored in the DB to the tracking
     mode instance that can evaluate whether an edition should be updated

--- a/keeper/editiontracking/trackingmodes.py
+++ b/keeper/editiontracking/trackingmodes.py
@@ -1,0 +1,88 @@
+__all__ = ('EditionTrackingModes',)
+
+from ..exceptions import ValidationError
+from .gitrefmode import GitRefTrackingMode
+from .lsstdocmode import LsstDocTrackingMode
+
+
+class EditionTrackingModes:
+    """Collection of edition tracking mode objects.
+
+    These modes determine how an edition should be updated with new builds.
+    """
+
+    _modes = {
+        1: GitRefTrackingMode(),
+        2: LsstDocTrackingMode(),
+    }
+    """Map of tracking mode ID (an integer stored in the DB to the tracking
+    mode instance that can evaluate whether an edition should be updated
+    based on its own logic.
+    """
+
+    _name_map = {mode.name: _id
+                 for _id, mode in _modes.items()}
+    """Map of mode names to DB IDs.
+
+    This is the inverse of ``_modes``.
+    """
+
+    def __getitem__(self, key):
+        if not isinstance(key, int):
+            key = self.name_to_id(key)
+        return self._modes[key]
+
+    def name_to_id(self, mode):
+        """Convert a mode name (string used by the web API) to a mode ID
+        (integer) used by the DB.
+
+        Parameters
+        ----------
+        mode : `str`
+            Mode name.
+
+        Returns
+        -------
+        mode_id : `int`
+            Mode ID.
+
+        Raises
+        ------
+        ValidationError
+            Raised if ``mode`` is unknown.
+        """
+        try:
+            mode_id = self._name_map[mode]
+        except KeyError:
+            message = ('Edition tracking mode {!r} unknown. Valid values '
+                       'are {!r}')
+            raise ValidationError(message.format(mode, self._name_map.keys()))
+        return mode_id
+
+    def id_to_name(self, mode_id):
+        """Convert a mode ID (integer used by the DB) to a name used by the
+        web API.
+
+        Parameters
+        ----------
+        mode_id : `int`
+            Mode ID.
+
+        Returns
+        -------
+        mode : `str`
+            Mode name.
+
+        Raises
+        ------
+        ValidationError
+            Raised if ``mode`` is unknown.
+        """
+        try:
+            mode = self._modes[mode_id]
+        except KeyError:
+            message = ('Edition tracking mode ID {!r} unknown. Valid values '
+                       'are {!r}')
+            raise ValidationError(
+                message.format(mode_id, self._modes.keys()))
+        return mode.name

--- a/keeper/editiontracking/trackingmodes.py
+++ b/keeper/editiontracking/trackingmodes.py
@@ -5,6 +5,7 @@ from .gitrefmode import GitRefTrackingMode
 from .lsstdocmode import LsstDocTrackingMode
 from .eupsmajormode import EupsMajorReleaseTrackingMode
 from .eupsweeklymode import EupsWeeklyReleaseTrackingMode
+from .eupsdailymode import EupsDailyReleaseTrackingMode
 
 
 class EditionTrackingModes:
@@ -18,6 +19,7 @@ class EditionTrackingModes:
         2: LsstDocTrackingMode(),
         3: EupsMajorReleaseTrackingMode(),
         4: EupsWeeklyReleaseTrackingMode(),
+        5: EupsDailyReleaseTrackingMode(),
     }
     """Map of tracking mode ID (an integer stored in the DB to the tracking
     mode instance that can evaluate whether an edition should be updated

--- a/keeper/editiontracking/trackingmodes.py
+++ b/keeper/editiontracking/trackingmodes.py
@@ -4,6 +4,7 @@ from ..exceptions import ValidationError
 from .gitrefmode import GitRefTrackingMode
 from .lsstdocmode import LsstDocTrackingMode
 from .eupsmajormode import EupsMajorReleaseTrackingMode
+from .eupsweeklymode import EupsWeeklyReleaseTrackingMode
 
 
 class EditionTrackingModes:
@@ -16,6 +17,7 @@ class EditionTrackingModes:
         1: GitRefTrackingMode(),
         2: LsstDocTrackingMode(),
         3: EupsMajorReleaseTrackingMode(),
+        4: EupsWeeklyReleaseTrackingMode(),
     }
     """Map of tracking mode ID (an integer stored in the DB to the tracking
     mode instance that can evaluate whether an edition should be updated

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.10.0"
+          image: "lsstsqre/ltd-keeper:1.11.0"
           ports:
             - containerPort: 3031
               name: keeper

--- a/kubernetes/keeper-mgmt-pod.yaml
+++ b/kubernetes/keeper-mgmt-pod.yaml
@@ -34,7 +34,7 @@ spec:
         mountPath: /etc/ssl/certs
 
     - name: uwsgi
-      image: "lsstsqre/ltd-keeper:1.10.0"
+      image: "lsstsqre/ltd-keeper:1.11.0"
       imagePullPolicy: "Always"
       # Container should do nothing on start; let the user access it
       # http://kubernetes.io/docs/user-guide/containers/#how-docker-handles-command-and-arguments

--- a/kubernetes/keeper-worker-deployment.yaml
+++ b/kubernetes/keeper-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 
         - name: keeper-worker
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.10.0"
+          image: "lsstsqre/ltd-keeper:1.11.0"
           command: ["/bin/bash"]
           args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
           volumeMounts:

--- a/tests/test_eupsdailymode.py
+++ b/tests/test_eupsdailymode.py
@@ -12,6 +12,12 @@ def test_parsing():
     assert tag.month == 2
     assert tag.day == 1
 
+    # Git variant
+    tag = DailyReleaseTag('d.2018.02.01')
+    assert tag.year == 2018
+    assert tag.month == 2
+    assert tag.day == 1
+
     with pytest.raises(ValueError):
         DailyReleaseTag('2018_02_01')
 

--- a/tests/test_eupsdailymode.py
+++ b/tests/test_eupsdailymode.py
@@ -1,0 +1,25 @@
+"""Tests for `keeper.editiontracking.eupsdailymode`.
+"""
+
+import pytest
+
+from keeper.editiontracking.eupsdailymode import DailyReleaseTag
+
+
+def test_parsing():
+    tag = DailyReleaseTag('d_2018_02_01')
+    assert tag.year == 2018
+    assert tag.month == 2
+    assert tag.day == 1
+
+    with pytest.raises(ValueError):
+        DailyReleaseTag('2018_02_01')
+
+    with pytest.raises(ValueError):
+        DailyReleaseTag('d_2018_02')
+
+
+def test_comparisons():
+    assert DailyReleaseTag('d_2018_02_01') == DailyReleaseTag('d_2018_02_01')
+    assert DailyReleaseTag('d_2018_02_02') >= DailyReleaseTag('d_2018_02_01')
+    assert DailyReleaseTag('d_2018_02_02') > DailyReleaseTag('d_2018_02_01')

--- a/tests/test_eupsmajormode.py
+++ b/tests/test_eupsmajormode.py
@@ -1,0 +1,30 @@
+"""Unit tests for keeper.editiontracking.eupsmajormode.
+"""
+
+import pytest
+
+from keeper.editiontracking.eupsmajormode import MajorReleaseTag
+
+
+def test_parsing():
+    tag = MajorReleaseTag('v1_0')
+    assert tag.major == 1
+    assert tag.minor == 0
+
+    tag = MajorReleaseTag('v16_1')
+    assert tag.major == 16
+    assert tag.minor == 1
+
+    with pytest.raises(ValueError):
+        MajorReleaseTag('2_0')
+
+    with pytest.raises(ValueError):
+        MajorReleaseTag('v2')
+
+
+def test_comparisons():
+    assert MajorReleaseTag('v1_0') > MajorReleaseTag('v0_1')
+    assert MajorReleaseTag('v1_0') != MajorReleaseTag('v0_1')
+
+    assert MajorReleaseTag('v1_0') == MajorReleaseTag('v1_0')
+    assert MajorReleaseTag('v1_0') >= MajorReleaseTag('v1_0')

--- a/tests/test_eupsmajormode.py
+++ b/tests/test_eupsmajormode.py
@@ -15,11 +15,24 @@ def test_parsing():
     assert tag.major == 16
     assert tag.minor == 1
 
+    # Git variant
+    tag = MajorReleaseTag('1.0')
+    assert tag.major == 1
+    assert tag.minor == 0
+
+    # Git variant
+    tag = MajorReleaseTag('16.1')
+    assert tag.major == 16
+    assert tag.minor == 1
+
     with pytest.raises(ValueError):
         MajorReleaseTag('2_0')
 
     with pytest.raises(ValueError):
         MajorReleaseTag('v2')
+
+    with pytest.raises(ValueError):
+        MajorReleaseTag('2.0.0')
 
 
 def test_comparisons():

--- a/tests/test_eupsweeklymode.py
+++ b/tests/test_eupsweeklymode.py
@@ -15,6 +15,16 @@ def test_parsing():
     assert tag.year == 2018
     assert tag.week == 26
 
+    # Git variant
+    tag = WeeklyReleaseTag('w.2018.01')
+    assert tag.year == 2018
+    assert tag.week == 1
+
+    # Git variant
+    tag = WeeklyReleaseTag('w.2018.26')
+    assert tag.year == 2018
+    assert tag.week == 26
+
     with pytest.raises(ValueError):
         WeeklyReleaseTag('v1_0')
     with pytest.raises(ValueError):

--- a/tests/test_eupsweeklymode.py
+++ b/tests/test_eupsweeklymode.py
@@ -1,0 +1,33 @@
+"""Tests for `keeper.editiontracking.eupsweeklymode`.
+"""
+
+import pytest
+
+from keeper.editiontracking.eupsweeklymode import WeeklyReleaseTag
+
+
+def test_parsing():
+    tag = WeeklyReleaseTag('w_2018_01')
+    assert tag.year == 2018
+    assert tag.week == 1
+
+    tag = WeeklyReleaseTag('w_2018_26')
+    assert tag.year == 2018
+    assert tag.week == 26
+
+    with pytest.raises(ValueError):
+        WeeklyReleaseTag('v1_0')
+    with pytest.raises(ValueError):
+        WeeklyReleaseTag('w_2018')
+    with pytest.raises(ValueError):
+        WeeklyReleaseTag('w_2018_01rc1')
+
+
+def test_comparisons():
+    assert WeeklyReleaseTag('w_2018_01') > WeeklyReleaseTag('w_2017_01')
+    assert not WeeklyReleaseTag('w_2018_01') < WeeklyReleaseTag('w_2017_01')
+
+    assert WeeklyReleaseTag('w_2018_20') >= WeeklyReleaseTag('w_2018_20')
+    assert WeeklyReleaseTag('w_2018_20') >= WeeklyReleaseTag('w_2018_01')
+    assert WeeklyReleaseTag('w_2018_20') <= WeeklyReleaseTag('w_2018_20')
+    assert not WeeklyReleaseTag('w_2018_20') == WeeklyReleaseTag('w_2018_01')

--- a/tests/test_lsstdocmode.py
+++ b/tests/test_lsstdocmode.py
@@ -1,9 +1,9 @@
-"""Tests for the app.gitrefutils module.
+"""Tests for the keeper.editiontracking.lsstdocmode module.
 """
 
 import pytest
 
-from keeper.gitrefutils import LsstDocVersionTag
+from keeper.editiontracking.lsstdocmode import LsstDocVersionTag
 
 
 def test_lsst_doc_tag():

--- a/tests/test_track_eups_daily_tag.py
+++ b/tests/test_track_eups_daily_tag.py
@@ -1,0 +1,117 @@
+"""Test an Edition that tracks an eups daily release (`eups_daily_release`).
+"""
+
+
+def test_eups_daily_release_edition(client, mocker):
+    """Test an edition that tracks the most recent EUPS daily release.
+    """
+    # These mocks are needed but not checked
+    mocker.patch('keeper.api_v1.builds.launch_task_chain')
+    mocker.patch('keeper.models.append_task_to_chain')
+    mocker.patch('keeper.api_v1.products.append_task_to_chain')
+    mocker.patch('keeper.api_v1.products.launch_task_chain')
+    mocker.patch('keeper.api_v1.builds.append_task_to_chain')
+    mocker.patch('keeper.api_v1.editions.append_task_to_chain')
+    mocker.patch('keeper.api_v1.editions.launch_task_chain')
+
+    # ========================================================================
+    # Add product /products/pipelines
+    p1_data = {
+        'slug': 'pipelines',
+        'doc_repo': 'https://github.com/lsst/pipelines',
+        'main_mode': 'eups_daily_release',
+        'title': 'LSST Science Pipelines',
+        'root_domain': 'lsst.io',
+        'root_fastly_domain': 'global.ssl.fastly.net',
+        'bucket_name': 'bucket-name'
+    }
+    r = client.post('/products/', p1_data)
+    p1_url = r.headers['Location']
+
+    # Get the URL for the default edition
+    r = client.get(p1_url + '/editions/')
+    edition_url = r.json['editions'][0]
+
+    # ========================================================================
+    # Test tracking mode of default edition
+    r = client.get(edition_url)
+    assert r.json['mode'] == 'eups_daily_release'
+
+    # ========================================================================
+    # Create a build for 'd_2018_07_01'
+    b1_data = {
+        'slug': 'b1',
+        'github_requester': 'jonathansick',
+        'git_refs': ['d_2018_07_01']
+    }
+    r = client.post('/products/pipelines/builds/', b1_data)
+    b1_url = r.headers['Location']
+
+    r = client.patch(b1_url, {'uploaded': True})
+
+    # Manually reset pending_rebuild (the rebuild_edition task would have
+    # done this automatically)
+    r = client.get(edition_url)
+    assert r.json['pending_rebuild'] is True
+    r = client.patch(edition_url, {'pending_rebuild': False})
+
+    # Test that the main edition updated
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+    assert r.json['pending_rebuild'] is False
+
+    # ========================================================================
+    # Create a build for the 'master' branch that is not tracked
+    b2_data = {
+        'slug': 'b2',
+        'github_requester': 'jonathansick',
+        'git_refs': ['master']
+    }
+    r = client.post('/products/pipelines/builds/', b2_data)
+    b2_url = r.headers['Location']
+    r = client.patch(b2_url, {'uploaded': True})
+
+    # Test that the main edition *did not* update because this build is
+    # neither for master not a semantic version.
+    # with semantic versions
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+
+    # ========================================================================
+    # Create a build with a newer weekly release tag that is tracked
+    b3_data = {
+        'slug': 'b3',
+        'github_requester': 'jonathansick',
+        'git_refs': ['d_2018_07_02']
+    }
+    r = client.post('/products/pipelines/builds/', b3_data)
+    b3_url = r.headers['Location']
+    r = client.patch(b3_url, {'uploaded': True})
+
+    # Manually reset pending_rebuild (the rebuild_edition task would have
+    # done this automatically)
+    r = client.get(edition_url)
+    assert r.json['pending_rebuild'] is True
+    r = client.patch(edition_url, {'pending_rebuild': False})
+
+    # Test that the main edition updated
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url
+    assert r.json['pending_rebuild'] is False
+
+    # ========================================================================
+    # Create a build with a older weekly release tag that is not tracked
+    b4_data = {
+        'slug': 'b4',
+        'github_requester': 'jonathansick',
+        'git_refs': ['d_2017_01_01']
+    }
+    r = client.post('/products/pipelines/builds/', b4_data)
+    b4_url = r.headers['Location']
+    r = client.patch(b4_url, {'uploaded': True})
+
+    # Test that the main edition *did not* update because this build is
+    # neither for master not a semantic version.
+    # with semantic versions
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url

--- a/tests/test_track_eups_major_tag.py
+++ b/tests/test_track_eups_major_tag.py
@@ -1,0 +1,117 @@
+"""Test an Edition that tracks eups major releases (`eups_major_release`).
+"""
+
+
+def test_eups_major_release_edition(client, mocker):
+    """Test an edition that tracks the most recent EUPS major release.
+    """
+    # These mocks are needed but not checked
+    mocker.patch('keeper.api_v1.builds.launch_task_chain')
+    mocker.patch('keeper.models.append_task_to_chain')
+    mocker.patch('keeper.api_v1.products.append_task_to_chain')
+    mocker.patch('keeper.api_v1.products.launch_task_chain')
+    mocker.patch('keeper.api_v1.builds.append_task_to_chain')
+    mocker.patch('keeper.api_v1.editions.append_task_to_chain')
+    mocker.patch('keeper.api_v1.editions.launch_task_chain')
+
+    # ========================================================================
+    # Add product /products/pipelines
+    p1_data = {
+        'slug': 'pipelines',
+        'doc_repo': 'https://github.com/lsst/pipelines',
+        'main_mode': 'eups_major_release',
+        'title': 'LSST Science Pipelines',
+        'root_domain': 'lsst.io',
+        'root_fastly_domain': 'global.ssl.fastly.net',
+        'bucket_name': 'bucket-name'
+    }
+    r = client.post('/products/', p1_data)
+    p1_url = r.headers['Location']
+
+    # Get the URL for the default edition
+    r = client.get(p1_url + '/editions/')
+    edition_url = r.json['editions'][0]
+
+    # ========================================================================
+    # Test tracking mode of default edition
+    r = client.get(edition_url)
+    assert r.json['mode'] == 'eups_major_release'
+
+    # ========================================================================
+    # Create a build for 'v1_0'
+    b1_data = {
+        'slug': 'b1',
+        'github_requester': 'jonathansick',
+        'git_refs': ['v1_0']
+    }
+    r = client.post('/products/pipelines/builds/', b1_data)
+    b1_url = r.headers['Location']
+
+    r = client.patch(b1_url, {'uploaded': True})
+
+    # Manually reset pending_rebuild (the rebuild_edition task would have
+    # done this automatically)
+    r = client.get(edition_url)
+    assert r.json['pending_rebuild'] is True
+    r = client.patch(edition_url, {'pending_rebuild': False})
+
+    # Test that the main edition updated
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+    assert r.json['pending_rebuild'] is False
+
+    # ========================================================================
+    # Create a build for the 'master' branch that is not tracked
+    b2_data = {
+        'slug': 'b2',
+        'github_requester': 'jonathansick',
+        'git_refs': ['master']
+    }
+    r = client.post('/products/pipelines/builds/', b2_data)
+    b2_url = r.headers['Location']
+    r = client.patch(b2_url, {'uploaded': True})
+
+    # Test that the main edition *did not* update because this build is
+    # neither for master not a semantic version.
+    # with semantic versions
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+
+    # ========================================================================
+    # Create a build with a newer semantic release tag that is tracked
+    b3_data = {
+        'slug': 'b3',
+        'github_requester': 'jonathansick',
+        'git_refs': ['v2_0']
+    }
+    r = client.post('/products/pipelines/builds/', b3_data)
+    b3_url = r.headers['Location']
+    r = client.patch(b3_url, {'uploaded': True})
+
+    # Manually reset pending_rebuild (the rebuild_edition task would have
+    # done this automatically)
+    r = client.get(edition_url)
+    assert r.json['pending_rebuild'] is True
+    r = client.patch(edition_url, {'pending_rebuild': False})
+
+    # Test that the main edition updated
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url
+    assert r.json['pending_rebuild'] is False
+
+    # ========================================================================
+    # Create a build with a older semantic release tag that is not tracked
+    b4_data = {
+        'slug': 'b4',
+        'github_requester': 'jonathansick',
+        'git_refs': ['v1_5']
+    }
+    r = client.post('/products/pipelines/builds/', b4_data)
+    b4_url = r.headers['Location']
+    r = client.patch(b4_url, {'uploaded': True})
+
+    # Test that the main edition *did not* update because this build is
+    # neither for master not a semantic version.
+    # with semantic versions
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url

--- a/tests/test_track_eups_weekly_tag.py
+++ b/tests/test_track_eups_weekly_tag.py
@@ -1,0 +1,117 @@
+"""Test an Edition that tracks eups weekly release (`eups_weekly_release`).
+"""
+
+
+def test_eups_weekly_release_edition(client, mocker):
+    """Test an edition that tracks the most recent EUPS weekly release.
+    """
+    # These mocks are needed but not checked
+    mocker.patch('keeper.api_v1.builds.launch_task_chain')
+    mocker.patch('keeper.models.append_task_to_chain')
+    mocker.patch('keeper.api_v1.products.append_task_to_chain')
+    mocker.patch('keeper.api_v1.products.launch_task_chain')
+    mocker.patch('keeper.api_v1.builds.append_task_to_chain')
+    mocker.patch('keeper.api_v1.editions.append_task_to_chain')
+    mocker.patch('keeper.api_v1.editions.launch_task_chain')
+
+    # ========================================================================
+    # Add product /products/pipelines
+    p1_data = {
+        'slug': 'pipelines',
+        'doc_repo': 'https://github.com/lsst/pipelines',
+        'main_mode': 'eups_weekly_release',
+        'title': 'LSST Science Pipelines',
+        'root_domain': 'lsst.io',
+        'root_fastly_domain': 'global.ssl.fastly.net',
+        'bucket_name': 'bucket-name'
+    }
+    r = client.post('/products/', p1_data)
+    p1_url = r.headers['Location']
+
+    # Get the URL for the default edition
+    r = client.get(p1_url + '/editions/')
+    edition_url = r.json['editions'][0]
+
+    # ========================================================================
+    # Test tracking mode of default edition
+    r = client.get(edition_url)
+    assert r.json['mode'] == 'eups_weekly_release'
+
+    # ========================================================================
+    # Create a build for 'w_2018_01'
+    b1_data = {
+        'slug': 'b1',
+        'github_requester': 'jonathansick',
+        'git_refs': ['w_2018_01']
+    }
+    r = client.post('/products/pipelines/builds/', b1_data)
+    b1_url = r.headers['Location']
+
+    r = client.patch(b1_url, {'uploaded': True})
+
+    # Manually reset pending_rebuild (the rebuild_edition task would have
+    # done this automatically)
+    r = client.get(edition_url)
+    assert r.json['pending_rebuild'] is True
+    r = client.patch(edition_url, {'pending_rebuild': False})
+
+    # Test that the main edition updated
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+    assert r.json['pending_rebuild'] is False
+
+    # ========================================================================
+    # Create a build for the 'master' branch that is not tracked
+    b2_data = {
+        'slug': 'b2',
+        'github_requester': 'jonathansick',
+        'git_refs': ['master']
+    }
+    r = client.post('/products/pipelines/builds/', b2_data)
+    b2_url = r.headers['Location']
+    r = client.patch(b2_url, {'uploaded': True})
+
+    # Test that the main edition *did not* update because this build is
+    # neither for master not a semantic version.
+    # with semantic versions
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b1_url
+
+    # ========================================================================
+    # Create a build with a newer weekly release tag that is tracked
+    b3_data = {
+        'slug': 'b3',
+        'github_requester': 'jonathansick',
+        'git_refs': ['w_2018_02']
+    }
+    r = client.post('/products/pipelines/builds/', b3_data)
+    b3_url = r.headers['Location']
+    r = client.patch(b3_url, {'uploaded': True})
+
+    # Manually reset pending_rebuild (the rebuild_edition task would have
+    # done this automatically)
+    r = client.get(edition_url)
+    assert r.json['pending_rebuild'] is True
+    r = client.patch(edition_url, {'pending_rebuild': False})
+
+    # Test that the main edition updated
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url
+    assert r.json['pending_rebuild'] is False
+
+    # ========================================================================
+    # Create a build with a older weekly release tag that is not tracked
+    b4_data = {
+        'slug': 'b4',
+        'github_requester': 'jonathansick',
+        'git_refs': ['w_2017_36']
+    }
+    r = client.post('/products/pipelines/builds/', b4_data)
+    b4_url = r.headers['Location']
+    r = client.patch(b4_url, {'uploaded': True})
+
+    # Test that the main edition *did not* update because this build is
+    # neither for master not a semantic version.
+    # with semantic versions
+    r = client.get(edition_url)
+    assert r.json['build_url'] == b3_url


### PR DESCRIPTION
This release improves and expands the system of edition tracking modes.

There are three new tracking modes:

- ``eups_major_release`` tracks an EUPS major release tag (``vX_Y``) and its Git variant (``X.Y``).
- ``eups_weekly_release`` tracks an EUPS weekly release tag (``w_YYYY_WW``) and its Git variant (``w.YYYY.WW``).
- ``eups_daily_release`` tracks an EUPS daily release tag (``d_YYYY_MM_DD``) and its Git variant (``d.YYYY.MM.DD``).

In addition, the code for determining whether an edition should rebuild or not given the tracking mode has been refactored out of the ``Edition.should_rebuild`` model method and into a new ``keeper.editiontracking`` subpackage.
Each tracking mode is now built around a uniform interface.