### PR TITLE
DM-54734: Discover dashboard API URL via Rubin Repertoire

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pydantic-settings>=2",
     "base32-lib",
     "rubin-gafaelfawr",
+    "rubin-repertoire",
     "safir[db,arq]>=13",
     "uvicorn[standard]>=0.34",
 ]

--- a/server-changelog.d/20260421_120000_DM_54734.md
+++ b/server-changelog.d/20260421_120000_DM_54734.md
@@ -1,0 +1,7 @@
+### Backwards-incompatible changes
+
+- Removed the static `Configuration.published_base_url` setting. The dashboard API URL surfaced as `docverse.api_url` is now fetched at build time from Rubin Repertoire via `DiscoveryClient.url_for_internal("docverse")`. `DOCVERSE_PUBLISHED_BASE_URL` is no longer read; set `REPERTOIRE_BASE_URL` instead and register Docverse as an internal service in the environment's Repertoire.
+
+### New features
+
+- The FastAPI app lifespan and the arq worker's `startup()` both construct a process-wide `rubin.repertoire.DiscoveryClient` that shares the existing `httpx.AsyncClient`, exposed via `Factory` / `HandlerFactory` and on `ctx["discovery"]` so dashboard builds can look up service URLs at render time.

--- a/src/docverse/config.py
+++ b/src/docverse/config.py
@@ -70,16 +70,6 @@ class Configuration(BaseSettings):
         validation_alias="REPERTOIRE_BASE_URL",
     )
 
-    published_base_url: HttpUrl = Field(
-        HttpUrl("https://roundtable-dev.lsst.cloud/docverse/api"),
-        title="Publicly visible base URL of the Docverse API",
-        description=(
-            "Surfaced to dashboard templates as ``docverse.api_url``."
-            " Will be replaced by a Rubin Repertoire lookup once that"
-            " integration lands (see issue #185)."
-        ),
-    )
-
     credential_encryption_key: SecretStr = Field(
         title="Fernet key for encrypting organization credentials",
         description=(

--- a/src/docverse/dependencies/context.py
+++ b/src/docverse/dependencies/context.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Annotated, Any
 
 from fastapi import Depends, Request, Response
+from rubin.repertoire import DiscoveryClient
 from safir.arq import ArqQueue
 from safir.dependencies.arq import arq_dependency
 from safir.dependencies.db_session import db_session_dependency
@@ -81,6 +82,7 @@ class ContextDependency:
         self._credential_encryptor: CredentialEncryptor | None = None
         self._superadmin_usernames: list[str] = []
         self._arq_queue_name: str = "arq:queue"
+        self._discovery: DiscoveryClient | None = None
 
     async def __call__(
         self,
@@ -109,6 +111,7 @@ class ContextDependency:
                 user_info_store=self._user_info_store,
                 credential_encryptor=self._credential_encryptor,
                 superadmin_usernames=self._superadmin_usernames,
+                discovery=self._discovery,
                 default_queue_name=self._arq_queue_name,
             ),
         )
@@ -119,6 +122,7 @@ class ContextDependency:
         credential_encryptor: CredentialEncryptor | None = None,
         superadmin_usernames: list[str] | None = None,
         arq_queue_name: str | None = None,
+        discovery: DiscoveryClient | None = None,
     ) -> None:
         """Initialize the process-wide shared context."""
         self._initialized = True
@@ -130,6 +134,8 @@ class ContextDependency:
             self._superadmin_usernames = superadmin_usernames
         if arq_queue_name is not None:
             self._arq_queue_name = arq_queue_name
+        if discovery is not None:
+            self._discovery = discovery
 
     async def aclose(self) -> None:
         """Clean up the per-process configuration."""

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import httpx
 import structlog
+from rubin.repertoire import DiscoveryClient
 from safir.arq import ArqQueue
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .config import Configuration
 from .services.authorization import AuthorizationService
 from .services.build import BuildService
 from .services.credential import CredentialService
@@ -53,6 +53,7 @@ class Factory:
         superadmin_usernames: list[str] | None = None,
         http_client: httpx.AsyncClient | None = None,
         arq_queue: ArqQueue | None = None,
+        discovery: DiscoveryClient | None = None,
         *,
         default_queue_name: str,
     ) -> None:
@@ -62,6 +63,7 @@ class Factory:
         self._superadmin_usernames = superadmin_usernames or []
         self._http_client = http_client
         self._arq_queue = arq_queue
