### PR TITLE
DM-32710: Update main as default branch for editions (1.23.0 release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+1.23.0 (2021-11-29)
+===================
+
+- Change "master" to "main" as the tracked branch for default editions when a product is created.
+- Update the lsstdoc tracking mode so that it accepts either master or main as the name of a default branch to track if a semantic version is not available yet.
+
 1.22.0 (2021-04-27)
 ===================
 

--- a/keeper/api/products.py
+++ b/keeper/api/products.py
@@ -223,7 +223,7 @@ def new_product() -> Tuple[str, int, Dict[str, str]]:
 
         # Create a default edition for the product
         edition_data = {
-            "tracked_refs": ["master"],
+            "tracked_refs": ["main"],
             "slug": "main",
             "title": "Latest",
         }

--- a/keeper/editiontracking/lsstdocmode.py
+++ b/keeper/editiontracking/lsstdocmode.py
@@ -44,10 +44,10 @@ class LsstDocTrackingMode(TrackingModeBase):
         # build is tracking `master`, then allow this rebuild.
         # This is used in the period before a semantic version is
         # available.
-        if candidate_build.git_refs[0] == "master":
-            if (
-                edition.build_id is None
-                or edition.build.git_refs[0] == "master"
+        if candidate_build.git_refs[0] in ("master", "main"):
+            if edition.build_id is None or edition.build.git_refs[0] in (
+                "main",
+                "master",
             ):
                 return True
 

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 
 images:
   - name: lsstsqre/ltd-keeper
-    newTag: 1.22.0
+    newTag: 1.23.0

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -47,7 +47,7 @@ def test_builds(client: TestClient, mocker: Mock) -> None:
     mocker.resetall()
 
     e = {
-        "tracked_refs": ["master"],
+        "tracked_refs": ["main"],
         "slug": "latest",
         "title": "Latest",
         "published_url": "pipelines.lsst.io",
@@ -66,7 +66,7 @@ def test_builds(client: TestClient, mocker: Mock) -> None:
     b1 = {
         "slug": "b1",
         "github_requester": "jonathansick",
-        "git_refs": ["master"],
+        "git_refs": ["main"],
     }
     r = client.post("/products/pipelines/builds/", b1)
     assert r.status == 201
@@ -166,7 +166,7 @@ def test_builds(client: TestClient, mocker: Mock) -> None:
     # Add an auto-slugged build
     mocker.resetall()
 
-    b2 = {"git_refs": ["master"]}
+    b2 = {"git_refs": ["main"]}
     r = client.post("/products/pipelines/builds/", b2)
 
     assert r.status == 201
@@ -183,7 +183,7 @@ def test_builds(client: TestClient, mocker: Mock) -> None:
     # Add an auto-slugged build
     mocker.resetall()
 
-    b3 = {"git_refs": ["master"]}
+    b3 = {"git_refs": ["main"]}
     r = client.post("/products/pipelines/builds/", b3)
 
     assert r.status == 201
@@ -208,7 +208,7 @@ def test_builds(client: TestClient, mocker: Mock) -> None:
     # Add a build with a badly formatted git_refs
     mocker.resetall()
 
-    b5 = {"slug": "another-bad-build", "git_refs": "master"}
+    b5 = {"slug": "another-bad-build", "git_refs": "main"}
     with pytest.raises(ValidationError):
         r = client.post("/products/pipelines/builds/", b5)
 

--- a/tests/test_builds_v2.py
+++ b/tests/test_builds_v2.py
@@ -62,7 +62,7 @@ def test_builds_v2(client: TestClient, mocker: Mock) -> None:
     mocker.resetall()
 
     e = {
-        "tracked_refs": ["master"],
+        "tracked_refs": ["main"],
         "slug": "latest",
         "title": "Latest",
         "published_url": "pipelines.lsst.io",
@@ -81,7 +81,7 @@ def test_builds_v2(client: TestClient, mocker: Mock) -> None:
     b1 = {
         "slug": "b1",
         "github_requester": "jonathansick",
-        "git_refs": ["master"],
+        "git_refs": ["main"],
     }
     r = client.post(
         "/products/pipelines/builds/", b1, headers={"Accept": v2_json_type}
@@ -189,7 +189,7 @@ def test_builds_v2(client: TestClient, mocker: Mock) -> None:
     # Add an auto-slugged build
     mocker.resetall()
 
-    b2 = {"git_refs": ["master"]}
+    b2 = {"git_refs": ["main"]}
     r = client.post("/products/pipelines/builds/", b2)
 
     assert r.status == 201
@@ -206,7 +206,7 @@ def test_builds_v2(client: TestClient, mocker: Mock) -> None:
     # Add an auto-slugged build
     mocker.resetall()
 
-    b3 = {"git_refs": ["master"]}
+    b3 = {"git_refs": ["main"]}
     r = client.post(
         "/products/pipelines/builds/", b3, headers={"Accept": v2_json_type}
     )
@@ -233,7 +233,7 @@ def test_builds_v2(client: TestClient, mocker: Mock) -> None:
     # Add a build with a badly formatted git_refs
     mocker.resetall()
 
-    b5 = {"slug": "another-bad-build", "git_refs": "master"}
+    b5 = {"slug": "another-bad-build", "git_refs": "main"}
     with pytest.raises(ValidationError):
         r = client.post(
             "/products/pipelines/builds/", b5, headers={"Accept": v2_json_type}

--- a/tests/test_editions.py
+++ b/tests/test_editions.py
@@ -53,15 +53,15 @@ def test_editions(client: TestClient, mocker: Mock) -> None:
     assert e0["pending_rebuild"] is False
 
     # ========================================================================
-    # Create a build of the 'master' branch
+    # Create a build of the 'main' branch
     mocker.resetall()
 
-    r = client.post("/products/pipelines/builds/", {"git_refs": ["master"]})
+    r = client.post("/products/pipelines/builds/", {"git_refs": ["main"]})
     b1_url = r.json["self_url"]
     assert r.status == 201
 
     # ========================================================================
-    # Confirm build of the 'master' branch
+    # Confirm build of the 'main' branch
     mocker.resetall()
 
     client.patch(b1_url, {"uploaded": True})
@@ -81,15 +81,15 @@ def test_editions(client: TestClient, mocker: Mock) -> None:
     r = client.patch(e0_url, {"pending_rebuild": False})
 
     # ========================================================================
-    # Create a second build of the 'master' branch
+    # Create a second build of the 'main' branch
     mocker.resetall()
 
-    r = client.post("/products/pipelines/builds/", {"git_refs": ["master"]})
+    r = client.post("/products/pipelines/builds/", {"git_refs": ["main"]})
     assert r.status == 201
     b2_url = r.json["self_url"]
 
     # ========================================================================
-    # Confirm second build of the 'master' branch
+    # Confirm second build of the 'main' branch
     mocker.resetall()
 
     client.patch(b2_url, {"uploaded": True})
@@ -109,11 +109,11 @@ def test_editions(client: TestClient, mocker: Mock) -> None:
     r = client.patch(e0_url, {"pending_rebuild": False})
 
     # ========================================================================
-    # Setup an edition also tracking master called 'latest'
+    # Setup an edition also tracking main called 'latest'
     mocker.resetall()
 
     e1 = {
-        "tracked_refs": ["master"],
+        "tracked_refs": ["main"],
         "slug": "latest",
         "title": "Latest",
         "build_url": b1_url,
@@ -181,11 +181,11 @@ def test_editions(client: TestClient, mocker: Mock) -> None:
     # Change the tracked_refs with PATCH
     mocker.resetall()
 
-    r = client.patch(e1_url, {"tracked_refs": ["tickets/DM-9999", "master"]})
+    r = client.patch(e1_url, {"tracked_refs": ["tickets/DM-9999", "main"]})
 
     assert r.status == 200
     assert r.json["tracked_refs"][0] == "tickets/DM-9999"
-    assert r.json["tracked_refs"][1] == "master"
+    assert r.json["tracked_refs"][1] == "main"
     assert r.json["pending_rebuild"] is False  # no need to rebuild
 
     mock_registry[
@@ -217,7 +217,7 @@ def test_editions(client: TestClient, mocker: Mock) -> None:
     with pytest.raises(ValidationError):
         r = client.post(
             "/products/pipelines/editions/",
-            {"slug": "main", "tracked_refs": ["master"], "title": "Main"},
+            {"slug": "main", "tracked_refs": ["main"], "title": "Main"},
         )
 
 

--- a/tests/test_patch_edition_mode.py
+++ b/tests/test_patch_edition_mode.py
@@ -21,7 +21,7 @@ def test_pach_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
 
     1. Create a product with the default GIT_REF tracking mode for the
        main edition.
-    2. Post a build on `master`; it is tracked.
+    2. Post a build on `main`; it is tracked.
     3. Post a `v1.0` build; it is not tracked.
     4. Patch the main edition to use the LSST_DOC tracking mode.
     5. Post a `v1.1` build that is tracked.
@@ -53,7 +53,7 @@ def test_pach_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
     mock_registry["keeper.api.products.launch_task_chain"].assert_called_once()
 
     # ========================================================================
-    # Create a build on 'master'
+    # Create a build on 'main'
     mocker.resetall()
 
     # Get the URL for the default edition
@@ -63,20 +63,19 @@ def test_pach_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
     b1_data = {
         "slug": "b1",
         "github_requester": "jonathansick",
-        "git_refs": ["master"],
+        "git_refs": ["main"],
     }
     r = client.post(product_url + "/builds/", b1_data)
     b1_url = r.headers["Location"]
 
     # ========================================================================
-    # Create a build on 'master'
+    # Confirm the build on 'main'
     mocker.resetall()
 
     r = client.patch(b1_url, {"uploaded": True})
 
     # Test that the main edition updated.
     r = client.get(e1_url)
-
     assert r.json["build_url"] == b1_url
 
     # Check pending_rebuild semaphore and manually reset it since the celery

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -63,7 +63,7 @@ def test_products(client: TestClient, mocker: Mock) -> None:
     r = client.get(default_ed_url)
     assert r.json["slug"] == "main"
     assert r.json["title"] == "Latest"
-    assert r.json["tracked_refs"] == ["master"]
+    assert r.json["tracked_refs"] == ["main"]
     assert r.json["published_url"] == "https://pipelines.lsst.io"
 
     # ========================================================================

--- a/tests/test_track_eups_daily_tag.py
+++ b/tests/test_track_eups_daily_tag.py
@@ -64,18 +64,18 @@ def test_eups_daily_release_edition(client: TestClient, mocker: Mock) -> None:
     assert r.json["pending_rebuild"] is False
 
     # ========================================================================
-    # Create a build for the 'master' branch that is not tracked
+    # Create a build for the 'main' branch that is not tracked
     b2_data = {
         "slug": "b2",
         "github_requester": "jonathansick",
-        "git_refs": ["master"],
+        "git_refs": ["main"],
     }
     r = client.post("/products/pipelines/builds/", b2_data)
     b2_url = r.headers["Location"]
     r = client.patch(b2_url, {"uploaded": True})
 
     # Test that the main edition *did not* update because this build is
-    # neither for master not a semantic version.
+    # neither for main not a semantic version.
     # with semantic versions
     r = client.get(edition_url)
     assert r.json["build_url"] == b1_url
@@ -114,7 +114,7 @@ def test_eups_daily_release_edition(client: TestClient, mocker: Mock) -> None:
     r = client.patch(b4_url, {"uploaded": True})
 
     # Test that the main edition *did not* update because this build is
-    # neither for master not a semantic version.
+    # neither for main not a semantic version.
     # with semantic versions
     r = client.get(edition_url)
     assert r.json["build_url"] == b3_url

--- a/tests/test_track_eups_major_tag.py
+++ b/tests/test_track_eups_major_tag.py
@@ -63,18 +63,18 @@ def test_eups_major_release_edition(client: TestClient, mocker: Mock) -> None:
     assert r.json["pending_rebuild"] is False
 
     # ========================================================================
-    # Create a build for the 'master' branch that is not tracked
+    # Create a build for the 'main' branch that is not tracked
     b2_data = {
         "slug": "b2",
         "github_requester": "jonathansick",
-        "git_refs": ["master"],
+        "git_refs": ["main"],
     }
     r = client.post("/products/pipelines/builds/", b2_data)
     b2_url = r.headers["Location"]
     r = client.patch(b2_url, {"uploaded": True})
 
     # Test that the main edition *did not* update because this build is
-    # neither for master not a semantic version.
+    # neither for main not a semantic version.
     # with semantic versions
     r = client.get(edition_url)
     assert r.json["build_url"] == b1_url
@@ -113,7 +113,7 @@ def test_eups_major_release_edition(client: TestClient, mocker: Mock) -> None:
     r = client.patch(b4_url, {"uploaded": True})
 
     # Test that the main edition *did not* update because this build is
-    # neither for master not a semantic version.
+    # neither for main not a semantic version.
     # with semantic versions
     r = client.get(edition_url)
     assert r.json["build_url"] == b3_url

--- a/tests/test_track_eups_weekly_tag.py
+++ b/tests/test_track_eups_weekly_tag.py
@@ -88,18 +88,18 @@ def test_eups_weekly_release_edition(client: TestClient, mocker: Mock) -> None:
     assert r.json["pending_rebuild"] is False
 
     # ========================================================================
-    # Create a build for the 'master' branch that is not tracked
+    # Create a build for the 'main' branch that is not tracked
     b2_data = {
         "slug": "b2",
         "github_requester": "jonathansick",
-        "git_refs": ["master"],
+        "git_refs": ["main"],
     }
     r = client.post("/products/pipelines/builds/", b2_data)
     b2_url = r.headers["Location"]
     r = client.patch(b2_url, {"uploaded": True})
 
     # Test that the main edition *did not* update because this build is
-    # neither for master not a semantic version.
+    # neither for main not a semantic version.
     # with semantic versions
     r = client.get(edition_url)
     assert r.json["build_url"] == b1_url
@@ -146,7 +146,7 @@ def test_eups_weekly_release_edition(client: TestClient, mocker: Mock) -> None:
     r = client.patch(b4_url, {"uploaded": True})
 
     # Test that the main edition *did not* update because this build is
-    # neither for master nor a semantic version.
+    # neither for main nor a semantic version.
     # with semantic versions
     r = client.get(edition_url)
     assert r.json["build_url"] == b3_url

--- a/tests/test_track_lsst_doc.py
+++ b/tests/test_track_lsst_doc.py
@@ -17,11 +17,11 @@ if TYPE_CHECKING:
 def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
     """Test an edition that tracks LSST Doc semantic versions.
 
-    1. Create a build on `master`; it should be tracked because the LSST_DOC
-       mode tracks master if a semantic version tag hasn't been pushed yet.
+    1. Create a build on `main`; it should be tracked because the LSST_DOC
+       mode tracks main if a semantic version tag hasn't been pushed yet.
     2. Create a ticket branch; it isn't tracked.
     3. Create a v1.0 build; it is tracked.
-    4. Create another build on `master`; it isn't tracked because we already
+    4. Create another build on `main`; it isn't tracked because we already
        have the v1.0 build.
     5. Create a v0.9 build that is not tracked because it's older.
     6. Create a v1.1 build that **is** tracked because it's newer.
@@ -53,43 +53,42 @@ def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
     # ========================================================================
     # Get the URL for the default edition
     r = client.get(p1_url + "/editions/")
-    main_edition_url = r.json["editions"][0]
-    assert main_edition_url == "http://example.test/editions/1"
+    default_edition_url = r.json["editions"][0]
+    assert default_edition_url == "http://example.test/editions/1"
 
     # ========================================================================
-    # Create a build on 'master'
+    # Create edition to reflect the main branch
+    r = client.post(
+        p1_url + "/editions/",
+        {"tracked_refs": ["main"], "slug": "current", "title": "main"},
+    )
+    main_edition_url = r.headers["Location"]
+
+    # ========================================================================
+    # Create a build on 'main'
     mocker.resetall()
 
     b1_data = {
         "slug": "b1",
         "github_requester": "jonathansick",
-        "git_refs": ["master"],
+        "git_refs": ["main"],
     }
     r = client.post("/products/ldm-151/builds/", b1_data)
     b1_url = r.headers["Location"]
 
     # ========================================================================
-    # Confirm build on 'master'
+    # Confirm build on 'main'
     mocker.resetall()
 
     r = client.patch(b1_url, {"uploaded": True})
 
     mock_registry["keeper.models.append_task_to_chain"].assert_any_call(
-        rebuild_edition.si(main_edition_url, 1)
+        rebuild_edition.si(default_edition_url, 1)
     )
 
-    # The 'master' edition was also automatically created to track master.
-    r = client.get(p1_url + "/editions/")
-    master_edition_url = r.json["editions"][1]
-    mock_registry["keeper.models.append_task_to_chain"].assert_any_call(
-        rebuild_edition.si(master_edition_url, 2)
-    )
-    # Check that it's tracking the master branch
-    r = client.get(master_edition_url)
-    assert r.json["mode"] == "git_refs"
-    assert r.json["slug"] == "master"
-    assert r.json["title"] == "master"
-    assert r.json["tracked_refs"] == ["master"]
+    # Check that it's tracking the main branch
+    r = client.get(main_edition_url)
+    assert r.json["build_url"] == b1_url
 
     # Manually reset pending_rebuild (the rebuild_edition task would have
     # done this automatically)
@@ -97,10 +96,10 @@ def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
     assert r.json["pending_rebuild"] is True
     r = client.patch(main_edition_url, {"pending_rebuild": False})
 
-    # And for the master edition
-    r = client.get(master_edition_url)
+    # And for the main edition
+    r = client.get(default_edition_url)
     assert r.json["pending_rebuild"] is True
-    r = client.patch(master_edition_url, {"pending_rebuild": False})
+    r = client.patch(default_edition_url, {"pending_rebuild": False})
 
     # Test that the main edition updated because there are no builds yet
     # with semantic versions
@@ -136,7 +135,7 @@ def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
     mock_registry["keeper.api.builds.launch_task_chain"].assert_called_once()
 
     # Test that the main edition *did not* update because this build is
-    # neither for master not a semantic version.
+    # neither for main not a semantic version.
     # with semantic versions
     r = client.get(main_edition_url)
     assert r.json["build_url"] == b1_url
@@ -179,8 +178,8 @@ def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
         rebuild_edition.si("http://example.test/editions/4", 4)
     )
 
-    # Test that the main edition updated
-    r = client.get(main_edition_url)
+    # Test that the default edition updated
+    r = client.get(default_edition_url)
     assert r.json["build_url"] == b3_url
     assert r.json["pending_rebuild"] is True
 
@@ -190,39 +189,39 @@ def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
     assert r.json["pending_rebuild"] is True
 
     # Manually reset the pending_rebuild semaphores
-    r = client.patch(main_edition_url, {"pending_rebuild": False})
+    r = client.patch(default_edition_url, {"pending_rebuild": False})
     r = client.patch(
         "http://example.test/editions/4", {"pending_rebuild": False}
     )
 
     # ========================================================================
-    # Create another build on 'master'
+    # Create another build on 'main'
     mocker.resetall()
 
     b4_data = {
         "slug": "b4",
         "github_requester": "jonathansick",
-        "git_refs": ["master"],
+        "git_refs": ["main"],
     }
     r = client.post("/products/ldm-151/builds/", b4_data)
     b4_url = r.headers["Location"]
 
     # ========================================================================
-    # Confirm master build
+    # Confirm main build
     mocker.resetall()
 
     r = client.patch(b4_url, {"uploaded": True})
 
-    # Test that the main edition *did not* update because now it's sticking
+    # Test that the default edition *did not* update because now it's sticking
     # to only show semantic versions.
-    r = client.get(main_edition_url)
+    r = client.get(default_edition_url)
     assert r.json["build_url"] == b3_url
 
-    # Test that the **master** edition did update, though
-    r = client.get(master_edition_url)
+    # Test that the **main** edition did update, though
+    r = client.get(main_edition_url)
     assert r.json["build_url"] == b4_url
     assert r.json["pending_rebuild"] is True
-    r = client.patch(master_edition_url, {"pending_rebuild": False})
+    r = client.patch(main_edition_url, {"pending_rebuild": False})
 
     # ========================================================================
     # Create a build with a **older** semantic version tag.
@@ -242,8 +241,8 @@ def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
 
     r = client.patch(b5_url, {"uploaded": True})
 
-    # Test that the main edition *did not* update b/c it's older
-    r = client.get(main_edition_url)
+    # Test that the default edition *did not* update b/c it's older
+    r = client.get(default_edition_url)
     assert r.json["build_url"] == b3_url
 
     # ========================================================================
@@ -259,8 +258,8 @@ def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
     b6_url = r.headers["Location"]
     r = client.patch(b6_url, {"uploaded": True})
 
-    # Test that the main edition updated
-    r = client.get(main_edition_url)
+    # Test that the default edition updated
+    r = client.get(default_edition_url)
     assert r.json["build_url"] == b6_url
 
     # Rebuilds for the main and v1-0 editions were triggered
@@ -272,7 +271,7 @@ def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
     )
 
     # Manually reset the pending_rebuild semaphores
-    r = client.patch(main_edition_url, {"pending_rebuild": False})
+    r = client.patch(default_edition_url, {"pending_rebuild": False})
     r = client.patch(
         "http://example.test/editions/6", {"pending_rebuild": False}
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ from keeper.utils import (
     [
         (["tickets/DM-1234"], "DM-1234"),
         (["tickets/LCR-758"], "LCR-758"),
-        (["master"], "master"),
+        (["main"], "main"),
         (["u/rowen/r12_patch1"], "u-rowen-r12_patch1"),
         (
             ["tickets/DM-1234", "tickets/DM-5678"],


### PR DESCRIPTION
- Change "master" to "main" as the tracked branch for default editions when a product is created.
- Update the lsstdoc tracking mode so that it accepts either master or main as the name of a default branch to track if a semantic version is not available yet.
