### PR TITLE
Improve devcontainer and agent ralph loop

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -56,4 +56,11 @@ RUN { \
     } > /etc/sudoers.d/firewall \
     && chmod 0440 /etc/sudoers.d/firewall
 
+# Oh-my-zsh for the node user + sane default .zshrc
+RUN chsh -s /usr/bin/zsh node \
+    && runuser -u node -- sh -c \
+       'RUNZSH=no CHSH=no KEEP_ZSHRC=yes sh -c \
+        "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"'
+COPY --chown=node:node zshrc /home/node/.zshrc
+
 USER node

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -66,6 +66,10 @@ echo "Run the test suite and fix any failures" | .devcontainer/run.sh
 .devcontainer/run.sh --login
 ```
 
+The login shell is zsh with oh-my-zsh (robbyrussell theme) preconfigured.
+Command history is persisted to the `docverse-cmdhistory` named volume, so
+it survives `--rebuild`.
+
 ### Stop the container
 
 ```bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,7 @@
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
+    "UV_LINK_MODE": "copy",
     "ANTHROPIC_API_KEY": "",
     "ANTHROPIC_AUTH_TOKEN": "",
     "CLAUDE_CODE_USE_BEDROCK": "",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
     "type=volume,source=docverse-workspace,target=/workspace",
     "type=volume,source=docverse-claude-home,target=/home/node/.claude",
     "type=volume,source=docverse-cmdhistory,target=/commandhistory",
-    "type=volume,source=docverse-uv-cache,target=/home/node/.cache/uv"
+    "type=volume,source=docverse-uv-cache,target=/home/node/.cache/uv",
+    "type=volume,source=docverse-docker-cache,target=/var/lib/docker"
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,5 +30,6 @@
   "postCreateCommand": "sudo chown -R node:node /workspace /home/node/.claude /commandhistory /home/node/.cache/uv",
   "postStartCommand": "sudo /usr/local/bin/init-firewall.sh && sudo cron",
   "waitFor": "postStartCommand",
