### PR TITLE
DM-25740: Respect X-Forwarded-Proto header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+1.19.0 (2020-07-01)
+===================
+
+- ``LTD_KEEPER_PROXY_FIX`` environment lets you toggle the Werkzeug ProxyFix middleware trust the ``X-Forwarded-`` headers from proxy servers (default is "0", or "off").
+  The ``LTD_KEEPER_TRUST_X_FOR``, ``LTD_KEEPER_TRUST_X_PROTO``, ``LTD_KEEPER_TRUST_X_HOST``, ``LTD_KEEPER_TRUST_X_PORT``, and ``LTD_KEEPER_TRUST_X_PREFIX`` environment variable settings specify the number of proxies to trust for the given the header when ``LTD_KEEPER_PROXY_FIX`` is enabled.
+
+
 1.18.0 (2020-03-20)
 ===================
 

--- a/keeper/config.py
+++ b/keeper/config.py
@@ -35,6 +35,36 @@ class Config(object):
     # See http://stackoverflow.com/a/33790196
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    PROXY_FIX = bool(int(os.getenv("LTD_KEEPER_PROXY_FIX", "0")))
+    """Activate the Werkzeug ProxyFix middleware by setting to 1.
+
+    Only activate this middleware when LTD Keeper is deployed behind a
+    trusted proxy.
+
+    Related configurations:
+
+    - ``TRUST_X_FOR``
+    - ``TRUST_X_PROTO``
+    - ``TRUST_X_HOST``
+    - ``TRUST_X_PORT``
+    - ``TRUST_X_PREFIX``
+    """
+
+    TRUST_X_FOR = int(os.getenv("LTD_KEEPER_X_FOR", "1"))
+    """Number of values to trust for X-Forwarded-For."""
+
+    TRUST_X_PROTO = int(os.getenv("LTD_KEEPER_X_PROTO", "1"))
+    """Number of values to trust for X-Forwarded-Proto."""
+
+    TRUST_X_HOST = int(os.getenv("LTD_KEEPER_X_HOST", "1"))
+    """Number of values to trust for X-Forwarded-Host."""
+
+    TRUST_X_PORT = int(os.getenv("LTD_KEEPER_X_PORT", "0"))
+    """Number of values to trust for X-Forwarded-Port."""
+
+    TRUST_X_PREFIX = int(os.getenv("LTD_KEEPER_X_PREFIX", "0"))
+    """Number of values to trust for X-Forwarded-Prefix."""
+
     @abc.abstractclassmethod
     def init_app(cls, app):
         pass

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -7,3 +7,7 @@ resources:
   - redis-service.yaml
   - keeper-deployment.yaml
   - keeper-service.yaml
+
+images:
+  - name: lsstsqre/ltd-keeper
+    newTag: tickets-DM-25740

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup_requires = [
 
 # Installation (application runtime) requirements
 install_requires = [
-    'Flask==1.0.3',
+    'Flask==1.1.2',
     'uWSGI==2.0.18',
     'Flask-SQLAlchemy==2.4.0',
     'SQLAlchemy==1.3.4',

--- a/setup.py
+++ b/setup.py
@@ -54,12 +54,12 @@ install_requires = [
 
 # Test dependencies
 tests_require = [
-    'pytest==3.6.3',
-    'pytest-cov==2.7.1',
-    'pytest-flake8==1.0.4',
+    'pytest==5.4.3',
+    'pytest-cov==2.10.0',
+    'pytest-flake8==1.0.6',
     'responses==0.10.6',
-    'pytest-mock==1.10.4',
-    'mock==3.0.5',
+    'pytest-mock==3.1.1',
+    'mock==4.0.2',
 ]
 
 # Sphinx documentation requirements


### PR DESCRIPTION
When operating behind a trusted proxy, we want to use the `X-Forwarded-` headers from the proxy to set the hostname and scheme for the API's URLs. The `PROXY_FIX` environment variable lets you toggle the Werkzeug [ProxyFix](https://werkzeug.palletsprojects.com/en/1.0.x/middleware/proxy_fix/#werkzeug.middleware.proxy_fix.ProxyFix) middleware
to do just that (default is "0", or "off").

The `TRUST_X_FOR`, `TRUST_X_PROTO`, `TRUST_X_HOST`, `TRUST_X_PORT`, and `TRUST_X_PREFIX` environment variable settings specify the number of proxies to trust for the given the header when `PROXY_FIX` is enabled.
