### PR TITLE
DM-15416: Fix issue with new builds corresponding to "manual" editions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+1.14.1 (2018-08-12)
+===================
+
+- Removed unneeded code from the ``new_build`` route that was throwing an error if the build corresponded to an edition with a manual tracking mode (as opposed to Git refs).
+
+`DM-15416 <https://jira.lsstcorp.org/browse/DM-15416>`__.
+
 1.14.0 (2018-08-09)
 ===================
 

--- a/keeper/api_v1/builds.py
+++ b/keeper/api_v1/builds.py
@@ -166,18 +166,12 @@ def new_build(slug):
             db.session.add(edition)
             db.session.commit()
 
-            edition_id = edition.id
-
             logger.info('Created edition',
                         url=edition.get_url(),
                         id=edition.id,
                         tracked_refs=edition.tracked_refs)
         except Exception:
             db.session.rollback()
-
-        # try to get that edition again
-        edition_test = Edition.query.get(edition_id)
-        logger.debug('Got edition', value=edition_test, id=edition_id)
 
     # Run the task queue
     append_task_to_chain(build_dashboard.si(product_url))

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.14.0"
+          image: "lsstsqre/ltd-keeper:1.14.1"
           ports:
             - containerPort: 3031
               name: keeper

--- a/kubernetes/keeper-mgmt-pod.yaml
+++ b/kubernetes/keeper-mgmt-pod.yaml
@@ -34,7 +34,7 @@ spec:
         mountPath: /etc/ssl/certs
 
     - name: uwsgi
-      image: "lsstsqre/ltd-keeper:1.14.0"
+      image: "lsstsqre/ltd-keeper:1.14.1"
       imagePullPolicy: "Always"
       # Container should do nothing on start; let the user access it
       # http://kubernetes.io/docs/user-guide/containers/#how-docker-handles-command-and-arguments

--- a/kubernetes/keeper-worker-deployment.yaml
+++ b/kubernetes/keeper-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 
         - name: keeper-worker
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.14.0"
+          image: "lsstsqre/ltd-keeper:1.14.1"
           command: ["/bin/bash"]
           args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
           volumeMounts:


### PR DESCRIPTION
Removed unneeded code from the ``new_build`` route that was throwing an error if the build corresponded to an edition with a manual tracking mode (as opposed to Git refs).