### PR TITLE
DM-15243: Add auto increment feature for edition slugs and 'manual' tracking mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,21 @@
 Change log
 ##########
 
-1.13.0 (2017-07-11)
+1.14.0 (2018-08-09)
+===================
+
+- New ``autoincrement`` feature for Edition slugs.
+  Now an edition can be created with ``autoincrement=True``.
+  Instead of passing a known slug, this features computes the next available integer slug.
+  This feature is designed for the notebook-based report system to create report instances with monotonically increasing instance numbers.
+
+- New ``manual`` tracking mode.
+  This mode ensures that an edition is *not* updated automatically with a new build.
+  The edition can only be updated with a manual PATCH requrest that modifies the build URL.
+
+`DM-15243 <https://jira.lsstcorp.org/browse/DM-15243>`__.
+
+1.13.0 (2018-07-11)
 ===================
 
 - Make an Edition's ``tracked_refs`` field ``None`` when its tracking mode is not ``git_refs`` (only the ``git_refs`` mode uses ``tracked_refs``).
@@ -10,7 +24,7 @@ Change log
 
 `DM-15075 <https://jira.lsstcorp.org/browse/DM-15075>`__.
 
-1.12.0 (2017-07-10)
+1.12.0 (2018-07-10)
 ===================
 
 - Update to Python 3.6.6 (in Docker base image and Travis).

--- a/keeper/api_v1/editions.py
+++ b/keeper/api_v1/editions.py
@@ -65,7 +65,8 @@ def new_edition(slug):
     :param slug: Product slug.
 
     :<json string build_url: URL of the build entity this Edition uses.
-    :<json string slug: URL-safe name for edition.
+    :<json string slug: URL-safe name for edition. Don't include this field
+        when using ``autoincrement: true``.
     :<json string title: Human-readable name for edition.
     :<json str mode: Tracking mode.
        ``git_refs``: track the Git ref specified by ``tracked_refs``.
@@ -73,6 +74,9 @@ def new_edition(slug):
     :<json array tracked_refs: Git ref(s) that describe the version of the
         Product that this this Edition is intended to point to when using
         the ``git_refs`` tracking mode.
+    :<json bool autoincrement: Instead of providing a ``slug``, the server
+        automatically assigns an integer slug that is one larger than
+        existing slug integers. Starts from ``1``.
 
     :resheader Location: URL of the created Edition resource.
 