+        self._discovery = discovery
         self._default_queue_name = default_queue_name
 
     def set_logger(self, logger: structlog.stdlib.BoundLogger) -> None:
@@ -255,17 +257,17 @@ class Factory:
             logger=self._logger,
         )
 
-    def create_dashboard_publisher(
-        self, *, config: Configuration
-    ) -> DashboardPublisher:
+    def create_dashboard_publisher(self) -> DashboardPublisher:
         """Create a DashboardPublisher for one render.
 
-        Parameters
-        ----------
-        config
-            Application configuration. Passed in explicitly so tests can
-            inject a fake URL rather than relying on env vars.
+        Raises
+        ------
+        RuntimeError
+            If the Repertoire discovery client is not configured.
         """
+        if self._discovery is None:
+            msg = "DiscoveryClient is required to build a DashboardPublisher"
+            raise RuntimeError(msg)
         return DashboardPublisher(
             org_store=self._create_org_store(),
             project_store=self._create_project_store(),
@@ -273,7 +275,7 @@ class Factory:
                 session=self._session, logger=self._logger
             ),
             build_store=BuildStore(session=self._session, logger=self._logger),
-            config=config,
+            discovery=self._discovery,
             logger=self._logger,
         )
 
@@ -385,6 +387,7 @@ class HandlerFactory(Factory):
         user_info_store: UserInfoStore,
         credential_encryptor: CredentialEncryptor | None = None,
         superadmin_usernames: list[str] | None = None,
+        discovery: DiscoveryClient | None = None,
         *,
         default_queue_name: str,
     ) -> None:
@@ -394,6 +397,7 @@ class HandlerFactory(Factory):
             credential_encryptor=credential_encryptor,
             superadmin_usernames=superadmin_usernames,
             arq_queue=arq_queue,
+            discovery=discovery,
             default_queue_name=default_queue_name,
         )
         self._user_info_store = user_info_store

--- a/src/docverse/main.py
+++ b/src/docverse/main.py
@@ -9,6 +9,7 @@ from importlib.metadata import metadata, version
 import structlog
 from fastapi import FastAPI
 from rubin.gafaelfawr import GafaelfawrClient
+from rubin.repertoire import DiscoveryClient
 from safir.database import create_database_engine, is_database_current
 from safir.dependencies.arq import arq_dependency
 from safir.dependencies.db_session import db_session_dependency
@@ -81,12 +82,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
     http_client = await http_client_dependency()
     gafaelfawr_client = GafaelfawrClient(http_client)
     user_info_store = GafaelfawrUserInfoStore(gafaelfawr_client)
+    discovery = DiscoveryClient(
+        http_client,
+        base_url=str(config.repertoire_base_url),
+        logger=logger,
+    )
 
     await context_dependency.initialize(
         credential_encryptor=encryptor,
         superadmin_usernames=config.superadmin_usernames,
         user_info_store=user_info_store,
         arq_queue_name=config.arq_queue_name,
+        discovery=discovery,
     )
     yield
     await context_dependency.aclose()

--- a/src/docverse/services/dashboard/context.py
+++ b/src/docverse/services/dashboard/context.py
@@ -6,9 +6,9 @@ from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
 
 import structlog
+from rubin.repertoire import DiscoveryClient
 
 from docverse.client.models import EditionKind
-from docverse.config import Configuration
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.build import Build
 from docverse.domain.dashboard_context import (
@@ -138,14 +138,14 @@ class DashboardContextBuilder:
         project_store: ProjectStore,
         edition_store: EditionStore,
         build_store: BuildStore,
-        config: Configuration,
+        discovery: DiscoveryClient,
         logger: structlog.stdlib.BoundLogger,
     ) -> None:
         self._org_store = org_store
         self._project_store = project_store
         self._edition_store = edition_store
         self._build_store = build_store
