### PR TITLE
Implement dashboard generation from built-in templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ pgdb/
 
 integration_tests/ltd_keeper_doc_examples.txt
 
+# Dashboard development
+dashboard_dev
+
 # Kubernetes deployment
 kubernetes/cloudsql-secrets.yaml
 kubernetes/keeper-secrets.yaml

--- a/keeper/dashboard/__init__.py
+++ b/keeper/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Domain for edition dashboards."""

--- a/keeper/dashboard/context.py
+++ b/keeper/dashboard/context.py
@@ -1,0 +1,145 @@
+"""Generate Jinja template rendering context from domain models."""
+
+from __future__ import annotations
+
+from collections import UserList
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional, Sequence
+
+from keeper.models import Build, Edition, EditionKind, Product
+
+
+@dataclass
+class ProjectContext:
+    """Template context model for a project."""
+
+    title: str
+    """Project title."""
+
+    source_repo_url: str
+    """Url of the associated GitHub repository."""
+
+    url: str
+    """Root URL where this project is published."""
+
+    @classmethod
+    def from_product(cls, product: Product) -> ProjectContext:
+        return cls(
+            title=product.title,
+            source_repo_url=product.doc_repo,
+            url=product.published_url,
+        )
+
+
+@dataclass
+class EditionContext:
+    """Template context model for an edition."""
+
+    title: str
+    """Human-readable label for this edition."""
+
+    url: str
+    """URL where this edition is published."""
+
+    date_updated: datetime
+    """Date when this edition was last updated."""
+
+    kind: EditionKind
+    """The edition's kind."""
+
+    slug: str
+    """The edition's slug."""
+
+    git_ref: Optional[str]
+    """The git ref that this edition tracks."""
+
+    @classmethod
+    def from_edition(cls, edition: Edition) -> EditionContext:
+        return cls(
+            title=edition.title,
+            url=edition.published_url,
+            date_updated=edition.date_rebuilt,
+            kind=edition.kind,
+            slug=edition.slug,
+            git_ref=edition.tracked_ref,
+        )
+
+
+class EditionContextList(UserList):
+    def __init__(self, contexts: Sequence[EditionContext]) -> None:
+        self.data: List[EditionContext] = list(contexts)
+        self.data.sort(key=lambda x: x.date_updated)
+
+    @property
+    def main_edition(self) -> EditionContext:
+        for edition in self.data:
+            if edition.slug == "__main":
+                return edition
+        raise ValueError("No __main edition found")
+
+
+@dataclass
+class BuildContext:
+    """Template context model for a build."""
+
+    slug: str
+    """The URL slug for this build."""
+
+    url: str
+    """The URL for this build."""
+
+    git_ref: Optional[str]
+    """The git ref associated with this build (if appropriate."""
+
+    date: datetime
+    """Date when the build was uploaded."""
+
+    @classmethod
+    def from_build(cls, build: Build) -> BuildContext:
+        return cls(
+            slug=build.slug,
+            url=build.published_url,
+            git_ref=build.git_ref,
+            date=build.date_created,
+        )
+
+
+class BuildContextList(UserList):
+    def __init__(self, contexts: Sequence[BuildContext]) -> None:
+        self.data: List[BuildContext] = list(contexts)
+        self.data.sort(key=lambda x: x.date)
+
+
+@dataclass
+class Context:
+    """A class that creates Jinja template rendering context from
+    domain models.
+    """
+
+    project_context: ProjectContext
+
+    edition_contexts: EditionContextList
+
+    build_contexts: BuildContextList
+
+    @classmethod
+    def create(cls, product: Product) -> Context:
+        project_context = ProjectContext.from_product(product)
+
+        edition_contexts: EditionContextList = EditionContextList(
+            [
+                EditionContext.from_edition(edition)
+                for edition in product.editions
+            ]
+        )
+
+        build_contexts: BuildContextList = BuildContextList(
+            [BuildContext.from_build(build) for build in product.builds]
+        )
+
+        return cls(
+            project_context=project_context,
+            edition_contexts=edition_contexts,
+            build_contexts=build_contexts,
+        )

