### PR TITLE
DM-54538: Add publish-edition CLI command

### DIFF
--- a/alembic/versions/20260407_0000_a1b2c3d4e5f7_add_builds_storage_prefix.py
+++ b/alembic/versions/20260407_0000_a1b2c3d4e5f7_add_builds_storage_prefix.py
@@ -11,6 +11,7 @@ Create Date: 2026-04-07 00:00:00.000000+00:00
 import sqlalchemy as sa
 
 from alembic import op
+from docverse.domain.base32id import serialize_base32_id
 
 # revision identifiers, used by Alembic.
 revision: str = "a1b2c3d4e5f7"
@@ -20,10 +21,32 @@ depends_on: str | None = None
 
 
 def upgrade() -> None:
+    # Step 1: Add column as nullable
     op.add_column(
         "builds",
-        sa.Column("storage_prefix", sa.String(512), nullable=False),
+        sa.Column("storage_prefix", sa.String(512), nullable=True),
     )
+
+    # Step 2: Backfill existing rows
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text(
+            "SELECT builds.id, builds.public_id, projects.slug "
+            "FROM builds JOIN projects ON builds.project_id = projects.id"
+        )
+    ).fetchall()
+    for build_id, public_id, project_slug in rows:
+        base32_id = serialize_base32_id(public_id)
+        storage_prefix = f"{project_slug}/__builds/{base32_id}/"
+        conn.execute(
+            sa.text(
+                "UPDATE builds SET storage_prefix = :prefix WHERE id = :id"
+            ),
+            {"prefix": storage_prefix, "id": build_id},
+        )
+
+    # Step 3: Set column to NOT NULL
+    op.alter_column("builds", "storage_prefix", nullable=False)
 
 
 def downgrade() -> None:

