### PR TITLE
DM-54723: Serve project dashboard at /v/ via Cloudflare worker

### DIFF
--- a/cloudflare-worker/src/dashboardStore.ts
+++ b/cloudflare-worker/src/dashboardStore.ts
@@ -58,7 +58,14 @@ export function createDashboardStore(r2: R2Bucket): DashboardStore {
   const safeGet = async (key: string): Promise<R2ObjectBody | null> => {
     try {
       return await r2.get(key);
-    } catch {
+    } catch (err) {
+      console.warn(
+        JSON.stringify({
+          event: "dashboard_store_r2_error",
+          key,
+          error: String(err),
+        }),
+      );
       return null;
     }
   };

--- a/cloudflare-worker/src/dashboardStore.ts
+++ b/cloudflare-worker/src/dashboardStore.ts
@@ -1,0 +1,38 @@
+/**
+ * Dashboard artifact store (deep module).
+ *
+ * Encapsulates the `__`-prefixed R2 key layout for per-project dashboard
+ * artifacts. Callers must never construct raw `__*` keys: the resolver and
+ * its tests depend on this module as the single place that knows the key
+ * convention.
+ *
+ * Every getter returns `null` on miss and never throws.
+ */
+
+export interface DashboardStore {
+  /**
+   * Fetch the rendered dashboard HTML for a project.
+   *
+   * @param project - Project slug.
+   * @returns The R2 object body on hit, or `null` on miss / R2 error.
+   */
+  getDashboard(project: string): Promise<R2ObjectBody | null>;
+}
+
+/**
+ * Build a DashboardStore backed by the given R2 bucket.
+ *
+ * The returned store owns the key layout so callers never see raw
+ * `__`-prefixed keys.
+ */
+export function createDashboardStore(r2: R2Bucket): DashboardStore {
+  return {
+    async getDashboard(project: string): Promise<R2ObjectBody | null> {
+      try {
+        return await r2.get(`${project}/__dashboard.html`);
+      } catch {
+        return null;
+      }
+    },
+  };
+}

--- a/cloudflare-worker/src/dashboardStore.ts
+++ b/cloudflare-worker/src/dashboardStore.ts
@@ -38,6 +38,14 @@ export interface DashboardStore {
     project: string,
     edition: string,
   ): Promise<R2ObjectBody | null>;
+
+  /**
+   * Fetch the project's branded 404 HTML page.
+   *
+   * @param project - Project slug.
+   * @returns The R2 object body on hit, or `null` on miss / R2 error.
+   */
+  get404(project: string): Promise<R2ObjectBody | null>;
 }
 
 /**
@@ -68,6 +76,13 @@ export function createDashboardStore(r2: R2Bucket): DashboardStore {
     ): Promise<R2ObjectBody | null> {
       try {
         return await r2.get(`${project}/__editions/${edition}.json`);
+      } catch {
+        return null;
+      }
+    },
+    async get404(project: string): Promise<R2ObjectBody | null> {
+      try {
+        return await r2.get(`${project}/__404.html`);
       } catch {
         return null;
       }

--- a/cloudflare-worker/src/dashboardStore.ts
+++ b/cloudflare-worker/src/dashboardStore.ts
@@ -55,37 +55,29 @@ export interface DashboardStore {
  * `__`-prefixed keys.
  */
 export function createDashboardStore(r2: R2Bucket): DashboardStore {
+  const safeGet = async (key: string): Promise<R2ObjectBody | null> => {
+    try {
+      return await r2.get(key);
+    } catch {
+      return null;
+    }
+  };
+
   return {
-    async getDashboard(project: string): Promise<R2ObjectBody | null> {
-      try {
-        return await r2.get(`${project}/__dashboard.html`);
-      } catch {
-        return null;
-      }
+    getDashboard(project: string): Promise<R2ObjectBody | null> {
+      return safeGet(`${project}/__dashboard.html`);
     },
-    async getSwitcher(project: string): Promise<R2ObjectBody | null> {
-      try {
-        return await r2.get(`${project}/__switcher.json`);
-      } catch {
-        return null;
-      }
+    getSwitcher(project: string): Promise<R2ObjectBody | null> {
+      return safeGet(`${project}/__switcher.json`);
     },
-    async getEditionMeta(
+    getEditionMeta(
       project: string,
       edition: string,
     ): Promise<R2ObjectBody | null> {
-      try {
-        return await r2.get(`${project}/__editions/${edition}.json`);
-      } catch {
-        return null;
-      }
+      return safeGet(`${project}/__editions/${edition}.json`);
     },
-    async get404(project: string): Promise<R2ObjectBody | null> {
-      try {
-        return await r2.get(`${project}/__404.html`);
-      } catch {
-        return null;
-      }
+    get404(project: string): Promise<R2ObjectBody | null> {
+      return safeGet(`${project}/__404.html`);
     },
   };
 }

--- a/cloudflare-worker/src/dashboardStore.ts
+++ b/cloudflare-worker/src/dashboardStore.ts
@@ -17,6 +17,14 @@ export interface DashboardStore {
    * @returns The R2 object body on hit, or `null` on miss / R2 error.
    */
   getDashboard(project: string): Promise<R2ObjectBody | null>;
+
+  /**
+   * Fetch the version-switcher JSON for a project.
+   *
+   * @param project - Project slug.
+   * @returns The R2 object body on hit, or `null` on miss / R2 error.
+   */
+  getSwitcher(project: string): Promise<R2ObjectBody | null>;
 }
 
 /**
@@ -30,6 +38,13 @@ export function createDashboardStore(r2: R2Bucket): DashboardStore {
     async getDashboard(project: string): Promise<R2ObjectBody | null> {
       try {
         return await r2.get(`${project}/__dashboard.html`);
+      } catch {
+        return null;
+      }
+    },
+    async getSwitcher(project: string): Promise<R2ObjectBody | null> {
+      try {
+        return await r2.get(`${project}/__switcher.json`);
       } catch {
         return null;
       }

--- a/cloudflare-worker/src/dashboardStore.ts
+++ b/cloudflare-worker/src/dashboardStore.ts
@@ -25,6 +25,19 @@ export interface DashboardStore {
    * @returns The R2 object body on hit, or `null` on miss / R2 error.
    */
   getSwitcher(project: string): Promise<R2ObjectBody | null>;
+
+  /**
+   * Fetch the per-edition metadata JSON (canonical URL, `is_canonical`) for
+   * a given edition of a project.
+   *
+   * @param project - Project slug.
+   * @param edition - Edition name.
+   * @returns The R2 object body on hit, or `null` on miss / R2 error.
+   */
+  getEditionMeta(
+    project: string,
+    edition: string,
+  ): Promise<R2ObjectBody | null>;
 }
 
 /**
@@ -45,6 +58,16 @@ export function createDashboardStore(r2: R2Bucket): DashboardStore {
     async getSwitcher(project: string): Promise<R2ObjectBody | null> {
       try {
         return await r2.get(`${project}/__switcher.json`);
+      } catch {
+        return null;
+      }
+    },
+    async getEditionMeta(
+      project: string,
+      edition: string,
+    ): Promise<R2ObjectBody | null> {
+      try {
+        return await r2.get(`${project}/__editions/${edition}.json`);
       } catch {
         return null;
       }

--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -1,3 +1,4 @@
+import { createDashboardStore } from "./dashboardStore";
 import { resolve } from "./resolver";
 import { parseRoute } from "./router";
 import { Env } from "./types";
@@ -15,6 +16,13 @@ export default {
         headers: { "Content-Type": "text/plain" },
       });
     }
-    return resolve(route, request, env.EDITIONS_KV, env.BUILDS_R2);
+    const dashboardStore = createDashboardStore(env.BUILDS_R2);
+    return resolve(
+      route,
+      request,
+      env.EDITIONS_KV,
+      env.BUILDS_R2,
+      dashboardStore,
+    );
   },
 } satisfies ExportedHandler<Env>;

--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -23,6 +23,7 @@ export default {
       env.EDITIONS_KV,
       env.BUILDS_R2,
       dashboardStore,
+      ctx,
     );
   },
 } satisfies ExportedHandler<Env>;

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -66,11 +66,26 @@ export async function resolve(
     case "redirect":
       return resolveRedirect(route.to, request);
     case "dashboard":
-      return resolveDashboard(route.project, dashboardStore);
+      return resolveDashboardFamily(
+        route.project,
+        "text/html; charset=utf-8",
+        () => dashboardStore.getDashboard(route.project),
+        dashboardStore,
+      );
     case "switcher":
-      return resolveSwitcher(route.project, dashboardStore);
+      return resolveDashboardFamily(
+        route.project,
+        "application/json; charset=utf-8",
+        () => dashboardStore.getSwitcher(route.project),
+        dashboardStore,
+      );
     case "edition_meta":
-      return resolveEditionMeta(route.project, route.edition, dashboardStore);
+      return resolveDashboardFamily(
+        route.project,
+        "application/json; charset=utf-8",
+        () => dashboardStore.getEditionMeta(route.project, route.edition),
+        dashboardStore,
+      );
     case "edition":
       return resolveEdition(route, request, kv, r2, dashboardStore);
     default:
@@ -84,57 +99,27 @@ function resolveRedirect(to: string, request: Request): Response {
   return Response.redirect(url.toString(), 301);
 }
 
-async function resolveDashboard(
+/**
+ * Shared response builder for dashboard-family routes (dashboard, switcher,
+ * edition_meta). Each caller supplies a fetcher that delegates to the
+ * appropriate `DashboardStore` getter plus the `Content-Type` the response
+ * should carry. 404 fallback goes through `notFoundResponse` so the branded
+ * `__404.html` / plain-text degradation is uniform across the family.
+ */
+async function resolveDashboardFamily(
   project: string,
+  contentType: string,
+  fetcher: () => Promise<R2ObjectBody | null>,
   dashboardStore: DashboardStore,
 ): Promise<Response> {
-  const object = await dashboardStore.getDashboard(project);
+  const object = await fetcher();
   if (object === null) {
     return notFoundResponse(project, dashboardStore);
   }
   return new Response(object.body, {
     status: 200,
     headers: {
-      "Content-Type": "text/html; charset=utf-8",
-      "Content-Length": object.size.toString(),
-      "ETag": object.httpEtag,
-      "Cache-Control": "public, max-age=60",
-    },
-  });
-}
-
-async function resolveSwitcher(
-  project: string,
-  dashboardStore: DashboardStore,
-): Promise<Response> {
-  const object = await dashboardStore.getSwitcher(project);
-  if (object === null) {
-    return notFoundResponse(project, dashboardStore);
-  }
-  return new Response(object.body, {
-    status: 200,
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
-      "Content-Length": object.size.toString(),
-      "ETag": object.httpEtag,
-      "Cache-Control": "public, max-age=60",
-    },
-  });
-}
-
-async function resolveEditionMeta(
-  project: string,
-  edition: string,
-  dashboardStore: DashboardStore,
-): Promise<Response> {
-  const object = await dashboardStore.getEditionMeta(project, edition);
-  if (object === null) {
-    return notFoundResponse(project, dashboardStore);
-  }
-  return new Response(object.body, {
-    status: 200,
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
+      "Content-Type": contentType,
       "Content-Length": object.size.toString(),
       "ETag": object.httpEtag,
       "Cache-Control": "public, max-age=60",

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -73,6 +73,8 @@ export async function resolve(
       return resolveEditionMeta(route.project, route.edition, dashboardStore);
     case "edition":
       return resolveEdition(route, request, kv, r2, dashboardStore);
+    default:
+      return route satisfies never;
   }
 }
 

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -10,7 +10,8 @@
  *      resolution.
  *   4. Return the R2 object with `Content-Type` inferred from the file
  *      extension and `Cache-Control: public, max-age=60`.
- *   5. Return a plain-text 404 on missing KV entry or missing R2 object.
+ *   5. Route any 404 (missing KV entry, malformed KV JSON, missing R2
+ *      object after the index-html fallback) through `notFoundResponse`.
  *
  * - `dashboard` routes delegate to `DashboardStore.getDashboard()`, which
  *   encapsulates the `__`-prefixed R2 key layout. The response body is the
@@ -29,6 +30,16 @@
  *
  * - `redirect` routes return a 301 with `Location` set to `route.to` on the
  *   request's origin, preserving the original query string.
+ *
+ * 404 handling: every 404-producing branch in this module routes through
+ * `notFoundResponse(project, dashboardStore)`, which serves the project's
+ * branded `{project}/__404.html` when present and degrades to plain-text
+ * `Not Found` otherwise. Both variants apply the same
+ * `Cache-Control: public, max-age=60` so dashboard rebuilds and newly
+ * published editions become visible within one minute and 404s don't get
+ * CDN-stuck. Unroutable requests (no extractable project slug) bypass this
+ * helper at the worker entry point, since there's no project to fall back
+ * on.
  */
 
 import mime from "mime";
@@ -61,7 +72,7 @@ export async function resolve(
     case "edition_meta":
       return resolveEditionMeta(route.project, route.edition, dashboardStore);
     case "edition":
-      return resolveEdition(route, request, kv, r2);
+      return resolveEdition(route, request, kv, r2, dashboardStore);
   }
 }
 
@@ -77,7 +88,7 @@ async function resolveDashboard(
 ): Promise<Response> {
   const object = await dashboardStore.getDashboard(project);
   if (object === null) {
-    return notFoundText();
+    return notFoundResponse(project, dashboardStore);
   }
   return new Response(object.body, {
     status: 200,
@@ -96,7 +107,7 @@ async function resolveSwitcher(
 ): Promise<Response> {
   const object = await dashboardStore.getSwitcher(project);
   if (object === null) {
-    return notFoundText();
+    return notFoundResponse(project, dashboardStore);
   }
   return new Response(object.body, {
     status: 200,
@@ -116,7 +127,7 @@ async function resolveEditionMeta(
 ): Promise<Response> {
   const object = await dashboardStore.getEditionMeta(project, edition);
   if (object === null) {
-    return notFoundText();
+    return notFoundResponse(project, dashboardStore);
   }
   return new Response(object.body, {
     status: 200,
@@ -134,19 +145,20 @@ async function resolveEdition(
   request: Request,
   kv: KVNamespace,
   r2: R2Bucket,
+  dashboardStore: DashboardStore,
 ): Promise<Response> {
   // Step 1: Look up the edition mapping in KV
   const kvKey = `${route.project}/${route.edition}`;
   const kvValue = await kv.get(kvKey);
   if (kvValue === null) {
-    return notFoundText();
+    return notFoundResponse(route.project, dashboardStore);
   }
 
   let mapping: EditionMapping;
   try {
     mapping = JSON.parse(kvValue);
   } catch {
-    return notFoundText();
+    return notFoundResponse(route.project, dashboardStore);
   }
 
   // Normalize r2_prefix to always end with "/"
@@ -179,7 +191,7 @@ async function resolveEdition(
   }
 
   if (object === null) {
-    return notFoundText();
+    return notFoundResponse(route.project, dashboardStore);
   }
 
   // Step 4: Infer Content-Type from file extension
@@ -197,9 +209,33 @@ async function resolveEdition(
   });
 }
 
-function notFoundText(): Response {
+/**
+ * Build a 404 response for a routable request, preferring the project's
+ * branded `__404.html` and degrading to plain text on miss. Both variants
+ * apply the same `Cache-Control: public, max-age=60` so CDN behavior is
+ * uniform across the `/v/` namespace.
+ */
+export async function notFoundResponse(
+  project: string,
+  dashboardStore: DashboardStore,
+): Promise<Response> {
+  const object = await dashboardStore.get404(project);
+  if (object !== null) {
+    return new Response(object.body, {
+      status: 404,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Length": object.size.toString(),
+        "ETag": object.httpEtag,
+        "Cache-Control": "public, max-age=60",
+      },
+    });
+  }
   return new Response("Not Found", {
     status: 404,
-    headers: { "Content-Type": "text/plain" },
+    headers: {
+      "Content-Type": "text/plain",
+      "Cache-Control": "public, max-age=60",
+    },
   });
 }

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -17,6 +17,11 @@
  *   R2 object with `Content-Type: text/html; charset=utf-8` and
  *   `Cache-Control: public, max-age=60`.
  *
+ * - `switcher` routes delegate to `DashboardStore.getSwitcher()`, returning
+ *   the project's version-switcher JSON with
+ *   `Content-Type: application/json; charset=utf-8` and the same
+ *   `Cache-Control` as other dashboard-family responses.
+ *
  * - `redirect` routes return a 301 with `Location` set to `route.to` on the
  *   request's origin, preserving the original query string.
  */
@@ -46,6 +51,8 @@ export async function resolve(
       return resolveRedirect(route.to, request);
     case "dashboard":
       return resolveDashboard(route.project, dashboardStore);
+    case "switcher":
+      return resolveSwitcher(route.project, dashboardStore);
     case "edition":
       return resolveEdition(route, request, kv, r2);
   }
@@ -69,6 +76,25 @@ async function resolveDashboard(
     status: 200,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
+      "Content-Length": object.size.toString(),
+      "ETag": object.httpEtag,
+      "Cache-Control": "public, max-age=60",
+    },
+  });
+}
+
+async function resolveSwitcher(
+  project: string,
+  dashboardStore: DashboardStore,
+): Promise<Response> {
+  const object = await dashboardStore.getSwitcher(project);
+  if (object === null) {
+    return notFoundText();
+  }
+  return new Response(object.body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
       "Content-Length": object.size.toString(),
       "ETag": object.httpEtag,
       "Cache-Control": "public, max-age=60",

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -22,6 +22,11 @@
  *   `Content-Type: application/json; charset=utf-8` and the same
  *   `Cache-Control` as other dashboard-family responses.
  *
+ * - `edition_meta` routes delegate to `DashboardStore.getEditionMeta()`,
+ *   returning per-edition metadata (canonical URL, `is_canonical`) with the
+ *   same JSON `Content-Type` and `Cache-Control` as other dashboard-family
+ *   responses.
+ *
  * - `redirect` routes return a 301 with `Location` set to `route.to` on the
  *   request's origin, preserving the original query string.
  */
@@ -53,6 +58,8 @@ export async function resolve(
       return resolveDashboard(route.project, dashboardStore);
     case "switcher":
       return resolveSwitcher(route.project, dashboardStore);
+    case "edition_meta":
+      return resolveEditionMeta(route.project, route.edition, dashboardStore);
     case "edition":
       return resolveEdition(route, request, kv, r2);
   }
@@ -88,6 +95,26 @@ async function resolveSwitcher(
   dashboardStore: DashboardStore,
 ): Promise<Response> {
   const object = await dashboardStore.getSwitcher(project);
+  if (object === null) {
+    return notFoundText();
+  }
+  return new Response(object.body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Content-Length": object.size.toString(),
+      "ETag": object.httpEtag,
+      "Cache-Control": "public, max-age=60",
+    },
+  });
+}
+
+async function resolveEditionMeta(
+  project: string,
+  edition: string,
+  dashboardStore: DashboardStore,
+): Promise<Response> {
+  const object = await dashboardStore.getEditionMeta(project, edition);
   if (object === null) {
     return notFoundText();
   }

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -1,17 +1,26 @@
 /**
- * KV-to-R2 resolution module.
+ * Route-to-response resolver.
  *
- * Given a parsed route (project, edition, file path), this module:
- * 1. Looks up the KV key `{project}/{edition}` to get the build mapping
- * 2. Constructs the R2 object key as `{r2_prefix}{file_path}`
- * 3. Tries exact path, then `{path}/index.html` for directory index resolution
- * 4. Returns the R2 object with Content-Type inferred from the file extension
- *    and Cache-Control: public, max-age=60
- * 5. Returns a plain text 404 for missing KV entries or missing R2 objects
+ * Dispatches on `route.kind`:
+ *
+ * - `edition` routes follow the existing KV → R2 hot path:
+ *   1. Look up `{project}/{edition}` in KV to get the build mapping.
+ *   2. Construct the R2 object key as `{r2_prefix}{file_path}`.
+ *   3. Try exact path, then `{path}/index.html` for directory index
+ *      resolution.
+ *   4. Return the R2 object with `Content-Type` inferred from the file
+ *      extension and `Cache-Control: public, max-age=60`.
+ *   5. Return a plain-text 404 on missing KV entry or missing R2 object.
+ *
+ * - `dashboard` routes delegate to `DashboardStore.getDashboard()`, which
+ *   encapsulates the `__`-prefixed R2 key layout. The response body is the
+ *   R2 object with `Content-Type: text/html; charset=utf-8` and
+ *   `Cache-Control: public, max-age=60`.
  */
 
 import mime from "mime";
-import type { Route } from "./router";
+import type { DashboardStore } from "./dashboardStore";
+import type { Route, EditionRoute } from "./router";
 
 /** Shape of the JSON value stored in the editions KV namespace. */
 interface EditionMapping {
@@ -20,10 +29,44 @@ interface EditionMapping {
 }
 
 /**
- * Resolve a route to an R2 object and return an HTTP response.
+ * Resolve a route to an HTTP response.
  */
 export async function resolve(
   route: Route,
+  request: Request,
+  kv: KVNamespace,
+  r2: R2Bucket,
+  dashboardStore: DashboardStore,
+): Promise<Response> {
+  switch (route.kind) {
+    case "dashboard":
+      return resolveDashboard(route.project, dashboardStore);
+    case "edition":
+      return resolveEdition(route, request, kv, r2);
+  }
+}
+
+async function resolveDashboard(
+  project: string,
+  dashboardStore: DashboardStore,
+): Promise<Response> {
+  const object = await dashboardStore.getDashboard(project);
+  if (object === null) {
+    return notFoundText();
+  }
+  return new Response(object.body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Content-Length": object.size.toString(),
+      "ETag": object.httpEtag,
+      "Cache-Control": "public, max-age=60",
+    },
+  });
+}
+
+async function resolveEdition(
+  route: EditionRoute,
   request: Request,
   kv: KVNamespace,
   r2: R2Bucket,
@@ -32,20 +75,14 @@ export async function resolve(
   const kvKey = `${route.project}/${route.edition}`;
   const kvValue = await kv.get(kvKey);
   if (kvValue === null) {
-    return new Response("Not Found", {
-      status: 404,
-      headers: { "Content-Type": "text/plain" },
-    });
+    return notFoundText();
   }
 
   let mapping: EditionMapping;
   try {
     mapping = JSON.parse(kvValue);
   } catch {
-    return new Response("Not Found", {
-      status: 404,
-      headers: { "Content-Type": "text/plain" },
-    });
+    return notFoundText();
   }
 
   // Normalize r2_prefix to always end with "/"
@@ -78,10 +115,7 @@ export async function resolve(
   }
 
   if (object === null) {
-    return new Response("Not Found", {
-      status: 404,
-      headers: { "Content-Type": "text/plain" },
-    });
+    return notFoundText();
   }
 
   // Step 4: Infer Content-Type from file extension
@@ -96,5 +130,12 @@ export async function resolve(
       "ETag": object.httpEtag,
       "Cache-Control": "public, max-age=60",
     },
+  });
+}
+
+function notFoundText(): Response {
+  return new Response("Not Found", {
+    status: 404,
+    headers: { "Content-Type": "text/plain" },
   });
 }

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -16,7 +16,10 @@
  * - `dashboard` routes delegate to `DashboardStore.getDashboard()`, which
  *   encapsulates the `__`-prefixed R2 key layout. The response body is the
  *   R2 object with `Content-Type: text/html; charset=utf-8` and
- *   `Cache-Control: public, max-age=60`.
+ *   `Cache-Control: public, max-age=60`. When the request carries an
+ *   `If-None-Match` header whose full value exactly matches the R2 object's
+ *   `httpEtag`, the resolver returns a bodiless 304 with the same `ETag` and
+ *   `Cache-Control` headers instead.
  *
  * - `switcher` routes delegate to `DashboardStore.getSwitcher()`, returning
  *   the project's version-switcher JSON with
@@ -70,6 +73,7 @@ export async function resolve(
         route.project,
         "text/html; charset=utf-8",
         () => dashboardStore.getDashboard(route.project),
+        request,
         dashboardStore,
       );
     case "switcher":
@@ -77,6 +81,7 @@ export async function resolve(
         route.project,
         "application/json; charset=utf-8",
         () => dashboardStore.getSwitcher(route.project),
+        request,
         dashboardStore,
       );
     case "edition_meta":
@@ -84,6 +89,7 @@ export async function resolve(
         route.project,
         "application/json; charset=utf-8",
         () => dashboardStore.getEditionMeta(route.project, route.edition),
+        request,
         dashboardStore,
       );
     case "edition":
@@ -105,16 +111,32 @@ function resolveRedirect(to: string, request: Request): Response {
  * appropriate `DashboardStore` getter plus the `Content-Type` the response
  * should carry. 404 fallback goes through `notFoundResponse` so the branded
  * `__404.html` / plain-text degradation is uniform across the family.
+ *
+ * Conditional-GET: if the request's `If-None-Match` header value matches the
+ * R2 object's `httpEtag` exactly, return a bodiless 304 with the same `ETag`
+ * and `Cache-Control` headers. The match is a full-string compare against
+ * the header value; RFC 7232 weak-tag / comma-list semantics are out of
+ * scope for v1.
  */
 async function resolveDashboardFamily(
   project: string,
   contentType: string,
   fetcher: () => Promise<R2ObjectBody | null>,
+  request: Request,
   dashboardStore: DashboardStore,
 ): Promise<Response> {
   const object = await fetcher();
   if (object === null) {
     return notFoundResponse(project, dashboardStore);
+  }
+  if (request.headers.get("If-None-Match") === object.httpEtag) {
+    return new Response(null, {
+      status: 304,
+      headers: {
+        "ETag": object.httpEtag,
+        "Cache-Control": "public, max-age=60",
+      },
+    });
   }
   return new Response(object.body, {
     status: 200,

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -50,6 +50,13 @@
  * `ctx.waitUntil(caches.default.put(...))` so repeated 404s for the same
  * project don't re-hit R2 within the 60-second TTL. Both the branded and
  * the plain-text fallback branches are cached.
+ *
+ * Defensive against `get404` rejections: `DashboardStore.get404` is
+ * documented as "never throws", but `notFoundResponse` is the last line of
+ * defense for 404 production. The `get404` call is wrapped in a try/catch
+ * so a buggy or future implementation that rejects still degrades to the
+ * plain-text fallback rather than letting a rejection propagate out of the
+ * worker.
  */
 
 import mime from "mime";
@@ -251,7 +258,12 @@ export async function notFoundResponse(
   if (cached !== undefined) {
     return cached;
   }
-  const object = await dashboardStore.get404(project);
+  let object: R2ObjectBody | null;
+  try {
+    object = await dashboardStore.get404(project);
+  } catch {
+    object = null;
+  }
   const response =
     object !== null
       ? new Response(object.body, {

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -16,6 +16,9 @@
  *   encapsulates the `__`-prefixed R2 key layout. The response body is the
  *   R2 object with `Content-Type: text/html; charset=utf-8` and
  *   `Cache-Control: public, max-age=60`.
+ *
+ * - `redirect` routes return a 301 with `Location` set to `route.to` on the
+ *   request's origin, preserving the original query string.
  */
 
 import mime from "mime";
@@ -39,11 +42,19 @@ export async function resolve(
   dashboardStore: DashboardStore,
 ): Promise<Response> {
   switch (route.kind) {
+    case "redirect":
+      return resolveRedirect(route.to, request);
     case "dashboard":
       return resolveDashboard(route.project, dashboardStore);
     case "edition":
       return resolveEdition(route, request, kv, r2);
   }
+}
+
+function resolveRedirect(to: string, request: Request): Response {
+  const url = new URL(request.url);
+  url.pathname = to;
+  return Response.redirect(url.toString(), 301);
 }
 
 async function resolveDashboard(

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -120,7 +120,6 @@ async function resolveDashboardFamily(
     status: 200,
     headers: {
       "Content-Type": contentType,
-      "Content-Length": object.size.toString(),
       "ETag": object.httpEtag,
       "Cache-Control": "public, max-age=60",
     },
@@ -189,7 +188,6 @@ async function resolveEdition(
     status: 200,
     headers: {
       "Content-Type": contentType,
-      "Content-Length": object.size.toString(),
       "ETag": object.httpEtag,
       "Cache-Control": "public, max-age=60",
     },

--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -35,14 +35,21 @@
  *   request's origin, preserving the original query string.
  *
  * 404 handling: every 404-producing branch in this module routes through
- * `notFoundResponse(project, dashboardStore)`, which serves the project's
- * branded `{project}/__404.html` when present and degrades to plain-text
- * `Not Found` otherwise. Both variants apply the same
+ * `notFoundResponse(project, dashboardStore, ctx)`, which serves the
+ * project's branded `{project}/__404.html` when present and degrades to
+ * plain-text `Not Found` otherwise. Both variants apply the same
  * `Cache-Control: public, max-age=60` so dashboard rebuilds and newly
  * published editions become visible within one minute and 404s don't get
  * CDN-stuck. Unroutable requests (no extractable project slug) bypass this
  * helper at the worker entry point, since there's no project to fall back
  * on.
+ *
+ * 404 caching: `notFoundResponse` consults `caches.default` before calling
+ * `dashboardStore.get404`, keyed per project. On miss it constructs the
+ * branded-HTML or plain-text response and writes it back via
+ * `ctx.waitUntil(caches.default.put(...))` so repeated 404s for the same
+ * project don't re-hit R2 within the 60-second TTL. Both the branded and
+ * the plain-text fallback branches are cached.
  */
 
 import mime from "mime";
@@ -64,6 +71,7 @@ export async function resolve(
   kv: KVNamespace,
   r2: R2Bucket,
   dashboardStore: DashboardStore,
+  ctx: ExecutionContext,
 ): Promise<Response> {
   switch (route.kind) {
     case "redirect":
@@ -75,6 +83,7 @@ export async function resolve(
         () => dashboardStore.getDashboard(route.project),
         request,
         dashboardStore,
+        ctx,
       );
     case "switcher":
       return resolveDashboardFamily(
@@ -83,6 +92,7 @@ export async function resolve(
         () => dashboardStore.getSwitcher(route.project),
         request,
         dashboardStore,
+        ctx,
       );
     case "edition_meta":
       return resolveDashboardFamily(
@@ -91,9 +101,10 @@ export async function resolve(
         () => dashboardStore.getEditionMeta(route.project, route.edition),
         request,
         dashboardStore,
+        ctx,
       );
     case "edition":
-      return resolveEdition(route, request, kv, r2, dashboardStore);
+      return resolveEdition(route, request, kv, r2, dashboardStore, ctx);
     default:
       return route satisfies never;
   }
@@ -124,10 +135,11 @@ async function resolveDashboardFamily(
   fetcher: () => Promise<R2ObjectBody | null>,
   request: Request,
   dashboardStore: DashboardStore,
+  ctx: ExecutionContext,
 ): Promise<Response> {
   const object = await fetcher();
   if (object === null) {
-    return notFoundResponse(project, dashboardStore);
+    return notFoundResponse(project, dashboardStore, ctx);
   }
   if (request.headers.get("If-None-Match") === object.httpEtag) {
     return new Response(null, {
@@ -154,19 +166,20 @@ async function resolveEdition(
   kv: KVNamespace,
   r2: R2Bucket,
   dashboardStore: DashboardStore,
+  ctx: ExecutionContext,
 ): Promise<Response> {
   // Step 1: Look up the edition mapping in KV
   const kvKey = `${route.project}/${route.edition}`;
   const kvValue = await kv.get(kvKey);
   if (kvValue === null) {
-    return notFoundResponse(route.project, dashboardStore);
+    return notFoundResponse(route.project, dashboardStore, ctx);
   }
 
   let mapping: EditionMapping;
   try {
     mapping = JSON.parse(kvValue);
   } catch {
-    return notFoundResponse(route.project, dashboardStore);
+    return notFoundResponse(route.project, dashboardStore, ctx);
   }
 
   // Normalize r2_prefix to always end with "/"
@@ -199,7 +212,7 @@ async function resolveEdition(
   }
 
   if (object === null) {
-    return notFoundResponse(route.project, dashboardStore);
+    return notFoundResponse(route.project, dashboardStore, ctx);
   }
 
   // Step 4: Infer Content-Type from file extension
@@ -221,28 +234,53 @@ async function resolveEdition(
  * branded `__404.html` and degrading to plain text on miss. Both variants
  * apply the same `Cache-Control: public, max-age=60` so CDN behavior is
  * uniform across the `/v/` namespace.
+ *
+ * Consults `caches.default` before calling `get404` so repeated 404s for the
+ * same project don't re-hit R2 within the 60-second TTL. The cache key is a
+ * synthetic, project-scoped URL; both the branded HTML and the plain-text
+ * fallback branches are cached. Cache writes are dispatched via
+ * `ctx.waitUntil` so they don't delay the response.
  */
 export async function notFoundResponse(
   project: string,
   dashboardStore: DashboardStore,
+  ctx: ExecutionContext,
 ): Promise<Response> {
-  const object = await dashboardStore.get404(project);
-  if (object !== null) {
-    return new Response(object.body, {
-      status: 404,
-      headers: {
-        "Content-Type": "text/html; charset=utf-8",
-        "Content-Length": object.size.toString(),
-        "ETag": object.httpEtag,
-        "Cache-Control": "public, max-age=60",
-      },
-    });
+  const cacheKey = notFoundCacheKey(project);
+  const cached = await caches.default.match(cacheKey);
+  if (cached !== undefined) {
+    return cached;
   }
-  return new Response("Not Found", {
-    status: 404,
-    headers: {
-      "Content-Type": "text/plain",
-      "Cache-Control": "public, max-age=60",
-    },
-  });
+  const object = await dashboardStore.get404(project);
+  const response =
+    object !== null
+      ? new Response(object.body, {
+          status: 404,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            "Content-Length": object.size.toString(),
+            "ETag": object.httpEtag,
+            "Cache-Control": "public, max-age=60",
+          },
+        })
+      : new Response("Not Found", {
+          status: 404,
+          headers: {
+            "Content-Type": "text/plain",
+            "Cache-Control": "public, max-age=60",
+          },
+        });
+  ctx.waitUntil(caches.default.put(cacheKey, response.clone()));
+  return response;
+}
+
+/**
+ * Build the `caches.default` cache key for a project's 404 response.
+ *
+ * The URL is synthetic (no real host) and project-scoped, so entries are
+ * isolated per project without colliding with any request-path URL.
+ * Exported so tests can evict cached entries between runs.
+ */
+export function notFoundCacheKey(project: string): Request {
+  return new Request(`https://cache/__404/${encodeURIComponent(project)}`);
 }

--- a/cloudflare-worker/src/router.ts
+++ b/cloudflare-worker/src/router.ts
@@ -37,8 +37,20 @@ export interface DashboardRoute {
   project: string;
 }
 
+/**
+ * Redirect route — returns a 301 to `to`.
+ *
+ * Used to canonicalize `/v` (no trailing slash) to `/v/` so that relative
+ * links inside the dashboard HTML resolve correctly.
+ */
+export interface RedirectRoute {
+  kind: "redirect";
+  /** Target pathname (absolute, starts with "/"). */
+  to: string;
+}
+
 /** Result of parsing a request URL. */
-export type Route = EditionRoute | DashboardRoute;
+export type Route = EditionRoute | DashboardRoute | RedirectRoute;
 
 /** Supported URL routing schemes. */
 export type UrlScheme = "subdomain" | "path-prefix";
@@ -75,14 +87,23 @@ export function parseRoute(
  * Classify a project-relative path into a Route.
  *
  * Classification order:
- * 1. `v/` or `v/index.html` → dashboard route.
- * 2. Anything else starting with `v/` → named-edition route.
- * 3. Anything else → `__main`-edition route.
+ * 1. Exactly `v` (no trailing slash) → redirect to `requestPathname + "/"`.
+ * 2. `v/` or `v/index.html` → dashboard route.
+ * 3. Anything else starting with `v/` → named-edition route.
+ * 4. Anything else → `__main`-edition route.
  */
-function classifyRelativePath(project: string, relativePath: string): Route {
+function classifyRelativePath(
+  project: string,
+  relativePath: string,
+  requestPathname: string,
+): Route {
   const stripped = relativePath.startsWith("/")
     ? relativePath.slice(1)
     : relativePath;
+
+  if (stripped === "v") {
+    return { kind: "redirect", to: `${requestPathname}/` };
+  }
 
   if (stripped === "v/" || stripped === "v/index.html") {
     return { kind: "dashboard", project };
@@ -129,7 +150,7 @@ function parseSubdomainRoute(request: Request): Route | null {
     return null;
   }
 
-  return classifyRelativePath(project, url.pathname);
+  return classifyRelativePath(project, url.pathname, url.pathname);
 }
 
 function parsePathPrefixRoute(
@@ -160,7 +181,7 @@ function parsePathPrefixRoute(
     if (pathname === "") {
       return null;
     }
-    return classifyRelativePath(pathname, "");
+    return classifyRelativePath(pathname, "", url.pathname);
   }
 
   const project = pathname.slice(0, slashIndex);
@@ -169,7 +190,7 @@ function parsePathPrefixRoute(
   }
 
   const rest = pathname.slice(slashIndex); // includes leading "/"
-  return classifyRelativePath(project, rest);
+  return classifyRelativePath(project, rest, url.pathname);
 }
 
 /**

--- a/cloudflare-worker/src/router.ts
+++ b/cloudflare-worker/src/router.ts
@@ -21,8 +21,10 @@
  *   Matches exactly `/v/switcher.json`.
  * - `{kind: 'edition_meta', project, edition}` — per-edition metadata JSON
  *   (canonical URL, `is_canonical`). Matches exactly
- *   `/v/{edition}/_docverse.json`; deeper paths like
- *   `/v/main/_docverse.json/extra` fall through to edition routing.
+ *   `/v/{edition}/_docverse.json`, and also `/_docverse.json` at the
+ *   project root (resolved to the `__main` edition). Deeper paths like
+ *   `/v/main/_docverse.json/extra` or `/sub/_docverse.json` fall through
+ *   to edition routing.
  */
 
 /** Edition (build) route — resolved via KV → R2. */
@@ -124,7 +126,10 @@ export function parseRoute(
  * 3. `v/switcher.json` → switcher route.
  * 4. `v/{edition}/_docverse.json` (exactly) → edition_meta route.
  * 5. Anything else starting with `v/` → named-edition route.
- * 6. Anything else → `__main`-edition route.
+ * 6. Exactly `_docverse.json` at the project root → edition_meta route for
+ *    the `__main` edition. Deeper paths (`_docverse.json/extra`,
+ *    `sub/_docverse.json`) fall through to the `__main` edition file route.
+ * 7. Anything else → `__main`-edition route.
  */
 function classifyRelativePath(
   project: string,
@@ -150,6 +155,10 @@ function classifyRelativePath(
   const editionMetaMatch = matchEditionMeta(stripped);
   if (editionMetaMatch !== null) {
     return { kind: "edition_meta", project, edition: editionMetaMatch };
+  }
+
+  if (stripped === "_docverse.json") {
+    return { kind: "edition_meta", project, edition: DEFAULT_EDITION };
   }
 
   if (stripped.startsWith("v/")) {

--- a/cloudflare-worker/src/router.ts
+++ b/cloudflare-worker/src/router.ts
@@ -19,6 +19,10 @@
  *   exactly `/v/` and `/v/index.html`.
  * - `{kind: 'switcher', project}` — the per-project version-switcher JSON.
  *   Matches exactly `/v/switcher.json`.
+ * - `{kind: 'edition_meta', project, edition}` — per-edition metadata JSON
+ *   (canonical URL, `is_canonical`). Matches exactly
+ *   `/v/{edition}/_docverse.json`; deeper paths like
+ *   `/v/main/_docverse.json/extra` fall through to edition routing.
  */
 
 /** Edition (build) route — resolved via KV → R2. */
@@ -47,6 +51,20 @@ export interface SwitcherRoute {
 }
 
 /**
+ * Edition-metadata route — served from `{project}/__editions/{edition}.json`
+ * in R2. Exposes per-edition metadata (canonical URL, `is_canonical`) at
+ * `/v/{edition}/_docverse.json` so that client-side JS and programmatic
+ * consumers can check canonicality without round-tripping to the API.
+ */
+export interface EditionMetaRoute {
+  kind: "edition_meta";
+  /** Project slug (e.g., "pipelines"). */
+  project: string;
+  /** Edition name (e.g., "main", "v1.0"). */
+  edition: string;
+}
+
+/**
  * Redirect route — returns a 301 to `to`.
  *
  * Used to canonicalize `/v` (no trailing slash) to `/v/` so that relative
@@ -63,6 +81,7 @@ export type Route =
   | EditionRoute
   | DashboardRoute
   | SwitcherRoute
+  | EditionMetaRoute
   | RedirectRoute;
 
 /** Supported URL routing schemes. */
@@ -103,8 +122,9 @@ export function parseRoute(
  * 1. Exactly `v` (no trailing slash) → redirect to `requestPathname + "/"`.
  * 2. `v/` or `v/index.html` → dashboard route.
  * 3. `v/switcher.json` → switcher route.
- * 4. Anything else starting with `v/` → named-edition route.
- * 5. Anything else → `__main`-edition route.
+ * 4. `v/{edition}/_docverse.json` (exactly) → edition_meta route.
+ * 5. Anything else starting with `v/` → named-edition route.
+ * 6. Anything else → `__main`-edition route.
  */
 function classifyRelativePath(
   project: string,
@@ -125,6 +145,11 @@ function classifyRelativePath(
 
   if (stripped === "v/switcher.json") {
     return { kind: "switcher", project };
+  }
+
+  const editionMetaMatch = matchEditionMeta(stripped);
+  if (editionMetaMatch !== null) {
+    return { kind: "edition_meta", project, edition: editionMetaMatch };
   }
 
   if (stripped.startsWith("v/")) {
@@ -209,6 +234,27 @@ function parsePathPrefixRoute(
 
   const rest = pathname.slice(slashIndex); // includes leading "/"
   return classifyRelativePath(project, rest, url.pathname);
+}
+
+/**
+ * If `stripped` matches the exact pattern `v/{edition}/_docverse.json`,
+ * return the edition name. Otherwise return `null`.
+ *
+ * The match requires exactly three path segments (`v`, `{edition}`,
+ * `_docverse.json`) with no trailing content, so `v/main/_docverse.json/extra`
+ * falls through to edition routing and is not silently captured.
+ */
+const EDITION_META_SUFFIX = "/_docverse.json";
+
+function matchEditionMeta(stripped: string): string | null {
+  if (!stripped.startsWith("v/") || !stripped.endsWith(EDITION_META_SUFFIX)) {
+    return null;
+  }
+  const edition = stripped.slice(2, stripped.length - EDITION_META_SUFFIX.length);
+  if (edition === "" || edition.includes("/")) {
+    return null;
+  }
+  return edition;
 }
 
 /**

--- a/cloudflare-worker/src/router.ts
+++ b/cloudflare-worker/src/router.ts
@@ -1,31 +1,44 @@
 /**
  * URL routing module.
  *
- * Parses incoming HTTP requests into a structured route consisting of
- * project slug, edition name, and file path. Supports two URL schemes:
+ * Parses incoming HTTP requests into a structured route. Supports two
+ * URL schemes:
  *
  * - **Subdomain**: project slug from the leftmost subdomain label of the
- *   Host header; edition and path from the URL path.
+ *   Host header; remaining classification from the URL path.
  * - **Path-prefix**: project slug extracted from the URL path after an
- *   optional configurable root prefix; edition and path from the remaining
- *   path.
+ *   optional configurable root prefix; remaining classification from the
+ *   rest of the path.
  *
- * Edition URL grammar:
- * - `/page.html` or `/` → `__main` edition
- * - `/v/{edition}/page.html` → named edition
+ * A parsed route is a discriminated union on the `kind` field:
+ *
+ * - `{kind: 'edition', project, edition, path}` — a build URL resolved via
+ *   the KV → R2 hot path. `/page.html` or `/` maps to the `__main` edition;
+ *   `/v/{edition}/...` maps to a named edition.
+ * - `{kind: 'dashboard', project}` — the project dashboard page. Matches
+ *   exactly `/v/` and `/v/index.html`.
  */
 
-/** Result of parsing a request URL. */
-export interface Route {
+/** Edition (build) route — resolved via KV → R2. */
+export interface EditionRoute {
+  kind: "edition";
   /** Project slug (e.g., "pipelines"). */
   project: string;
-
   /** Edition name (e.g., "__main", "v1.0", "main"). */
   edition: string;
-
   /** File path within the edition (e.g., "page.html", "api/index.html"). */
   path: string;
 }
+
+/** Dashboard route — served from `{project}/__dashboard.html` in R2. */
+export interface DashboardRoute {
+  kind: "dashboard";
+  /** Project slug (e.g., "pipelines"). */
+  project: string;
+}
+
+/** Result of parsing a request URL. */
+export type Route = EditionRoute | DashboardRoute;
 
 /** Supported URL routing schemes. */
 export type UrlScheme = "subdomain" | "path-prefix";
@@ -59,40 +72,45 @@ export function parseRoute(
 }
 
 /**
- * Parse edition and path from a URL path relative to the project root.
+ * Classify a project-relative path into a Route.
  *
- * Handles the edition URL grammar:
- * - `/v/{edition}/...` → named edition with remaining path
- * - anything else → `__main` edition
+ * Classification order:
+ * 1. `v/` or `v/index.html` → dashboard route.
+ * 2. Anything else starting with `v/` → named-edition route.
+ * 3. Anything else → `__main`-edition route.
  */
-function parseEditionAndPath(relativePath: string): {
-  edition: string;
-  path: string;
-} {
-  // Remove leading slash
+function classifyRelativePath(project: string, relativePath: string): Route {
   const stripped = relativePath.startsWith("/")
     ? relativePath.slice(1)
     : relativePath;
 
-  // Check for /v/{edition}/... pattern
+  if (stripped === "v/" || stripped === "v/index.html") {
+    return { kind: "dashboard", project };
+  }
+
   if (stripped.startsWith("v/")) {
     const afterV = stripped.slice(2); // after "v/"
     const slashIndex = afterV.indexOf("/");
     if (slashIndex === -1) {
       // Path is exactly "v/{edition}" with no trailing slash
       const edition = afterV || DEFAULT_EDITION;
-      return { edition, path: "" };
+      return { kind: "edition", project, edition, path: "" };
     }
     const edition = afterV.slice(0, slashIndex);
     if (edition === "") {
-      // Path is "v/..." with empty edition — treat as __main
-      return { edition: DEFAULT_EDITION, path: afterV.slice(1) };
+      // Path is "v//..." with empty edition — treat as __main
+      return {
+        kind: "edition",
+        project,
+        edition: DEFAULT_EDITION,
+        path: afterV.slice(1),
+      };
     }
     const path = afterV.slice(slashIndex + 1);
-    return { edition, path };
+    return { kind: "edition", project, edition, path };
   }
 
-  return { edition: DEFAULT_EDITION, path: stripped };
+  return { kind: "edition", project, edition: DEFAULT_EDITION, path: stripped };
 }
 
 function parseSubdomainRoute(request: Request): Route | null {
@@ -111,8 +129,7 @@ function parseSubdomainRoute(request: Request): Route | null {
     return null;
   }
 
-  const { edition, path } = parseEditionAndPath(url.pathname);
-  return { project, edition, path };
+  return classifyRelativePath(project, url.pathname);
 }
 
 function parsePathPrefixRoute(
@@ -143,8 +160,7 @@ function parsePathPrefixRoute(
     if (pathname === "") {
       return null;
     }
-    const { edition, path } = parseEditionAndPath("");
-    return { project: pathname, edition, path };
+    return classifyRelativePath(pathname, "");
   }
 
   const project = pathname.slice(0, slashIndex);
@@ -153,8 +169,7 @@ function parsePathPrefixRoute(
   }
 
   const rest = pathname.slice(slashIndex); // includes leading "/"
-  const { edition, path } = parseEditionAndPath(rest);
-  return { project, edition, path };
+  return classifyRelativePath(project, rest);
 }
 
 /**

--- a/cloudflare-worker/src/router.ts
+++ b/cloudflare-worker/src/router.ts
@@ -17,6 +17,8 @@
  *   `/v/{edition}/...` maps to a named edition.
  * - `{kind: 'dashboard', project}` — the project dashboard page. Matches
  *   exactly `/v/` and `/v/index.html`.
+ * - `{kind: 'switcher', project}` — the per-project version-switcher JSON.
+ *   Matches exactly `/v/switcher.json`.
  */
 
 /** Edition (build) route — resolved via KV → R2. */
@@ -37,6 +39,13 @@ export interface DashboardRoute {
   project: string;
 }
 
+/** Switcher route — served from `{project}/__switcher.json` in R2. */
+export interface SwitcherRoute {
+  kind: "switcher";
+  /** Project slug (e.g., "pipelines"). */
+  project: string;
+}
+
 /**
  * Redirect route — returns a 301 to `to`.
  *
@@ -50,7 +59,11 @@ export interface RedirectRoute {
 }
 
 /** Result of parsing a request URL. */
-export type Route = EditionRoute | DashboardRoute | RedirectRoute;
+export type Route =
+  | EditionRoute
+  | DashboardRoute
+  | SwitcherRoute
+  | RedirectRoute;
 
 /** Supported URL routing schemes. */
 export type UrlScheme = "subdomain" | "path-prefix";
@@ -89,8 +102,9 @@ export function parseRoute(
  * Classification order:
  * 1. Exactly `v` (no trailing slash) → redirect to `requestPathname + "/"`.
  * 2. `v/` or `v/index.html` → dashboard route.
- * 3. Anything else starting with `v/` → named-edition route.
- * 4. Anything else → `__main`-edition route.
+ * 3. `v/switcher.json` → switcher route.
+ * 4. Anything else starting with `v/` → named-edition route.
+ * 5. Anything else → `__main`-edition route.
  */
 function classifyRelativePath(
   project: string,
@@ -107,6 +121,10 @@ function classifyRelativePath(
 
   if (stripped === "v/" || stripped === "v/index.html") {
     return { kind: "dashboard", project };
+  }
+
+  if (stripped === "v/switcher.json") {
+    return { kind: "switcher", project };
   }
 
   if (stripped.startsWith("v/")) {

--- a/cloudflare-worker/test/dashboardStore.test.ts
+++ b/cloudflare-worker/test/dashboardStore.test.ts
@@ -78,3 +78,42 @@ describe("DashboardStore.getDashboard", () => {
     await expect(store.getDashboard("sqr-112")).resolves.toBeNull();
   });
 });
+
+describe("DashboardStore.getSwitcher", () => {
+  it("returns the R2 object for {project}/__switcher.json on hit", async () => {
+    const r2 = createMockR2({
+      "sqr-112/__switcher.json": {
+        body: streamFromString('[{"name":"main","url":"/v/main/"}]'),
+        size: 34,
+      },
+    });
+    const store = createDashboardStore(r2);
+
+    const object = await store.getSwitcher("sqr-112");
+
+    expect(object).not.toBeNull();
+    expect(r2.get).toHaveBeenCalledWith("sqr-112/__switcher.json");
+    const body = await new Response(object!.body).text();
+    expect(body).toBe('[{"name":"main","url":"/v/main/"}]');
+  });
+
+  it("returns null on miss", async () => {
+    const r2 = createMockR2({});
+    const store = createDashboardStore(r2);
+
+    const object = await store.getSwitcher("sqr-112");
+
+    expect(object).toBeNull();
+  });
+
+  it("never throws when R2.get rejects", async () => {
+    const r2 = {
+      get: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    } as unknown as R2Bucket;
+    const store = createDashboardStore(r2);
+
+    await expect(store.getSwitcher("sqr-112")).resolves.toBeNull();
+  });
+});

--- a/cloudflare-worker/test/dashboardStore.test.ts
+++ b/cloudflare-worker/test/dashboardStore.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { createDashboardStore } from "../src/dashboardStore";
+
+/**
+ * Create a mock R2 bucket whose `get()` returns the body stored at the
+ * given key, or null if the key is not present.
+ */
+function createMockR2(
+  store: Record<
+    string,
+    { body: ReadableStream; size: number }
+  > = {},
+): R2Bucket {
+  return {
+    get: vi.fn(async (key: string) => {
+      const obj = store[key];
+      if (!obj) return null;
+      return {
+        body: obj.body,
+        size: obj.size,
+        httpEtag: `"${key}-etag"`,
+        httpMetadata: {},
+      } as R2ObjectBody;
+    }),
+    put: vi.fn(),
+    delete: vi.fn(),
+    list: vi.fn(),
+    head: vi.fn(),
+    createMultipartUpload: vi.fn(),
+    resumeMultipartUpload: vi.fn(),
+  } as unknown as R2Bucket;
+}
+
+function streamFromString(s: string): ReadableStream {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(s));
+      controller.close();
+    },
+  });
+}
+
+describe("DashboardStore.getDashboard", () => {
+  it("returns the R2 object for {project}/__dashboard.html on hit", async () => {
+    const r2 = createMockR2({
+      "sqr-112/__dashboard.html": {
+        body: streamFromString("<html>dashboard</html>"),
+        size: 22,
+      },
+    });
+    const store = createDashboardStore(r2);
+
+    const object = await store.getDashboard("sqr-112");
+
+    expect(object).not.toBeNull();
+    expect(r2.get).toHaveBeenCalledWith("sqr-112/__dashboard.html");
+    const body = await new Response(object!.body).text();
+    expect(body).toBe("<html>dashboard</html>");
+  });
+
+  it("returns null on miss", async () => {
+    const r2 = createMockR2({});
+    const store = createDashboardStore(r2);
+
+    const object = await store.getDashboard("sqr-112");
+
+    expect(object).toBeNull();
+  });
+
+  it("never throws when R2.get rejects", async () => {
+    const r2 = {
+      get: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    } as unknown as R2Bucket;
+    const store = createDashboardStore(r2);
+
+    await expect(store.getDashboard("sqr-112")).resolves.toBeNull();
+  });
+});

--- a/cloudflare-worker/test/dashboardStore.test.ts
+++ b/cloudflare-worker/test/dashboardStore.test.ts
@@ -201,3 +201,86 @@ describe("DashboardStore.get404", () => {
     await expect(store.get404("sqr-112")).resolves.toBeNull();
   });
 });
+
+describe("DashboardStore logging on R2 error", () => {
+  function rejectingR2(message: string): R2Bucket {
+    return {
+      get: vi.fn(async () => {
+        throw new Error(message);
+      }),
+    } as unknown as R2Bucket;
+  }
+
+  it.each([
+    [
+      "getDashboard",
+      "sqr-112/__dashboard.html",
+      (s: ReturnType<typeof createDashboardStore>) => s.getDashboard("sqr-112"),
+    ],
+    [
+      "getSwitcher",
+      "sqr-112/__switcher.json",
+      (s: ReturnType<typeof createDashboardStore>) => s.getSwitcher("sqr-112"),
+    ],
+    [
+      "getEditionMeta",
+      "sqr-112/__editions/main.json",
+      (s: ReturnType<typeof createDashboardStore>) =>
+        s.getEditionMeta("sqr-112", "main"),
+    ],
+    [
+      "get404",
+      "sqr-112/__404.html",
+      (s: ReturnType<typeof createDashboardStore>) => s.get404("sqr-112"),
+    ],
+  ])(
+    "%s emits a structured console.warn with {event, key, error} on R2 rejection",
+    async (_name, expectedKey, call) => {
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      const store = createDashboardStore(rejectingR2("boom"));
+
+      await call(store);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(warnSpy.mock.calls[0][0] as string);
+      expect(payload).toEqual({
+        event: "dashboard_store_r2_error",
+        key: expectedKey,
+        error: "Error: boom",
+      });
+      warnSpy.mockRestore();
+    },
+  );
+
+  it("does not log on hit", async () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const r2 = createMockR2({
+      "sqr-112/__dashboard.html": {
+        body: streamFromString("<html>dashboard</html>"),
+        size: 22,
+      },
+    });
+    const store = createDashboardStore(r2);
+
+    await store.getDashboard("sqr-112");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("does not log on plain miss", async () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const store = createDashboardStore(createMockR2({}));
+
+    await store.getDashboard("sqr-112");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/cloudflare-worker/test/dashboardStore.test.ts
+++ b/cloudflare-worker/test/dashboardStore.test.ts
@@ -117,3 +117,48 @@ describe("DashboardStore.getSwitcher", () => {
     await expect(store.getSwitcher("sqr-112")).resolves.toBeNull();
   });
 });
+
+describe("DashboardStore.getEditionMeta", () => {
+  it("returns the R2 object for {project}/__editions/{edition}.json on hit", async () => {
+    const r2 = createMockR2({
+      "sqr-112/__editions/main.json": {
+        body: streamFromString(
+          '{"canonical_url":"https://sqr-112.lsst.io/","is_canonical":true}',
+        ),
+        size: 63,
+      },
+    });
+    const store = createDashboardStore(r2);
+
+    const object = await store.getEditionMeta("sqr-112", "main");
+
+    expect(object).not.toBeNull();
+    expect(r2.get).toHaveBeenCalledWith("sqr-112/__editions/main.json");
+    const body = await new Response(object!.body).text();
+    expect(body).toBe(
+      '{"canonical_url":"https://sqr-112.lsst.io/","is_canonical":true}',
+    );
+  });
+
+  it("returns null on miss", async () => {
+    const r2 = createMockR2({});
+    const store = createDashboardStore(r2);
+
+    const object = await store.getEditionMeta("sqr-112", "main");
+
+    expect(object).toBeNull();
+  });
+
+  it("never throws when R2.get rejects", async () => {
+    const r2 = {
+      get: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    } as unknown as R2Bucket;
+    const store = createDashboardStore(r2);
+
+    await expect(
+      store.getEditionMeta("sqr-112", "main"),
+    ).resolves.toBeNull();
+  });
+});

--- a/cloudflare-worker/test/dashboardStore.test.ts
+++ b/cloudflare-worker/test/dashboardStore.test.ts
@@ -162,3 +162,42 @@ describe("DashboardStore.getEditionMeta", () => {
     ).resolves.toBeNull();
   });
 });
+
+describe("DashboardStore.get404", () => {
+  it("returns the R2 object for {project}/__404.html on hit", async () => {
+    const r2 = createMockR2({
+      "sqr-112/__404.html": {
+        body: streamFromString("<html>branded 404</html>"),
+        size: 24,
+      },
+    });
+    const store = createDashboardStore(r2);
+
+    const object = await store.get404("sqr-112");
+
+    expect(object).not.toBeNull();
+    expect(r2.get).toHaveBeenCalledWith("sqr-112/__404.html");
+    const body = await new Response(object!.body).text();
+    expect(body).toBe("<html>branded 404</html>");
+  });
+
+  it("returns null on miss", async () => {
+    const r2 = createMockR2({});
+    const store = createDashboardStore(r2);
+
+    const object = await store.get404("sqr-112");
+
+    expect(object).toBeNull();
+  });
+
+  it("never throws when R2.get rejects", async () => {
+    const r2 = {
+      get: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    } as unknown as R2Bucket;
+    const store = createDashboardStore(r2);
+
+    await expect(store.get404("sqr-112")).resolves.toBeNull();
+  });
+});

--- a/cloudflare-worker/test/index.test.ts
+++ b/cloudflare-worker/test/index.test.ts
@@ -143,6 +143,39 @@ describe("Worker integration — subdomain routing", () => {
     expect(response.status).toBe(404);
     expect(response.headers.get("Content-Type")).toBe("text/plain");
   });
+
+  it("serves the project dashboard at /v/ from __dashboard.html", async () => {
+    await seedR2Object(
+      "sqr-112/__dashboard.html",
+      "<html>dashboard</html>",
+    );
+
+    const response = await SELF.fetch("https://sqr-112.lsst.io/v/");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe("<html>dashboard</html>");
+  });
+
+  it("serves the dashboard at /v/index.html", async () => {
+    await seedR2Object(
+      "sqr-112/__dashboard.html",
+      "<html>dashboard</html>",
+    );
+
+    const response = await SELF.fetch(
+      "https://sqr-112.lsst.io/v/index.html",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(await response.text()).toBe("<html>dashboard</html>");
+  });
 });
 
 describe("Worker integration — path-prefix routing", () => {
@@ -232,5 +265,23 @@ describe("Worker integration — path-prefix routing", () => {
     );
 
     expect(response.status).toBe(404);
+  });
+
+  it("serves the project dashboard at /docs/{project}/v/", async () => {
+    await seedR2Object(
+      "sqr-112/__dashboard.html",
+      "<html>dashboard</html>",
+    );
+
+    const response = await fetchPathPrefix(
+      "https://docs.example.com/docs/sqr-112/v/",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe("<html>dashboard</html>");
   });
 });

--- a/cloudflare-worker/test/index.test.ts
+++ b/cloudflare-worker/test/index.test.ts
@@ -177,6 +177,26 @@ describe("Worker integration — subdomain routing", () => {
     expect(await response.text()).toBe("<html>dashboard</html>");
   });
 
+  it("serves the version switcher at /v/switcher.json from __switcher.json", async () => {
+    await seedR2Object(
+      "sqr-112/__switcher.json",
+      '[{"name":"main","url":"https://sqr-112.lsst.io/v/main/"}]',
+    );
+
+    const response = await SELF.fetch(
+      "https://sqr-112.lsst.io/v/switcher.json",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe(
+      '[{"name":"main","url":"https://sqr-112.lsst.io/v/main/"}]',
+    );
+  });
+
   it("301-redirects /v (no trailing slash) to /v/", async () => {
     const response = await SELF.fetch("https://sqr-112.lsst.io/v", {
       redirect: "manual",
@@ -294,5 +314,25 @@ describe("Worker integration — path-prefix routing", () => {
     );
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
     expect(await response.text()).toBe("<html>dashboard</html>");
+  });
+
+  it("serves the switcher at /docs/{project}/v/switcher.json", async () => {
+    await seedR2Object(
+      "sqr-112/__switcher.json",
+      '[{"name":"main","url":"/docs/sqr-112/v/main/"}]',
+    );
+
+    const response = await fetchPathPrefix(
+      "https://docs.example.com/docs/sqr-112/v/switcher.json",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe(
+      '[{"name":"main","url":"/docs/sqr-112/v/main/"}]',
+    );
   });
 });

--- a/cloudflare-worker/test/index.test.ts
+++ b/cloudflare-worker/test/index.test.ts
@@ -272,6 +272,49 @@ describe("Worker integration — subdomain routing", () => {
     expect(await response.text()).toBe("<html>branded 404 page</html>");
   });
 
+  it("serves __main edition metadata at project-root /_docverse.json", async () => {
+    await seedR2Object(
+      "sqr-112/__editions/__main.json",
+      '{"canonical_url":"https://sqr-112.lsst.io/","is_canonical":true}',
+    );
+
+    const response = await SELF.fetch(
+      "https://sqr-112.lsst.io/_docverse.json",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe(
+      '{"canonical_url":"https://sqr-112.lsst.io/","is_canonical":true}',
+    );
+  });
+
+  it("falls back to branded __404.html when project-root _docverse.json is missing", async () => {
+    // Miniflare-backed R2 persists across tests within a single run, so an
+    // earlier test that seeds sqr-112/__editions/__main.json would leak
+    // into this one. Delete the key to guarantee the edition_meta miss the
+    // branded-404 fallback depends on.
+    await env.BUILDS_R2.delete("sqr-112/__editions/__main.json");
+    await seedR2Object(
+      "sqr-112/__404.html",
+      "<html>branded 404 page</html>",
+    );
+
+    const response = await SELF.fetch(
+      "https://sqr-112.lsst.io/_docverse.json",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe("<html>branded 404 page</html>");
+  });
+
   it("serves a cached 404 on the second request without re-reading __404.html from R2", async () => {
     // Seed a branded 404 and spy on BUILDS_R2.get so we can count how many
     // times the worker reaches into R2 for the __404.html key across two
@@ -476,6 +519,26 @@ describe("Worker integration — path-prefix routing", () => {
 
     const response = await fetchPathPrefix(
       "https://docs.example.com/docs/sqr-112/v/main/_docverse.json",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe(
+      '{"canonical_url":"https://docs.example.com/docs/sqr-112/","is_canonical":true}',
+    );
+  });
+
+  it("serves __main edition metadata at project-root /docs/{project}/_docverse.json", async () => {
+    await seedR2Object(
+      "sqr-112/__editions/__main.json",
+      '{"canonical_url":"https://docs.example.com/docs/sqr-112/","is_canonical":true}',
+    );
+
+    const response = await fetchPathPrefix(
+      "https://docs.example.com/docs/sqr-112/_docverse.json",
     );
 
     expect(response.status).toBe(200);

--- a/cloudflare-worker/test/index.test.ts
+++ b/cloudflare-worker/test/index.test.ts
@@ -160,6 +160,29 @@ describe("Worker integration — subdomain routing", () => {
     expect(await response.text()).toBe("<html>dashboard</html>");
   });
 
+  it("dashboard response delivers the full body size without an explicit mismatching Content-Length", async () => {
+    // Regression guard for the PR #202 review finding: the worker used to
+    // manually set `Content-Length: object.size` on dashboard-family
+    // responses. That explicit header can disagree with the actual bytes
+    // Cloudflare's edge sends (e.g. when gzip is applied) and hang the
+    // response. After removing the manual header, any Content-Length the
+    // response carries must be the runtime's own — so if it is present it
+    // must equal the delivered body size, and the body must be fully
+    // streamed without truncation.
+    const body = "<html>dashboard with a distinctive length</html>";
+    const expectedSize = new TextEncoder().encode(body).byteLength;
+    await seedR2Object("sqr-112/__dashboard.html", body);
+
+    const response = await SELF.fetch("https://sqr-112.lsst.io/v/");
+
+    expect(response.status).toBe(200);
+    const contentLength = response.headers.get("content-length");
+    if (contentLength !== null) {
+      expect(Number(contentLength)).toBe(expectedSize);
+    }
+    expect((await response.arrayBuffer()).byteLength).toBe(expectedSize);
+  });
+
   it("serves the dashboard at /v/index.html", async () => {
     await seedR2Object(
       "sqr-112/__dashboard.html",

--- a/cloudflare-worker/test/index.test.ts
+++ b/cloudflare-worker/test/index.test.ts
@@ -12,9 +12,32 @@
  * same Miniflare-backed KV and R2 from `env`.
  */
 
-import { env, SELF } from "cloudflare:test";
-import { describe, it, expect, beforeEach } from "vitest";
+import {
+  env,
+  SELF,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import worker from "../src/index";
+import { notFoundCacheKey } from "../src/resolver";
+
+/**
+ * Projects that integration tests route through `notFoundResponse`.
+ * `caches.default` persists across tests inside a single Miniflare run,
+ * so evict each project's cached 404 entry before every test.
+ */
+const NOT_FOUND_TEST_PROJECTS = [
+  "pipelines",
+  "sqr-112",
+  "cache-hit-integration",
+];
+
+beforeEach(async () => {
+  for (const project of NOT_FOUND_TEST_PROJECTS) {
+    await caches.default.delete(notFoundCacheKey(project));
+  }
+});
 
 /**
  * Helper to seed KV with an edition mapping.
@@ -248,6 +271,65 @@ describe("Worker integration — subdomain routing", () => {
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
     expect(await response.text()).toBe("<html>branded 404 page</html>");
   });
+
+  it("serves a cached 404 on the second request without re-reading __404.html from R2", async () => {
+    // Seed a branded 404 and spy on BUILDS_R2.get so we can count how many
+    // times the worker reaches into R2 for the __404.html key across two
+    // successive requests. The first request populates caches.default;
+    // the second request must hit the cache and skip the R2 GET entirely.
+    //
+    // We use worker.fetch() with createExecutionContext() +
+    // waitOnExecutionContext() rather than SELF.fetch so the first
+    // request's ctx.waitUntil(caches.default.put(...)) is observable and
+    // drained before the second request runs — otherwise the put can
+    // race with the cache read in request #2 and the test flakes.
+    await seedR2Object(
+      "cache-hit-integration/__404.html",
+      "<html>cached 404 body</html>",
+    );
+    const r2Get = vi.spyOn(env.BUILDS_R2, "get");
+
+    const ctx1 = createExecutionContext();
+    const first = await worker.fetch(
+      new Request(
+        "https://cache-hit-integration.lsst.io/nonexistent.html",
+      ),
+      env,
+      ctx1,
+    );
+    await first.arrayBuffer();
+    await waitOnExecutionContext(ctx1);
+    const firstHitCount = r2Get.mock.calls.filter(
+      (call: unknown[]) => call[0] === "cache-hit-integration/__404.html",
+    ).length;
+
+    const ctx2 = createExecutionContext();
+    const second = await worker.fetch(
+      new Request(
+        "https://cache-hit-integration.lsst.io/another-missing.html",
+      ),
+      env,
+      ctx2,
+    );
+    await waitOnExecutionContext(ctx2);
+    const secondHitCount = r2Get.mock.calls.filter(
+      (call: unknown[]) => call[0] === "cache-hit-integration/__404.html",
+    ).length;
+
+    expect(first.status).toBe(404);
+    expect(second.status).toBe(404);
+    expect(second.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(second.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await second.text()).toBe("<html>cached 404 body</html>");
+    // First request populated the cache — one R2 GET for __404.html.
+    expect(firstHitCount).toBe(1);
+    // Second request was served from caches.default — no additional GET.
+    expect(secondHitCount).toBe(1);
+
+    r2Get.mockRestore();
+  });
 });
 
 describe("Worker integration — path-prefix routing", () => {
@@ -257,21 +339,30 @@ describe("Worker integration — path-prefix routing", () => {
 
   /**
    * Call the worker directly with path-prefix env overrides.
+   *
+   * Uses `createExecutionContext()` + `waitOnExecutionContext()` so any
+   * `ctx.waitUntil(caches.default.put(...))` kicked off inside the worker
+   * has settled before this helper returns. Otherwise a prior test's 404
+   * cache write could race with the next test's `beforeEach` eviction and
+   * re-poison `caches.default` for the shared project slug.
    */
   async function fetchPathPrefix(
     url: string,
     init?: RequestInit,
   ): Promise<Response> {
     const request = new Request(url, init);
-    return worker.fetch(
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
       request,
       {
         ...env,
         URL_SCHEME: "path-prefix" as const,
         PATH_PREFIX: "/docs/",
       },
-      { waitUntil: () => {}, passThroughOnException: () => {} } as unknown as ExecutionContext,
+      ctx,
     );
+    await waitOnExecutionContext(ctx);
+    return response;
   }
 
   beforeEach(async () => {

--- a/cloudflare-worker/test/index.test.ts
+++ b/cloudflare-worker/test/index.test.ts
@@ -176,6 +176,17 @@ describe("Worker integration — subdomain routing", () => {
     );
     expect(await response.text()).toBe("<html>dashboard</html>");
   });
+
+  it("301-redirects /v (no trailing slash) to /v/", async () => {
+    const response = await SELF.fetch("https://sqr-112.lsst.io/v", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(301);
+    expect(new URL(response.headers.get("Location") ?? "").pathname).toBe(
+      "/v/",
+    );
+  });
 });
 
 describe("Worker integration — path-prefix routing", () => {

--- a/cloudflare-worker/test/index.test.ts
+++ b/cloudflare-worker/test/index.test.ts
@@ -335,4 +335,24 @@ describe("Worker integration — path-prefix routing", () => {
       '[{"name":"main","url":"/docs/sqr-112/v/main/"}]',
     );
   });
+
+  it("serves edition metadata at /docs/{project}/v/{edition}/_docverse.json", async () => {
+    await seedR2Object(
+      "sqr-112/__editions/main.json",
+      '{"canonical_url":"https://docs.example.com/docs/sqr-112/","is_canonical":true}',
+    );
+
+    const response = await fetchPathPrefix(
+      "https://docs.example.com/docs/sqr-112/v/main/_docverse.json",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe(
+      '{"canonical_url":"https://docs.example.com/docs/sqr-112/","is_canonical":true}',
+    );
+  });
 });

--- a/cloudflare-worker/test/index.test.ts
+++ b/cloudflare-worker/test/index.test.ts
@@ -207,6 +207,24 @@ describe("Worker integration — subdomain routing", () => {
       "/v/",
     );
   });
+
+  it("serves the branded __404.html for an unknown edition", async () => {
+    await seedR2Object(
+      "pipelines/__404.html",
+      "<html>branded 404 page</html>",
+    );
+
+    const response = await SELF.fetch(
+      "https://pipelines.lsst.io/v/nonexistent/",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe("<html>branded 404 page</html>");
+  });
 });
 
 describe("Worker integration — path-prefix routing", () => {

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -45,11 +45,13 @@ function createMockR2(
 }
 
 /**
- * Create a mock DashboardStore backed by in-memory maps keyed by project.
+ * Create a mock DashboardStore backed by in-memory maps keyed by project
+ * (for dashboard/switcher) or `{project}/{edition}` (for edition_meta).
  */
 function createMockDashboardStore(
   dashboards: Record<string, { body: ReadableStream; size: number }> = {},
   switchers: Record<string, { body: ReadableStream; size: number }> = {},
+  editionMetas: Record<string, { body: ReadableStream; size: number }> = {},
 ): DashboardStore {
   return {
     getDashboard: vi.fn(async (project: string) => {
@@ -69,6 +71,16 @@ function createMockDashboardStore(
         body: obj.body,
         size: obj.size,
         httpEtag: `"${project}-switcher-etag"`,
+        httpMetadata: {},
+      } as R2ObjectBody;
+    }),
+    getEditionMeta: vi.fn(async (project: string, edition: string) => {
+      const obj = editionMetas[`${project}/${edition}`];
+      if (!obj) return null;
+      return {
+        body: obj.body,
+        size: obj.size,
+        httpEtag: `"${project}-${edition}-edition-meta-etag"`,
         httpMetadata: {},
       } as R2ObjectBody;
     }),
@@ -531,6 +543,87 @@ describe("resolve — switcher routes", () => {
 
     const response = await resolve(
       switcherRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+  });
+});
+
+describe("resolve — edition_meta routes", () => {
+  it("delegates to DashboardStore and returns JSON with edition-meta headers", async () => {
+    const metaRoute: Route = {
+      kind: "edition_meta",
+      project: "sqr-112",
+      edition: "main",
+    };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore(
+      {},
+      {},
+      {
+        "sqr-112/main": {
+          body: streamFromString(
+            '{"canonical_url":"https://sqr-112.lsst.io/","is_canonical":true}',
+          ),
+          size: 63,
+        },
+      },
+    );
+    const request = new Request(
+      "https://sqr-112.lsst.io/v/main/_docverse.json",
+    );
+
+    const response = await resolve(
+      metaRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(dashboardStore.getEditionMeta).toHaveBeenCalledWith(
+      "sqr-112",
+      "main",
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=60",
+    );
+    expect(await response.text()).toBe(
+      '{"canonical_url":"https://sqr-112.lsst.io/","is_canonical":true}',
+    );
+    // Edition / dashboard / switcher paths must not be touched for
+    // edition_meta dispatch.
+    expect(kv.get).not.toHaveBeenCalled();
+    expect(r2.get).not.toHaveBeenCalled();
+    expect(dashboardStore.getDashboard).not.toHaveBeenCalled();
+    expect(dashboardStore.getSwitcher).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 text when DashboardStore returns null for edition_meta", async () => {
+    const metaRoute: Route = {
+      kind: "edition_meta",
+      project: "sqr-112",
+      edition: "nonexistent",
+    };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request(
+      "https://sqr-112.lsst.io/v/nonexistent/_docverse.json",
+    );
+
+    const response = await resolve(
+      metaRoute,
       request,
       kv,
       r2,

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -470,3 +470,75 @@ describe("resolve — dashboard routes", () => {
     expect(response.headers.get("Content-Type")).toBe("text/plain");
   });
 });
+
+describe("resolve — redirect routes", () => {
+  it("returns a 301 with Location set to the redirect target", async () => {
+    const redirectRoute: Route = { kind: "redirect", to: "/v/" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request("https://sqr-112.lsst.io/v");
+
+    const response = await resolve(
+      redirectRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(301);
+    expect(new URL(response.headers.get("Location") ?? "").pathname).toBe(
+      "/v/",
+    );
+    // Edition / dashboard paths must not be touched for redirect dispatch.
+    expect(kv.get).not.toHaveBeenCalled();
+    expect(r2.get).not.toHaveBeenCalled();
+    expect(dashboardStore.getDashboard).not.toHaveBeenCalled();
+  });
+
+  it("preserves query string on redirect", async () => {
+    const redirectRoute: Route = { kind: "redirect", to: "/v/" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request("https://sqr-112.lsst.io/v?foo=bar&baz=1");
+
+    const response = await resolve(
+      redirectRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(301);
+    const location = new URL(response.headers.get("Location") ?? "");
+    expect(location.pathname).toBe("/v/");
+    expect(location.search).toBe("?foo=bar&baz=1");
+  });
+
+  it("redirects under path-prefix scheme target", async () => {
+    const redirectRoute: Route = {
+      kind: "redirect",
+      to: "/docs/sqr-112/v/",
+    };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request("https://docs.example.com/docs/sqr-112/v");
+
+    const response = await resolve(
+      redirectRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(301);
+    expect(new URL(response.headers.get("Location") ?? "").pathname).toBe(
+      "/docs/sqr-112/v/",
+    );
+  });
+});

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -138,7 +138,6 @@ describe("resolve — edition routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
-    expect(response.headers.get("Content-Length")).toBe("18");
     expect(response.headers.get("ETag")).toBe(
       '"pipelines/__main/b123/getting-started.html-etag"',
     );
@@ -253,7 +252,6 @@ describe("resolve — edition routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
-    expect(response.headers.get("Content-Length")).toBe("18");
     expect(response.headers.get("ETag")).toBe(
       '"pipelines/__main/b123/api/core/index.html-etag"',
     );
@@ -286,7 +284,6 @@ describe("resolve — edition routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
-    expect(response.headers.get("Content-Length")).toBe("22");
     expect(response.headers.get("ETag")).toBe(
       '"pipelines/__main/b123/index.html-etag"',
     );
@@ -319,7 +316,6 @@ describe("resolve — edition routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
-    expect(response.headers.get("Content-Length")).toBe("22");
     expect(response.headers.get("ETag")).toBe(
       '"pipelines/__main/b123/index.html-etag"',
     );
@@ -352,7 +348,6 @@ describe("resolve — edition routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/css");
-    expect(response.headers.get("Content-Length")).toBe("20");
     expect(response.headers.get("ETag")).toBe(
       '"pipelines/__main/b123/style.css-etag"',
     );
@@ -385,7 +380,6 @@ describe("resolve — edition routes", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/json");
-    expect(response.headers.get("Content-Length")).toBe("2");
     expect(response.headers.get("ETag")).toBe(
       '"pipelines/__main/b123/data.json-etag"',
     );
@@ -420,7 +414,6 @@ describe("resolve — edition routes", () => {
     expect(response.headers.get("Content-Type")).toBe(
       "application/octet-stream",
     );
-    expect(response.headers.get("Content-Length")).toBe("6");
     expect(response.headers.get("ETag")).toBe(
       '"pipelines/__main/b123/data.xyz123-etag"',
     );

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -52,6 +52,7 @@ function createMockDashboardStore(
   dashboards: Record<string, { body: ReadableStream; size: number }> = {},
   switchers: Record<string, { body: ReadableStream; size: number }> = {},
   editionMetas: Record<string, { body: ReadableStream; size: number }> = {},
+  notFounds: Record<string, { body: ReadableStream; size: number }> = {},
 ): DashboardStore {
   return {
     getDashboard: vi.fn(async (project: string) => {
@@ -81,6 +82,16 @@ function createMockDashboardStore(
         body: obj.body,
         size: obj.size,
         httpEtag: `"${project}-${edition}-edition-meta-etag"`,
+        httpMetadata: {},
+      } as R2ObjectBody;
+    }),
+    get404: vi.fn(async (project: string) => {
+      const obj = notFounds[project];
+      if (!obj) return null;
+      return {
+        body: obj.body,
+        size: obj.size,
+        httpEtag: `"${project}-404-etag"`,
         httpMetadata: {},
       } as R2ObjectBody;
     }),
@@ -704,5 +715,142 @@ describe("resolve — redirect routes", () => {
     expect(new URL(response.headers.get("Location") ?? "").pathname).toBe(
       "/docs/sqr-112/v/",
     );
+  });
+});
+
+describe("resolve — branded 404 fallback", () => {
+  it("serves __404.html with 404 status and HTML headers when dashboard route misses and __404.html is present", async () => {
+    const dashboardRoute: Route = { kind: "dashboard", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore(
+      {},
+      {},
+      {},
+      {
+        "sqr-112": {
+          body: streamFromString("<html>branded 404</html>"),
+          size: 24,
+        },
+      },
+    );
+    const request = new Request("https://sqr-112.lsst.io/v/");
+
+    const response = await resolve(
+      dashboardRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(dashboardStore.get404).toHaveBeenCalledWith("sqr-112");
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=60",
+    );
+    expect(await response.text()).toBe("<html>branded 404</html>");
+  });
+
+  it("serves __404.html when edition route's KV lookup misses and __404.html is present", async () => {
+    const editionRoute: Route = {
+      kind: "edition",
+      project: "sqr-112",
+      edition: "__main",
+      path: "page.html",
+    };
+    const kv = createMockKV({});
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore(
+      {},
+      {},
+      {},
+      {
+        "sqr-112": {
+          body: streamFromString("<html>branded 404</html>"),
+          size: 24,
+        },
+      },
+    );
+    const request = new Request("https://sqr-112.lsst.io/page.html");
+
+    const response = await resolve(
+      editionRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(dashboardStore.get404).toHaveBeenCalledWith("sqr-112");
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=60",
+    );
+    expect(await response.text()).toBe("<html>branded 404</html>");
+  });
+
+  it("falls back to plain-text Not Found with cache headers when __404.html is absent (dashboard branch)", async () => {
+    const dashboardRoute: Route = { kind: "dashboard", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request("https://sqr-112.lsst.io/v/");
+
+    const response = await resolve(
+      dashboardRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(dashboardStore.get404).toHaveBeenCalledWith("sqr-112");
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=60",
+    );
+    expect(await response.text()).toBe("Not Found");
+  });
+
+  it("falls back to plain-text Not Found with cache headers when __404.html is absent (edition R2 miss)", async () => {
+    const editionRoute: Route = {
+      kind: "edition",
+      project: "pipelines",
+      edition: "__main",
+      path: "missing.html",
+    };
+    const kv = createMockKV({
+      "pipelines/__main": JSON.stringify({
+        build_id: "b123",
+        r2_prefix: "pipelines/__main/b123/",
+      }),
+    });
+    const r2 = createMockR2({});
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request("https://pipelines.lsst.io/missing.html");
+
+    const response = await resolve(
+      editionRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(dashboardStore.get404).toHaveBeenCalledWith("pipelines");
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=60",
+    );
+    expect(await response.text()).toBe("Not Found");
   });
 });

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { resolve } from "../src/resolver";
+import type { DashboardStore } from "../src/dashboardStore";
 import type { Route } from "../src/router";
 
 /**
@@ -44,6 +45,26 @@ function createMockR2(
 }
 
 /**
+ * Create a mock DashboardStore backed by an in-memory map keyed by project.
+ */
+function createMockDashboardStore(
+  dashboards: Record<string, { body: ReadableStream; size: number }> = {},
+): DashboardStore {
+  return {
+    getDashboard: vi.fn(async (project: string) => {
+      const obj = dashboards[project];
+      if (!obj) return null;
+      return {
+        body: obj.body,
+        size: obj.size,
+        httpEtag: `"${project}-dashboard-etag"`,
+        httpMetadata: {},
+      } as R2ObjectBody;
+    }),
+  };
+}
+
+/**
  * Helper to create a ReadableStream from a string.
  */
 function streamFromString(s: string): ReadableStream {
@@ -55,8 +76,9 @@ function streamFromString(s: string): ReadableStream {
   });
 }
 
-describe("resolve", () => {
+describe("resolve — edition routes", () => {
   const route: Route = {
+    kind: "edition",
     project: "pipelines",
     edition: "__main",
     path: "getting-started.html",
@@ -75,9 +97,10 @@ describe("resolve", () => {
         size: 18,
       },
     });
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/getting-started.html");
 
-    const response = await resolve(route, request, kv, r2);
+    const response = await resolve(route, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
@@ -94,9 +117,10 @@ describe("resolve", () => {
   it("returns 404 when KV entry is missing", async () => {
     const kv = createMockKV({});
     const r2 = createMockR2({});
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/getting-started.html");
 
-    const response = await resolve(route, request, kv, r2);
+    const response = await resolve(route, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(404);
     expect(response.headers.get("Content-Type")).toBe("text/plain");
@@ -109,9 +133,10 @@ describe("resolve", () => {
       "pipelines/__main": "not-json",
     });
     const r2 = createMockR2({});
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/getting-started.html");
 
-    const response = await resolve(route, request, kv, r2);
+    const response = await resolve(route, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(404);
     expect(response.headers.get("Content-Type")).toBe("text/plain");
@@ -127,9 +152,10 @@ describe("resolve", () => {
       }),
     });
     const r2 = createMockR2({});
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/getting-started.html");
 
-    const response = await resolve(route, request, kv, r2);
+    const response = await resolve(route, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(404);
     expect(response.headers.get("Content-Type")).toBe("text/plain");
@@ -139,6 +165,7 @@ describe("resolve", () => {
 
   it("redirects to trailing slash for directory paths", async () => {
     const directoryRoute: Route = {
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "api/core",
@@ -155,9 +182,10 @@ describe("resolve", () => {
         size: 18,
       },
     });
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/api/core");
 
-    const response = await resolve(directoryRoute, request, kv, r2);
+    const response = await resolve(directoryRoute, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(301);
     expect(response.headers.get("Location")).toBe(
@@ -167,6 +195,7 @@ describe("resolve", () => {
 
   it("serves index.html when path has trailing slash", async () => {
     const directoryRoute: Route = {
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "api/core/",
@@ -183,9 +212,10 @@ describe("resolve", () => {
         size: 18,
       },
     });
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/api/core/");
 
-    const response = await resolve(directoryRoute, request, kv, r2);
+    const response = await resolve(directoryRoute, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
@@ -198,6 +228,7 @@ describe("resolve", () => {
 
   it("falls back to index.html for empty path", async () => {
     const rootRoute: Route = {
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "",
@@ -214,9 +245,10 @@ describe("resolve", () => {
         size: 22,
       },
     });
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/");
 
-    const response = await resolve(rootRoute, request, kv, r2);
+    const response = await resolve(rootRoute, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
@@ -229,6 +261,7 @@ describe("resolve", () => {
 
   it("falls back to index.html for empty path when r2_prefix lacks trailing slash", async () => {
     const rootRoute: Route = {
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "",
@@ -245,9 +278,10 @@ describe("resolve", () => {
         size: 22,
       },
     });
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/");
 
-    const response = await resolve(rootRoute, request, kv, r2);
+    const response = await resolve(rootRoute, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
@@ -260,6 +294,7 @@ describe("resolve", () => {
 
   it("infers Content-Type for CSS files", async () => {
     const cssRoute: Route = {
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "style.css",
@@ -276,9 +311,10 @@ describe("resolve", () => {
         size: 20,
       },
     });
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/style.css");
 
-    const response = await resolve(cssRoute, request, kv, r2);
+    const response = await resolve(cssRoute, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/css");
@@ -291,6 +327,7 @@ describe("resolve", () => {
 
   it("infers Content-Type for JSON files", async () => {
     const jsonRoute: Route = {
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "data.json",
@@ -307,9 +344,10 @@ describe("resolve", () => {
         size: 2,
       },
     });
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/data.json");
 
-    const response = await resolve(jsonRoute, request, kv, r2);
+    const response = await resolve(jsonRoute, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/json");
@@ -322,6 +360,7 @@ describe("resolve", () => {
 
   it("uses application/octet-stream for unknown extensions", async () => {
     const unknownRoute: Route = {
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "data.xyz123",
@@ -338,9 +377,10 @@ describe("resolve", () => {
         size: 6,
       },
     });
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/data.xyz123");
 
-    const response = await resolve(unknownRoute, request, kv, r2);
+    const response = await resolve(unknownRoute, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe(
@@ -355,6 +395,7 @@ describe("resolve", () => {
 
   it("returns 404 when both exact and index.html fallback miss", async () => {
     const directoryRoute: Route = {
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "nonexistent/dir",
@@ -366,10 +407,66 @@ describe("resolve", () => {
       }),
     });
     const r2 = createMockR2({});
+    const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/nonexistent/dir");
 
-    const response = await resolve(directoryRoute, request, kv, r2);
+    const response = await resolve(directoryRoute, request, kv, r2, dashboardStore);
 
     expect(response.status).toBe(404);
+  });
+});
+
+describe("resolve — dashboard routes", () => {
+  it("delegates to DashboardStore and returns the HTML body with dashboard headers", async () => {
+    const dashboardRoute: Route = { kind: "dashboard", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore({
+      "sqr-112": {
+        body: streamFromString("<html>dashboard</html>"),
+        size: 22,
+      },
+    });
+    const request = new Request("https://sqr-112.lsst.io/v/");
+
+    const response = await resolve(
+      dashboardRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(dashboardStore.getDashboard).toHaveBeenCalledWith("sqr-112");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=60",
+    );
+    expect(await response.text()).toBe("<html>dashboard</html>");
+    // Edition path must not be touched for dashboard dispatch.
+    expect(kv.get).not.toHaveBeenCalled();
+    expect(r2.get).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 text when DashboardStore returns null", async () => {
+    const dashboardRoute: Route = { kind: "dashboard", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request("https://sqr-112.lsst.io/v/");
+
+    const response = await resolve(
+      dashboardRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
   });
 });

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -45,10 +45,11 @@ function createMockR2(
 }
 
 /**
- * Create a mock DashboardStore backed by an in-memory map keyed by project.
+ * Create a mock DashboardStore backed by in-memory maps keyed by project.
  */
 function createMockDashboardStore(
   dashboards: Record<string, { body: ReadableStream; size: number }> = {},
+  switchers: Record<string, { body: ReadableStream; size: number }> = {},
 ): DashboardStore {
   return {
     getDashboard: vi.fn(async (project: string) => {
@@ -58,6 +59,16 @@ function createMockDashboardStore(
         body: obj.body,
         size: obj.size,
         httpEtag: `"${project}-dashboard-etag"`,
+        httpMetadata: {},
+      } as R2ObjectBody;
+    }),
+    getSwitcher: vi.fn(async (project: string) => {
+      const obj = switchers[project];
+      if (!obj) return null;
+      return {
+        body: obj.body,
+        size: obj.size,
+        httpEtag: `"${project}-switcher-etag"`,
         httpMetadata: {},
       } as R2ObjectBody;
     }),
@@ -460,6 +471,66 @@ describe("resolve — dashboard routes", () => {
 
     const response = await resolve(
       dashboardRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+  });
+});
+
+describe("resolve — switcher routes", () => {
+  it("delegates to DashboardStore and returns JSON with switcher headers", async () => {
+    const switcherRoute: Route = { kind: "switcher", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore(
+      {},
+      {
+        "sqr-112": {
+          body: streamFromString('[{"name":"main","url":"/v/main/"}]'),
+          size: 34,
+        },
+      },
+    );
+    const request = new Request("https://sqr-112.lsst.io/v/switcher.json");
+
+    const response = await resolve(
+      switcherRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(dashboardStore.getSwitcher).toHaveBeenCalledWith("sqr-112");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=60",
+    );
+    expect(await response.text()).toBe('[{"name":"main","url":"/v/main/"}]');
+    // Edition path must not be touched for switcher dispatch.
+    expect(kv.get).not.toHaveBeenCalled();
+    expect(r2.get).not.toHaveBeenCalled();
+    // Dashboard lookup must not be touched for switcher dispatch.
+    expect(dashboardStore.getDashboard).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 text when DashboardStore returns null for switcher", async () => {
+    const switcherRoute: Route = { kind: "switcher", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request("https://sqr-112.lsst.io/v/switcher.json");
+
+    const response = await resolve(
+      switcherRoute,
       request,
       kv,
       r2,

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -54,6 +54,7 @@ const NOT_FOUND_TEST_PROJECTS = [
   "sqr-112",
   "cache-hit-branded",
   "cache-hit-plain",
+  "rejecting-get404",
 ];
 
 afterEach(async () => {
@@ -1056,6 +1057,39 @@ describe("resolve — branded 404 fallback", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=60",
     );
+    expect(await response.text()).toBe("Not Found");
+  });
+
+  it("falls back to plain-text Not Found when get404 itself rejects (defensive against contract regression)", async () => {
+    const dashboardRoute: Route = {
+      kind: "dashboard",
+      project: "rejecting-get404",
+    };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore: DashboardStore = {
+      getDashboard: vi.fn(async () => null),
+      getSwitcher: vi.fn(async () => null),
+      getEditionMeta: vi.fn(async () => null),
+      get404: vi.fn(async () => {
+        throw new Error("simulated R2 outage");
+      }),
+    };
+    const request = new Request("https://rejecting-get404.lsst.io/v/");
+
+    const response = await resolve(
+      dashboardRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+      ctx,
+    );
+
+    expect(dashboardStore.get404).toHaveBeenCalledWith("rejecting-get404");
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
     expect(await response.text()).toBe("Not Found");
   });
 

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -639,6 +639,169 @@ describe("resolve — edition_meta routes", () => {
   });
 });
 
+describe("resolve — dashboard-family If-None-Match 304 handling", () => {
+  it("returns 304 with ETag and Cache-Control when If-None-Match matches the dashboard httpEtag", async () => {
+    const dashboardRoute: Route = { kind: "dashboard", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore({
+      "sqr-112": {
+        body: streamFromString("<html>dashboard</html>"),
+        size: 22,
+      },
+    });
+    const request = new Request("https://sqr-112.lsst.io/v/", {
+      headers: { "If-None-Match": '"sqr-112-dashboard-etag"' },
+    });
+
+    const response = await resolve(
+      dashboardRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(304);
+    expect(response.headers.get("ETag")).toBe('"sqr-112-dashboard-etag"');
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(response.headers.get("Content-Type")).toBeNull();
+    expect(await response.text()).toBe("");
+  });
+
+  it("returns 200 when If-None-Match does not match the dashboard httpEtag", async () => {
+    const dashboardRoute: Route = { kind: "dashboard", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore({
+      "sqr-112": {
+        body: streamFromString("<html>dashboard</html>"),
+        size: 22,
+      },
+    });
+    const request = new Request("https://sqr-112.lsst.io/v/", {
+      headers: { "If-None-Match": '"stale-etag"' },
+    });
+
+    const response = await resolve(
+      dashboardRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("ETag")).toBe('"sqr-112-dashboard-etag"');
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(await response.text()).toBe("<html>dashboard</html>");
+  });
+
+  it("returns 200 when the request omits If-None-Match (dashboard)", async () => {
+    const dashboardRoute: Route = { kind: "dashboard", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore({
+      "sqr-112": {
+        body: streamFromString("<html>dashboard</html>"),
+        size: 22,
+      },
+    });
+    const request = new Request("https://sqr-112.lsst.io/v/");
+
+    const response = await resolve(
+      dashboardRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("ETag")).toBe('"sqr-112-dashboard-etag"');
+    expect(await response.text()).toBe("<html>dashboard</html>");
+  });
+
+  it("returns 304 when If-None-Match matches the switcher httpEtag", async () => {
+    const switcherRoute: Route = { kind: "switcher", project: "sqr-112" };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore(
+      {},
+      {
+        "sqr-112": {
+          body: streamFromString('[{"name":"main","url":"/v/main/"}]'),
+          size: 34,
+        },
+      },
+    );
+    const request = new Request("https://sqr-112.lsst.io/v/switcher.json", {
+      headers: { "If-None-Match": '"sqr-112-switcher-etag"' },
+    });
+
+    const response = await resolve(
+      switcherRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(304);
+    expect(response.headers.get("ETag")).toBe('"sqr-112-switcher-etag"');
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe("");
+  });
+
+  it("returns 304 when If-None-Match matches the edition_meta httpEtag", async () => {
+    const metaRoute: Route = {
+      kind: "edition_meta",
+      project: "sqr-112",
+      edition: "main",
+    };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore(
+      {},
+      {},
+      {
+        "sqr-112/main": {
+          body: streamFromString(
+            '{"canonical_url":"https://sqr-112.lsst.io/","is_canonical":true}',
+          ),
+          size: 63,
+        },
+      },
+    );
+    const request = new Request(
+      "https://sqr-112.lsst.io/v/main/_docverse.json",
+      {
+        headers: {
+          "If-None-Match": '"sqr-112-main-edition-meta-etag"',
+        },
+      },
+    );
+
+    const response = await resolve(
+      metaRoute,
+      request,
+      kv,
+      r2,
+      dashboardStore,
+    );
+
+    expect(response.status).toBe(304);
+    expect(response.headers.get("ETag")).toBe(
+      '"sqr-112-main-edition-meta-etag"',
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await response.text()).toBe("");
+  });
+});
+
 describe("resolve — redirect routes", () => {
   it("returns a 301 with Location set to the redirect target", async () => {
     const redirectRoute: Route = { kind: "redirect", to: "/v/" };

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -1,7 +1,73 @@
-import { describe, it, expect, vi } from "vitest";
-import { resolve } from "../src/resolver";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { resolve, notFoundCacheKey } from "../src/resolver";
 import type { DashboardStore } from "../src/dashboardStore";
 import type { Route } from "../src/router";
+
+/**
+ * Stub ExecutionContext for tests. Every `waitUntil` promise is tracked and
+ * awaited by `afterEach` so that cache writes from one test complete before
+ * the next test's `beforeEach` evicts cached entries; without this, a
+ * previous test's pending `caches.default.put` could race with and re-poison
+ * the current test's cache state.
+ */
+const pendingCtxPromises: Promise<unknown>[] = [];
+
+const ctx: ExecutionContext = {
+  waitUntil: (p: Promise<unknown>) => {
+    pendingCtxPromises.push(Promise.resolve(p).catch(() => {}));
+  },
+  passThroughOnException: () => {},
+} as unknown as ExecutionContext;
+
+/**
+ * Variant ctx used by tests that consult the cache twice within a single
+ * test: the test explicitly flushes pending `waitUntil` promises between
+ * the two resolve calls so the second call observes the first call's write.
+ */
+function createWaitingCtx(): {
+  ctx: ExecutionContext;
+  flush: () => Promise<void>;
+} {
+  const pending: Promise<unknown>[] = [];
+  return {
+    ctx: {
+      waitUntil: (p: Promise<unknown>) => {
+        pending.push(Promise.resolve(p).catch(() => {}));
+      },
+      passThroughOnException: () => {},
+    } as unknown as ExecutionContext,
+    flush: async () => {
+      await Promise.all(pending);
+      pending.length = 0;
+    },
+  };
+}
+
+/**
+ * Projects that tests route through `notFoundResponse`. `caches.default`
+ * persists across tests inside a single Miniflare run, so evict the cached
+ * 404 entry for each project before every test to keep assertions on
+ * `get404` call counts deterministic.
+ */
+const NOT_FOUND_TEST_PROJECTS = [
+  "pipelines",
+  "sqr-112",
+  "cache-hit-branded",
+  "cache-hit-plain",
+];
+
+afterEach(async () => {
+  // Wait for any `ctx.waitUntil` cache writes kicked off by the previous
+  // test to settle before the next `beforeEach` evicts cache entries.
+  await Promise.all(pendingCtxPromises);
+  pendingCtxPromises.length = 0;
+});
+
+beforeEach(async () => {
+  for (const project of NOT_FOUND_TEST_PROJECTS) {
+    await caches.default.delete(notFoundCacheKey(project));
+  }
+});
 
 /**
  * Create a mock KV namespace.
@@ -134,7 +200,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/getting-started.html");
 
-    const response = await resolve(route, request, kv, r2, dashboardStore);
+    const response = await resolve(route, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
@@ -153,7 +219,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/getting-started.html");
 
-    const response = await resolve(route, request, kv, r2, dashboardStore);
+    const response = await resolve(route, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(404);
     expect(response.headers.get("Content-Type")).toBe("text/plain");
@@ -169,7 +235,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/getting-started.html");
 
-    const response = await resolve(route, request, kv, r2, dashboardStore);
+    const response = await resolve(route, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(404);
     expect(response.headers.get("Content-Type")).toBe("text/plain");
@@ -188,7 +254,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/getting-started.html");
 
-    const response = await resolve(route, request, kv, r2, dashboardStore);
+    const response = await resolve(route, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(404);
     expect(response.headers.get("Content-Type")).toBe("text/plain");
@@ -218,7 +284,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/api/core");
 
-    const response = await resolve(directoryRoute, request, kv, r2, dashboardStore);
+    const response = await resolve(directoryRoute, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(301);
     expect(response.headers.get("Location")).toBe(
@@ -248,7 +314,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/api/core/");
 
-    const response = await resolve(directoryRoute, request, kv, r2, dashboardStore);
+    const response = await resolve(directoryRoute, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
@@ -280,7 +346,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/");
 
-    const response = await resolve(rootRoute, request, kv, r2, dashboardStore);
+    const response = await resolve(rootRoute, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
@@ -312,7 +378,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/");
 
-    const response = await resolve(rootRoute, request, kv, r2, dashboardStore);
+    const response = await resolve(rootRoute, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/html");
@@ -344,7 +410,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/style.css");
 
-    const response = await resolve(cssRoute, request, kv, r2, dashboardStore);
+    const response = await resolve(cssRoute, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("text/css");
@@ -376,7 +442,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/data.json");
 
-    const response = await resolve(jsonRoute, request, kv, r2, dashboardStore);
+    const response = await resolve(jsonRoute, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/json");
@@ -408,7 +474,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/data.xyz123");
 
-    const response = await resolve(unknownRoute, request, kv, r2, dashboardStore);
+    const response = await resolve(unknownRoute, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe(
@@ -437,7 +503,7 @@ describe("resolve — edition routes", () => {
     const dashboardStore = createMockDashboardStore();
     const request = new Request("https://example.com/pipelines/nonexistent/dir");
 
-    const response = await resolve(directoryRoute, request, kv, r2, dashboardStore);
+    const response = await resolve(directoryRoute, request, kv, r2, dashboardStore, ctx);
 
     expect(response.status).toBe(404);
   });
@@ -462,6 +528,7 @@ describe("resolve — dashboard routes", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(dashboardStore.getDashboard).toHaveBeenCalledWith("sqr-112");
@@ -491,6 +558,7 @@ describe("resolve — dashboard routes", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(404);
@@ -520,6 +588,7 @@ describe("resolve — switcher routes", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(dashboardStore.getSwitcher).toHaveBeenCalledWith("sqr-112");
@@ -551,6 +620,7 @@ describe("resolve — switcher routes", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(404);
@@ -589,6 +659,7 @@ describe("resolve — edition_meta routes", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(dashboardStore.getEditionMeta).toHaveBeenCalledWith(
@@ -632,6 +703,7 @@ describe("resolve — edition_meta routes", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(404);
@@ -660,6 +732,7 @@ describe("resolve — dashboard-family If-None-Match 304 handling", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(304);
@@ -689,6 +762,7 @@ describe("resolve — dashboard-family If-None-Match 304 handling", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(200);
@@ -718,6 +792,7 @@ describe("resolve — dashboard-family If-None-Match 304 handling", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(200);
@@ -748,6 +823,7 @@ describe("resolve — dashboard-family If-None-Match 304 handling", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(304);
@@ -791,6 +867,7 @@ describe("resolve — dashboard-family If-None-Match 304 handling", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(304);
@@ -816,6 +893,7 @@ describe("resolve — redirect routes", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(301);
@@ -841,6 +919,7 @@ describe("resolve — redirect routes", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(301);
@@ -865,6 +944,7 @@ describe("resolve — redirect routes", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(response.status).toBe(301);
@@ -898,6 +978,7 @@ describe("resolve — branded 404 fallback", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(dashboardStore.get404).toHaveBeenCalledWith("sqr-112");
@@ -939,6 +1020,7 @@ describe("resolve — branded 404 fallback", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(dashboardStore.get404).toHaveBeenCalledWith("sqr-112");
@@ -965,6 +1047,7 @@ describe("resolve — branded 404 fallback", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(dashboardStore.get404).toHaveBeenCalledWith("sqr-112");
@@ -999,6 +1082,7 @@ describe("resolve — branded 404 fallback", () => {
       kv,
       r2,
       dashboardStore,
+      ctx,
     );
 
     expect(dashboardStore.get404).toHaveBeenCalledWith("pipelines");
@@ -1008,5 +1092,62 @@ describe("resolve — branded 404 fallback", () => {
       "public, max-age=60",
     );
     expect(await response.text()).toBe("Not Found");
+  });
+});
+
+describe("resolve — 404 caching via caches.default", () => {
+  it("does not call get404 again on a second 404 for the same project (branded HTML branch is cached)", async () => {
+    const editionRoute: Route = {
+      kind: "edition",
+      project: "cache-hit-branded",
+      edition: "__main",
+      path: "page.html",
+    };
+    const kv = createMockKV({}); // Missing KV entry → 404 path
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore({}, {}, {}, {
+      "cache-hit-branded": {
+        body: streamFromString("<html>branded 404</html>"),
+        size: 24,
+      },
+    });
+    const { ctx, flush } = createWaitingCtx();
+    const request = new Request("https://cache-hit-branded.lsst.io/page.html");
+
+    const first = await resolve(editionRoute, request, kv, r2, dashboardStore, ctx);
+    await first.arrayBuffer();
+    await flush();
+    const second = await resolve(editionRoute, request, kv, r2, dashboardStore, ctx);
+
+    expect(dashboardStore.get404).toHaveBeenCalledTimes(1);
+    expect(second.status).toBe(404);
+    expect(second.headers.get("Content-Type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(second.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await second.text()).toBe("<html>branded 404</html>");
+  });
+
+  it("does not call get404 again on a second 404 for the same project (plain-text fallback is cached)", async () => {
+    const dashboardRoute: Route = {
+      kind: "dashboard",
+      project: "cache-hit-plain",
+    };
+    const kv = createMockKV();
+    const r2 = createMockR2();
+    const dashboardStore = createMockDashboardStore();
+    const { ctx, flush } = createWaitingCtx();
+    const request = new Request("https://cache-hit-plain.lsst.io/v/");
+
+    const first = await resolve(dashboardRoute, request, kv, r2, dashboardStore, ctx);
+    await first.arrayBuffer();
+    await flush();
+    const second = await resolve(dashboardRoute, request, kv, r2, dashboardStore, ctx);
+
+    expect(dashboardStore.get404).toHaveBeenCalledTimes(1);
+    expect(second.status).toBe(404);
+    expect(second.headers.get("Content-Type")).toBe("text/plain");
+    expect(second.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(await second.text()).toBe("Not Found");
   });
 });

--- a/cloudflare-worker/test/router.test.ts
+++ b/cloudflare-worker/test/router.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseRoute, Route, UrlScheme } from "../src/router";
+import { parseRoute, UrlScheme } from "../src/router";
 
 /**
  * Helper to create a minimal Request object from a URL string.
@@ -17,6 +17,7 @@ describe("Subdomain routing", () => {
       scheme,
     );
     expect(route).toEqual({
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "",
@@ -29,6 +30,7 @@ describe("Subdomain routing", () => {
       scheme,
     );
     expect(route).toEqual({
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "getting-started.html",
@@ -41,6 +43,7 @@ describe("Subdomain routing", () => {
       scheme,
     );
     expect(route).toEqual({
+      kind: "edition",
       project: "pipelines",
       edition: "__main",
       path: "modules/lsst.pipe/index.html",
@@ -53,6 +56,7 @@ describe("Subdomain routing", () => {
       scheme,
     );
     expect(route).toEqual({
+      kind: "edition",
       project: "pipelines",
       edition: "main",
       path: "",
@@ -65,6 +69,7 @@ describe("Subdomain routing", () => {
       scheme,
     );
     expect(route).toEqual({
+      kind: "edition",
       project: "pipelines",
       edition: "v1.0",
       path: "changelog.html",
@@ -77,6 +82,7 @@ describe("Subdomain routing", () => {
       scheme,
     );
     expect(route).toEqual({
+      kind: "edition",
       project: "pipelines",
       edition: "weekly-2024",
       path: "api/core.html",
@@ -89,6 +95,7 @@ describe("Subdomain routing", () => {
       scheme,
     );
     expect(route).toEqual({
+      kind: "edition",
       project: "pipelines",
       edition: "main",
       path: "",
@@ -101,6 +108,7 @@ describe("Subdomain routing", () => {
       scheme,
     );
     expect(route).toEqual({
+      kind: "edition",
       project: "sqr-112",
       edition: "__main",
       path: "",
@@ -117,15 +125,42 @@ describe("Subdomain routing", () => {
     expect(route).toBeNull();
   });
 
-  it("routes /v/ with no edition to __main", () => {
+  it("classifies /v/ as a dashboard route", () => {
     const route = parseRoute(
-      makeRequest("https://pipelines.lsst.io/v/"),
+      makeRequest("https://sqr-112.lsst.io/v/"),
       scheme,
     );
     expect(route).toEqual({
-      project: "pipelines",
-      edition: "__main",
-      path: "",
+      kind: "dashboard",
+      project: "sqr-112",
+    });
+  });
+
+  it("classifies /v/index.html as a dashboard route", () => {
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/v/index.html"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "dashboard",
+      project: "sqr-112",
+    });
+  });
+
+  it("classifies /v/switcher.json/extra as an edition named switcher.json", () => {
+    // Locks in classification order: only /v/ and /v/index.html are
+    // dashboard routes; everything else under /v/ is an edition. Later
+    // slices will add switcher / edition-meta routes; this negative case
+    // guards against over-matching.
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/v/switcher.json/extra"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "edition",
+      project: "sqr-112",
+      edition: "switcher.json",
+      path: "extra",
     });
   });
 });
@@ -140,6 +175,7 @@ describe("Path-prefix routing", () => {
         scheme,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "__main",
         path: "",
@@ -152,6 +188,7 @@ describe("Path-prefix routing", () => {
         scheme,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "__main",
         path: "getting-started.html",
@@ -166,6 +203,7 @@ describe("Path-prefix routing", () => {
         scheme,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "main",
         path: "changelog.html",
@@ -178,6 +216,7 @@ describe("Path-prefix routing", () => {
         scheme,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "v2.0",
         path: "",
@@ -190,6 +229,7 @@ describe("Path-prefix routing", () => {
         scheme,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "main",
         path: "",
@@ -202,6 +242,7 @@ describe("Path-prefix routing", () => {
         scheme,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "__main",
         path: "",
@@ -214,6 +255,7 @@ describe("Path-prefix routing", () => {
         scheme,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "__main",
         path: "api/core/index.html",
@@ -227,6 +269,41 @@ describe("Path-prefix routing", () => {
       );
       expect(route).toBeNull();
     });
+
+    it("classifies /{project}/v/ as a dashboard route", () => {
+      const route = parseRoute(
+        makeRequest("https://docs.example.com/sqr-112/v/"),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "dashboard",
+        project: "sqr-112",
+      });
+    });
+
+    it("classifies /{project}/v/index.html as a dashboard route", () => {
+      const route = parseRoute(
+        makeRequest("https://docs.example.com/sqr-112/v/index.html"),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "dashboard",
+        project: "sqr-112",
+      });
+    });
+
+    it("classifies /{project}/v/switcher.json/extra as edition switcher.json", () => {
+      const route = parseRoute(
+        makeRequest("https://docs.example.com/sqr-112/v/switcher.json/extra"),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "edition",
+        project: "sqr-112",
+        edition: "switcher.json",
+        path: "extra",
+      });
+    });
   });
 
   describe("with root prefix", () => {
@@ -239,6 +316,7 @@ describe("Path-prefix routing", () => {
         prefix,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "__main",
         path: "",
@@ -252,6 +330,7 @@ describe("Path-prefix routing", () => {
         prefix,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "__main",
         path: "getting-started.html",
@@ -267,6 +346,7 @@ describe("Path-prefix routing", () => {
         prefix,
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "main",
         path: "changelog.html",
@@ -298,6 +378,7 @@ describe("Path-prefix routing", () => {
         "/docs",
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "__main",
         path: "index.html",
@@ -311,9 +392,34 @@ describe("Path-prefix routing", () => {
         "docs/",
       );
       expect(route).toEqual({
+        kind: "edition",
         project: "pipelines",
         edition: "__main",
         path: "index.html",
+      });
+    });
+
+    it("classifies /docs/{project}/v/ as a dashboard route", () => {
+      const route = parseRoute(
+        makeRequest("https://example.com/docs/sqr-112/v/"),
+        scheme,
+        prefix,
+      );
+      expect(route).toEqual({
+        kind: "dashboard",
+        project: "sqr-112",
+      });
+    });
+
+    it("classifies /docs/{project}/v/index.html as a dashboard route", () => {
+      const route = parseRoute(
+        makeRequest("https://example.com/docs/sqr-112/v/index.html"),
+        scheme,
+        prefix,
+      );
+      expect(route).toEqual({
+        kind: "dashboard",
+        project: "sqr-112",
       });
     });
   });

--- a/cloudflare-worker/test/router.test.ts
+++ b/cloudflare-worker/test/router.test.ts
@@ -184,6 +184,46 @@ describe("Subdomain routing", () => {
       to: "/v/",
     });
   });
+
+  it("classifies /v/{edition}/_docverse.json as an edition_meta route", () => {
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/v/main/_docverse.json"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "edition_meta",
+      project: "sqr-112",
+      edition: "main",
+    });
+  });
+
+  it("classifies /v/{edition}/_docverse.json with a dashy edition name", () => {
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/v/weekly-2024/_docverse.json"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "edition_meta",
+      project: "sqr-112",
+      edition: "weekly-2024",
+    });
+  });
+
+  it("classifies /v/main/_docverse.json/extra as an edition file path", () => {
+    // Locks in classification order: the exact-match edition_meta branch
+    // must not swallow deeper paths. /v/main/_docverse.json/extra must
+    // continue to route as edition "main", path "_docverse.json/extra".
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/v/main/_docverse.json/extra"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "edition",
+      project: "sqr-112",
+      edition: "main",
+      path: "_docverse.json/extra",
+    });
+  });
 });
 
 describe("Path-prefix routing", () => {
@@ -345,6 +385,33 @@ describe("Path-prefix routing", () => {
       expect(route).toEqual({
         kind: "redirect",
         to: "/sqr-112/v/",
+      });
+    });
+
+    it("classifies /{project}/v/{edition}/_docverse.json as edition_meta", () => {
+      const route = parseRoute(
+        makeRequest("https://docs.example.com/sqr-112/v/main/_docverse.json"),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "edition_meta",
+        project: "sqr-112",
+        edition: "main",
+      });
+    });
+
+    it("classifies /{project}/v/main/_docverse.json/extra as edition path", () => {
+      const route = parseRoute(
+        makeRequest(
+          "https://docs.example.com/sqr-112/v/main/_docverse.json/extra",
+        ),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "edition",
+        project: "sqr-112",
+        edition: "main",
+        path: "_docverse.json/extra",
       });
     });
   });

--- a/cloudflare-worker/test/router.test.ts
+++ b/cloudflare-worker/test/router.test.ts
@@ -224,6 +224,48 @@ describe("Subdomain routing", () => {
       path: "_docverse.json/extra",
     });
   });
+
+  it("classifies /_docverse.json at project root as __main edition_meta", () => {
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/_docverse.json"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "edition_meta",
+      project: "sqr-112",
+      edition: "__main",
+    });
+  });
+
+  it("classifies /_docverse.json/extra as a regular __main edition path", () => {
+    // The reserved name only applies at the exact project root — deeper
+    // paths must fall through to the __main edition file route.
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/_docverse.json/extra"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "edition",
+      project: "sqr-112",
+      edition: "__main",
+      path: "_docverse.json/extra",
+    });
+  });
+
+  it("classifies /sub/_docverse.json as a regular __main edition path", () => {
+    // Reserved name applies only at the project root, not inside
+    // subdirectories of the __main edition.
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/sub/_docverse.json"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "edition",
+      project: "sqr-112",
+      edition: "__main",
+      path: "sub/_docverse.json",
+    });
+  });
 });
 
 describe("Path-prefix routing", () => {
@@ -414,6 +456,44 @@ describe("Path-prefix routing", () => {
         path: "_docverse.json/extra",
       });
     });
+
+    it("classifies /{project}/_docverse.json as __main edition_meta", () => {
+      const route = parseRoute(
+        makeRequest("https://docs.example.com/sqr-112/_docverse.json"),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "edition_meta",
+        project: "sqr-112",
+        edition: "__main",
+      });
+    });
+
+    it("classifies /{project}/_docverse.json/extra as a __main edition path", () => {
+      const route = parseRoute(
+        makeRequest("https://docs.example.com/sqr-112/_docverse.json/extra"),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "edition",
+        project: "sqr-112",
+        edition: "__main",
+        path: "_docverse.json/extra",
+      });
+    });
+
+    it("classifies /{project}/sub/_docverse.json as a __main edition path", () => {
+      const route = parseRoute(
+        makeRequest("https://docs.example.com/sqr-112/sub/_docverse.json"),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "edition",
+        project: "sqr-112",
+        edition: "__main",
+        path: "sub/_docverse.json",
+      });
+    });
   });
 
   describe("with root prefix", () => {
@@ -554,6 +634,19 @@ describe("Path-prefix routing", () => {
       expect(route).toEqual({
         kind: "redirect",
         to: "/docs/sqr-112/v/",
+      });
+    });
+
+    it("classifies /docs/{project}/_docverse.json as __main edition_meta", () => {
+      const route = parseRoute(
+        makeRequest("https://example.com/docs/sqr-112/_docverse.json"),
+        scheme,
+        prefix,
+      );
+      expect(route).toEqual({
+        kind: "edition_meta",
+        project: "sqr-112",
+        edition: "__main",
       });
     });
   });

--- a/cloudflare-worker/test/router.test.ts
+++ b/cloudflare-worker/test/router.test.ts
@@ -147,11 +147,21 @@ describe("Subdomain routing", () => {
     });
   });
 
+  it("classifies /v/switcher.json as a switcher route", () => {
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/v/switcher.json"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "switcher",
+      project: "sqr-112",
+    });
+  });
+
   it("classifies /v/switcher.json/extra as an edition named switcher.json", () => {
-    // Locks in classification order: only /v/ and /v/index.html are
-    // dashboard routes; everything else under /v/ is an edition. Later
-    // slices will add switcher / edition-meta routes; this negative case
-    // guards against over-matching.
+    // Locks in classification order: exact-match dashboard-family routes
+    // (dashboard, switcher) win over the generic /v/ edition fallback, but
+    // anything with extra path segments falls back to edition routing.
     const route = parseRoute(
       makeRequest("https://sqr-112.lsst.io/v/switcher.json/extra"),
       scheme,
@@ -303,6 +313,17 @@ describe("Path-prefix routing", () => {
       });
     });
 
+    it("classifies /{project}/v/switcher.json as a switcher route", () => {
+      const route = parseRoute(
+        makeRequest("https://docs.example.com/sqr-112/v/switcher.json"),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "switcher",
+        project: "sqr-112",
+      });
+    });
+
     it("classifies /{project}/v/switcher.json/extra as edition switcher.json", () => {
       const route = parseRoute(
         makeRequest("https://docs.example.com/sqr-112/v/switcher.json/extra"),
@@ -441,6 +462,18 @@ describe("Path-prefix routing", () => {
       );
       expect(route).toEqual({
         kind: "dashboard",
+        project: "sqr-112",
+      });
+    });
+
+    it("classifies /docs/{project}/v/switcher.json as a switcher route", () => {
+      const route = parseRoute(
+        makeRequest("https://example.com/docs/sqr-112/v/switcher.json"),
+        scheme,
+        prefix,
+      );
+      expect(route).toEqual({
+        kind: "switcher",
         project: "sqr-112",
       });
     });

--- a/cloudflare-worker/test/router.test.ts
+++ b/cloudflare-worker/test/router.test.ts
@@ -163,6 +163,17 @@ describe("Subdomain routing", () => {
       path: "extra",
     });
   });
+
+  it("classifies /v (no trailing slash) as a redirect to /v/", () => {
+    const route = parseRoute(
+      makeRequest("https://sqr-112.lsst.io/v"),
+      scheme,
+    );
+    expect(route).toEqual({
+      kind: "redirect",
+      to: "/v/",
+    });
+  });
 });
 
 describe("Path-prefix routing", () => {
@@ -304,6 +315,17 @@ describe("Path-prefix routing", () => {
         path: "extra",
       });
     });
+
+    it("classifies /{project}/v (no trailing slash) as a redirect", () => {
+      const route = parseRoute(
+        makeRequest("https://docs.example.com/sqr-112/v"),
+        scheme,
+      );
+      expect(route).toEqual({
+        kind: "redirect",
+        to: "/sqr-112/v/",
+      });
+    });
   });
 
   describe("with root prefix", () => {
@@ -420,6 +442,18 @@ describe("Path-prefix routing", () => {
       expect(route).toEqual({
         kind: "dashboard",
         project: "sqr-112",
+      });
+    });
+
+    it("classifies /docs/{project}/v (no trailing slash) as a redirect", () => {
+      const route = parseRoute(
+        makeRequest("https://example.com/docs/sqr-112/v"),
+        scheme,
+        prefix,
+      );
+      expect(route).toEqual({
+        kind: "redirect",
+        to: "/docs/sqr-112/v/",
       });
     });
   });


### PR DESCRIPTION
## Summary

- Tracer-bullet vertical slice: `project.lsst.io/v/` and `/v/index.html` now serve `{project}/__dashboard.html` from `BUILDS_R2` with `Content-Type: text/html; charset=utf-8` and `Cache-Control: public, max-age=60`. Identical behavior in the path-prefix scheme.
- Introduces the structural scaffolding reused by later dashboard slices: `Route` is now a discriminated union on `kind` (`edition` | `dashboard`), a new `DashboardStore` deep module owns the `__`-prefixed R2 key layout, and the resolver dispatches on `route.kind` so the existing KV → R2 edition flow stays unchanged.
- No Wrangler bindings, KV schemas, or deployment config touched.

## Validation steps

- [x] Confirm `/v/` and `/v/index.html` both return the dashboard body in a Miniflare `wrangler dev` session (subdomain and path-prefix schemes).
- [x] Confirm an edition build URL (e.g. `/getting-started.html`) still streams through KV → R2 unchanged.
- [ ] Confirm `/v/switcher.json/extra` classifies as an edition named `switcher.json` (locks in classification order for later slices).

## References

- Closes #197
- Closes #198
- Closes #200
- Closes #203
- Closes #204
- Closes #205
- Closes #207
- Closes #208
- Closes #206
- Closes #217
- PRD: #196
- Jira: https://rubinobs.atlassian.net/browse/DM-54723