--- a/keeper/dashboard/context.py
+++ b/keeper/dashboard/context.py
@@ -99,13 +99,17 @@ class EditionContextList(UserList):
 
     @property
     def releases(self) -> List[EditionContext]:
-        """All edititions tagged as releases."""
+        """All editions tagged as releases."""
         release_kinds = (
             EditionKind.release,
             EditionKind.major,
             EditionKind.minor,
         )
-        release_items = [e for e in self.data if e.kind in release_kinds]
+        release_items = [
+            e
+            for e in self.data
+            if (e.kind in release_kinds and e.slug != "__main")
+        ]
         sorted_items = sorted(
             release_items, key=lambda x: x.slug, reverse=True
         )
@@ -118,7 +122,11 @@ class EditionContextList(UserList):
     @property
     def drafts(self) -> List[EditionContext]:
         """All editions tagged as drafts."""
-        draft_items = [e for e in self.data if e.kind == EditionKind.draft]
+        draft_items = [
+            e
+            for e in self.data
+            if (e.kind == EditionKind.draft and e.slug != "__main")
+        ]
         return sorted(draft_items, key=lambda x: x.date_updated, reverse=True)
 
 

--- a/keeper/dashboard/jinjafilters.py
+++ b/keeper/dashboard/jinjafilters.py
@@ -1,0 +1,12 @@
+"""Filters for Jinja2 templates."""
+
+from __future__ import annotations
+
+__all__ = ["filter_simple_date"]
+
+from datetime import datetime
+
+
+def filter_simple_date(value: datetime) -> str:
+    """Filter a `datetime.datetime` into a 'YYYY-MM-DD' string."""
+    return value.strftime("%Y-%m-%d")

--- a/keeper/dashboard/static/app.css
+++ b/keeper/dashboard/static/app.css
@@ -1,0 +1,52 @@
+// Resets
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}
+
+// System font stack
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+}

--- a/keeper/dashboard/static/app.css
+++ b/keeper/dashboard/static/app.css
@@ -1,4 +1,4 @@
-// Resets
+/* Resets */
 *,
 *::before,
 *::after {
@@ -45,8 +45,52 @@ h6 {
   overflow-wrap: break-word;
 }
 
-// System font stack
+/* System font stack */
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
     Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+}
