### PR TITLE
DM-15072: Update to celery 4.2.0 and Python 3.6.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 matrix:
   include:
     # This is the ltd-mason documentation deployment build
-    - python: "3.5"
+    - python: "3.6"
       env: LTD_MASON_BUILD=true DEPLOY_DOCKER_IMAGE=true
 install:
   - "make install"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+1.12.0 (2017-07-10)
+===================
+
+- Update to Python 3.6.6 (in Docker base image and Travis).
+- Update boto to 1.7.54 (for Python 3.6.6 compatibility).
+- Update Celery to 4.2.0 (to fix a compatibility issue with Kombu 4.2's release).
+
 1.11.0 (2018-07-09)
 ===================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5.1
+FROM python:3.6.6
 
 MAINTAINER Jonathan Sick <jsick@lsst.org>
 LABEL description="API server for LSST the Docs" \

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.11.0"
+          image: "lsstsqre/ltd-keeper:1.12.0"
           ports:
             - containerPort: 3031
               name: keeper

--- a/kubernetes/keeper-mgmt-pod.yaml
+++ b/kubernetes/keeper-mgmt-pod.yaml
@@ -34,7 +34,7 @@ spec:
         mountPath: /etc/ssl/certs
 
     - name: uwsgi
-      image: "lsstsqre/ltd-keeper:1.11.0"
+      image: "lsstsqre/ltd-keeper:1.12.0"
       imagePullPolicy: "Always"
       # Container should do nothing on start; let the user access it
       # http://kubernetes.io/docs/user-guide/containers/#how-docker-handles-command-and-arguments

--- a/kubernetes/keeper-worker-deployment.yaml
+++ b/kubernetes/keeper-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 
         - name: keeper-worker
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.11.0"
+          image: "lsstsqre/ltd-keeper:1.12.0"
           command: ["/bin/bash"]
           args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
           volumeMounts:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ install_requires = [
     'boto3==1.2.3',
     'requests==2.18.4',
     'structlog==17.2.0',
-    'celery[redis]==4.1.0'
+    'celery[redis]==4.2.0'
 ]
 
 # Test dependencies

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,12 @@ author = 'Association of Universities for Research in Astronomy, Inc.'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 classifiers = [
-    'Development Status :: 5 - Production/Stable'
-    'Programming Language :: Python :: 3.5'
-    'Programming Language :: Python :: 3.6'
-    'License :: OSI Approved :: MIT License'
-    'Framework :: Flask'
-    'Intended Audience :: Science/Research'
-    'Topic :: Documentation'
+    'Development Status :: 5 - Production/Stable',
+    'Programming Language :: Python :: 3.6',
+    'License :: OSI Approved :: MIT License',
+    'Framework :: Flask',
+    'Intended Audience :: Science/Research',
+    'Topic :: Documentation',
 ],
 keywords = 'lsst lsst-the-docs'
 
@@ -45,7 +44,7 @@ install_requires = [
     'Flask-HTTPAuth==2.2.1',
     'Flask-Migrate==2.1.1',
     'python-dateutil==2.4.2',
-    'boto3==1.2.3',
+    'boto3==1.7.54',
     'requests==2.18.4',
     'structlog==17.2.0',
     'celery[redis]==4.2.0'


### PR DESCRIPTION
- Update to Python 3.6.6 (in Docker base image and Travis).
- Update boto to 1.7.54 (for Python 3.6.6 compatibility).
- Update Celery to 4.2.0 (to fix a compatibility issue with Kombu 4.2's release).

Fixes #36 