### PR TITLE
DM-27608: Fix docker image name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,23 +88,23 @@ jobs:
 
       - name: Pull previous images
         run: |
-          docker pull lsstsqre/example:deps-${{steps.vars.outputs.tag}} || true
-          docker pull lsstsqre/example:${{steps.vars.outputs.tag}} || true
+          docker pull lsstsqre/ltd-keeper:deps-${{steps.vars.outputs.tag}} || true
+          docker pull lsstsqre/ltd-keeper:${{steps.vars.outputs.tag}} || true
 
       - name: Build the dependencies Docker image
         run: |
           docker build --target dependencies-image \
-            --cache-from=lsstsqre/example:deps-${{steps.vars.outputs.tag}} \
-            --tag lsstsqre/example:deps-${{steps.vars.outputs.tag}} .
+            --cache-from=lsstsqre/ltd-keeper:deps-${{steps.vars.outputs.tag}} \
+            --tag lsstsqre/ltd-keeper:deps-${{steps.vars.outputs.tag}} .
 
       - name: Build the runtime Docker image
         run: |
           docker build --target runtime-image \
-            --cache-from=lsstsqre/example:${{steps.vars.outputs.tag}} \
-            --tag lsstsqre/example:${{steps.vars.outputs.tag}} .
+            --cache-from=lsstsqre/ltd-keeper:${{steps.vars.outputs.tag}} \
+            --tag lsstsqre/ltd-keeper:${{steps.vars.outputs.tag}} .
 
       - name: Push Docker images
         if: ${{ github.event_name == 'push' }}
         run: |
-          docker push lsstsqre/example:deps-${{steps.vars.outputs.tag}}
-          docker push lsstsqre/example:${{steps.vars.outputs.tag}}
+          docker push lsstsqre/ltd-keeper:deps-${{steps.vars.outputs.tag}}
+          docker push lsstsqre/ltd-keeper:${{steps.vars.outputs.tag}}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change log
 ##########
 
+1.20.2 (2011-11-16)
+===================
+
+Fix name of Docker image in GitHub Actions CI workflow build job.
+
 1.20.1 (2020-11-16)
 ===================
 

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 
 images:
   - name: lsstsqre/ltd-keeper
-    newTag: 1.20.1
+    newTag: 1.20.2


### PR DESCRIPTION
This was missed in the initial conversion to GitHub Actions.