-        self._config = config
+        self._discovery = discovery
         self._logger = logger
 
     async def build(
@@ -170,6 +170,11 @@ class DashboardContextBuilder:
         if project is None:
             msg = f"Project {project_id} not found"
             raise NotFoundError(msg)
+
+        api_url = await self._discovery.url_for_internal("docverse")
+        if api_url is None:
+            msg = "Docverse is not registered in Repertoire"
+            raise RuntimeError(msg)
 
         editions = await self._edition_store.list_all_by_project(project_id)
 
@@ -202,7 +207,7 @@ class DashboardContextBuilder:
             editions=editions_context,
             assets=AssetsContext(),
             docverse=DocverseContext(
-                api_url=str(self._config.published_base_url),
+                api_url=api_url,
                 version=_docverse_version(),
             ),
             rendered_at=rendered_at or datetime.now(tz=UTC),

--- a/src/docverse/services/dashboard/publisher.py
+++ b/src/docverse/services/dashboard/publisher.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass, replace
 from datetime import datetime
 
 import structlog
+from rubin.repertoire import DiscoveryClient
 
-from docverse.config import Configuration
 from docverse.domain.dashboard_context import DashboardContext, EditionContext
 from docverse.storage.build_store import BuildStore
 from docverse.storage.dashboard_templates.template_source import (
@@ -75,7 +75,7 @@ class DashboardPublisher:
         project_store: ProjectStore,
         edition_store: EditionStore,
         build_store: BuildStore,
-        config: Configuration,
+        discovery: DiscoveryClient,
         logger: structlog.stdlib.BoundLogger,
         template_source: TemplateSource | None = None,
     ) -> None:
@@ -83,7 +83,7 @@ class DashboardPublisher:
         self._project_store = project_store
         self._edition_store = edition_store
         self._build_store = build_store
-        self._config = config
+        self._discovery = discovery
         self._logger = logger
         self._template_source = template_source or BuiltInTemplateSource()
 
@@ -100,7 +100,7 @@ class DashboardPublisher:
             project_store=self._project_store,
             edition_store=self._edition_store,
             build_store=self._build_store,
-            config=self._config,
+            discovery=self._discovery,
             logger=self._logger,
         )
         return await builder.build(

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import httpx
 import structlog
+from rubin.repertoire import DiscoveryClient
 from safir.arq import ArqQueue
 from safir.dependencies.db_session import db_session_dependency
 
@@ -53,6 +54,7 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
     encryptor: CredentialEncryptor = ctx["encryptor"]
     http_client: httpx.AsyncClient = ctx["http_client"]
     arq_queue: ArqQueue | None = ctx.get("arq_queue")
+    discovery: DiscoveryClient = ctx["discovery"]
 
     async for session in db_session_dependency():
         factory = Factory(
@@ -61,6 +63,7 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
             credential_encryptor=encryptor,
             http_client=http_client,
             arq_queue=arq_queue,
+            discovery=discovery,
             default_queue_name=config.arq_queue_name,
         )
         queue_job_store = QueueJobStore(session=session, logger=logger)
@@ -87,7 +90,7 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                     )
                     raise RuntimeError(msg)  # noqa: TRY301
 
-                publisher = factory.create_dashboard_publisher(config=config)
+                publisher = factory.create_dashboard_publisher()
                 rendered_at = datetime.now(tz=UTC)
                 context = await publisher.build_context(
                     org_id=org_id,

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import httpx
 import structlog
+from rubin.repertoire import DiscoveryClient
 from safir.arq import RedisArqQueue
 from safir.database import create_database_engine, is_database_current
 from safir.dependencies.db_session import db_session_dependency
@@ -65,6 +66,11 @@ async def startup(ctx: dict[str, Any]) -> None:
     )
 
     ctx["http_client"] = httpx.AsyncClient()
+    ctx["discovery"] = DiscoveryClient(
+        ctx["http_client"],
+        base_url=str(config.repertoire_base_url),
+        logger=logger,
+    )
 
     if config.arq_redis_settings is None:
         msg = "arq_redis_settings must be configured for the worker"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterator
