### PR TITLE
Add branch safety phase to work-it skill

### DIFF
--- a/.claude/skills/work-it/SKILL.md
+++ b/.claude/skills/work-it/SKILL.md
@@ -7,6 +7,19 @@ description: Execute a unit of development work end-to-end using red/green/refac
 
 Execute a complete unit of development work using red/green/refactor TDD in tracer-bullet slices.
 
+## Phase 0: Branch safety
+
+**Never do work on the `main` branch.** Before any implementation:
+
+1. Check the current branch with `git branch --show-current`.
+2. If already on a non-main feature branch, proceed to Phase 1.
+3. If on `main`:
+   - If the task or issue specifies a branch name, check it out:
+     - If it exists locally, `git checkout <branch>`.
+     - If it exists on the remote, `git checkout -b <branch> origin/<branch>`.
+     - If it doesn't exist, create it: `git checkout -b <branch> main`.
+   - If no branch name is specified, **ask the user** what branch to create or work from before proceeding.
+
 ## Phase 1: Understand the task
 
 - Read any referenced plan or PRD.


### PR DESCRIPTION
## Summary

- Adds a Phase 0 (branch safety) to the work-it skill that prevents working directly on `main`
- If the task specifies a branch name, it checks out or creates that branch automatically
- If no branch is specified, it asks the user before proceeding

## Test plan

- [ ] Invoke `/work-it` on `main` — should prompt for a branch before doing any work
- [ ] Invoke `/work-it` on a feature branch — should proceed normally