### PR TITLE
Unblock dependabot PRs on build / manifest check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,13 +131,18 @@ jobs:
     uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v3
     with:
       images: ghcr.io/${{ github.repository }}
-    # Build on server releases and ticket branch PRs (exclude client releases)
-    if: >
-      (github.event_name == 'release'
-       && !startsWith(github.event.release.tag_name, 'client/'))
-      || (github.event_name != 'merge_group'
-          && (startsWith(github.head_ref, 'tickets/')
-              || startsWith(github.head_ref, 't/')))
+      # Only push on server releases and ticket branch PRs (exclude client
+      # releases). Non-matching PRs still build the image as validation but
+      # skip the push + manifest steps — this lets the required
+      # `build / manifest` check report as "Skipped" (which counts as
+      # passing) instead of hanging in "Expected" forever on dependabot
+      # and similar PRs.
+      push: >-
+        ${{ (github.event_name == 'release'
+             && !startsWith(github.event.release.tag_name, 'client/'))
+            || (github.event_name != 'merge_group'
+                && (startsWith(github.head_ref, 'tickets/')
+                    || startsWith(github.head_ref, 't/'))) }}
 
   client-test-packaging:
     name: Test client packaging


### PR DESCRIPTION
## Summary
- Move the ticket-branch/release gate from the `build` job's `if:` into the reusable workflow's `push` input so the job always runs on PRs.
- When `push` is false, the reusable workflow still builds the image (Dockerfile validation) but its inner `manifest` job skips via its own `if:` — a skipped required check counts as passing, unblocking dependabot, renovate, and `u/*` PRs that currently hang on `build / manifest`.
- Ticket branches and server releases continue to build and push exactly as before; `merge_group` runs remain excluded from push.

## Test plan
- [ ] This PR itself — a `u/*` branch — should become mergeable: `build / setup` green, `build / containers` green (builds without pushing), `build / manifest` reports as Skipped.
- [ ] Next PR on a `tickets/DM-*` branch still runs `build / manifest` and pushes images to `ghcr.io` (unchanged).
- [ ] Any open dependabot PR unblocks after this lands on `main`.