--- a/keeper/editiontracking/manualmode.py
+++ b/keeper/editiontracking/manualmode.py
@@ -1,0 +1,20 @@
+"""Mode that does not automatically update an edition.
+"""
+
+__all__ = ('ManualTrackingMode',)
+
+
+class ManualTrackingMode:
+    """Tracking mode that does not track (requires that an edition's build_url
+    be manually updated to update the edition).
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def name(self):
+        return 'manual'
+
+    def should_update(self, edition, candidate_build):
+        return False

--- a/keeper/editiontracking/trackingmodes.py
+++ b/keeper/editiontracking/trackingmodes.py
@@ -6,6 +6,7 @@ from .lsstdocmode import LsstDocTrackingMode
 from .eupsmajormode import EupsMajorReleaseTrackingMode
 from .eupsweeklymode import EupsWeeklyReleaseTrackingMode
 from .eupsdailymode import EupsDailyReleaseTrackingMode
+from .manualmode import ManualTrackingMode
 
 
 class EditionTrackingModes:
@@ -20,6 +21,7 @@ class EditionTrackingModes:
         3: EupsMajorReleaseTrackingMode(),
         4: EupsWeeklyReleaseTrackingMode(),
         5: EupsDailyReleaseTrackingMode(),
+        6: ManualTrackingMode(),
     }
     """Map of tracking mode ID (an integer stored in the DB to the tracking
     mode instance that can evaluate whether an edition should be updated

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.13.0"
+          image: "lsstsqre/ltd-keeper:1.14.0"
           ports:
             - containerPort: 3031
               name: keeper

--- a/kubernetes/keeper-mgmt-pod.yaml
+++ b/kubernetes/keeper-mgmt-pod.yaml
@@ -34,7 +34,7 @@ spec:
         mountPath: /etc/ssl/certs
 
     - name: uwsgi
-      image: "lsstsqre/ltd-keeper:1.13.0"
+      image: "lsstsqre/ltd-keeper:1.14.0"
       imagePullPolicy: "Always"
       # Container should do nothing on start; let the user access it
       # http://kubernetes.io/docs/user-guide/containers/#how-docker-handles-command-and-arguments

--- a/kubernetes/keeper-worker-deployment.yaml
+++ b/kubernetes/keeper-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 
         - name: keeper-worker
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.13.0"
+          image: "lsstsqre/ltd-keeper:1.14.0"
           command: ["/bin/bash"]
           args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
           volumeMounts:

--- a/tests/test_editions_autoincrement.py
+++ b/tests/test_editions_autoincrement.py
@@ -1,0 +1,141 @@
+"""Test making editions where their slug is a monotonically increasing integer,
+using the autoincrement=True feature.
+"""
+
+
+def test_editions_autoincrement(client, mocker):
+    """Test creating editions with autoincrement=True.
+    """
+    mocks = {}
+    mocks['product_append_task'] = mocker.patch(
+        'keeper.api_v1.products.append_task_to_chain')
+    mocks['product_launch_chain'] = mocker.patch(
+        'keeper.api_v1.products.launch_task_chain')
+    mocks['mocked_build_append_task'] = mocker.patch(
+        'keeper.api_v1.builds.append_task_to_chain')
+    mocks['mocked_build_launch_chain'] = mocker.patch(
+        'keeper.api_v1.builds.launch_task_chain')
+    mocks['mocked_models_append_task'] = mocker.patch(
+        'keeper.models.append_task_to_chain')
+    mocks['mocked_edition_append_task'] = mocker.patch(
+        'keeper.api_v1.editions.append_task_to_chain')
+    mocks['mocked_edition_launch_chain'] = mocker.patch(
+        'keeper.api_v1.editions.launch_task_chain')
+
+    # ========================================================================
+    # Add product /products/testr-000
+    mocker.resetall()
+
+    p = {'slug': 'testr-000',
+         'doc_repo': 'https://github.com/lsst/TESTR-000',
+         'title': 'Demo test report',
+         'root_domain': 'lsst.io',
+         'root_fastly_domain': 'global.ssl.fastly.net',
+         'bucket_name': 'bucket-name',
+         'main_mode': 'manual'}
+    r = client.post('/products/', p)
+    product_url = r.headers['Location']
+
+    # ========================================================================
+    # Get default edition
+    # mocker.resetall()
+
+    # edition_urls = client.get('/products/pipelines/editions/').json
+    # e0_url = edition_urls['editions'][0]
+
+    # ========================================================================
+    # Create first autoincremented edition
+    mocker.resetall()
+
+    response = client.post(
+        product_url + '/editions/',
+        {
+            'autoincrement': 'True',
+            'mode': 'manual',
+        })
+    assert response.status == 201
+    e1_url = response.headers['Location']
+
+    # ========================================================================
+    # Get first autoincremented edition
+    mocker.resetall()
+
+    response = client.get(e1_url)
+    assert response.status == 200
+    assert response.json['self_url'] == e1_url
+    assert response.json['slug'] == '1'
+    assert response.json['title'] == '1'
+    assert response.json['mode'] == 'manual'
+
+    # ========================================================================
+    # Create second autoincremented edition
+    mocker.resetall()
+
+    response = client.post(
+        product_url + '/editions/',
+        {
+            'autoincrement': 'True',
+            'mode': 'manual',
+        })
+    assert response.status == 201
+    e2_url = response.headers['Location']
+
+    # ========================================================================
+    # Get second autoincremented edition
+    mocker.resetall()
+
+    response = client.get(e2_url)
+    assert response.status == 200
+    assert response.json['self_url'] == e2_url
+    assert response.json['slug'] == '2'
+    assert response.json['title'] == '2'
+    assert response.json['mode'] == 'manual'
+
+    # ========================================================================
+    # Create a regular (git_ref tracking) edition
+    mocker.resetall()
+
+    response = client.post(
+        product_url + '/editions/',
+        {
+            'tracked_refs': ['v1.0'],
+            'slug': 'v1.0',
+            'title': 'v1.0'
+        })
+    assert response.status == 201
+    e3_url = response.headers['Location']
+
+    # ========================================================================
+    # Get that v1.0 edition
+    mocker.resetall()
+
+    response = client.get(e3_url)
+    assert response.status == 200
+    assert response.json['self_url'] == e3_url
+    assert response.json['slug'] == 'v1.0'
+    assert response.json['title'] == 'v1.0'
+    assert response.json['mode'] == 'git_refs'
+
+    # ========================================================================
+    # Create third autoincremented edition
+    mocker.resetall()
+
+    response = client.post(
+        product_url + '/editions/',
+        {
+            'autoincrement': 'True',
+            'mode': 'manual',
+        })
+    assert response.status == 201
+    e4_url = response.headers['Location']
+
+    # ========================================================================
+    # Get third autoincremented edition
+    mocker.resetall()
+
+    response = client.get(e4_url)
+    assert response.status == 200
+    assert response.json['self_url'] == e4_url
+    assert response.json['slug'] == '3'
+    assert response.json['title'] == '3'
+    assert response.json['mode'] == 'manual'

--- a/tests/test_manualmode.py
+++ b/tests/test_manualmode.py
@@ -1,0 +1,17 @@
+"""Test the manual tracking mode.
+"""
+
+from keeper.editiontracking.trackingmodes import EditionTrackingModes
+
+
+def test_manual_mode():
+    """Test the ManualTrackingMode.
+    """
+    modes = EditionTrackingModes()
+
+    mode = modes['manual']
+
+    assert mode.name == 'manual'
+
+    # Never returns True, by definition
+    assert mode.should_update(None, None) is False


### PR DESCRIPTION
This PR adds features needed by the new notebook-based report system (https://github.com/lsst-sqre/sqre-uservice-nbreport)

- New `autoincrement=True` field when creating editions that automatically assigns a monotonically increasing integer slug to the edition (and auto-assigns a title).

- New `manual` tracking mode that prevents an edition from automatically updating with new builds. Users can still update the edition manually using a PATCH.