### PR TITLE
Add support for path-based project layouts

### DIFF
--- a/migrations/versions/8c431c5e70a8_v2_tables.py
+++ b/migrations/versions/8c431c5e70a8_v2_tables.py
@@ -147,6 +147,8 @@ def upgrade():
     op.execute("UPDATE products SET organization_id = 1")
     # Make products.organization_id non-nullable
     op.alter_column("products", "organization_id", nullable=False)
+    # Make root_fastly_domain nullable
+    op.alter_column("products", "root_fastly_domain", nullable=True)
 
 
 def downgrade():
@@ -169,3 +171,6 @@ def downgrade():
     op.drop_table("tags")
     op.drop_table("dashboardtemplates")
     op.drop_table("organizations")
+
+    # Make root_fastly_domain non-nullable
+    op.alter_column("products", "root_fastly_domain", nullable=False)

--- a/tests/v2api/test_project_path_layout.py
+++ b/tests/v2api/test_project_path_layout.py
@@ -1,0 +1,165 @@
+"""Test /v2/ APIs for projects with a path-based layout."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mock import MagicMock
+
+from keeper.testutils import MockTaskQueue
+
+if TYPE_CHECKING:
+    from unittest.mock import Mock
+
+    from keeper.testutils import TestClient
+
+
+def test_projects(client: TestClient, mocker: Mock) -> None:
+    task_queue = mocker.patch(
+        "keeper.taskrunner.inspect_task_queue", return_value=None
+    )
+    task_queue = MockTaskQueue(mocker)  # noqa
+
+    mock_presigned_url = {
+        "url": "https://example.com",
+        "fields": {"key": "a/b/${filename}"},
+    }
+    presign_post_mock = mocker.patch(
+        "keeper.services.createbuild.presign_post_url_for_prefix",
+        new=MagicMock(return_value=mock_presigned_url),
+    )
+    presign_post_mock = mocker.patch(
+        "keeper.services.createbuild.presign_post_url_for_directory_object",
+        new=MagicMock(return_value=mock_presigned_url),
+    )
+    s3_session_mock = mocker.patch(
+        "keeper.services.createbuild.open_s3_session"
+    )
+
+    # Create a default organization ===========================================
+    mocker.resetall()
+
+    request_data = {
+        "slug": "test1",
+        "title": "Test 1",
+        "layout": "path",
+        "domain": "www.example.org",
+        "path_prefix": "/orgprefix",
+        "bucket_name": "test-bucket",
+        "fastly_support": False,
+    }
+    r = client.post("/v2/orgs", request_data)
+    task_queue.apply_task_side_effects()
+    assert r.status == 201
+    org1_url = r.headers["Location"]
+    org1_projects_url = r.json["projects_url"]
+
+    # Get project list (should be empty) ======================================
+    mocker.resetall()
+
+    r = client.get(org1_projects_url)
+    assert r.status == 200
+    assert len(r.json) == 0
+
+    # Create a project ========================================================
+    mocker.resetall()
+
+    request_data = {
+        "slug": "alpha",
+        "title": "Alpha",
+        "source_repo_url": "https://github.com/example/alpha",
+        "default_edition_mode": "git_refs",
+    }
+    r = client.post(org1_projects_url, request_data)
+    task_queue.apply_task_side_effects()
+    assert r.status == 201
+    project1_url = r.headers["Location"]
+    project1_data = r.json
+
+    assert project1_data["organization_url"] == org1_url
+    assert project1_data["self_url"] == project1_url
+    assert project1_data["published_url"] == (
+        "https://www.example.org/orgprefix/alpha"
+    )
+    project1_builds_url = project1_data["builds_url"]
+    project1_editions_url = project1_data["editions_url"]
+    project1_default_edition_url = project1_data["default_edition"]["self_url"]
+
+    # Get project list again ==================================================
+    mocker.resetall()
+
+    r = client.get(org1_projects_url)
+    assert r.status == 200
+    assert r.json[0] == project1_data
+
+    # Create a build ==========================================================
+    mocker.resetall()
+
+    build1_request = {"git_ref": "master"}
+    r = client.post(project1_builds_url, build1_request)
+    task_queue.apply_task_side_effects()
+    s3_session_mock.assert_called_once()
+    presign_post_mock.assert_called_once()
+    assert r.status == 201
+    assert r.json["project_url"] == project1_url
+    assert r.json["date_created"] is not None
+    assert r.json["date_ended"] is None
+    assert r.json["uploaded"] is False
+    assert r.json["published_url"] == (
+        "https://www.example.org/orgprefix/alpha/builds/1"
+    )
+    assert "post_prefix_urls" in r.json
+    assert "post_dir_urls" in r.json
+    assert len(r.json["surrogate_key"]) == 32  # should be a uuid4 -> hex
+    build1_url = r.headers["Location"]
+
+    # ========================================================================
+    # List builds
+    mocker.resetall()
+
+    r = client.get(project1_builds_url)
+    assert len(r.json) == 1
+
+    # ========================================================================
+    # Register upload
+    mocker.resetall()
+
+    r = client.patch(build1_url, {"uploaded": True})
+    task_queue.apply_task_side_effects()
+    assert r.status == 202
+
+    task_queue.assert_launched_once()
+    task_queue.assert_edition_build_v2(
+        project1_default_edition_url,
+        build1_url,
+    )
+    task_queue.assert_dashboard_build_v2(project1_url)
+
+    r = client.get(build1_url)
+    assert r.json["uploaded"] is True
+
+    # =========================================================================
+    # Get the default edition
+    mocker.resetall()
+    r = client.get(project1_default_edition_url)
+    assert r.status == 200
+    data = r.json
+
+    assert data["build_url"] == build1_url
+    assert data["published_url"] == ("https://www.example.org/orgprefix/alpha")
+
+    # =========================================================================
+    # Create a new edition
+    mocker.resetall()
+    edition2_data = {
+        "slug": "another-edition",
+        "title": "Another edition",
+        "build_url": build1_url,
+        "mode": "manual",
+    }
+    r = client.post(project1_editions_url, edition2_data)
+    task_queue.apply_task_side_effects()
+    assert r.status == 202
+    assert r.json["published_url"] == (
+        "https://www.example.org/orgprefix/alpha/v/another-edition"
+    )


### PR DESCRIPTION
This updates how published URLs are computed for projects/products, editions, and builds, to support path-based project layouts.

Note that root_fastly_domain is set to nullable now to support this change.