### PR TITLE
Fix Ralph iteration task branch handover

### DIFF
--- a/ralph/afk.sh
+++ b/ralph/afk.sh
@@ -280,7 +280,12 @@ def field(body, name):
         re.IGNORECASE,
     )
     m = pat.search(body)
-    return m.group(1).strip() if m else ""
+    if not m:
+        return ""
+    value = m.group(1).strip()
+    # Strip markdown code-span backticks (single or double) and any
+    # whitespace that was padded around them.
+    return value.strip("`").strip()
 
 for it in items:
     num = it["number"]


### PR DESCRIPTION
## Summary
- Strip markdown code-span backticks from Ralph metadata fields in `ralph/afk.sh`'s `field()` parser so `Branch`, `Jira Key`, `Parent PRD`, and `Task Order` propagate clean values end-to-end.
- Fixes the bug where the rubin-prd-to-issues skill's backtick-wrapped Metadata cells leaked into the host log, the container's `git checkout` (creating a literal-backtick branch), and the rendered `implement-prompt.md` (double-backtick sandwich around `__BRANCH__`).
- Purely a host-side normalization — no changes to issue templates, prompt templates, or the skill itself.

## Test plan
- [x] Unit: feed a synthetic body with backtick-wrapped values through the `field()` helper and confirm clean output.
- [x] Regression: confirm unwrapped values (e.g. `| Branch | tickets/DM-99999 |`) are a no-op.
- [x] Regression: confirm double-backtick wrapping (`` ``x`` ``) also strips cleanly.
- [ ] Integration: on the next Ralph loop iteration against a real issue, verify the `Setting up branch '...'` log line, the iter-NN-implement.prompt.md rendering, and the in-container `git branch --show-current` all show a clean branch name.