### PR TITLE
Add git_ref tracking mode

### DIFF
--- a/keeper/api/_models.py
+++ b/keeper/api/_models.py
@@ -256,6 +256,13 @@ class EditionResponse(BaseModel):
         task: celery.Task = None,
     ) -> EditionResponse:
         """Create an EditionResponse from the Edition ORM model instance."""
+        if edition.mode_name == "git_refs":
+            tracked_refs = edition.tracked_refs
+        elif edition.mode_name == "git_ref":
+            tracked_refs = [edition.tracked_ref]
+        else:
+            tracked_refs = None
+
         obj: Dict[str, Any] = {
             "self_url": url_for_edition(edition),
             "product_url": url_for_product(edition.product),
@@ -271,11 +278,7 @@ class EditionResponse(BaseModel):
             "date_rebuilt": edition.date_rebuilt,
             "date_ended": edition.date_ended,
             "mode": edition.mode_name,
-            "tracked_refs": (
-                edition.tracked_refs
-                if edition.mode_name == "git_refs"
-                else None
-            ),
+            "tracked_refs": tracked_refs,
             "pending_rebuild": edition.pending_rebuild,
             "surrogate_key": edition.surrogate_key,
             "queue_url": url_for_task(task) if task is not None else None,

--- a/keeper/editiontracking/gitrefmode.py
+++ b/keeper/editiontracking/gitrefmode.py
@@ -1,4 +1,4 @@
-"""Implements the ``git_refs`` tracking mode."""
+"""Implements the ``git_ref`` tracking mode."""
 
 from __future__ import annotations
 
@@ -9,18 +9,17 @@ from keeper.editiontracking.base import TrackingModeBase
 if TYPE_CHECKING:
     from keeper.models import Build, Edition
 
-__all__ = ["GitRefsTrackingMode"]
+__all__ = ["GitRefTrackingMode"]
 
 
-class GitRefsTrackingMode(TrackingModeBase):
-    """Tracking mode where an edition tracks an array of Git refs.
-
-    This is the default mode if Edition.mode is None.
+class GitRefTrackingMode(TrackingModeBase):
+    """Tracking mode where an edition tracks a given git_ref (commonly
+    a branch).
     """
 
     @property
     def name(self) -> str:
-        return "git_refs"
+        return "git_ref"
 
     def should_update(
         self, edition: Optional[Edition], candidate_build: Optional[Build]
@@ -29,7 +28,7 @@ class GitRefsTrackingMode(TrackingModeBase):
             return False
 
         if (candidate_build.product == edition.product) and (
-            candidate_build.git_refs == edition.tracked_refs
+            candidate_build.git_ref == edition.tracked_ref
         ):
             return True
         else:

--- a/keeper/editiontracking/gitrefsmode.py
+++ b/keeper/editiontracking/gitrefsmode.py
@@ -9,11 +9,11 @@ from keeper.editiontracking.base import TrackingModeBase
 if TYPE_CHECKING:
     from keeper.models import Build, Edition
 
-__all__ = ["GitRefTrackingMode"]
+__all__ = ["GitRefsTrackingMode"]
 
 
-class GitRefTrackingMode(TrackingModeBase):
-    """Default tracking mode where an edition tracks an array of Git refs.
+class GitRefsTrackingMode(TrackingModeBase):
+    """Tracking mode where an edition tracks an array of Git refs.
 
     This is the default mode if Edition.mode is None.
     """

--- a/keeper/editiontracking/trackingmodes.py
+++ b/keeper/editiontracking/trackingmodes.py
@@ -6,7 +6,7 @@ from keeper.editiontracking.base import TrackingModeBase
 from keeper.editiontracking.eupsdailymode import EupsDailyReleaseTrackingMode
 from keeper.editiontracking.eupsmajormode import EupsMajorReleaseTrackingMode
 from keeper.editiontracking.eupsweeklymode import EupsWeeklyReleaseTrackingMode
-from keeper.editiontracking.gitrefmode import GitRefTrackingMode
+from keeper.editiontracking.gitrefsmode import GitRefsTrackingMode
 from keeper.editiontracking.lsstdocmode import LsstDocTrackingMode
 from keeper.editiontracking.manualmode import ManualTrackingMode
 from keeper.exceptions import ValidationError
@@ -21,7 +21,7 @@ class EditionTrackingModes:
     """
 
     _modes = {
-        1: GitRefTrackingMode(),
+        1: GitRefsTrackingMode(),
         2: LsstDocTrackingMode(),
         3: EupsMajorReleaseTrackingMode(),
         4: EupsWeeklyReleaseTrackingMode(),

--- a/keeper/editiontracking/trackingmodes.py
+++ b/keeper/editiontracking/trackingmodes.py
@@ -6,6 +6,7 @@ from keeper.editiontracking.base import TrackingModeBase
 from keeper.editiontracking.eupsdailymode import EupsDailyReleaseTrackingMode
 from keeper.editiontracking.eupsmajormode import EupsMajorReleaseTrackingMode
 from keeper.editiontracking.eupsweeklymode import EupsWeeklyReleaseTrackingMode
+from keeper.editiontracking.gitrefmode import GitRefTrackingMode
 from keeper.editiontracking.gitrefsmode import GitRefsTrackingMode
 from keeper.editiontracking.lsstdocmode import LsstDocTrackingMode
 from keeper.editiontracking.manualmode import ManualTrackingMode
@@ -27,6 +28,7 @@ class EditionTrackingModes:
         4: EupsWeeklyReleaseTrackingMode(),
         5: EupsDailyReleaseTrackingMode(),
         6: ManualTrackingMode(),
+        7: GitRefTrackingMode(),
     }
     """Map of tracking mode ID (an integer stored in the DB to the tracking
     mode instance that can evaluate whether an edition should be updated

--- a/keeper/models.py
+++ b/keeper/models.py
@@ -758,6 +758,13 @@ class Edition(db.Model):  # type: ignore
     mode: ``git_refs``.
     """
 
+    tracked_ref = db.Column(db.Unicode(255), nullable=True)
+    """The Git ref this Edition tracks and publishes if the tracking mode
+    is ``git_ref``.
+
+    For other tracking modes, this field may be `None`.
+    """
+
     tracked_refs = db.Column(MutableList.as_mutable(JSONEncodedVARCHAR(2048)))
     """The list of Git refs this Edition tracks and publishes if the tracking
     mode is ``git_refs``.
@@ -956,7 +963,7 @@ class Edition(db.Model):  # type: ignore
     @property
     def default_mode_name(self) -> str:
         """Default tracking mode name if ``Edition.mode`` is `None` (`str`)."""
-        return "git_refs"
+        return "git_ref"
 
     @property
     def default_mode_id(self) -> int:

--- a/keeper/services/createbuild.py
+++ b/keeper/services/createbuild.py
@@ -137,12 +137,12 @@ def create_autotracking_edition(
     )
     if edition_count == 0 and is_authorized(Permission.ADMIN_EDITION):
         try:
-            edition_slug = auto_slugify_edition(build.git_refs)
+            edition_slug = auto_slugify_edition([build.git_ref])
             edition = create_edition(
                 product=product,
                 title=edition_slug,
                 slug=edition_slug,
-                tracking_mode="git_refs",
+                tracking_mode="git_ref",
                 tracked_ref=build.git_ref,
             )
             db.session.add(edition)
@@ -152,7 +152,7 @@ def create_autotracking_edition(
                 "Created edition because of a build",
                 slug=edition.slug,
                 id=edition.id,
-                tracked_refs=edition.tracked_refs,
+                tracked_ref=edition.tracked_ref,
             )
             return edition
         except Exception:

--- a/keeper/services/createedition.py
+++ b/keeper/services/createedition.py
@@ -46,7 +46,7 @@ def create_edition(
         slug.
     tracked_ref : str, optional
         The name of the Git ref that this edition tracks, if ``tracking_mode``
-        is ``"git_refs"``.
+        is ``"git_refs"`` or ``"git_ref"``.
     build : Build, optional
         The build to initially publish with this edition.
 
@@ -73,7 +73,13 @@ def create_edition(
     else:
         edition.set_mode(edition.default_mode_name)
 
+    # Set both tracked_ref and tracked_refs for the purposes of the migration
+    # for now
     if edition.mode_name == "git_refs":
+        edition.tracked_refs = [tracked_ref]
+        edition.tracked_ref = tracked_ref
+    elif edition.mode_name == "git_ref":
+        edition.tracked_ref = tracked_ref
         edition.tracked_refs = [tracked_ref]
 
     db.session.add(edition)

--- a/keeper/services/updateedition.py
+++ b/keeper/services/updateedition.py
@@ -35,6 +35,7 @@ def update_edition(
 
     if tracked_ref is not None:
         edition.tracked_refs = [tracked_ref]
+        edition.tracked_ref = tracked_ref
 
     if tracking_mode is not None:
         edition.set_mode(tracking_mode)

--- a/migrations/versions/f8eeb27a49e7_add_edition_tracked_ref_column.py
+++ b/migrations/versions/f8eeb27a49e7_add_edition_tracked_ref_column.py
@@ -1,0 +1,25 @@
+"""Add Edition tracked_ref column
+
+Revision ID: f8eeb27a49e7
+Revises: febbe2d7e47b
+Create Date: 2022-03-19 18:02:05.929442
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f8eeb27a49e7"
+down_revision = "febbe2d7e47b"
+
+
+def upgrade():
+    with op.batch_alter_table("editions", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("tracked_ref", sa.Unicode(length=255), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("editions", schema=None) as batch_op:
+        batch_op.drop_column("tracked_ref")

--- a/tests/test_editions.py
+++ b/tests/test_editions.py
@@ -181,7 +181,10 @@ def test_editions(client: TestClient, mocker: Mock) -> None:
     # Change the tracked_refs with PATCH
     mocker.resetall()
 
-    r = client.patch(e1_url, {"tracked_refs": ["tickets/DM-9999", "main"]})
+    r = client.patch(
+        e1_url,
+        {"mode": "git_refs", "tracked_refs": ["tickets/DM-9999", "main"]},
+    )
     task_queue.apply_task_side_effects()
 
     assert r.status == 200
@@ -192,7 +195,7 @@ def test_editions(client: TestClient, mocker: Mock) -> None:
     task_queue.assert_dashboard_build_v1(product_url)
 
     # ========================================================================
-    # Deprecate the editon
+    # Deprecate the edition
     mocker.resetall()
 
     r = client.delete(e1_url)
@@ -206,6 +209,12 @@ def test_editions(client: TestClient, mocker: Mock) -> None:
     # Deprecated editions no longer in the editions list
     r = client.get(product_url + "/editions/")
     assert r.status == 200
+    final_edition_urls = r.json["editions"]
+    print(final_edition_urls)
+    for f_url in final_edition_urls:
+        rf = client.get(f_url)
+        print(rf.json)
+
     # only default edition (main) remains
     assert len(r.json["editions"]) == 1
 

--- a/tests/test_track_lsst_doc.py
+++ b/tests/test_track_lsst_doc.py
@@ -95,7 +95,7 @@ def test_lsst_doc_edition(client: TestClient, mocker: Mock) -> None:
 
     # Check that it's tracking the main branch
     r = client.get(main_edition_url)
-    assert r.json["mode"] == "git_refs"
+    assert r.json["mode"] == "git_ref"
     assert r.json["slug"] == "main"
     assert r.json["title"] == "main"
     assert r.json["tracked_refs"] == ["main"]

--- a/tests/v2api/test_project.py
+++ b/tests/v2api/test_project.py
@@ -71,7 +71,7 @@ def test_projects(client: TestClient, mocker: Mock) -> None:
         "slug": "alpha",
         "title": "Alpha",
         "source_repo_url": "https://github.com/example/alpha",
-        "default_edition_mode": "git_refs",
+        "default_edition_mode": "git_ref",
     }
     r = client.post(org1_projects_url, request_data)
     task_queue.apply_task_side_effects()
@@ -152,4 +152,5 @@ def test_projects(client: TestClient, mocker: Mock) -> None:
     assert r.status == 200
     data = r.json
 
+    # It should be tracking build 1 because it's of the main branch
     assert data["build_url"] == build1_url


### PR DESCRIPTION
The new `git_ref` tracking mode will replace `git_refs`, and tracks only a single git ref rather than multiple refs, as the previous mode was doing. This is the new default tracking mode, through `git_refs` is still available.

A new `Edition.tracked_ref` column is added, replacing the JSON-encoded `Edition.tracked_refs`.

To enable the transition, the services populate both `tracked_ref` and `tracked_refs`.