### PR TITLE
Force OpenSSH format for signing key and set vim as default editor

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv \
     fzf \
     zsh \
+    vim \
     iptables \
     ipset \
     iproute2 \
@@ -32,7 +33,8 @@ RUN npm install -g @anthropic-ai/claude-code@latest
 # Git signing defaults (identity + signing key path set per-session by agent-entry)
 RUN git config --system gpg.format ssh \
     && git config --system commit.gpgsign true \
-    && git config --system tag.gpgsign true
+    && git config --system tag.gpgsign true \
+    && git config --system core.editor vim
 
 # Firewall script
 COPY init-firewall.sh /usr/local/bin/init-firewall.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,8 @@
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "UV_LINK_MODE": "copy",
+    "EDITOR": "vim",
+    "VISUAL": "vim",
     "ANTHROPIC_API_KEY": "",
     "ANTHROPIC_AUTH_TOKEN": "",
     "CLAUDE_CODE_USE_BEDROCK": "",

--- a/.devcontainer/lib/secrets.sh
+++ b/.devcontainer/lib/secrets.sh
@@ -25,7 +25,9 @@ load_sandbox_secrets() {
     echo "Loading secrets from 1Password..."
     GH_TOKEN=$(op read --account "$op_account" "$gh_token_uri") \
         || die "Failed to read GH token from 1Password"
-    SIGNING_KEY_PEM=$(op read --account "$op_account" "$signing_key_private_uri") \
+    # op CLI defaults to PKCS#8 PEM for Ed25519 SSH keys, but git SSH signing
+    # (ssh-keygen -Y sign) only accepts OpenSSH format. Force it explicitly.
+    SIGNING_KEY_PEM=$(op read --account "$op_account" "${signing_key_private_uri}?ssh-format=openssh") \
         || die "Failed to read signing key (private)"
     SIGNING_KEY_PUB=$(op read --account "$op_account" "$signing_key_public_uri") \
         || die "Failed to read signing key (public)"


### PR DESCRIPTION
This pull request makes several improvements to the development container configuration, focusing on enhancing the default editing experience and ensuring compatibility with SSH key formats for Git signing. The changes also include minor updates to installed packages and environment variables.

**Development environment enhancements:**

* Added `vim` to the list of installed packages in `.devcontainer/Dockerfile`, ensuring it is available in the container.
* Set `core.editor` to `vim` in the global Git configuration, making `vim` the default editor for Git commands.
* Set the `EDITOR` and `VISUAL` environment variables to `vim` in `.devcontainer/devcontainer.json`, standardizing the default editor across tools.

**SSH key compatibility for Git signing:**

* Updated the `load_sandbox_secrets` function in `.devcontainer/lib/secrets.sh` to explicitly request the OpenSSH format for the signing key from 1Password, ensuring compatibility with Git SSH signing operations.