### PR TITLE
DM-15518: Handle deletions when there are more than 1000 files in an edition

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Change log
 ##########
 
+1.14.2 (2018-10-08)
+===================
+
+- Fixes a bug in ``keeper.s3.delete_directory`` related to "directories" that have 1000 or more objects.
+  The S3 and Boto APIs for deleting objects cannot handle more than 1000 object keys at once.
+  Now this function internally paginates over objects to bypass this limitation.
+
+- Adds an experimental Kubernetes deployment of Flower_ to help monitor the Celery task queue.
+
+`DM-15518 <https://jira.lsstcorp.org/browse/DM-15518>`__.
+
 1.14.1 (2018-08-12)
 ===================
 
@@ -19,7 +30,7 @@ Change log
 
 - New ``manual`` tracking mode.
   This mode ensures that an edition is *not* updated automatically with a new build.
-  The edition can only be updated with a manual PATCH requrest that modifies the build URL.
+  The edition can only be updated with a manual PATCH request that modifies the build URL.
 
 `DM-15243 <https://jira.lsstcorp.org/browse/DM-15243>`__.
 
@@ -308,3 +319,5 @@ Interaction with AWS S3 and Route53 with product provisioning and build uploads.
 First Flask application prototype and API design documentation.
 
 `DM-5100 <https://jira.lsst.org/ <https://jira.lsstcorp.org/browse/DM-5100>`__.
+
+.. _Flower: https://flower.readthedocs.io/

--- a/kubernetes/flower-deployment.yaml
+++ b/kubernetes/flower-deployment.yaml
@@ -1,0 +1,29 @@
+# Deployment of the Flower monitoring app for celery.
+# Connect to Flower using kubectl port forwarding:
+#   kubectl port-forward <pod> 8080:5555
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: flower
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: "flower"
+    spec:
+      containers:
+
+        - name: "flower"
+          imagePullPolicy: "Always"
+          # https://hub.docker.com/r/mher/flower/
+          image: "mher/flower:0.9"
+          command: ["flower", "--port 5555", "--broker=$(REDIS_URL)"]
+          ports:
+            - containerPort: 5555
+              name: "flower"
+          env:
+            # References the keeper-redis service
+            - name: REDIS_URL
+              value: "redis://keeper-redis:6379"

--- a/kubernetes/flower-service.yaml
+++ b/kubernetes/flower-service.yaml
@@ -1,0 +1,17 @@
+# This Services provides a cluster endpoint for the redis pod.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: flower
+  labels:
+    name: flower
+spec:
+  type: ClusterIP
+  ports:
+    - name: flower
+      protocol: TCP
+      port: 80
+      targetPort: flower
+  selector:
+    name: flower

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.14.1"
+          image: "lsstsqre/ltd-keeper:1.14.2"
           ports:
             - containerPort: 3031
               name: keeper

--- a/kubernetes/keeper-mgmt-pod.yaml
+++ b/kubernetes/keeper-mgmt-pod.yaml
@@ -34,7 +34,7 @@ spec:
         mountPath: /etc/ssl/certs
 
     - name: uwsgi
-      image: "lsstsqre/ltd-keeper:1.14.1"
+      image: "lsstsqre/ltd-keeper:1.14.2"
       imagePullPolicy: "Always"
       # Container should do nothing on start; let the user access it
       # http://kubernetes.io/docs/user-guide/containers/#how-docker-handles-command-and-arguments

--- a/kubernetes/keeper-worker-deployment.yaml
+++ b/kubernetes/keeper-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 
         - name: keeper-worker
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.14.1"
+          image: "lsstsqre/ltd-keeper:1.14.2"
           command: ["/bin/bash"]
           args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
           volumeMounts:


### PR DESCRIPTION
- Fixes a bug in `keeper.s3.delete_directory` related to "directories" that have 1000 or more objects.
  The S3 and Boto APIs for deleting objects cannot handle more than 1000 object keys at once.
  Now this function internally paginates over objects to bypass this limitation.

- Adds an experimental Kubernetes deployment of [Flower](https://flower.readthedocs.io/) to help monitor the Celery task queue.
