### PR TITLE
DM-27608: Fix lsstdoc tracking mode with double-digit version components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change log
 ##########
 
+1.20.1 (2020-11-16)
+===================
+
+Fixes the "lsstdoc" tracking mode, where version strings with double-digit numbers weren't being parsed correctly.
+
 1.20.0 (2020-08-27)
 ===================
 

--- a/keeper/editiontracking/lsstdocmode.py
+++ b/keeper/editiontracking/lsstdocmode.py
@@ -103,8 +103,15 @@ class LsstDocVersionTag:
             raise ValueError(
                 "{:r} is not a LSST document version tag".format(version_str)
             )
-        self.major = int(match.group("major"))
-        self.minor = int(match.group("minor"))
+        self.version = (int(match.group("major")), int(match.group("minor")))
+
+    @property
+    def major(self) -> int:
+        return self.version[0]
+
+    @property
+    def minor(self) -> int:
+        return self.version[1]
 
     def __repr__(self) -> str:
         return "LsstDocVersion({:r})".format(self.version_str)
@@ -115,7 +122,7 @@ class LsstDocVersionTag:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, LsstDocVersionTag):
             raise NotImplementedError
-        return self.major == other.major and self.minor == other.minor
+        return self.version == other.version
 
     def __ne__(self, other: object) -> bool:
         if not isinstance(other, LsstDocVersionTag):
@@ -126,10 +133,8 @@ class LsstDocVersionTag:
         if not isinstance(other, LsstDocVersionTag):
             raise NotImplementedError
 
-        if self.major > other.major:
+        if self.version > other.version:
             return True
-        elif self.major == other.major:
-            return self.minor > other.minor
         else:
             return False
 

--- a/keeper/editiontracking/lsstdocmode.py
+++ b/keeper/editiontracking/lsstdocmode.py
@@ -22,7 +22,7 @@ DOCUSHARE_PATTERN = re.compile(r"docushare-v(?P<version>[\d\.]+)")
 
 # The RFC-405/LPM-51 format for LSST semantic document versions.
 # v<minor>.<major>
-LSST_DOC_V_TAG = re.compile(r"^v(?P<major>[\d+])\.(?P<minor>[\d+])$")
+LSST_DOC_V_TAG = re.compile(r"^v(?P<major>[\d]+)\.(?P<minor>[\d]+)$")
 
 
 class LsstDocTrackingMode(TrackingModeBase):

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 
 images:
   - name: lsstsqre/ltd-keeper
-    newTag: 1.20.0
+    newTag: 1.20.1

--- a/tests/test_lsstdocmode.py
+++ b/tests/test_lsstdocmode.py
@@ -11,6 +11,11 @@ def test_lsst_doc_tag() -> None:
     assert version.major == 1
     assert version.minor == 2
 
+    version10 = LsstDocVersionTag("v10.2")
+
+    assert version10.major == 10
+    assert version10.minor == 2
+
 
 def test_invalid_lsst_doc_tag() -> None:
     with pytest.raises(ValueError):

--- a/tests/test_lsstdocmode.py
+++ b/tests/test_lsstdocmode.py
@@ -17,6 +17,13 @@ def test_lsst_doc_tag() -> None:
     assert version10.minor == 2
 
 
+def test_lsst_doc_tag_order() -> None:
+    v39 = LsstDocVersionTag("v3.9")
+    v311 = LsstDocVersionTag("v3.11")
+
+    assert v311 > v39
+
+
 def test_invalid_lsst_doc_tag() -> None:
     with pytest.raises(ValueError):
         LsstDocVersionTag("1.2")


### PR DESCRIPTION
Fixes the "lsstdoc" tracking mode, where version strings with double-digit numbers weren't being parsed correctly.