### PR TITLE
DM-21494: Support deployments with Kustomize

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,20 @@
 Change log
 ##########
 
+1.16.0 (2019-10-06)
+===================
+
+- Introduced a new Kustomize-based deployment for LTD Keeper in the ``/manifests/`` repository directory.
+  This deployment is designed to work with the Roundtable application platform.
+  See LSST the Docs's deployment on Roundtable at https://github.com/lsst-sqre/roundtable/tree/master/deployments/lsst-the-docs.
+
+- Dropped the Nginx pod from the ``keeper`` pod.
+  Now we assume that LTD Keeper is being deployed behind a solid reverse proxy, such as ``nginx-ingress``, and that we don't need to introduce yet another webserver into the stack.
+
+- Since nginx is no longer in the application pod, we switch uWSGI to use the ``http-socket`` mode instead of ``socket``.
+
+[`DM-21494 <https://jira.lsst.org/browse/DM-21494>`_]
+
 1.15.1 (2019-08-06)
 ===================
 

--- a/manifests/keeper-cm.yaml
+++ b/manifests/keeper-cm.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keeper
+data:
+  profile: "production"
+  # <project>.<region>.<instance_name>
+  cloud-sql-instance: "plasma-geode-127520:us-central1:ltd-sql-1"
+  url-scheme: "https"
+  # Cluster DNS url to LTD Dasher
+  dasher-url: "http://dasher:3031"
+  log-level: "INFO"

--- a/manifests/keeper-deployment.yaml
+++ b/manifests/keeper-deployment.yaml
@@ -1,0 +1,229 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keeper-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      name: keeper-api
+  template:
+    metadata:
+      labels:
+        name: keeper-api
+    spec:
+      containers:
+
+        - name: cloudsql-proxy
+          image: b.gcr.io/cloudsql-docker/gce-proxy:1.05
+          command: ["/cloud_sql_proxy", "-dir=/cloudsql", "-credential_file=/secret/file.json", "-instances=$(CLOUD_SQL_INSTANCE)"]
+          env:
+          - name: CLOUD_SQL_INSTANCE
+            valueFrom:
+              configMapKeyRef:
+                name: keeper
+                key: cloud-sql-instance
+          volumeMounts:
+          - name: cloudsql
+            mountPath: /cloudsql
+          - name: cloudsql-secret-volume
+            mountPath: /secret/
+          - name: cloudsql-ssl-certs
+            mountPath: /etc/ssl/certs
+
+        - name: app
+          imagePullPolicy: "Always"
+          image: "lsstsqre/ltd-keeper:tickets-DM-21494"
+          ports:
+            - containerPort: 3031
+              name: keeper-uwsgi
+          volumeMounts:
+            - name: cloudsql
+              mountPath: /cloudsql
+          env:
+            # References the keeper-redis service
+            - name: REDIS_URL
+              value: "redis://keeper-redis:6379"
+            # Environment variables from the keeper configmap
+            - name: LTD_KEEPER_PROFILE
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: profile
+            - name: LTD_KEEPER_URL_SCHEME
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: url-scheme
+            - name: LTD_DASHER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: dasher-url
+            # Environment variables from the keeper secret
+            - name: LTD_KEEPER_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: secret-key
+            - name: LTD_KEEPER_AWS_ID
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: aws-id
+            - name: LTD_KEEPER_AWS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: aws-secret
+            - name: LTD_KEEPER_FASTLY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: fastly-id
+            - name: LTD_KEEPER_FASTLY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: fastly-key
+            - name: LTD_KEEPER_BOOTSTRAP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: default-user
+            - name: LTD_KEEPER_BOOTSTRAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: default-password
+            - name: LTD_KEEPER_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: db-url
+
+      volumes:
+        - name: cloudsql-secret-volume
+          secret:
+            secretName: cloudsql
+        - name: cloudsql-ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
+        - name: cloudsql
+          emptyDir: {}
+
+---
+# Deployment of celery workers for keeper
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keeper-worker-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      name: keeper-worker
+  template:
+    metadata:
+      labels:
+        name: keeper-worker
+    spec:
+      containers:
+
+        - name: cloudsql-proxy
+          image: b.gcr.io/cloudsql-docker/gce-proxy:1.05
+          command: ["/cloud_sql_proxy", "-dir=/cloudsql", "-credential_file=/secret/file.json", "-instances=$(CLOUD_SQL_INSTANCE)"]
+          env:
+          - name: CLOUD_SQL_INSTANCE
+            valueFrom:
+              configMapKeyRef:
+                name: keeper
+                key: cloud-sql-instance
+          volumeMounts:
+          - name: cloudsql
+            mountPath: /cloudsql
+          - name: cloudsql-secret-volume
+            mountPath: /secret/
+          - name: cloudsql-ssl-certs
+            mountPath: /etc/ssl/certs
+
+        - name: app
+          imagePullPolicy: "Always"
+          image: "lsstsqre/ltd-keeper:tickets-DM-21494"
+          command: ["/bin/bash"]
+          args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
+          volumeMounts:
+            - name: cloudsql
+              mountPath: /cloudsql
+          env:
+            # References the keeper-redis service
+            - name: REDIS_URL
+              value: "redis://keeper-redis:6379"
+            # Environment variables from the keeper configmap
+            - name: LTD_KEEPER_PROFILE
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: profile
+            - name: LTD_KEEPER_URL_SCHEME
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: url-scheme
+            - name: LTD_DASHER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: keeper
+                  key: dasher-url
+            # Environment variables from the keeper secret
+            - name: LTD_KEEPER_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: secret-key
+            - name: LTD_KEEPER_AWS_ID
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: aws-id
+            - name: LTD_KEEPER_AWS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: aws-secret
+            - name: LTD_KEEPER_FASTLY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: fastly-id
+            - name: LTD_KEEPER_FASTLY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: fastly-key
+            - name: LTD_KEEPER_BOOTSTRAP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: default-user
+            - name: LTD_KEEPER_BOOTSTRAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: default-password
+            - name: LTD_KEEPER_DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: keeper
+                  key: db-url
+
+      volumes:
+        - name: cloudsql-secret-volume
+          secret:
+            secretName: cloudsql
+        - name: cloudsql-ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
+        - name: cloudsql
+          emptyDir: {}