--- a/client/src/docverse/client/_cli.py
+++ b/client/src/docverse/client/_cli.py
@@ -334,7 +334,11 @@ async def _upload_async(  # noqa: PLR0913
             click.echo(f"Build created: {build.id}")
 
             if build.upload_url is None:
-                msg = "Server did not return an upload URL"
+                msg = (
+                    "Server did not return an upload URL. "
+                    "The organization may not have an object "
+                    "store configured."
+                )
                 raise DocverseClientError(msg)  # noqa: TRY301
 
             click.echo("Uploading tarball")

--- a/client/src/docverse/client/_cli.py
+++ b/client/src/docverse/client/_cli.py
@@ -237,6 +237,20 @@ def deploy_worker(
             tgz.unlink()
     (worker_dir / tarball_name).unlink(missing_ok=True)
 
+    # Phase 2b: install worker runtime dependencies
+    click.echo("Installing worker dependencies")
+    try:
+        subprocess.run(
+            ["npm", "install", "--production"],  # noqa: S607
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=str(dest_dir),
+        )
+    except subprocess.CalledProcessError as exc:
+        msg = f"npm install failed: {exc.stderr}"
+        raise click.ClickException(msg) from exc
+
     # Phase 3: wrangler deploy
     wrangler_cmd = [
         "npx",

--- a/client/src/docverse/client/_cli.py
+++ b/client/src/docverse/client/_cli.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -146,6 +149,117 @@ def upload(  # noqa: PLR0913
             verbose=verbose,
         )
     )
+
+
+@main.command()
+@click.option(
+    "--docverse-repo",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Path to the docverse monorepo root.",
+)
+@click.option(
+    "--deployments-repo",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Path to local docverse-cloudflare-deployments checkout.",
+)
+@click.option(
+    "--env",
+    "wrangler_env",
+    required=True,
+    help="Wrangler environment name (e.g., dev, production).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Build the worker bundle without deploying.",
+)
+def deploy_worker(
+    *,
+    docverse_repo: Path,
+    deployments_repo: Path,
+    wrangler_env: str,
+    dry_run: bool,
+) -> None:
+    """Pack and deploy the Cloudflare Worker."""
+    if not re.match(r"^[a-zA-Z0-9_-]+$", wrangler_env):
+        msg = (
+            f"Invalid environment name {wrangler_env!r}: "
+            "must contain only alphanumeric characters, hyphens, "
+            "and underscores"
+        )
+        raise click.ClickException(msg)
+
+    worker_dir = docverse_repo.resolve() / "cloudflare-worker"
+    if not worker_dir.is_dir():
+        msg = f"cloudflare-worker/ not found in {docverse_repo.resolve()}"
+        raise click.ClickException(msg)
+
+    deployments_repo = deployments_repo.resolve()
+    dest_dir = deployments_repo / "worker"
+    dest_dir.mkdir(exist_ok=True)
+
+    # Phase 1: npm pack
+    click.echo(f"Packing cloudflare worker from {worker_dir}")
+    try:
+        pack_result = subprocess.run(
+            ["npm", "pack", "--json"],  # noqa: S607
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=str(worker_dir),
+        )
+    except subprocess.CalledProcessError as exc:
+        msg = f"npm pack failed: {exc.stderr}"
+        raise click.ClickException(msg) from exc
+    try:
+        tarball_name = json.loads(pack_result.stdout)[0]["filename"]
+    except (json.JSONDecodeError, KeyError, IndexError) as exc:
+        msg = f"Failed to parse npm pack output: {pack_result.stdout!r}"
+        raise click.ClickException(msg) from exc
+
+    # Phase 2: copy and unpack into deployments repo
+    click.echo(f"Unpacking worker into {dest_dir}")
+    shutil.copy2(worker_dir / tarball_name, dest_dir / tarball_name)
+    try:
+        subprocess.run(  # noqa: S603
+            ["tar", "xzf", tarball_name, "--strip-components=1"],  # noqa: S607
+            check=True,
+            cwd=str(dest_dir),
+        )
+    except subprocess.CalledProcessError as exc:
+        msg = f"Failed to unpack worker tarball: {exc}"
+        raise click.ClickException(msg) from exc
+    finally:
+        for tgz in dest_dir.glob("*.tgz"):
+            tgz.unlink()
+    (worker_dir / tarball_name).unlink(missing_ok=True)
+
+    # Phase 3: wrangler deploy
+    wrangler_cmd = [
+        "npx",
+        "wrangler",
+        "deploy",
+        "--env",
+        wrangler_env,
+    ]
+    if dry_run:
+        outdir = deployments_repo / "dist"
+        wrangler_cmd.extend(["--dry-run", f"--outdir={outdir}"])
+    click.echo(f"Deploying worker (env={wrangler_env}, dry_run={dry_run})")
+    try:
+        subprocess.run(  # noqa: S603
+            wrangler_cmd,
+            check=True,
+            cwd=str(deployments_repo),
+        )
+    except subprocess.CalledProcessError as exc:
+        msg = f"wrangler deploy failed: {exc}"
+        raise click.ClickException(msg) from exc
+
+    click.echo(f"Worker deployed successfully (env={wrangler_env})")
 
 
 def _detect_git_ref() -> str:

--- a/client/src/docverse/client/models/builds.py
+++ b/client/src/docverse/client/models/builds.py
@@ -88,6 +88,8 @@ class BuildStatus(StrEnum):
 class BuildCreate(BaseModel):
     """Request model for creating a build."""
 
+    model_config = ConfigDict(extra="forbid")
+
     git_ref: Annotated[
         str,
         Field(
@@ -204,6 +206,8 @@ class BuildUpdate(BaseModel):
     Currently supports only the ``status`` field, used to signal
     that an upload is complete (set ``status`` to ``"uploaded"``).
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     status: BuildStatus | None = Field(
         default=None,

--- a/client/src/docverse/client/models/credentials.py
+++ b/client/src/docverse/client/models/credentials.py
@@ -80,6 +80,8 @@ CredentialPayload = Annotated[
 class OrganizationCredentialCreate(BaseModel):
     """Request model for creating an organization credential."""
 
+    model_config = ConfigDict(extra="forbid")
+
     label: Annotated[
         str,
         Field(

--- a/client/src/docverse/client/models/editions.py
+++ b/client/src/docverse/client/models/editions.py
@@ -90,6 +90,8 @@ class DefaultEditionConfig(BaseModel):
 class EditionCreate(BaseModel):
     """Request model for creating an edition."""
 
+    model_config = ConfigDict(extra="forbid")
+
     slug: Annotated[
         str,
         Field(
@@ -224,6 +226,8 @@ class EditionRollback(BaseModel):
 
 class EditionUpdate(BaseModel):
     """Request model for updating an edition (PATCH)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     title: str | None = Field(
         default=None, description="Display title for the edition."

--- a/client/src/docverse/client/models/memberships.py
+++ b/client/src/docverse/client/models/memberships.py
@@ -32,6 +32,8 @@ class OrgRole(StrEnum):
 class OrgMembershipCreate(BaseModel):
     """Request model for creating an organization membership."""
 
+    model_config = ConfigDict(extra="forbid")
+
     principal: str = Field(
         min_length=1,
         max_length=256,

--- a/client/src/docverse/client/models/organizations.py
+++ b/client/src/docverse/client/models/organizations.py
@@ -26,6 +26,8 @@ class UrlScheme(StrEnum):
 class OrganizationCreate(BaseModel):
     """Request model for creating an organization."""
 
+    model_config = ConfigDict(extra="forbid")
+
     slug: Annotated[
         str,
         Field(
@@ -203,6 +205,8 @@ class Organization(BaseModel):
 
 class OrganizationUpdate(BaseModel):
     """Request model for updating an organization (PATCH)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     title: str | None = Field(
         default=None, description="Display title for the organization."

--- a/client/src/docverse/client/models/projects.py
+++ b/client/src/docverse/client/models/projects.py
@@ -14,6 +14,8 @@ from .editions import Edition as EditionResponse
 class ProjectCreate(BaseModel):
     """Request model for creating a project."""
 
+    model_config = ConfigDict(extra="forbid")
+
     slug: Annotated[
         str,
         Field(
@@ -107,6 +109,8 @@ class Project(BaseModel):
 
 class ProjectUpdate(BaseModel):
     """Request model for updating a project (PATCH)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     title: str | None = Field(
         default=None, description="Display title for the project."

--- a/client/src/docverse/client/models/services.py
+++ b/client/src/docverse/client/models/services.py
@@ -136,6 +136,8 @@ ServiceConfig = Annotated[
 class OrganizationServiceCreate(BaseModel):
     """Request model for creating an organization service."""
 
+    model_config = ConfigDict(extra="forbid")
+
     label: Annotated[
         str,
         Field(
@@ -173,6 +175,8 @@ class OrganizationServiceCreate(BaseModel):
 
 class OrganizationServiceUpdate(BaseModel):
     """Request model for updating an organization service (PATCH)."""
+
+    model_config = ConfigDict(extra="forbid")
 
     credential_label: str | None = Field(
         default=None,

--- a/client/tests/deploy_worker_integration_test.py
+++ b/client/tests/deploy_worker_integration_test.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from docverse.cli import main
+from docverse.client._cli import main
 
 WRANGLER_TOML = textwrap.dedent("""\
     # Mock deployments repo wrangler.toml

--- a/client/tests/deploy_worker_test.py
+++ b/client/tests/deploy_worker_test.py
@@ -1,3 +1,4 @@
+# ruff: noqa: ARG001
 """Tests for the deploy-worker CLI command."""
 
 from __future__ import annotations
@@ -9,7 +10,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from click.testing import CliRunner
 
-from docverse.cli import main
+from docverse.client._cli import main
 
 
 @pytest.fixture
@@ -91,8 +92,8 @@ def test_deploy_worker_invalid_env_name(
     assert "Invalid environment name" in result.output
 
 
-@patch("docverse.cli.shutil.copy2")
-@patch("docverse.cli.subprocess.run")
+@patch("docverse.client._cli.shutil.copy2")
+@patch("docverse.client._cli.subprocess.run")
 def test_deploy_worker_happy_path(
     mock_run: MagicMock,
     mock_copy: MagicMock,
@@ -121,7 +122,8 @@ def test_deploy_worker_happy_path(
     deployments = mock_deployments_repo.resolve()
     dest_dir = deployments / "worker"
 
-    assert mock_run.call_count == 3
+    expected_call_count = 4
+    assert mock_run.call_count == expected_call_count
     mock_run.assert_has_calls(
         [
             call(
@@ -142,6 +144,13 @@ def test_deploy_worker_happy_path(
                 cwd=str(dest_dir),
             ),
             call(
+                ["npm", "install", "--production"],
+                check=True,
+                capture_output=True,
+                text=True,
+                cwd=str(dest_dir),
+            ),
+            call(
                 ["npx", "wrangler", "deploy", "--env", "dev"],
                 check=True,
                 cwd=str(deployments),
@@ -155,8 +164,8 @@ def test_deploy_worker_happy_path(
     )
 
 
-@patch("docverse.cli.shutil.copy2")
-@patch("docverse.cli.subprocess.run")
+@patch("docverse.client._cli.shutil.copy2")
+@patch("docverse.client._cli.subprocess.run")
 def test_deploy_worker_npm_pack_fails(
     mock_run: MagicMock,
     mock_copy: MagicMock,
@@ -189,8 +198,8 @@ def test_deploy_worker_npm_pack_fails(
     "bad_stdout",
     ["not json at all\n", "[]\n", '[{"no_filename": true}]\n'],
 )
-@patch("docverse.cli.shutil.copy2")
-@patch("docverse.cli.subprocess.run")
+@patch("docverse.client._cli.shutil.copy2")
+@patch("docverse.client._cli.subprocess.run")
 def test_deploy_worker_npm_pack_bad_json(
     mock_run: MagicMock,
     mock_copy: MagicMock,
@@ -220,8 +229,8 @@ def test_deploy_worker_npm_pack_bad_json(
     assert "Failed to parse npm pack output" in result.output
 
 
-@patch("docverse.cli.shutil.copy2")
-@patch("docverse.cli.subprocess.run")
+@patch("docverse.client._cli.shutil.copy2")
+@patch("docverse.client._cli.subprocess.run")
 def test_deploy_worker_tar_extract_fails(
     mock_run: MagicMock,
     mock_copy: MagicMock,
@@ -257,8 +266,8 @@ def test_deploy_worker_tar_extract_fails(
     assert "Failed to unpack worker tarball" in result.output
 
 
-@patch("docverse.cli.shutil.copy2")
-@patch("docverse.cli.subprocess.run")
+@patch("docverse.client._cli.shutil.copy2")
+@patch("docverse.client._cli.subprocess.run")
 def test_deploy_worker_wrangler_deploy_fails(
     mock_run: MagicMock,
     mock_copy: MagicMock,
@@ -266,11 +275,12 @@ def test_deploy_worker_wrangler_deploy_fails(
     mock_deployments_repo: Path,
 ) -> None:
     call_count = 0
+    succeed_count = 3
 
     def side_effect(*args: object, **kwargs: object) -> MagicMock:
         nonlocal call_count
         call_count += 1
-        if call_count <= 2:
+        if call_count <= succeed_count:
             return _npm_pack_side_effect(*args)
         raise subprocess.CalledProcessError(1, "wrangler")
 
@@ -319,8 +329,8 @@ def test_deploy_worker_missing_cloudflare_worker_dir(
     assert "cloudflare-worker/ not found" in result.output
 
 
-@patch("docverse.cli.shutil.copy2")
-@patch("docverse.cli.subprocess.run")
+@patch("docverse.client._cli.shutil.copy2")
+@patch("docverse.client._cli.subprocess.run")
 def test_deploy_worker_creates_worker_dest_dir(
     mock_run: MagicMock,
     mock_copy: MagicMock,
@@ -350,8 +360,8 @@ def test_deploy_worker_creates_worker_dest_dir(
 
 
 @pytest.mark.parametrize("env_name", ["dev", "production"])
-@patch("docverse.cli.shutil.copy2")
-@patch("docverse.cli.subprocess.run")
+@patch("docverse.client._cli.shutil.copy2")
+@patch("docverse.client._cli.subprocess.run")
 def test_deploy_worker_env_passed_to_wrangler(
     mock_run: MagicMock,
     mock_copy: MagicMock,
@@ -377,7 +387,7 @@ def test_deploy_worker_env_passed_to_wrangler(
 
     assert result.exit_code == 0, result.output
 
-    wrangler_call = mock_run.call_args_list[2]
+    wrangler_call = mock_run.call_args_list[3]
     assert wrangler_call == call(
         ["npx", "wrangler", "deploy", "--env", env_name],
         check=True,
@@ -385,8 +395,8 @@ def test_deploy_worker_env_passed_to_wrangler(
     )
 
 
-@patch("docverse.cli.shutil.copy2")
-@patch("docverse.cli.subprocess.run")
+@patch("docverse.client._cli.shutil.copy2")
+@patch("docverse.client._cli.subprocess.run")
 def test_deploy_worker_dry_run(
     mock_run: MagicMock,
     mock_copy: MagicMock,
@@ -414,7 +424,7 @@ def test_deploy_worker_dry_run(
 
     deployments = mock_deployments_repo.resolve()
     outdir = deployments / "dist"
-    wrangler_call = mock_run.call_args_list[2]
+    wrangler_call = mock_run.call_args_list[3]
     assert wrangler_call == call(
         [
             "npx",

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,20 +112,8 @@ def deploy_worker_test(session: nox.Session) -> None:
     """Integration test for deploy-worker (requires Node.js/npm)."""
     session.run(
         "pytest",
-        "tests/integration/",
+        "client/tests/deploy_worker_integration_test.py",
         *session.posargs,
-        env={
-            "DOCVERSE_DATABASE_URL": "postgresql://localhost/unused",
-            "DOCVERSE_DATABASE_PASSWORD": "unused",
-            "DOCVERSE_ALEMBIC_CONFIG_PATH": "alembic.ini",
-            "DOCVERSE_ARQ_MODE": "test",
-            "DOCVERSE_CREDENTIAL_ENCRYPTION_KEY": (
-                "nz4oCndEIQhi-PlZBzYzmK_jlacf05Hz3VnrRrZhq-k="
-            ),
-            "REPERTOIRE_BASE_URL": (
-                "https://roundtable.lsst.cloud/repertoire"
-            ),
-        },
     )
 
 

--- a/src/docverse/cli.py
+++ b/src/docverse/cli.py
@@ -212,7 +212,14 @@ def validate_db_schema(*, alembic_config_path: Path) -> None:
 def publish_edition(
     *, org: str, project: str, edition: str, build_id: str
 ) -> None:
-    """Publish an edition by writing a KV entry via the Cloudflare API."""
+    """Publish an edition by writing a KV entry via the Cloudflare API.
+
+    This is a temporary shim command for a proof-of-concept for publishing
+    on Cloudflare workers.
+
+    Required environment variables: CLOUDFLARE_API_TOKEN,
+    CLOUDFLARE_ACCOUNT_ID, and CLOUDFLARE_KV_NAMESPACE_ID.
+    """
     logger = structlog.get_logger("docverse")
 
     cf_api_token = os.environ.get("CLOUDFLARE_API_TOKEN")

--- a/src/docverse/cli.py
+++ b/src/docverse/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib.metadata
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -12,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 import click
+import httpx
 import structlog
 from alembic.config import Config
 from alembic.script import ScriptDirectory
@@ -21,9 +23,17 @@ from safir.database import (
     stamp_database,
 )
 from safir.logging import configure_logging
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_scoped_session, async_sessionmaker
 
 from .config import config
 from .database import check_database_state, get_current_revision, init_database
+from .dbschema.build import SqlBuild
+from .dbschema.edition import SqlEdition
+from .dbschema.organization import SqlOrganization
+from .dbschema.project import SqlProject
+from .domain.base32id import validate_base32_id
+from .domain.build import Build
 
 __all__ = ["help", "main"]
 
@@ -299,6 +309,188 @@ def deploy_worker(
         env=wrangler_env,
         dry_run=dry_run,
     )
+
+
+@main.command()
+@click.option(
+    "--org",
+    required=True,
+    help="Organization slug.",
+)
+@click.option(
+    "--project",
+    required=True,
+    help="Project slug.",
+)
+@click.option(
+    "--edition",
+    required=True,
+    help="Edition slug.",
+)
+@click.option(
+    "--build-id",
+    required=True,
+    help="Base32-encoded public build ID.",
+)
+def publish_edition(
+    *, org: str, project: str, edition: str, build_id: str
+) -> None:
+    """Publish an edition by writing a KV entry via the Cloudflare API."""
+    logger = structlog.get_logger("docverse")
+
+    cf_api_token = os.environ.get("CLOUDFLARE_API_TOKEN")
+    cf_account_id = os.environ.get("CLOUDFLARE_ACCOUNT_ID")
+    cf_kv_namespace_id = os.environ.get("CLOUDFLARE_KV_NAMESPACE_ID")
+
+    if not cf_api_token:
+        msg = "CLOUDFLARE_API_TOKEN environment variable is required"
+        raise click.ClickException(msg)
+    if not cf_account_id:
+        msg = "CLOUDFLARE_ACCOUNT_ID environment variable is required"
+        raise click.ClickException(msg)
+    if not cf_kv_namespace_id:
+        msg = "CLOUDFLARE_KV_NAMESPACE_ID environment variable is required"
+        raise click.ClickException(msg)
+
+    asyncio.run(
+        _publish_edition(
+            org_slug=org,
+            project_slug=project,
+            edition_slug=edition,
+            build_id=build_id,
+            cf_api_token=cf_api_token,
+            cf_account_id=cf_account_id,
+            cf_kv_namespace_id=cf_kv_namespace_id,
+            logger=logger,
+        )
+    )
+
+
+async def _publish_edition(  # noqa: PLR0913
+    *,
+    org_slug: str,
+    project_slug: str,
+    edition_slug: str,
+    build_id: str,
+    cf_api_token: str,
+    cf_account_id: str,
+    cf_kv_namespace_id: str,
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    """Look up the build and write the KV entry."""
+    build = await _lookup_build(
+        org_slug=org_slug,
+        project_slug=project_slug,
+        edition_slug=edition_slug,
+        build_id=build_id,
+    )
+
+    kv_key = f"{project_slug}/{edition_slug}"
+    kv_value = json.dumps(
+        {"build_id": build_id, "r2_prefix": build.storage_prefix}
+    )
+
+    url = (
+        f"https://api.cloudflare.com/client/v4/accounts/{cf_account_id}"
+        f"/storage/kv/namespaces/{cf_kv_namespace_id}/values/{kv_key}"
+    )
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.put(
+                url,
+                content=kv_value,
+                headers={
+                    "Authorization": f"Bearer {cf_api_token}",
+                    "Content-Type": "application/json",
+                },
+            )
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        msg = f"Cloudflare KV API error: {exc.response.status_code}"
+        raise click.ClickException(msg) from exc
+
+    logger.info(
+        "Published edition",
+        org=org_slug,
+        project=project_slug,
+        edition=edition_slug,
+        build_id=build_id,
+        kv_key=kv_key,
+    )
+
+
+async def _lookup_build(
+    *, org_slug: str, project_slug: str, edition_slug: str, build_id: str
+) -> Build:
+    """Look up a build by org/project/build-id using a temporary engine."""
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    try:
+        session_factory = async_scoped_session(
+            async_sessionmaker(engine),
+            scopefunc=asyncio.current_task,
+        )
+        session = session_factory()
+        try:
+            # Resolve org
+            result = await session.execute(
+                select(SqlOrganization).where(SqlOrganization.slug == org_slug)
+            )
+            org_row = result.scalar_one_or_none()
+            if org_row is None:
+                msg = f"Organization {org_slug!r} not found"
+                raise click.ClickException(msg)
+
+            # Resolve project
+            result = await session.execute(
+                select(SqlProject).where(
+                    SqlProject.org_id == org_row.id,
+                    SqlProject.slug == project_slug,
+                )
+            )
+            project_row = result.scalar_one_or_none()
+            if project_row is None:
+                msg = f"Project {project_slug!r} not found"
+                raise click.ClickException(msg)
+
+            # Resolve edition
+            result = await session.execute(
+                select(SqlEdition).where(
+                    SqlEdition.project_id == project_row.id,
+                    SqlEdition.slug == edition_slug,
+                    SqlEdition.date_deleted.is_(None),
+                )
+            )
+            edition_row = result.scalar_one_or_none()
+            if edition_row is None:
+                msg = f"Edition {edition_slug!r} not found"
+                raise click.ClickException(msg)
+
+            # Resolve build
+            try:
+                public_id = validate_base32_id(build_id)
+            except ValueError as exc:
+                msg = f"Invalid build ID {build_id!r}: {exc}"
+                raise click.ClickException(msg) from exc
+            result = await session.execute(
+                select(SqlBuild).where(
+                    SqlBuild.project_id == project_row.id,
+                    SqlBuild.public_id == public_id,
+                    SqlBuild.date_deleted.is_(None),
+                )
+            )
+            build_row = result.scalar_one_or_none()
+            if build_row is None:
+                msg = f"Build {build_id!r} not found"
+                raise click.ClickException(msg)
+
+            return Build.model_validate(build_row)
+        finally:
+            await session.close()
+    finally:
+        await engine.dispose()
 
 
 async def _cli_get_current_revision() -> str | None:

--- a/src/docverse/cli.py
+++ b/src/docverse/cli.py
@@ -6,8 +6,6 @@ import asyncio
 import importlib.metadata
 import json
 import os
-import re
-import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -188,127 +186,6 @@ def validate_db_schema(*, alembic_config_path: Path) -> None:
     ):
         msg = "Database schema is not current"
         raise click.ClickException(msg)
-
-
-@main.command()
-@click.option(
-    "--docverse-repo",
-    required=True,
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-    help="Path to the docverse monorepo root.",
-)
-@click.option(
-    "--deployments-repo",
-    required=True,
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
-    help="Path to local docverse-cloudflare-deployments checkout.",
-)
-@click.option(
-    "--env",
-    "wrangler_env",
-    required=True,
-    help="Wrangler environment name (e.g., dev, production).",
-)
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    default=False,
-    help="Build the worker bundle without deploying.",
-)
-def deploy_worker(
-    *,
-    docverse_repo: Path,
-    deployments_repo: Path,
-    wrangler_env: str,
-    dry_run: bool,
-) -> None:
-    """Pack and deploy the Cloudflare Worker."""
-    logger = structlog.get_logger("docverse")
-
-    if not re.match(r"^[a-zA-Z0-9_-]+$", wrangler_env):
-        msg = (
-            f"Invalid environment name {wrangler_env!r}: "
-            "must contain only alphanumeric characters, hyphens, "
-            "and underscores"
-        )
-        raise click.ClickException(msg)
-
-    worker_dir = docverse_repo.resolve() / "cloudflare-worker"
-    if not worker_dir.is_dir():
-        msg = f"cloudflare-worker/ not found in {docverse_repo.resolve()}"
-        raise click.ClickException(msg)
-
-    deployments_repo = deployments_repo.resolve()
-    dest_dir = deployments_repo / "worker"
-    dest_dir.mkdir(exist_ok=True)
-
-    # Phase 1: npm pack
-    logger.info("Packing cloudflare worker", worker_dir=str(worker_dir))
-    try:
-        pack_result = subprocess.run(
-            ["npm", "pack", "--json"],
-            check=True,
-            capture_output=True,
-            text=True,
-            cwd=str(worker_dir),
-        )
-    except subprocess.CalledProcessError as exc:
-        msg = f"npm pack failed: {exc.stderr}"
-        raise click.ClickException(msg) from exc
-    try:
-        tarball_name = json.loads(pack_result.stdout)[0]["filename"]
-    except (json.JSONDecodeError, KeyError, IndexError) as exc:
-        msg = f"Failed to parse npm pack output: {pack_result.stdout!r}"
-        raise click.ClickException(msg) from exc
-
-    # Phase 2: copy and unpack into deployments repo
-    logger.info(
-        "Unpacking worker into deployments repo",
-        tarball=tarball_name,
-        dest=str(dest_dir),
-    )
-    shutil.copy2(worker_dir / tarball_name, dest_dir / tarball_name)
-    try:
-        subprocess.run(
-            ["tar", "xzf", tarball_name, "--strip-components=1"],
-            check=True,
-            cwd=str(dest_dir),
-        )
-    except subprocess.CalledProcessError as exc:
-        msg = f"Failed to unpack worker tarball: {exc}"
-        raise click.ClickException(msg) from exc
-    finally:
-        for tgz in dest_dir.glob("*.tgz"):
-            tgz.unlink()
-    (worker_dir / tarball_name).unlink(missing_ok=True)
-
-    # Phase 3: wrangler deploy
-    wrangler_cmd = [
-        "npx",
-        "wrangler",
-        "deploy",
-        "--env",
-        wrangler_env,
-    ]
-    if dry_run:
-        outdir = deployments_repo / "dist"
-        wrangler_cmd.extend(["--dry-run", f"--outdir={outdir}"])
-    logger.info("Deploying worker", env=wrangler_env, dry_run=dry_run)
-    try:
-        subprocess.run(
-            wrangler_cmd,
-            check=True,
-            cwd=str(deployments_repo),
-        )
-    except subprocess.CalledProcessError as exc:
-        msg = f"wrangler deploy failed: {exc}"
-        raise click.ClickException(msg) from exc
-
-    logger.info(
-        "Worker deployed successfully",
-        env=wrangler_env,
-        dry_run=dry_run,
-    )
 
 
 @main.command()

--- a/src/docverse/exceptions.py
+++ b/src/docverse/exceptions.py
@@ -10,6 +10,7 @@ __all__ = [
     "InvalidBuildStateError",
     "InvalidJobStateError",
     "JobNotFoundError",
+    "MissingConfigurationError",
     "NotFoundError",
     "PermissionDeniedError",
 ]
@@ -27,6 +28,13 @@ class ConflictError(ClientRequestError):
 
     error = "conflict"
     status_code = status.HTTP_409_CONFLICT
+
+
+class MissingConfigurationError(ClientRequestError):
+    """The organization is missing required configuration."""
+
+    error = "missing_configuration"
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 class PermissionDeniedError(ClientRequestError):

--- a/src/docverse/handlers/orgs/builds.py
+++ b/src/docverse/handlers/orgs/builds.py
@@ -15,6 +15,7 @@ from docverse.dependencies.auth import (
 )
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.domain.base32id import serialize_base32_id
+from docverse.exceptions import MissingConfigurationError
 from docverse.handlers.params import (
     BuildIdParam,
     OrgSlugParam,
@@ -98,8 +99,16 @@ async def post_build(
     context: Annotated[RequestContext, Depends(context_dependency)],
     user: Annotated[AuthenticatedUser, Depends(require_uploader)],
 ) -> Build:
-    upload_url: str | None = None
     async with context.session.begin():
+        service_label = user.org.resolved_staging_store_label
+        if service_label is None:
+            msg = (
+                "Organization has no object store configured. "
+                "An administrator must add an object_storage service "
+                "before builds can be created."
+            )
+            raise MissingConfigurationError(msg)
+
         service = context.factory.create_build_service()
         build = await service.create(
             org_slug=org_slug,
@@ -108,18 +117,15 @@ async def post_build(
             uploader=user.username,
         )
 
-        # Generate a presigned upload URL if the org has a store
-        service_label = user.org.resolved_staging_store_label
-        if service_label is not None:
-            object_store = await context.factory.create_objectstore_for_org(
-                org_id=user.org.id,
-                service_label=service_label,
+        object_store = await context.factory.create_objectstore_for_org(
+            org_id=user.org.id,
+            service_label=service_label,
+        )
+        async with object_store:
+            upload_url = await object_store.generate_presigned_upload_url(
+                key=build.staging_key,
+                content_type="application/gzip",
             )
-            async with object_store:
-                upload_url = await object_store.generate_presigned_upload_url(
-                    key=build.staging_key,
-                    content_type="application/gzip",
-                )
 
         await context.session.commit()
     return Build.from_domain(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,16 +22,26 @@ from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_scoped_session
 
-from docverse.client.models import OrgMembershipCreate, OrgRole, PrincipalType
+from docverse.client.models import (
+    BuildAnnotations,
+    BuildCreate,
+    OrgMembershipCreate,
+    OrgRole,
+    PrincipalType,
+)
 from docverse.config import config
 from docverse.dbschema import Base
 from docverse.dependencies.context import RequestContext, context_dependency
+from docverse.domain.base32id import serialize_base32_id
 from docverse.main import app as docverse_app
+from docverse.storage.build_store import BuildStore
 from docverse.storage.membership_store import OrgMembershipStore
 from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
 from docverse.storage.user_info_store import StubUserInfoStore
 
 __all__ = [
+    "seed_build",
     "seed_group_member",
     "seed_member",
     "seed_org_with_admin",
@@ -112,6 +122,47 @@ async def seed_org_with_admin(
         headers={"X-Auth-Request-User": "superadmin"},
     )
     assert response.status_code == 201
+
+
+async def seed_build(
+    org_slug: str,
+    project_slug: str,
+    *,
+    git_ref: str = "main",
+    content_hash: str = (
+        "sha256:abcdef0123456789abcdef0123456789"
+        "abcdef0123456789abcdef0123456789"
+    ),
+    uploader: str = "testuser",
+    annotations: BuildAnnotations | None = None,
+) -> str:
+    """Create a build directly via the DB and return its base32 ID."""
+    logger = structlog.get_logger("docverse")
+    async for session in db_session_dependency():
+        async with session.begin():
+            org_store = OrganizationStore(session=session, logger=logger)
+            org = await org_store.get_by_slug(org_slug)
+            assert org is not None
+            proj_store = ProjectStore(session=session, logger=logger)
+            project = await proj_store.get_by_slug(
+                org_id=org.id, slug=project_slug
+            )
+            assert project is not None
+            build_store = BuildStore(session=session, logger=logger)
+            build = await build_store.create(
+                project_id=project.id,
+                project_slug=project.slug,
+                data=BuildCreate(
+                    git_ref=git_ref,
+                    content_hash=content_hash,
+                    annotations=annotations,
+                ),
+                uploader=uploader,
+            )
+            await session.commit()
+        return serialize_base32_id(build.public_id)
+    msg = "db_session_dependency yielded nothing"
+    raise AssertionError(msg)
 
 
 async def seed_member(

--- a/tests/handlers/authorization_test.py
+++ b/tests/handlers/authorization_test.py
@@ -10,7 +10,7 @@ import pytest
 from httpx import AsyncClient
 
 from docverse.client.models import OrgRole
-from tests.conftest import seed_member, seed_org_with_admin
+from tests.conftest import seed_build, seed_member, seed_org_with_admin
 
 CONTENT_HASH = (
     "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
@@ -35,14 +35,9 @@ async def _setup(client: AsyncClient) -> None:
     )
 
 
-async def _create_build(client: AsyncClient) -> str:
-    """Create a build and return its ID."""
-    resp = await client.post(
-        "/docverse/orgs/auth-org/projects/auth-proj/builds",
-        json={"git_ref": "main", "content_hash": CONTENT_HASH},
-        headers={"X-Auth-Request-User": "admin-user"},
-    )
-    return str(resp.json()["id"])
+async def _create_build() -> str:
+    """Create a build via direct DB seeding and return its ID."""
+    return await seed_build("auth-org", "auth-proj", uploader="admin-user")
 
 
 async def _create_edition(client: AsyncClient) -> str:
@@ -178,18 +173,19 @@ async def test_create_build_as_reader(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_create_build_as_uploader(client: AsyncClient) -> None:
     await _setup(client)
+    # Uploader has permission but org has no store → 422
     response = await client.post(
         "/docverse/orgs/auth-org/projects/auth-proj/builds",
         json={"git_ref": "main", "content_hash": CONTENT_HASH},
         headers={"X-Auth-Request-User": "upload-user"},
     )
-    assert response.status_code == 201
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio
 async def test_patch_build_as_reader(client: AsyncClient) -> None:
     await _setup(client)
-    build_id = await _create_build(client)
+    build_id = await _create_build()
     response = await client.patch(
         f"/docverse/orgs/auth-org/projects/auth-proj/builds/{build_id}",
         json={"status": "uploaded"},
@@ -201,7 +197,7 @@ async def test_patch_build_as_reader(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_delete_build_as_uploader(client: AsyncClient) -> None:
     await _setup(client)
-    build_id = await _create_build(client)
+    build_id = await _create_build()
     response = await client.delete(
         f"/docverse/orgs/auth-org/projects/auth-proj/builds/{build_id}",
         headers={"X-Auth-Request-User": "upload-user"},

--- a/tests/handlers/builds_test.py
+++ b/tests/handlers/builds_test.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from tests.conftest import seed_org_with_admin
+from docverse.client.models import BuildAnnotations
+from tests.conftest import seed_build, seed_org_with_admin
 
 CONTENT_HASH = (
     "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
@@ -37,34 +38,32 @@ async def test_create_build(client: AsyncClient) -> None:
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
-    assert response.status_code == 201
+    assert response.status_code == 422
     data = response.json()
-    assert data["git_ref"] == "main"
-    assert data["status"] == "pending"
-    # No credential configured for this org, so upload_url is None
-    assert data["upload_url"] is None
-    assert data["uploader"] == "testuser"
-    assert data["annotations"] is None
+    assert data["detail"][0]["type"] == "missing_configuration"
+    assert "object store" in data["detail"][0]["msg"].lower()
 
 
 @pytest.mark.asyncio
 async def test_create_build_with_annotations(client: AsyncClient) -> None:
+    """Annotations round-trip via DB seeding + GET (POST needs a store)."""
     await _setup(client)
-    annotations = {
-        "commit_sha": "abc123",
-        "ci_platform": "github-actions",
-        "custom_key": "custom_value",
-    }
-    response = await client.post(
-        "/docverse/orgs/build-org/projects/build-proj/builds",
-        json={
-            "git_ref": "main",
-            "content_hash": CONTENT_HASH,
-            "annotations": annotations,
-        },
+    build_id = await seed_build(
+        "build-org",
+        "build-proj",
+        annotations=BuildAnnotations.model_validate(
+            {
+                "commit_sha": "abc123",
+                "ci_platform": "github-actions",
+                "custom_key": "custom_value",
+            }
+        ),
+    )
+    response = await client.get(
+        f"/docverse/orgs/build-org/projects/build-proj/builds/{build_id}",
         headers={"X-Auth-Request-User": "testuser"},
     )
-    assert response.status_code == 201
+    assert response.status_code == 200
     data = response.json()
     assert data["annotations"]["commit_sha"] == "abc123"
     assert data["annotations"]["ci_platform"] == "github-actions"
@@ -74,11 +73,7 @@ async def test_create_build_with_annotations(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_list_builds(client: AsyncClient) -> None:
     await _setup(client)
-    await client.post(
-        "/docverse/orgs/build-org/projects/build-proj/builds",
-        json={"git_ref": "main", "content_hash": CONTENT_HASH},
-        headers={"X-Auth-Request-User": "testuser"},
-    )
+    await seed_build("build-org", "build-proj")
     response = await client.get(
         "/docverse/orgs/build-org/projects/build-proj/builds",
         headers={"X-Auth-Request-User": "testuser"},
@@ -92,12 +87,7 @@ async def test_list_builds(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_get_build(client: AsyncClient) -> None:
     await _setup(client)
-    create_resp = await client.post(
-        "/docverse/orgs/build-org/projects/build-proj/builds",
-        json={"git_ref": "main", "content_hash": CONTENT_HASH},
-        headers={"X-Auth-Request-User": "testuser"},
-    )
-    build_id = create_resp.json()["id"]
+    build_id = await seed_build("build-org", "build-proj")
     response = await client.get(
         f"/docverse/orgs/build-org/projects/build-proj/builds/{build_id}",
         headers={"X-Auth-Request-User": "testuser"},
@@ -109,12 +99,7 @@ async def test_get_build(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_patch_build_upload_complete(client: AsyncClient) -> None:
     await _setup(client)
-    create_resp = await client.post(
-        "/docverse/orgs/build-org/projects/build-proj/builds",
-        json={"git_ref": "main", "content_hash": CONTENT_HASH},
-        headers={"X-Auth-Request-User": "testuser"},
-    )
-    build_id = create_resp.json()["id"]
+    build_id = await seed_build("build-org", "build-proj")
     response = await client.patch(
         f"/docverse/orgs/build-org/projects/build-proj/builds/{build_id}",
         json={"status": "uploaded"},
@@ -129,12 +114,7 @@ async def test_patch_build_upload_complete(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_delete_build(client: AsyncClient) -> None:
     await _setup(client)
-    create_resp = await client.post(
-        "/docverse/orgs/build-org/projects/build-proj/builds",
-        json={"git_ref": "main", "content_hash": CONTENT_HASH},
-        headers={"X-Auth-Request-User": "testuser"},
-    )
-    build_id = create_resp.json()["id"]
+    build_id = await seed_build("build-org", "build-proj")
     response = await client.delete(
         f"/docverse/orgs/build-org/projects/build-proj/builds/{build_id}",
         headers={"X-Auth-Request-User": "testuser"},

--- a/tests/handlers/group_authorization_test.py
+++ b/tests/handlers/group_authorization_test.py
@@ -74,6 +74,7 @@ async def test_group_uploader_can_create_build(
     context_dependency._user_info_store = StubUserInfoStore(
         groups=["g_uploaders"]
     )
+    # Uploader has permission but org has no store → 422
     response = await client.post(
         "/docverse/orgs/grp-up-org/projects/grp-proj/builds",
         json={
@@ -82,7 +83,7 @@ async def test_group_uploader_can_create_build(
         },
         headers={"X-Auth-Request-User": "group-uploader"},
     )
-    assert response.status_code == 201
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/pagination_test.py
+++ b/tests/handlers/pagination_test.py
@@ -6,7 +6,7 @@ import pytest
 from httpx import AsyncClient
 from safir.database import PaginationLinkData
 
-from tests.conftest import seed_org_with_admin
+from tests.conftest import seed_build, seed_org_with_admin
 
 CONTENT_HASH = (
     "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
@@ -181,18 +181,10 @@ async def test_edition_pagination_forward(
 
 
 async def _create_build(
-    client: AsyncClient,
     project_slug: str,
 ) -> str:
-    """Create a build and return its ID."""
-    resp = await client.post(
-        f"/docverse/orgs/pag-org/projects/{project_slug}/builds",
-        json={"git_ref": "main", "content_hash": CONTENT_HASH},
-        headers=AUTH,
-    )
-    assert resp.status_code == 201
-    build_id: str = resp.json()["id"]
-    return build_id
+    """Create a build via direct DB seeding and return its ID."""
+    return await seed_build("pag-org", project_slug)
 
 
 @pytest.mark.asyncio
@@ -202,8 +194,8 @@ async def test_build_status_filter(
     """Filter builds by status."""
     await _setup(client)
     await _create_project(client, "bld-filt-proj")
-    await _create_build(client, "bld-filt-proj")
-    build_id = await _create_build(client, "bld-filt-proj")
+    await _create_build("bld-filt-proj")
+    build_id = await _create_build("bld-filt-proj")
 
     # Signal upload on second build → transitions to processing
     await client.patch(
@@ -242,7 +234,7 @@ async def test_build_pagination_forward(
     await _setup(client)
     await _create_project(client, "bld-pag-proj")
     for _ in range(4):
-        await _create_build(client, "bld-pag-proj")
+        await _create_build("bld-pag-proj")
 
     # Verify first page returns exactly limit items and has next link
     resp = await client.get(

--- a/tests/publish_edition_test.py
+++ b/tests/publish_edition_test.py
@@ -1,0 +1,276 @@
+"""Tests for the publish-edition CLI command."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from docverse.cli import main
+
+
+@pytest.fixture
+def cf_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Set Cloudflare environment variables."""
+    env = {
+        "CLOUDFLARE_API_TOKEN": "test-token",
+        "CLOUDFLARE_ACCOUNT_ID": "test-account-id",
+        "CLOUDFLARE_KV_NAMESPACE_ID": "test-namespace-id",
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return env
+
+
+def _make_mock_build(
+    storage_prefix: str = "myproject/__builds/ABC123/",
+) -> MagicMock:
+    """Create a mock Build domain object."""
+    build = MagicMock()
+    build.storage_prefix = storage_prefix
+    return build
+
+
+@patch("docverse.cli.httpx.AsyncClient")
+@patch("docverse.cli._lookup_build")
+def test_publish_edition_happy_path(
+    mock_lookup: MagicMock,
+    mock_httpx_cls: MagicMock,
+    cf_env: dict[str, str],
+) -> None:
+    mock_build = _make_mock_build()
+    mock_lookup.return_value = mock_build
+
+    # Set up mock httpx client
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.put = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "publish-edition",
+            "--org",
+            "myorg",
+            "--project",
+            "myproject",
+            "--edition",
+            "main",
+            "--build-id",
+            "ABC123",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+    # Verify DB lookup was called with correct args
+    mock_lookup.assert_called_once_with(
+        org_slug="myorg",
+        project_slug="myproject",
+        edition_slug="main",
+        build_id="ABC123",
+    )
+
+    # Verify Cloudflare KV API was called correctly
+    mock_client.put.assert_called_once()
+    call_args = mock_client.put.call_args
+    expected_url = (
+        "https://api.cloudflare.com/client/v4/accounts/test-account-id"
+        "/storage/kv/namespaces/test-namespace-id/values/myproject/main"
+    )
+    assert call_args[0][0] == expected_url
+
+    # Verify authorization header
+    assert call_args[1]["headers"]["Authorization"] == "Bearer test-token"
+
+    # Verify the JSON value written
+    kv_value = json.loads(call_args[1]["content"])
+    assert kv_value == {
+        "build_id": "ABC123",
+        "r2_prefix": "myproject/__builds/ABC123/",
+    }
+
+
+@patch("docverse.cli.httpx.AsyncClient")
+@patch("docverse.cli._lookup_build")
+def test_publish_edition_api_failure(
+    mock_lookup: MagicMock,
+    mock_httpx_cls: MagicMock,
+    cf_env: dict[str, str],
+) -> None:
+    mock_build = _make_mock_build()
+    mock_lookup.return_value = mock_build
+
+    # Set up mock httpx client that raises on status
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Server Error",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    mock_client = AsyncMock()
+    mock_client.put = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "publish-edition",
+            "--org",
+            "myorg",
+            "--project",
+            "myproject",
+            "--edition",
+            "main",
+            "--build-id",
+            "ABC123",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Cloudflare KV API error" in result.output
+
+
+@patch("docverse.cli.httpx.AsyncClient")
+@patch("docverse.cli._lookup_build")
+def test_publish_edition_build_not_found(
+    mock_lookup: MagicMock,
+    mock_httpx_cls: MagicMock,
+    cf_env: dict[str, str],
+) -> None:
+    mock_lookup.side_effect = click.ClickException(
+        "Build 'NOTFOUND' not found"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "publish-edition",
+            "--org",
+            "myorg",
+            "--project",
+            "myproject",
+            "--edition",
+            "main",
+            "--build-id",
+            "NOTFOUND",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Build 'NOTFOUND' not found" in result.output
+    mock_httpx_cls.assert_not_called()
+
+
+@patch("docverse.cli.httpx.AsyncClient")
+@patch("docverse.cli._lookup_build")
+def test_publish_edition_invalid_build_id(
+    mock_lookup: MagicMock,
+    mock_httpx_cls: MagicMock,
+    cf_env: dict[str, str],
+) -> None:
+    mock_lookup.side_effect = click.ClickException(
+        "Invalid build ID '!!INVALID!!': not a valid base32 string"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "publish-edition",
+            "--org",
+            "myorg",
+            "--project",
+            "myproject",
+            "--edition",
+            "main",
+            "--build-id",
+            "!!INVALID!!",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid build ID" in result.output
+    mock_httpx_cls.assert_not_called()
+
+
+@patch("docverse.cli.httpx.AsyncClient")
+@patch("docverse.cli._lookup_build")
+def test_publish_edition_edition_not_found(
+    mock_lookup: MagicMock,
+    mock_httpx_cls: MagicMock,
+    cf_env: dict[str, str],
+) -> None:
+    mock_lookup.side_effect = click.ClickException(
+        "Edition 'badslug' not found"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "publish-edition",
+            "--org",
+            "myorg",
+            "--project",
+            "myproject",
+            "--edition",
+            "badslug",
+            "--build-id",
+            "ABC123",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Edition 'badslug' not found" in result.output
+    mock_httpx_cls.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "missing_var",
+    [
+        "CLOUDFLARE_API_TOKEN",
+        "CLOUDFLARE_ACCOUNT_ID",
+        "CLOUDFLARE_KV_NAMESPACE_ID",
+    ],
+)
+def test_publish_edition_missing_env_var(
+    cf_env: dict[str, str],
+    missing_var: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(missing_var)
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "publish-edition",
+            "--org",
+            "myorg",
+            "--project",
+            "myproject",
+            "--edition",
+            "main",
+            "--build-id",
+            "ABC123",
+        ],
+    )
+    assert result.exit_code == 1
+    assert missing_var in result.output


### PR DESCRIPTION
## Summary

- Add `docverse-admin publish-edition` subcommand that updates which build is live for a given edition by writing a KV entry via the Cloudflare REST API
- Command takes `--org`, `--project`, `--edition`, and `--build-id` arguments, looks up the build record in the database to retrieve `storage_prefix`, then writes `{project}/{edition}` → `{"build_id": ..., "r2_prefix": ...}` to Cloudflare KV
- Requires `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_KV_NAMESPACE_ID` environment variables

### Additional fixes and improvements

- **Move `deploy-worker` command to client CLI** — the command is pure subprocess orchestration with no database or API interaction, so it belongs in `docverse` (client CLI) rather than `docverse-admin` (server CLI) which eagerly loads server configuration at import time
- **Install worker dependencies before `wrangler deploy`** — `npm pack` does not include `node_modules/`, so the worker's runtime dependency on `mime` was missing when esbuild tried to resolve it; added an `npm install --production` step after unpacking the tarball
- **Forbid extra fields in create/update request models** — added `extra="forbid"` to all create/update Pydantic models so unknown fields return 422 instead of being silently ignored (e.g., `publishing_store` vs `publishing_store_label`)
- **Return 422 when org has no object store configured** — guard `POST /builds` with a `MissingConfigurationError` instead of creating an unusable build row with `upload_url: null`; added `seed_build()` test helper and updated affected tests
- **Fix `builds.storage_prefix` migration** — the migration previously added the column as `NOT NULL` which fails on databases with existing rows; now adds as nullable, backfills using project slug and base32-encoded public_id, then alters to `NOT NULL`

## Validation steps

- [ ] Run `docverse-admin publish-edition --help` and verify the command shows up with `--org`, `--project`, `--edition`, and `--build-id` options
- [ ] Run the command against a dev environment with a real Cloudflare KV namespace and verify the key/value is written correctly
- [ ] Run `docverse deploy-worker --help` to verify the command moved to the client CLI
- [ ] Verify `POST /builds` returns 422 when the org has no object store configured
- [ ] Run the `storage_prefix` migration against a database with existing build rows

## References

- Closes #151
- PRD: #145
- Jira: https://rubinobs.atlassian.net/browse/DM-54538