+from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 import pytest_asyncio
+import respx
 import structlog
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from rubin.repertoire import DiscoveryClient, register_mock_discovery
 from safir.arq import MockArqQueue
 from safir.database import (
     create_database_engine,
@@ -46,6 +50,27 @@ __all__ = [
     "seed_member",
     "seed_org_with_admin",
 ]
+
+_DISCOVERY_FIXTURE = Path(__file__).parent / "data" / "discovery.json"
+
+
+@pytest.fixture(autouse=True)
+def mock_discovery() -> Iterator[respx.Router]:
+    """Mock the Repertoire discovery endpoint for the whole test suite.
+
+    Passes through any other HTTP requests so the ASGI transport used by
+    the FastAPI test client still reaches the app.
+    """
+    with respx.mock(assert_all_called=False, assert_all_mocked=False) as mock:
+        register_mock_discovery(mock, _DISCOVERY_FIXTURE)
+        yield mock
+
+
+@pytest_asyncio.fixture
+async def discovery_client() -> AsyncGenerator[DiscoveryClient]:
+    """Return a ``DiscoveryClient`` backed by the autouse respx mock."""
+    async with httpx.AsyncClient() as http_client:
+        yield DiscoveryClient(http_client)
 
 
 @pytest_asyncio.fixture

--- a/tests/data/discovery.json
+++ b/tests/data/discovery.json
@@ -1,0 +1,11 @@
+{
+  "applications": ["docverse"],
+  "environment_name": "docverse-test",
+  "services": {
+    "internal": {
+      "docverse": {
+        "url": "https://example.test/docverse/api"
+      }
+    }
+  }
+}

--- a/tests/services/dashboard/context_test.py
+++ b/tests/services/dashboard/context_test.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import httpx
 import pytest
+import respx
 import structlog
+from rubin.repertoire import DiscoveryClient, register_mock_discovery
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,7 +21,6 @@ from docverse.client.models import (
     TrackingMode,
     UrlScheme,
 )
-from docverse.config import Configuration
 from docverse.dbschema.edition import SqlEdition
 from docverse.domain.organization import Organization
 from docverse.domain.project import Project
@@ -36,14 +38,16 @@ def _logger() -> structlog.stdlib.BoundLogger:
     return structlog.get_logger("docverse")  # type: ignore[no-any-return]
 
 
-def _make_builder(session: AsyncSession) -> DashboardContextBuilder:
+def _make_builder(
+    session: AsyncSession, discovery_client: DiscoveryClient
+) -> DashboardContextBuilder:
     logger = _logger()
     return DashboardContextBuilder(
         org_store=OrganizationStore(session=session, logger=logger),
         project_store=ProjectStore(session=session, logger=logger),
         edition_store=EditionStore(session=session, logger=logger),
         build_store=BuildStore(session=session, logger=logger),
-        config=Configuration(),
+        discovery=discovery_client,
         logger=logger,
     )
 
@@ -122,6 +126,7 @@ async def _create_edition(
 @pytest.mark.asyncio
 async def test_context_builder_groups_editions_by_kind(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(db_session)
@@ -177,7 +182,7 @@ async def test_context_builder_groups_editions_by_kind(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
 
     assert ctx.editions.main is not None
@@ -192,6 +197,7 @@ async def test_context_builder_groups_editions_by_kind(
 @pytest.mark.asyncio
 async def test_releases_sorted_semver_descending(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(
@@ -209,7 +215,7 @@ async def test_releases_sorted_semver_descending(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
 
     assert [e.slug for e in ctx.editions.releases] == [
@@ -223,6 +229,7 @@ async def test_releases_sorted_semver_descending(
 @pytest.mark.asyncio
 async def test_drafts_sorted_by_date_updated_descending(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(
@@ -257,7 +264,7 @@ async def test_drafts_sorted_by_date_updated_descending(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
 
     assert [e.slug for e in ctx.editions.drafts] == [
@@ -269,6 +276,7 @@ async def test_drafts_sorted_by_date_updated_descending(
 @pytest.mark.asyncio
 async def test_alternates_sorted_alphabetically_by_title(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(
@@ -285,7 +293,7 @@ async def test_alternates_sorted_alphabetically_by_title(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
 
     assert [e.title for e in ctx.editions.alternates] == ["East", "West"]
@@ -294,6 +302,7 @@ async def test_alternates_sorted_alphabetically_by_title(
 @pytest.mark.asyncio
 async def test_edition_without_current_build_has_no_build(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(
@@ -309,7 +318,7 @@ async def test_edition_without_current_build_has_no_build(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
 
     assert ctx.editions.main is not None
@@ -319,6 +328,7 @@ async def test_edition_without_current_build_has_no_build(
 @pytest.mark.asyncio
 async def test_alternate_name_surfaces_into_edition_context(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(
@@ -339,7 +349,7 @@ async def test_alternate_name_surfaces_into_edition_context(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
 
     drafts = ctx.editions.drafts
@@ -350,6 +360,7 @@ async def test_alternate_name_surfaces_into_edition_context(
 @pytest.mark.asyncio
 async def test_main_surfaced_separately_not_in_releases(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(
@@ -372,7 +383,7 @@ async def test_main_surfaced_separately_not_in_releases(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
 
     assert ctx.editions.main is not None
@@ -383,6 +394,7 @@ async def test_main_surfaced_separately_not_in_releases(
 @pytest.mark.asyncio
 async def test_empty_project_yields_empty_groupings(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(
@@ -391,7 +403,7 @@ async def test_empty_project_yields_empty_groupings(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
 
     assert ctx.editions.main is None
@@ -405,6 +417,7 @@ async def test_empty_project_yields_empty_groupings(
 @pytest.mark.asyncio
 async def test_rendered_at_defaults_to_now_utc(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(
@@ -413,7 +426,7 @@ async def test_rendered_at_defaults_to_now_utc(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         before = datetime.now(tz=UTC)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
         after = datetime.now(tz=UTC)
@@ -425,6 +438,7 @@ async def test_rendered_at_defaults_to_now_utc(
 @pytest.mark.asyncio
 async def test_build_context_populated_when_current_build_set(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     async with db_session.begin():
         org, project = await _seed_org_and_project(
@@ -444,13 +458,58 @@ async def test_build_context_populated_when_current_build_set(
         await db_session.commit()
 
     async with db_session.begin():
-        builder = _make_builder(db_session)
+        builder = _make_builder(db_session, discovery_client)
         ctx = await builder.build(org_id=org.id, project_id=project.id)
 
     main = ctx.editions.main
     assert main is not None
     assert main.build is not None
     assert main.build.git_ref == "main"
+
+
+@pytest.mark.asyncio
+async def test_api_url_comes_from_repertoire_discovery(
+    db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
+) -> None:
+    """The built context's ``docverse.api_url`` is the Repertoire URL."""
+    async with db_session.begin():
+        org, project = await _seed_org_and_project(
+            db_session, org_slug="rep-org", project_slug="rep-proj"
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        builder = _make_builder(db_session, discovery_client)
+        ctx = await builder.build(org_id=org.id, project_id=project.id)
+
+    assert ctx.docverse.api_url == "https://example.test/docverse/api"
+
+
+@pytest.mark.asyncio
+async def test_build_raises_when_docverse_not_registered(
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """``build()`` raises when Repertoire returns no ``docverse`` URL."""
+    # Re-register discovery without a ``docverse`` internal service.
+    mock_discovery.reset()
+    register_mock_discovery(mock_discovery, {"services": {"internal": {}}})
+
+    async with db_session.begin():
+        org, project = await _seed_org_and_project(
+            db_session, org_slug="norep-org", project_slug="norep-proj"
+        )
+        await db_session.commit()
+
+    async with httpx.AsyncClient() as http_client:
+        discovery = DiscoveryClient(http_client)
+        async with db_session.begin():
+            builder = _make_builder(db_session, discovery)
+            with pytest.raises(
+                RuntimeError, match="not registered in Repertoire"
+            ):
+                await builder.build(org_id=org.id, project_id=project.id)
 
 
 def _make_org(base_domain: str, url_scheme: UrlScheme) -> Organization:

--- a/tests/services/dashboard/publisher_test.py
+++ b/tests/services/dashboard/publisher_test.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 import structlog
+from rubin.repertoire import DiscoveryClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import (
@@ -15,7 +16,6 @@ from docverse.client.models import (
     ProjectCreate,
     TrackingMode,
 )
-from docverse.config import Configuration
 from docverse.services.dashboard.publisher import DashboardPublisher
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_store import EditionStore
@@ -30,14 +30,16 @@ def _logger() -> structlog.stdlib.BoundLogger:
     return structlog.get_logger("docverse")  # type: ignore[no-any-return]
 
 
-def _make_publisher(session: AsyncSession) -> DashboardPublisher:
+def _make_publisher(
+    session: AsyncSession, discovery_client: DiscoveryClient
+) -> DashboardPublisher:
     logger = _logger()
     return DashboardPublisher(
         org_store=OrganizationStore(session=session, logger=logger),
         project_store=ProjectStore(session=session, logger=logger),
         edition_store=EditionStore(session=session, logger=logger),
         build_store=BuildStore(session=session, logger=logger),
-        config=Configuration(),
+        discovery=discovery_client,
         logger=logger,
     )
 
@@ -45,6 +47,7 @@ def _make_publisher(session: AsyncSession) -> DashboardPublisher:
 @pytest.mark.asyncio
 async def test_publisher_uploads_dashboard_and_switcher(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     logger = _logger()
     org_store = OrganizationStore(session=db_session, logger=logger)
@@ -97,7 +100,7 @@ async def test_publisher_uploads_dashboard_and_switcher(
         )
         await db_session.commit()
 
-    publisher = _make_publisher(db_session)
+    publisher = _make_publisher(db_session, discovery_client)
     mock_store = MockObjectStore()
 
     async def _provider() -> MockObjectStore:
@@ -147,6 +150,7 @@ async def test_publisher_uploads_dashboard_and_switcher(
 @pytest.mark.asyncio
 async def test_publisher_writes_per_edition_json_files(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     """One ``__editions/{slug}.json`` per non-deleted edition is uploaded."""
     logger = _logger()
@@ -188,7 +192,7 @@ async def test_publisher_writes_per_edition_json_files(
         )
         await db_session.commit()
 
-    publisher = _make_publisher(db_session)
+    publisher = _make_publisher(db_session, discovery_client)
     mock_store = MockObjectStore()
 
     async def _provider() -> MockObjectStore:
@@ -220,6 +224,7 @@ async def test_publisher_writes_per_edition_json_files(
 @pytest.mark.asyncio
 async def test_publisher_handles_empty_project(
     db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
 ) -> None:
     logger = _logger()
     org_store = OrganizationStore(session=db_session, logger=logger)
@@ -243,7 +248,7 @@ async def test_publisher_handles_empty_project(
         )
         await db_session.commit()
 
-    publisher = _make_publisher(db_session)
+    publisher = _make_publisher(db_session, discovery_client)
     mock_store = MockObjectStore()
 
     async def _provider() -> MockObjectStore:

--- a/tests/worker/dashboard_build_test.py
+++ b/tests/worker/dashboard_build_test.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 import structlog
 from cryptography.fernet import Fernet
+from rubin.repertoire import DiscoveryClient
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy import select, update
@@ -125,9 +126,11 @@ async def test_dashboard_build_completes_with_phase_transitions(
     )
 
     encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
+    http_client = httpx.AsyncClient()
     ctx: dict[str, Any] = {
         "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
+        "http_client": http_client,
+        "discovery": DiscoveryClient(http_client),
         "job_id": "test-arq-dashboard",
         "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
     }
@@ -210,9 +213,11 @@ async def test_dashboard_build_marks_failed_on_render_exception(
     )
 
     encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
+    http_client = httpx.AsyncClient()
     ctx: dict[str, Any] = {
         "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
+        "http_client": http_client,
+        "discovery": DiscoveryClient(http_client),
         "job_id": "test-arq-dash-fail",
         "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
     }

--- a/uv.lock
+++ b/uv.lock
@@ -608,6 +608,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rubin-gafaelfawr" },
+    { name = "rubin-repertoire" },
     { name = "safir", extra = ["arq", "db"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -649,6 +650,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2" },
     { name = "pydantic-settings", specifier = ">=2" },
     { name = "rubin-gafaelfawr" },
+    { name = "rubin-repertoire" },
     { name = "safir", extras = ["arq", "db"], specifier = ">=13" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]


### PR DESCRIPTION
## Summary

- Replaces the static `Configuration.published_base_url` with a runtime lookup through `DiscoveryClient.url_for_internal("docverse")`, surfaced as `docverse.api_url` on the dashboard context.
- Builds a `DiscoveryClient` once per process — in the arq worker's `startup()` (`ctx["discovery"]`) and in the FastAPI lifespan (handed to `context_dependency.initialize`) — and threads it through `Factory` / `HandlerFactory` so both surfaces are symmetric.
- `DashboardContextBuilder` (and `DashboardPublisher`) now take a `DiscoveryClient` instead of `Configuration`, and fail loudly at build time if Repertoire does not know about `docverse`.

## Validation steps

- [x] In a deploy preview with the companion Phalanx PRs applied, trigger a dashboard rebuild and confirm the rendered dashboard's `docverse.api_url` matches the environment's Repertoire registration rather than any stale value.
- [x] Unset `REPERTOIRE_BASE_URL` locally and confirm both `docverse` (FastAPI) and the arq worker refuse to start (Pydantic validation error from `Configuration`).

## References

- Closes #214
- PRD: #213
- Jira: https://rubinobs.atlassian.net/browse/DM-54734