### PR TITLE
DM-20487: Improve testing of the lsst_doc tracking mode scenario

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+Unreleased
+==========
+
+- Added additional tests to ensure that editions tracking ``master`` branches were automatically being created for documents using the ``lsst_doc`` tracking mode for the main edition.
+  No application fixes were required.
+  [`DM-20487 <https://jira.lsst.org/browse/DM-20487>`_]
+
 1.15.0 (2019-07-08)
 ===================
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018 Association of Universities for Research in Astronomy
+Copyright (c) 2016-2019 Association of Universities for Research in Astronomy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,6 @@ The documentation covers both the REST API consumption and DevOps perspectives.
 
 ****
 
-Copyright 2016–2018 Association of Universities for Research in Astronomy
-
 MIT license. See the LICENSE file. See also licenses/ for licenses of third-party code.
 
 .. _SQR-006: https://sqr-006.lsst.io

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'LTD Keeper'
-copyright = '2016–2018, Association of Universities for Research in Astronomy'
+copyright = '2016–2019, Association of Universities for Research in Astronomy'
 author = 'Association of Universities for Research in Astronomy'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Added additional tests to ensure that editions tracking ``master`` branches were automatically being created for documents using the ``lsst_doc`` tracking mode for the main edition. No application fixes were required.