+
+main {
+  /* max-width: 16rem; */
+  width: 100vw;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+@media (min-width: 62rem) {
+  main {
+    width: 62rem;
+  }
+}
+
+.main-edition-section {
+  margin-top: 1rem;
+}
+
+.main-edition-section__url {
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.version-section {
+  margin-top: 2rem;
+}
+
+.version-section__listing {
+  list-style: none;
+  padding-left: 0;
+}
+
+.version-section__listing > li {
+  margin-top: 1rem;
+}
+
+.dashboard-item-metadata {
+  list-style: none;
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 1.2rem;
+  padding-left: 0;
 }

--- a/keeper/dashboard/template/base.jinja
+++ b/keeper/dashboard/template/base.jinja
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>{% block page_title %}{% endblock page_title %}</title>
+  <meta name="description" content="{% block page_description %}{% endblock page_description %}">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="{{ asset_dir }}/app.css">
+</head>
+
+<body>
+  {% block body %}
+  {% endblock body %}
+</body>
+
+</html>

--- a/keeper/dashboard/template/build_dashboard.jinja
+++ b/keeper/dashboard/template/build_dashboard.jinja
@@ -1,0 +1,17 @@
+{% extends "base.jinja" %}
+
+{% block page_title %}{{ project.title }} builds{% endblock page_title %}
+{% block page_description %}Find documentation builds.{% endblock page_description %}
+
+{% block body %}
+<main>
+<header>
+<h1>{{ project.title }} builds</h1>
+</header>
+<section>
+  <header>
+  <h2>Builds</h2>
+  </header>
+</section>
+</main>
+{% endblock body %}

--- a/keeper/dashboard/template/edition_dashboard.jinja
+++ b/keeper/dashboard/template/edition_dashboard.jinja
@@ -1,0 +1,29 @@
+{% extends "base.jinja" %}
+
+{% block page_title %}{{ project.title }} editions{% endblock page_title %}
+{% block page_description %}Find documentation editions.{% endblock page_description %}
+
+{% block body %}
+<main>
+  <header>
+    <h1>{{ project.title }}</h1>
+  </header>
+
+  <section>
+    <header>
+      <h2>Current edition</h2>
+    </header>
+    <article class="dashboard-item">
+      {% set mainedition = editions.main_edition %}
+      <p class="current-edition__url"><a href=""></a></p>
+      <ul class="dashboard-item-metadata">
+        <li>Updated {{ mainedition.date_updated | simple_date }}</li>
+        {% if mainedition.git_ref %}
+          <li>Git ref <code>{{ mainedition.git_ref}}</code></li>
+        {% endif %}
+      </ul>
+    </article>
+  </section>
+
+</main>
+{% endblock body %}

--- a/keeper/dashboard/template/edition_dashboard.jinja
+++ b/keeper/dashboard/template/edition_dashboard.jinja
@@ -3,27 +3,74 @@
 {% block page_title %}{{ project.title }} editions{% endblock page_title %}
 {% block page_description %}Find documentation editions.{% endblock page_description %}
 
+{% macro edition_article(project, edition) -%}
+  <article class="dashboard-item">
+    <header>
+      <a href="{{ edition.url }}">
+        <h3>{{ edition.title }}</h3>
+      </a>
+    </header>
+    <ul class="dashboard-item-metadata">
+      <li>
+        Updated {{ edition.date_updated | simple_date }}
+      </li>
+      {% if edition.git_ref %}
+      <li>
+        GitHub: <a href="{{ edition.github_url }}"><code>{{ edition.git_ref }}</code></a>
+      </li>
+      {% endif %}
+    </ul>
+  </article>
+{%- endmacro %}
+
 {% block body %}
 <main>
+  {% set main_edition = editions.main_edition %}
+
   <header>
-    <h1>{{ project.title }}</h1>
+    <a href="{{main_edition.url}}"><h1>{{ project.title }}</h1></a>
   </header>
 
-  <section>
-    <header>
-      <h2>Current edition</h2>
-    </header>
-    <article class="dashboard-item">
-      {% set mainedition = editions.main_edition %}
-      <p class="current-edition__url"><a href=""></a></p>
-      <ul class="dashboard-item-metadata">
-        <li>Updated {{ mainedition.date_updated | simple_date }}</li>
-        {% if mainedition.git_ref %}
-          <li>Git ref <code>{{ mainedition.git_ref}}</code></li>
-        {% endif %}
-      </ul>
-    </article>
+  <section class="main-edition-section">
+    <p class="main-edition-section__url"><a href="{{main_edition.url}}">{{main_edition.url}}</a></p>
+    <p>
+      Default edition last updated {{ main_edition.date_updated | simple_date }}.
+      {% if main_edition.git_ref %}
+        Based on the <a href="{{ main_edition.github_url }}"><code>{{ main_edition.git_ref }}</code></a>
+        branch/tag at <a href="{{ project.source_repo_url }}">{{ project.source_repo_url }}</a>.
+      {% endif %}
+    </p>
   </section>
+
+  {% if editions.has_releases %}
+  <section class="version-section">
+    <header>
+      <h2>Releases</h2>
+    </header>
+    <ul class="version-section__listing">
+      {% for edition in editions.releases %}
+        <li>
+          {{ edition_article(project, edition) }}
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
+  {% if editions.has_drafts %}
+  <section class="version-section">
+    <header>
+      <h2>Drafts</h2>
+    </header>
+    <ul class="version-section__listing">
+      {% for edition in editions.drafts %}
+        <li>
+          {{ edition_article(project, edition) }}
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
 
 </main>
 {% endblock body %}

--- a/keeper/dashboard/templateproviders.py
+++ b/keeper/dashboard/templateproviders.py
@@ -4,6 +4,7 @@ Jinja2 rendering environment.
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import jinja2
@@ -54,3 +55,38 @@ class BuiltinTemplateProvider:
             builds=build_contexts,
             asset_dir="../_dashboard-assets",
         )
+
+    def render_locally(
+        self,
+        *,
+        directory: Path,
+        project_context: ProjectContext,
+        edition_contexts: EditionContextList,
+        build_contexts: BuildContextList,
+        clobber: bool = True,
+    ) -> None:
+        """Render the dashboard into a local directory for testing."""
+        if directory.exists():
+            shutil.rmtree(directory)
+        directory.mkdir()
+        assets_dir = directory.joinpath("_dashboard-assets")
+        # assets_dir.mkdir()
+        v_dir = directory.joinpath("v")
+        v_dir.mkdir()
+        builds_dir = directory.joinpath("builds")
+        builds_dir.mkdir()
+
+        shutil.copytree(self.static_dir, assets_dir)
+
+        edition_dashboard = self.render_edition_dashboard(
+            project_context=project_context,
+            edition_contexts=edition_contexts,
+        )
+        v_html_path = v_dir.joinpath("index.html")
+        v_html_path.write_text(edition_dashboard)
+
+        build_dashboard = self.render_build_dashboard(
+            project_context=project_context, build_contexts=build_contexts
+        )
+        build_html_path = builds_dir.joinpath("index.html")
+        build_html_path.write_text(build_dashboard)

--- a/keeper/dashboard/templateproviders.py
+++ b/keeper/dashboard/templateproviders.py
@@ -1,0 +1,56 @@
+"""Providers load templates from specific sources and provider a
+Jinja2 rendering environment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import jinja2
+
+from .context import BuildContextList, EditionContextList, ProjectContext
+from .jinjafilters import filter_simple_date
+
+
+class BuiltinTemplateProvider:
+    """A template provider for Keeper's built in dashboard templates."""
+
+    def __init__(self) -> None:
+        self.template_dir = Path(__file__).parent.joinpath("template")
+        self.static_dir = self.template_dir.joinpath("static")
+
+        self.jinja_env = self._create_environment()
+
+    def _create_environment(self) -> jinja2.Environment:
+        env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(self.template_dir),
+            autoescape=jinja2.select_autoescape(["html"]),
+        )
+        env.filters["simple_date"] = filter_simple_date
+        return env
+
+    def render_edition_dashboard(
+        self,
+        *,
+        project_context: ProjectContext,
+        edition_contexts: EditionContextList,
+    ) -> str:
+        template = self.jinja_env.get_template("edition_dashboard.jinja")
+        return template.render(
+            project=project_context,
+            editions=edition_contexts,
+            asset_dir="../_dashboard-assets",
+        )
+
+    def render_build_dashboard(
+        self,
+        *,
+        project_context: ProjectContext,
+        build_contexts: BuildContextList,
+    ) -> str:
+        template = self.jinja_env.get_template("build_dashboard.jinja")
+        return template.render(
+            project=project_context,
+            builds=build_contexts,
+            asset_dir="../_dashboard-assets",
+        )