+  "containerUser": "root",
   "remoteUser": "node"
 }

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -99,19 +99,44 @@ if gh_meta=$(curl -sf --max-time 10 https://api.github.com/meta 2>/dev/null); th
     echo "  Added GitHub CIDR ranges from meta API"
 fi
 
-# Fetch Cloudflare edge CIDRs (Docker Hub CDN is on Cloudflare)
-if cf_v4=$(curl -sf --max-time 10 https://www.cloudflare.com/ips-v4 2>/dev/null); then
-    while IFS= read -r cidr; do
-        [ -n "$cidr" ] && ipset add allowed_nets "$cidr" -exist
-    done <<< "$cf_v4"
-    echo "  Added Cloudflare IPv4 CIDRs"
-fi
-if cf_v6=$(curl -sf --max-time 10 https://www.cloudflare.com/ips-v6 2>/dev/null); then
-    while IFS= read -r cidr; do
-        [ -n "$cidr" ] && ipset add allowed_nets6 "$cidr" -exist
-    done <<< "$cf_v6"
-    echo "  Added Cloudflare IPv6 CIDRs"
-fi
+# Cloudflare edge CIDRs (Docker Hub CDN + R2 blob storage are on Cloudflare).
+# Source: https://www.cloudflare.com/ips-v4 and /ips-v6
+# Static list to avoid a chicken-and-egg with the firewall itself blocking
+# the curl. Refresh manually if a pull starts timing out on a new Cloudflare
+# range (updates are rare — years apart).
+CLOUDFLARE_IPV4_CIDRS=(
+    173.245.48.0/20
+    103.21.244.0/22
+    103.22.200.0/22
+    103.31.4.0/22
+    141.101.64.0/18
+    108.162.192.0/18
+    190.93.240.0/20
+    188.114.96.0/20
+    197.234.240.0/22
+    198.41.128.0/17
+    162.158.0.0/15
+    104.16.0.0/13
+    104.24.0.0/14
+    172.64.0.0/13
+    131.0.72.0/22
+)
+CLOUDFLARE_IPV6_CIDRS=(
+    2400:cb00::/32
+    2606:4700::/32
+    2803:f800::/32
+    2405:b500::/32
+    2405:8100::/32
+    2a06:98c0::/29
+    2c0f:f248::/32
+)
+for cidr in "${CLOUDFLARE_IPV4_CIDRS[@]}"; do
+    ipset add allowed_nets "$cidr" -exist
+done
+for cidr in "${CLOUDFLARE_IPV6_CIDRS[@]}"; do
+    ipset add allowed_nets6 "$cidr" -exist
+done
+echo "  Added Cloudflare CIDRs (static)"
 
 # Flush existing OUTPUT rules (idempotent re-run)
 iptables -F OUTPUT 2>/dev/null || true

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -99,6 +99,20 @@ if gh_meta=$(curl -sf --max-time 10 https://api.github.com/meta 2>/dev/null); th
     echo "  Added GitHub CIDR ranges from meta API"
 fi
 
+# Fetch Cloudflare edge CIDRs (Docker Hub CDN is on Cloudflare)
+if cf_v4=$(curl -sf --max-time 10 https://www.cloudflare.com/ips-v4 2>/dev/null); then
+    while IFS= read -r cidr; do
+        [ -n "$cidr" ] && ipset add allowed_nets "$cidr" -exist
+    done <<< "$cf_v4"
+    echo "  Added Cloudflare IPv4 CIDRs"
+fi
+if cf_v6=$(curl -sf --max-time 10 https://www.cloudflare.com/ips-v6 2>/dev/null); then
+    while IFS= read -r cidr; do
+        [ -n "$cidr" ] && ipset add allowed_nets6 "$cidr" -exist
+    done <<< "$cf_v6"
+    echo "  Added Cloudflare IPv6 CIDRs"
+fi
+
 # Flush existing OUTPUT rules (idempotent re-run)
 iptables -F OUTPUT 2>/dev/null || true
 ip6tables -F OUTPUT 2>/dev/null || true

--- a/.devcontainer/zshrc
+++ b/.devcontainer/zshrc
@@ -1,0 +1,20 @@
+# oh-my-zsh
+export ZSH="$HOME/.oh-my-zsh"
+ZSH_THEME="robbyrussell"
+plugins=(git sudo fzf docker)
+source "$ZSH/oh-my-zsh.sh"
+
+# Persist history on the /commandhistory named volume (survives rebuilds)
+HISTFILE=/commandhistory/.zsh_history
+HISTSIZE=10000
+SAVEHIST=10000
+setopt SHARE_HISTORY HIST_IGNORE_DUPS HIST_IGNORE_SPACE
+
+# Default to the docverse workspace on login shells
+if [ -d /workspace/docverse ] && [ -z "$_DOCVERSE_CD_DONE" ]; then
+    export _DOCVERSE_CD_DONE=1
+    cd /workspace/docverse
+fi
+
+# Ensure uv's user-installed binaries are on PATH (no-op if dir absent)
+export PATH="$HOME/.local/bin:$PATH"

--- a/ralph/afk.sh
+++ b/ralph/afk.sh
@@ -447,7 +447,7 @@ run_phase() {
 # stdin: result text. stdout: pick JSON (one line) if sentinel present, else
 # empty. Returns 0 always; caller inspects output emptiness.
 parse_pick_sentinel() {
-    python3 - <<'PYEOF'
+    python3 -c '
 import json, re, sys
 text = sys.stdin.read()
 m = re.search(r"<ralph-pick>\s*(.*?)\s*</ralph-pick>", text, re.DOTALL)
@@ -459,7 +459,7 @@ try:
 except Exception:
     sys.exit(0)
 print(json.dumps(obj))
-PYEOF
+'
 }
 
 # ---- Helper: set up the picked task's branch inside the container ----

--- a/ralph/afk.sh
+++ b/ralph/afk.sh
@@ -478,6 +478,19 @@ container_branch_setup() {
     # Try local, then remote-tracking, then a fresh branch from main.
     local out
     if out=$(container_exec git -C /workspace/docverse checkout "$branch" 2>&1); then
+        # FF to origin if an upstream exists. The earlier branch-specific
+        # fetch made origin/$branch current; --ff-only keeps this safe by
+        # refusing to clobber local-only commits (divergence is surfaced
+        # as a setup failure for the user to resolve manually).
+        if container_exec git -C /workspace/docverse \
+                rev-parse --verify --quiet "origin/$branch" >/dev/null 2>&1; then
+            if ! out=$(container_exec git -C /workspace/docverse \
+                    merge --ff-only "origin/$branch" 2>&1); then
+                errs+=$'git merge --ff-only origin/'"$branch"$':\n'"$out"$'\n'
+                printf '%s' "$errs"
+                return 1
+            fi
+        fi
         return 0
     fi
     errs+=$'git checkout '"$branch"$':\n'"$out"$'\n'
@@ -489,10 +502,10 @@ container_branch_setup() {
     errs+=$'git checkout -b '"$branch"$' origin/'"$branch"$':\n'"$out"$'\n'
 
     if out=$(container_exec git -C /workspace/docverse \
-            checkout -b "$branch" main 2>&1); then
+            checkout -b "$branch" origin/main 2>&1); then
         return 0
     fi
-    errs+=$'git checkout -b '"$branch"$' main:\n'"$out"$'\n'
+    errs+=$'git checkout -b '"$branch"$' origin/main:\n'"$out"$'\n'
 
     printf '%s' "$errs"
     return 1


### PR DESCRIPTION
## Summary

Hardening and papercut fixes for the devcontainer sandbox and the ralph agent loop.

### Devcontainer
- Run container as `root` so the docker-in-docker entrypoint can start `dockerd` cleanly (`remoteUser=node` is preserved for app-level execution).
- Mount a named volume at `/var/lib/docker` so pulled images persist across `--rebuild`.
- Embed a static Cloudflare CIDR list in `init-firewall.sh` and add it to the ipsets so Docker Hub's Cloudflare-fronted blob CDN isn't blocked mid-pull. Replaces the earlier curl-based fetch, which had a chicken-and-egg bootstrap problem on re-runs.
- Preconfigure zsh with oh-my-zsh, a curated `.zshrc` (git/sudo/fzf/docker plugins, `robbyrussell` theme), persistent history at `/commandhistory`, and auto-cd into `/workspace/docverse` on login.
- Set `UV_LINK_MODE=copy` in `containerEnv` to silence uv's hardlink-fallback warning, since the uv cache and workspace live on separate named volumes (different filesystems from uv's perspective).

### ralph agent loop
- `container_branch_setup` now fast-forwards existing local task branches against `origin/$branch` (guarded by `rev-parse --verify` so brand-new branches skip cleanly). Prevents Claude from running against a stale tip when origin has advanced.
- Fix `parse_pick_sentinel` in `ralph/afk.sh`: switch `python3 -` + heredoc to `python3 -c '...'` so stdin stays connected to the outer pipe and the sentinel extractor actually sees the phase output.

## Test plan

- [x] `.devcontainer/run.sh --rebuild --login` drops into zsh at `/workspace/docverse` with no zsh-newuser-install wizard
- [x] Inside container: `docker pull postgres:17` completes without hitting blocked Cloudflare IPs
- [x] Inside container: `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test -- tests/storage/edition_store_test.py -x` runs without the uv hardlink warning
- [ ] `ralph/afk.sh` select phase produces a well-formed `<ralph-pick>` sentinel that downstream phases accept
- [ ] Re-running ralph against an existing task branch fast-forwards to `origin/$branch` instead of checking out a stale local tip