### PR TITLE
DM-23899: Send an edition.updated webhook to LTD Events (1.18.0 release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Change log
 ##########
 
+1.18.0 (2020-03-20)
+===================
+
+- This version adds initial support for `LTD Events <https://github.com/lsst-sqre/ltd-events>`_, which acts as an adapter between LSST the Docs and the SQuaRE Events (Kafka) messaging system in the `Roundtable <https://roundtable.lsst.io>`_ platform.
+  Now, when an edition is updated, LTD Keeper sends an ``edition.updated`` payload to the LTD Events webhook endpoint.
+
+  More event types will be added in the future.
+
+  The LTD Events webhook endpoint is configured through the ``LTD_EVENTS_URL`` environment variable.
+  If this environment variable is left unset, a webhook request isn't sent.
+
+[`DM-23899 <https://jira.lsst.org/browse/DM-23899>`__]
+
 1.17.0 (2019-11-14)
 ===================
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2019 Association of Universities for Research in Astronomy
+Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,8 +56,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'LTD Keeper'
-copyright = '2016–2019, Association of Universities for Research in Astronomy'
-author = 'Association of Universities for Research in Astronomy'
+copyright = '2016–2020, Association of Universities for Research in Astronomy, Inc. (AURA)'
+author = 'Association of Universities for Research in Astronomy, Inc. (AURA)'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/keeper/config.py
+++ b/keeper/config.py
@@ -29,6 +29,7 @@ class Config(object):
     LTD_DASHER_URL = os.getenv('LTD_DASHER_URL', None)
     CELERY_RESULT_URL = os.getenv('REDIS_URL', 'redis://localhost:6379')
     CELERY_BROKER_URL = os.getenv('REDIS_URL', 'redis://localhost:6379')
+    LTD_EVENTS_URL = os.getenv('LTD_EVENTS_URL', None)
 
     # Suppresses a warning until Flask-SQLAlchemy 3
     # See http://stackoverflow.com/a/33790196

--- a/manifests/keeper-deployment.yaml
+++ b/manifests/keeper-deployment.yaml
@@ -34,7 +34,7 @@ spec:
 
         - name: app
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.17.0"
+          image: "lsstsqre/ltd-keeper:1.18.0"
           ports:
             - containerPort: 3031
               name: keeper-uwsgi
@@ -150,7 +150,7 @@ spec:
 
         - name: app
           imagePullPolicy: "Always"
-          image: "lsstsqre/ltd-keeper:1.17.0"
+          image: "lsstsqre/ltd-keeper:1.18.0"
           command: ["/bin/bash"]
           args: ["-c", "/ltd-keeper/run-celery-worker.bash"]
           volumeMounts:


### PR DESCRIPTION
This version adds initial support for [LTD Events](https://github.com/lsst-sqre/ltd-events), which acts as an adapter between LSST the Docs and the SQuaRE Events (Kafka) messaging system in the [Roundtable](https://roundtable.lsst.io) platform. Now, when an edition is updated, LTD Keeper sends an `edition.updated` payload to the LTD Events webhook endpoint.

More event types will be added in the future.

The LTD Events webhook endpoint is configured through the `LTD_EVENTS_URL` environment variable. If this environment variable is left unset, a webhook request isn't sent.

Related LTD Events PR: https://github.com/lsst-sqre/ltd-events/pull/1