--- a/keeper/dashboard/templateproviders.py
+++ b/keeper/dashboard/templateproviders.py
@@ -17,7 +17,7 @@ class BuiltinTemplateProvider:
 
     def __init__(self) -> None:
         self.template_dir = Path(__file__).parent.joinpath("template")
-        self.static_dir = self.template_dir.joinpath("static")
+        self.static_dir = Path(__file__).parent.joinpath("static")
 
         self.jinja_env = self._create_environment()
 

--- a/keeper/services/createproduct.py
+++ b/keeper/services/createproduct.py
@@ -57,6 +57,7 @@ def create_product(
     product.title = title
     # Compatibility with v1 table architecture. This can be removed once
     # these fields are dropped from the Product model
+    # print(f"create_product {org.root_domain}")
     product.root_domain = org.root_domain
     product.root_fastly_domain = org.fastly_domain
     product.bucket_name = org.bucket_name

--- a/keeper/services/dashboard.py
+++ b/keeper/services/dashboard.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+import boto3
+from ltdconveyor.s3 import (
+    create_dir_redirect_object,
+    upload_dir,
+    upload_object,
+)
+
+from keeper import fastly, s3
 from keeper.dashboard.context import Context
 from keeper.dashboard.templateproviders import BuiltinTemplateProvider
 
@@ -17,17 +26,123 @@ def build_dashboard(product: Product, logger: Any) -> None:
     """Build a dashboard (run from a Celery task)."""
     logger.debug("In build_dashboard service function.")
 
+    organization = product.organization
+
+    aws_id = organization.aws_id
+    aws_secret = organization.get_aws_secret_key()
+    aws_region = organization.get_aws_region()
+    use_public_read_acl = organization.get_bucket_public_read()
+
+    fastly_service_id = organization.fastly_service_id
+    fastly_key = organization.get_fastly_api_key()
+
+    # Render dashboards using the built-in dashboard template provider;
+    # eventually we'll add the ability to get templates from a configured
+    # S3 bucket location.
     context = Context.create(product)
     template_provider = BuiltinTemplateProvider()
-    print(
-        template_provider.render_edition_dashboard(
-            project_context=context.project_context,
-            edition_contexts=context.edition_contexts,
-        )
+    edition_html = template_provider.render_edition_dashboard(
+        project_context=context.project_context,
+        edition_contexts=context.edition_contexts,
     )
-    print(
-        template_provider.render_build_dashboard(
-            project_context=context.project_context,
-            build_contexts=context.build_contexts,
+    build_html = template_provider.render_build_dashboard(
+        project_context=context.project_context,
+        build_contexts=context.build_contexts,
+    )
+
+    if aws_id is not None and aws_secret is not None:
+        s3_service = s3.open_s3_resource(
+            key_id=aws_id,
+            access_key=aws_secret.get_secret_value(),
+            aws_region=aws_region,
         )
+
+        upload_dir(
+            product.organization.bucket_name,
+            f"{product.slug}/_dashboard-assets",
+            str(template_provider.static_dir),
+            upload_dir_redirect_objects=True,
+            surrogate_key=product.surrogate_key,
+            surrogate_control="max-age=31536000",
+            cache_control="no-cache",
+            acl="public-read" if use_public_read_acl else None,
+            aws_access_key_id=aws_id,
+            aws_secret_access_key=aws_secret,
+        )
+
+        upload_dashboard_html(
+            html=edition_html,
+            key="v/index.html",
+            product=product,
+            s3_service=s3_service,
+        )
+        upload_dashboard_html(
+            html=build_html,
+            key="builds/index.html",
+            product=product,
+            s3_service=s3_service,
+        )
+
+    else:
+        logger.warning(
+            "Skipping dashboard uploads because AWS credentials are not set"
+        )
+
+    if (
+        organization.fastly_support
+        and fastly_service_id is not None
+        and fastly_key is not None
+    ):
+        logger.info("Starting Fastly purge_key")
+        fastly_service = fastly.FastlyService(
+            fastly_service_id, fastly_key.get_secret_value()
+        )
+        fastly_service.purge_key(product.surrogate_key)
+        logger.info("Finished Fastly purge_key")
+    else:
+        logger.warning("Skipping Fastly purge because credentials are not set")
+
+
+def upload_dashboard_html(
+    *,
+    html: str,
+    key: str,
+    product: Product,
+    s3_service: boto3.resources.base.ServiceResource,
+) -> None:
+    bucket = s3_service.Bucket(product.organization.bucket_name)
+
+    if not key.startswith("/"):
+        key = f"/{key}"
+
+    object_path = f"{product.slug}{key}"
+
+    # Have Fastly cache the dashboard for a year (or until purged)
+    metadata = {
+        "surrogate-key": product.surrogate_key,
+        "surrogate-control": "max-age=31536000",
+    }
+    acl = "public-read"
+    # Have the *browser* never cache the dashboard
+    cache_control = "no-cache"
+
+    # Upload HTML object
+    upload_object(
+        object_path,
+        bucket,
+        content=html,
+        metadata=metadata,
+        acl=acl,
+        cache_control=cache_control,
+        content_type="text/html",
+    )
+
+    # Upload directory redirect object
+    bucket_dir_path = PurePosixPath(object_path).parent
+    create_dir_redirect_object(
+        bucket_dir_path,
+        bucket,
+        metadata=metadata,
+        acl=acl,
+        cache_control=cache_control,
     )

--- a/keeper/services/dashboard.py
+++ b/keeper/services/dashboard.py
@@ -1,8 +1,11 @@
-"""This service updates an edition's dashboard."""
+"""This service updates project's edition and build dashboards."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+
+from keeper.dashboard.context import Context
+from keeper.dashboard.templateproviders import BuiltinTemplateProvider
 
 if TYPE_CHECKING:
     from keeper.models import Product
@@ -12,5 +15,19 @@ __all__ = ["build_dashboard"]
 
 def build_dashboard(product: Product, logger: Any) -> None:
     """Build a dashboard (run from a Celery task)."""
-    # TODO implement this service
     logger.debug("In build_dashboard service function.")
+
+    context = Context.create(product)
+    template_provider = BuiltinTemplateProvider()
+    print(
+        template_provider.render_edition_dashboard(
+            project_context=context.project_context,
+            edition_contexts=context.edition_contexts,
+        )
+    )
+    print(
+        template_provider.render_build_dashboard(
+            project_context=context.project_context,
+            build_contexts=context.build_contexts,
+        )
+    )

--- a/keeper/testutils.py
+++ b/keeper/testutils.py
@@ -43,6 +43,8 @@ class TestClient:
     - `json`: the return data, parse as JSON into a Python `dict` object.
     """
 
+    __test__ = False
+
     def __init__(self, app: Flask, username: str, password: str = "") -> None:
         self.app = app
         self.auth = "Basic " + b64encode(

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
 
 images:
   - name: 'lsstsqre/ltd-keeper:latest'
-    newTag: u-jsickcodes-deploy-2-0
+    newTag: 2.0.0-alpha.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -43,13 +43,13 @@ markupsafe==2.1.1
     #   jinja2
 mock==4.0.3
     # via -r requirements/dev.in
-mypy==0.960
+mypy==0.961
     # via
     #   -r requirements/dev.in
     #   sqlalchemy-stubs
 mypy-extensions==0.4.3
     # via mypy
-numpydoc==1.3.1
+numpydoc==1.4.0
     # via -r requirements/dev.in
 packaging==21.3
     # via
@@ -76,7 +76,7 @@ pytz==2022.1
     # via
     #   -c requirements/main.txt
     #   babel
-requests==2.27.1
+requests==2.28.0
     # via
     #   -c requirements/main.txt
     #   responses
@@ -89,7 +89,7 @@ six==1.16.0
     #   sphinxcontrib-httpdomain
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==5.0.0
+sphinx==5.0.1
     # via
     #   -r requirements/dev.in
     #   numpydoc
@@ -118,7 +118,7 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
-types-mock==4.0.14
+types-mock==4.0.15
     # via -r requirements/dev.in
 types-python-dateutil==2.8.17
     # via -r requirements/dev.in

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -23,3 +23,4 @@ celery[redis]
 pydantic
 cryptography
 Jinja2
+ltd-conveyor

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -22,3 +22,4 @@ structlog
 celery[redis]
 pydantic
 cryptography
+Jinja2

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -12,9 +12,11 @@ async-timeout==4.0.2
     # via redis
 billiard==3.6.4.0
     # via celery
-boto3==1.24.1
-    # via -r requirements/main.in
-botocore==1.27.1
+boto3==1.24.7
+    # via
+    #   -r requirements/main.in
+    #   ltd-conveyor
+botocore==1.27.7
     # via
     #   boto3
     #   s3transfer
@@ -33,6 +35,7 @@ click==8.1.3
     #   click-plugins
     #   click-repl
     #   flask
+    #   ltd-conveyor
 click-didyoumean==0.3.0
     # via celery
 click-plugins==1.1.1
@@ -78,6 +81,8 @@ jmespath==1.0.0
     #   botocore
 kombu==5.2.4
     # via celery
+ltd-conveyor==0.8.1
+    # via -r requirements/main.in
 mako==1.2.0
     # via alembic
 markupsafe==2.1.1
@@ -106,8 +111,10 @@ pytz==2022.1
     # via celery
 redis==4.3.3
     # via celery
-requests==2.27.1
-    # via -r requirements/main.in
+requests==2.28.0
+    # via
+    #   -r requirements/main.in
+    #   ltd-conveyor
 s3transfer==0.6.0
     # via boto3
 six==1.16.0
@@ -123,6 +130,8 @@ structlog==21.5.0
     # via -r requirements/main.in
 typing-extensions==4.2.0
     # via pydantic
+uritemplate==4.1.1
+    # via ltd-conveyor
 urllib3==1.26.9
     # via
     #   botocore

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -69,7 +69,9 @@ itsdangerous==2.0.1
     #   -r requirements/main.in
     #   flask
 jinja2==3.1.2
-    # via flask
+    # via
+    #   -r requirements/main.in
+    #   flask
 jmespath==1.0.0
     # via
     #   boto3
@@ -102,7 +104,7 @@ python-dateutil==2.8.2
     #   botocore
 pytz==2022.1
     # via celery
-redis==4.3.2
+redis==4.3.3
     # via celery
 requests==2.27.1
     # via -r requirements/main.in

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -1,0 +1,64 @@
+"""Tests for keeper.dashboard and keeper.services.dashboard."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from structlog import get_logger
+
+from keeper.models import OrganizationLayoutMode, db
+from keeper.services.createbuild import create_build
+from keeper.services.createorg import create_organization
+from keeper.services.createproduct import create_product
+from keeper.services.dashboard import build_dashboard
+from keeper.testutils import MockTaskQueue, TestClient
+
+
+def test_builtin_template(client: TestClient, mocker: Mock) -> None:
+    logger = get_logger("keeper")
+
+    task_queue = mocker.patch(
+        "keeper.taskrunner.inspect_task_queue", return_value=None
+    )
+    task_queue = MockTaskQueue(mocker)  # noqa
+
+    org = create_organization(
+        slug="test",
+        title="Test",
+        layout=OrganizationLayoutMode.path,
+        domain="example.org",
+        path_prefix="/",
+        bucket_name="example",
+        s3_public_read=False,
+        fastly_support=False,
+        aws_id=None,
+        aws_region=None,
+        aws_secret=None,
+        fastly_domain=None,
+        fastly_service_id=None,
+        fastly_api_key=None,
+    )
+    db.session.add(org)
+    db.session.commit()
+
+    # This print is somehow required; not exactly sure why.
+    print(f"test {org.root_domain}")
+
+    product, default_edition = create_product(
+        org=org,
+        slug="myproject",
+        doc_repo="https://git.example.org/myproject",
+        title="My Project",
+    )
+    print(product)
+    build, _ = create_build(
+        product=product,
+        git_ref="main",
+    )
+    default_edition.build = build
+    db.session.add(build)
+    db.session.add(default_edition)
+    db.session.commit()
+
+    build_dashboard(product, logger)
+    assert False

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -61,4 +61,3 @@ def test_builtin_template(client: TestClient, mocker: Mock) -> None:
     db.session.commit()
 
     build_dashboard(product, logger)
-    assert False

--- a/tests/test_dashboard_template.py
+++ b/tests/test_dashboard_template.py
@@ -1,0 +1,58 @@
+"""Test the built-in dashboard template by rendering to a local directory."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+from keeper.dashboard.context import (
+    BuildContext,
+    BuildContextList,
+    EditionContext,
+    EditionContextList,
+    ProjectContext,
+)
+from keeper.dashboard.templateproviders import BuiltinTemplateProvider
+from keeper.models import EditionKind
+
+
+def test_templates() -> None:
+    output_dir = Path(__file__).parent.parent.joinpath("dashboard_dev")
+
+    # Create mock data
+    project = ProjectContext(
+        title="LTD Test Project",
+        source_repo_url="https://github.com/lsst-sqre/ltd-keeper",
+        url="https://example.com/ltd-test/",
+    )
+    editions: List[EditionContext] = []
+    builds: List[BuildContext] = []
+
+    editions.append(
+        EditionContext(
+            title="Current",
+            url="https://example.com/ltd-test/",
+            date_updated=datetime(2022, 6, 21, tzinfo=timezone.utc),
+            kind=EditionKind.main,
+            slug="__main",
+            git_ref="main",
+        )
+    )
+
+    builds.append(
+        BuildContext(
+            slug="1",
+            url="https://example.com/ltd-test/builds/1",
+            git_ref="main",
+            date=datetime(2022, 6, 21, tzinfo=timezone.utc),
+        )
+    )
+
+    template = BuiltinTemplateProvider()
+    template.render_locally(
+        directory=output_dir,
+        project_context=project,
+        edition_contexts=EditionContextList(editions),
+        build_contexts=BuildContextList(builds),
+    )

--- a/tests/test_dashboard_template.py
+++ b/tests/test_dashboard_template.py
@@ -33,10 +33,56 @@ def test_templates() -> None:
         EditionContext(
             title="Current",
             url="https://example.com/ltd-test/",
-            date_updated=datetime(2022, 6, 21, tzinfo=timezone.utc),
+            date_updated=datetime(2022, 6, 24, tzinfo=timezone.utc),
             kind=EditionKind.main,
             slug="__main",
             git_ref="main",
+            github_url="https://example.com/ltd-test/tree/main",
+        )
+    )
+
+    editions.append(
+        EditionContext(
+            title="1.0.0",
+            url="https://example.com/ltd-test/v/1.0.0",
+            date_updated=datetime(2022, 6, 21, tzinfo=timezone.utc),
+            kind=EditionKind.release,
+            slug="1.0.0",
+            git_ref="1.0.0",
+            github_url="https://example.com/ltd-test/tree/1.0.0",
+        )
+    )
+    editions.append(
+        EditionContext(
+            title="1.1.0",
+            url="https://example.com/ltd-test/v/1.1.0",
+            date_updated=datetime(2022, 6, 22, tzinfo=timezone.utc),
+            kind=EditionKind.release,
+            slug="1.1.0",
+            git_ref="1.1.0",
+            github_url="https://example.com/ltd-test/tree/1.1.0",
+        )
+    )
+    editions.append(
+        EditionContext(
+            title="2.0.0",
+            url="https://example.com/ltd-test/v/2.0.0",
+            date_updated=datetime(2022, 6, 24, tzinfo=timezone.utc),
+            kind=EditionKind.release,
+            slug="2.0.0",
+            git_ref="2.0.0",
+            github_url="https://example.com/ltd-test/tree/2.0.0",
+        )
+    )
+    editions.append(
+        EditionContext(
+            title="my-branch",
+            url="https://example.com/ltd-test/v/my-branch",
+            date_updated=datetime(2022, 6, 24, tzinfo=timezone.utc),
+            kind=EditionKind.draft,
+            slug="my-branch",
+            git_ref="my-branch",
+            github_url="https://example.com/ltd-test/tree/my-branch",
         )
     )
 


### PR DESCRIPTION
This PR reimplements dashboard generation for LTD Keeper v2. This functionality was originally part of [LTD Dasher](https://github.com/lsst-sqre/ltd-dasher). Since LTD Keeper v2 now support multiple missions, the dashboard generation code is being moved into LTD Keeper itself for easier maintainability.

The ultimate intent is for each organization to develop and configure their own dashboard HTML templates and assets. The default template though, will be built-in. This PR implements that `BuiltinTemplateProvider` and also enables us to develop other infrastructure related to dashaboard templates such as Jinja context objects and S3 uploading.