--- a/manifests/keeper-deployment.yaml
+++ b/manifests/keeper-deployment.yaml
@@ -34,7 +34,7 @@ spec:
 
         - name: app
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:tickets-DM-21494"
+          image: "lsstsqre/ltd-keeper:1.16.0"
           ports:
             - containerPort: 3031
               name: keeper-uwsgi
@@ -150,7 +150,7 @@ spec:
 
         - name: app
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:tickets-DM-21494"
+          image: "lsstsqre/ltd-keeper:1.16.0"
           command: ["/bin/bash"]
           args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
           volumeMounts:

--- a/manifests/keeper-service.yaml
+++ b/manifests/keeper-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: keeper
+  labels:
+    name: keeper
+spec:
+  ports:
+    - name: keeper-http
+      protocol: TCP
+      port: 8080
+      targetPort: keeper-uwsgi
+  selector:
+    name: keeper-api

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - keeper-cm.yaml
+  - redis-deployment.yaml
+  - redis-service.yaml
+  - keeper-deployment.yaml
+  - keeper-service.yaml

--- a/manifests/redis-deployment.yaml
+++ b/manifests/redis-deployment.yaml
@@ -1,0 +1,28 @@
+# Deployment of a redis DB.
+#
+# This deployment isn't high-availability, nor does it have persistent storage.
+# Those features may be added in the future (particularly by replacing this
+# deployment with a HA Redis Helm chart.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keeper-redis
+spec:
+  replicas: 1  # Don't scale this deployment up
+  selector:
+    matchLabels:
+      name: keeper-redis
+  template:
+    metadata:
+      labels:
+        name: "keeper-redis"
+    spec:
+      containers:
+
+        - name: "redis"
+          imagePullPolicy: "Always"
+          image: "redis:4-alpine"
+          ports:
+            - containerPort: 6379
+              name: "keeper-redis"

--- a/manifests/redis-service.yaml
+++ b/manifests/redis-service.yaml
@@ -1,0 +1,17 @@
+# This Services provides a cluster endpoint for the redis pod.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: keeper-redis
+  labels:
+    name: keeper-redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: keeper-redis
+      protocol: TCP
+      port: 6379
+      targetPort: keeper-redis
+  selector:
+    name: keeper-redis

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,6 +1,14 @@
 [uwsgi]
-socket = :3031
 module = keeper
 callable = flask_app
+
 processes = 4
 threads = 2
+
+http-socket = :3031
+http-enable-proxy-protocol = 1
+http-auto-chunked = true
+http-keepalive = 75
+http-timeout = 75
+stats = :1717
+stats-http = 1


### PR DESCRIPTION
- Introduced a new Kustomize-based deployment for LTD Keeper in the `/manifests/` repository directory. This deployment is designed to work with the Roundtable application platform. See LSST the Docs's deployment on Roundtable at https://github.com/lsst-sqre/roundtable/tree/master/deployments/lsst-the-docs.
- Dropped the Nginx pod from the `keeper` pod. Now we assume that LTD Keeper is being deployed behind a solid reverse proxy, such as `nginx-ingress`, and that we don't need to introduce yet another webserver into the stack.
- Since Nginx is no longer in the application pod, we switch uWSGI to use the `http-socket` mode instead of ``socket``.

To be released as 1.16.0.