### PR TITLE
DM-16061: Handle cases when there are no objects to delete

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+1.14.3 (2018-10-09)
+===================
+
+- Fixes a problem with the new ``keeper.s3.delete_directory`` implementation when the S3 prefix has no corresponding objects.
+
+`DM-16061 <https://jira.lsstcorp.org/browse/DM-15518>`_
+
 1.14.2 (2018-10-08)
 ===================
 

--- a/keeper/s3.py
+++ b/keeper/s3.py
@@ -51,7 +51,10 @@ def delete_directory(bucket_name, root_path,
 
     keys = dict(Objects=[])
     for item in pages.search('Contents'):
-        keys['Objects'].append({'Key': item['Key']})
+        try:
+            keys['Objects'].append({'Key': item['Key']})
+        except TypeError:  # item is none; nothing to delete
+            continue
         # Delete immediately when 1000 objects are listed
         # the delete_objects method can only take a maximum of 1000 keys
         if len(keys['Objects']) >= 1000:
@@ -64,7 +67,7 @@ def delete_directory(bucket_name, root_path,
             keys = dict(Objects=[])
 
     # Delete remaining keys
-    if len(keys['Objects']):
+    if len(keys['Objects']) > 0:
         try:
             client.delete_objects(Bucket=bucket_name, Delete=keys)
         except Exception:

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.14.2"
+          image: "lsstsqre/ltd-keeper:1.14.3"
           ports:
             - containerPort: 3031
               name: keeper

--- a/kubernetes/keeper-mgmt-pod.yaml
+++ b/kubernetes/keeper-mgmt-pod.yaml
@@ -34,7 +34,7 @@ spec:
         mountPath: /etc/ssl/certs
 
     - name: uwsgi
-      image: "lsstsqre/ltd-keeper:1.14.2"
+      image: "lsstsqre/ltd-keeper:1.14.3"
       imagePullPolicy: "Always"
       # Container should do nothing on start; let the user access it
       # http://kubernetes.io/docs/user-guide/containers/#how-docker-handles-command-and-arguments

--- a/kubernetes/keeper-worker-deployment.yaml
+++ b/kubernetes/keeper-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
 
         - name: keeper-worker
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.14.2"
+          image: "lsstsqre/ltd-keeper:1.14.3"
           command: ["/bin/bash"]
           args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
           volumeMounts:

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -76,6 +76,12 @@ def test_delete_directory(request):
         else:
             assert bucket_path in bucket_paths
 
+    # Attempt to delete an empty prefix. Ensure it does not raise an exception.
+    delete_directory(os.getenv('LTD_KEEPER_TEST_BUCKET'),
+                     bucket_root + 'empty-prefix/',
+                     os.getenv('LTD_KEEPER_TEST_AWS_ID'),
+                     os.getenv('LTD_KEEPER_TEST_AWS_SECRET'))
+
 
 @pytest.mark.skipif(os.getenv('LTD_KEEPER_TEST_AWS_ID') is None or
                     os.getenv('LTD_KEEPER_TEST_AWS_SECRET') is None or


### PR DESCRIPTION
Fixes a problem with the new `keeper.s3.delete_directory` implementation when the S3 prefix has no corresponding objects.