### PR TITLE
DM-20901: Fix automatic edition creation with v2 routes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,11 @@
 Change log
 ##########
 
-Unreleased
-==========
+1.15.1 (2019-08-06)
+===================
+
+- Fixed a bug that prevented logging configuration and authorization tests with the "v2" endpoint for ``POST products/<product>/builds/``.
+  [`DM-20768 <https://jira.lsst.org/browse/DM-20768>`_]
 
 - Added additional tests to ensure that editions tracking ``master`` branches were automatically being created for documents using the ``lsst_doc`` tracking mode for the main edition.
   No application fixes were required.

--- a/keeper/api/post_products_builds.py
+++ b/keeper/api/post_products_builds.py
@@ -157,6 +157,9 @@ def post_products_builds_v1(slug):
 
 
 @post_products_builds_v1.support(v2_json_type)
+@log_route()
+@token_auth.login_required
+@permission_required(Permission.UPLOAD_BUILD)
 def post_products_builds_v2(slug):
     """Handle POST /products/../builds/ (version 2).
     """

--- a/keeper/api/post_products_builds.py
+++ b/keeper/api/post_products_builds.py
@@ -291,12 +291,17 @@ def _create_edition(product, build):
             db.session.add(edition)
             db.session.commit()
 
-            logger.info('Created edition',
+            logger.info('Created edition because of a build',
                         url=edition.get_url(),
                         id=edition.id,
                         tracked_refs=edition.tracked_refs)
         except Exception:
+            logger.exception('Error while automatically creating an edition')
             db.session.rollback()
+    else:
+        logger.info('Did not create a new edition because of a build',
+                    authorized=is_authorized(Permission.ADMIN_EDITION),
+                    edition_count=edition_count)
     if edition:
         return edition
 

--- a/kubernetes/keeper-deployment.yaml
+++ b/kubernetes/keeper-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
         - name: uwsgi
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.15.0"
+          image: "lsstsqre/ltd-keeper:1.15.1"
           ports:
             - containerPort: 3031
               name: keeper


### PR DESCRIPTION
Fixed a bug that prevented logging configuration and authorization tests with the "v2" endpoint for `POST products/<product>/builds/`.