### PR TITLE
DM-54693: Add LockService for advisory-lock coordination

### DIFF
--- a/alembic/versions/20260422_0000_l0m1n2o3p4q5_add_builds_project_id_git_ref_composite_index.py
+++ b/alembic/versions/20260422_0000_l0m1n2o3p4q5_add_builds_project_id_git_ref_composite_index.py
@@ -1,0 +1,39 @@
+"""Replace ``idx_builds_project_id`` with composite ``(project_id, git_ref)``.
+
+The stale-build guard in ``build_processing`` runs
+``SELECT max(id) FROM builds WHERE project_id = :p AND git_ref = :r`` at
+every job entry. The existing single-column indexes on ``project_id`` and
+``git_ref`` alone force a table scan of the project's build history. A
+composite ``(project_id, git_ref)`` index serves that query directly and
+also covers any remaining ``project_id``-only filters via its leading
+column, so the old ``idx_builds_project_id`` is dropped. The
+``idx_builds_git_ref`` single-column index is kept — the composite's
+leading column is ``project_id``, so it cannot serve queries that filter
+only by ``git_ref``.
+
+Revision ID: l0m1n2o3p4q5
+Revises: k9l0m1n2o3p4
+Create Date: 2026-04-22 00:00:00.000000+00:00
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "l0m1n2o3p4q5"
+down_revision: str | None = "k9l0m1n2o3p4"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_builds_project_id_git_ref",
+        "builds",
+        ["project_id", "git_ref"],
+    )
+    op.drop_index("idx_builds_project_id", table_name="builds")
+
+
+def downgrade() -> None:
+    op.create_index("idx_builds_project_id", "builds", ["project_id"])
+    op.drop_index("idx_builds_project_id_git_ref", table_name="builds")

--- a/src/docverse/dbschema/build.py
+++ b/src/docverse/dbschema/build.py
@@ -79,7 +79,7 @@ class SqlBuild(Base):
     )
 
     __table_args__ = (
-        Index("idx_builds_project_id", "project_id"),
+        Index("idx_builds_project_id_git_ref", "project_id", "git_ref"),
         Index("idx_builds_status", "status"),
         Index("idx_builds_git_ref", "git_ref"),
     )

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -136,7 +136,13 @@ class Factory:
         )
 
     def create_edition_tracking_service(self) -> EditionTrackingService:
-        """Create an EditionTrackingService."""
+        """Create an EditionTrackingService.
+
+        The factory always wires in a :class:`LockService` so worker
+        call paths (``build_processing``) get the EDITION_UPDATE
+        advisory lock around each ``set_current_build`` call. Direct
+        unit-test constructions of the service may pass ``None``.
+        """
         return EditionTrackingService(
             edition_store=EditionStore(
                 session=self._session, logger=self._logger
@@ -147,6 +153,7 @@ class Factory:
             project_store=self._create_project_store(),
             org_store=self._create_org_store(),
             logger=self._logger,
+            lock_service=self.create_lock_service(),
         )
 
     def create_edition_service(self) -> EditionService:

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -16,7 +16,10 @@ from .services.dashboard.enqueue import DashboardBuildEnqueuer
 from .services.dashboard.publisher import DashboardPublisher
 from .services.edition import EditionService
 from .services.edition_publishing import EditionPublishingService
-from .services.edition_tracking import EditionTrackingService
+from .services.edition_tracking import (
+    EditionTrackingDeps,
+    EditionTrackingService,
+)
 from .services.infrastructure import InfrastructureService
 from .services.lock_service import LockService
 from .services.organization import OrganizationService
@@ -141,9 +144,10 @@ class Factory:
         The factory always wires in a :class:`LockService` so worker
         call paths (``build_processing``) get the EDITION_UPDATE
         advisory lock around each ``set_current_build`` call. Direct
-        unit-test constructions of the service may pass ``None``.
+        unit-test constructions of the service may omit ``lock_service``
+        on the :class:`EditionTrackingDeps` dataclass.
         """
-        return EditionTrackingService(
+        deps = EditionTrackingDeps(
             edition_store=EditionStore(
                 session=self._session, logger=self._logger
             ),
@@ -155,6 +159,7 @@ class Factory:
             logger=self._logger,
             lock_service=self.create_lock_service(),
         )
+        return EditionTrackingService(deps)
 
     def create_edition_service(self) -> EditionService:
         """Create an EditionService."""

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -18,6 +18,7 @@ from .services.edition import EditionService
 from .services.edition_publishing import EditionPublishingService
 from .services.edition_tracking import EditionTrackingService
 from .services.infrastructure import InfrastructureService
+from .services.lock_service import LockService
 from .services.organization import OrganizationService
 from .services.project import ProjectService
 from .storage.build_store import BuildStore
@@ -230,6 +231,10 @@ class Factory:
             org_store=self._create_org_store(),
             logger=self._logger,
         )
+
+    def create_lock_service(self) -> LockService:
+        """Create a LockService bound to this factory's session."""
+        return LockService(session=self._session, logger=self._logger)
 
     def create_edition_publishing_service(self) -> EditionPublishingService:
         """Create an EditionPublishingService."""

--- a/src/docverse/services/edition_tracking.py
+++ b/src/docverse/services/edition_tracking.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal
 
 import structlog
@@ -46,6 +47,25 @@ _VERSION_MODES = frozenset(
 )
 
 
+@dataclass(frozen=True)
+class EditionTrackingDeps:
+    """Collaborators required by :class:`EditionTrackingService`.
+
+    ``lock_service`` is optional: when set (workers), each
+    ``set_current_build`` call is wrapped in an EDITION_UPDATE advisory
+    lock so it serializes against concurrent ``publish_edition`` jobs
+    and admin-triggered edition pointer changes. ``None`` for
+    non-worker call paths (unit tests, out-of-scope code paths).
+    """
+
+    edition_store: EditionStore
+    history_store: EditionBuildHistoryStore
+    project_store: ProjectStore
+    org_store: OrganizationStore
+    logger: structlog.stdlib.BoundLogger
+    lock_service: LockService | None = None
+
+
 class EditionTrackingService:
     """Orchestrate edition tracking when a build completes.
 
@@ -54,25 +74,8 @@ class EditionTrackingService:
     stale-build guard), and records build history.
     """
 
-    def __init__(  # noqa: PLR0913
-        self,
-        edition_store: EditionStore,
-        history_store: EditionBuildHistoryStore,
-        project_store: ProjectStore,
-        org_store: OrganizationStore,
-        logger: structlog.stdlib.BoundLogger,
-        lock_service: LockService | None = None,
-    ) -> None:
-        self._edition_store = edition_store
-        self._history_store = history_store
-        self._project_store = project_store
-        self._org_store = org_store
-        self._logger = logger
-        # Optional: when set (workers), each set_current_build call is
-        # wrapped in an EDITION_UPDATE advisory lock so it serializes
-        # against concurrent publish_edition jobs and admin-triggered
-        # edition pointer changes. None for non-worker call paths.
-        self._lock_service = lock_service
+    def __init__(self, deps: EditionTrackingDeps) -> None:
+        self._deps = deps
 
     async def track_build(self, build: Build) -> EditionTrackingResult:
         """Evaluate tracking rules for a completed build.
@@ -94,7 +97,7 @@ class EditionTrackingService:
             (data integrity violation).
         """
         # 1. Load project
-        project = await self._project_store.get_by_id(build.project_id)
+        project = await self._deps.project_store.get_by_id(build.project_id)
         if project is None:
             msg = (
                 f"Project id={build.project_id} not found"
@@ -103,7 +106,7 @@ class EditionTrackingService:
             raise RuntimeError(msg)
 
         # 2. Load org
-        org = await self._org_store.get_by_id(project.org_id)
+        org = await self._deps.org_store.get_by_id(project.org_id)
         if org is None:
             msg = (
                 f"Organization id={project.org_id} not found"
@@ -121,7 +124,7 @@ class EditionTrackingService:
                 build.git_ref, rules, alternate_name=build.alternate_name
             )
         except InvalidSlugError as exc:
-            self._logger.warning(
+            self._deps.logger.warning(
                 "Invalid slug derived from git ref",
                 git_ref=build.git_ref,
                 error=str(exc),
@@ -131,7 +134,7 @@ class EditionTrackingService:
             return EditionTrackingResult(derived_slug=None, suppressed=False)
 
         if derivation is None:
-            self._logger.info(
+            self._deps.logger.info(
                 "Git ref suppressed by ignore rule",
                 git_ref=build.git_ref,
                 build_id=build.id,
@@ -139,7 +142,7 @@ class EditionTrackingService:
             )
             return EditionTrackingResult(derived_slug=None, suppressed=True)
 
-        self._logger.info(
+        self._deps.logger.info(
             "Derived edition slug",
             slug=derivation.slug,
             edition_kind=derivation.edition_kind,
@@ -149,7 +152,7 @@ class EditionTrackingService:
         )
 
         # 5. Find matching editions (includes version-based modes)
-        editions = await self._edition_store.find_matching_editions(
+        editions = await self._deps.edition_store.find_matching_editions(
             project_id=project.id,
             git_ref=build.git_ref,
             alternate_name=build.alternate_name,
@@ -225,7 +228,7 @@ class EditionTrackingService:
     ) -> EditionTrackingOutcome:
         """Attempt to update a single edition's build pointer."""
         if not self._should_update(edition, build):
-            self._logger.info(
+            self._deps.logger.info(
                 "Version guard skipped edition",
                 edition_slug=edition.slug,
                 edition_id=edition.id,
@@ -252,7 +255,7 @@ class EditionTrackingService:
             skip_date_guard=skip_date_guard,
         )
         if updated is None:
-            self._logger.info(
+            self._deps.logger.info(
                 "Stale build skipped for edition",
                 edition_slug=edition.slug,
                 edition_id=edition.id,
@@ -274,17 +277,17 @@ class EditionTrackingService:
             and updated.alternate_name is None
             and build.alternate_name is not None
         ):
-            await self._edition_store.set_alternate_name(
+            await self._deps.edition_store.set_alternate_name(
                 edition_id=updated.id, alternate_name=build.alternate_name
             )
 
-        await self._history_store.record(
+        await self._deps.history_store.record(
             edition_id=edition.id, build_id=build.id
         )
         action: Literal["updated", "created"] = (
             "created" if auto_created else "updated"
         )
-        self._logger.info(
+        self._deps.logger.info(
             "Edition pointer updated",
             edition_slug=edition.slug,
             edition_id=edition.id,
@@ -309,15 +312,15 @@ class EditionTrackingService:
     ) -> Edition | None:
         """Update the edition pointer under an EDITION_UPDATE lock.
 
-        When ``self._lock_service`` is configured (worker call paths),
+        When ``self._deps.lock_service`` is configured (worker call paths),
         the call serializes against concurrent ``publish_edition`` jobs
         and admin-triggered edition pointer changes for the same
         edition. With no lock service (unit-test call paths), the
         update runs unwrapped — non-worker callers are explicitly
         out of scope per the design (SQR-112).
         """
-        if self._lock_service is None:
-            return await self._edition_store.set_current_build(
+        if self._deps.lock_service is None:
+            return await self._deps.edition_store.set_current_build(
                 edition_id=edition_id,
                 build_id=build_id,
                 skip_date_guard=skip_date_guard,
@@ -327,8 +330,8 @@ class EditionTrackingService:
             project_id=project_id,
             edition_id=edition_id,
         )
-        async with self._lock_service.acquire(lock_key):
-            return await self._edition_store.set_current_build(
+        async with self._deps.lock_service.acquire(lock_key):
+            return await self._deps.edition_store.set_current_build(
                 edition_id=edition_id,
                 build_id=build_id,
                 skip_date_guard=skip_date_guard,
@@ -424,18 +427,18 @@ class EditionTrackingService:
         the existing edition is returned instead.
         """
         # Race guard: check if another worker already created it
-        existing = await self._edition_store.get_by_slug(
+        existing = await self._deps.edition_store.get_by_slug(
             project_id=project_id, slug=derivation.slug
         )
         if existing is not None:
-            self._logger.info(
+            self._deps.logger.info(
                 "Edition already exists, skipping auto-create",
                 slug=derivation.slug,
                 project_id=project_id,
             )
             return existing
 
-        edition = await self._edition_store.create_internal(
+        edition = await self._deps.edition_store.create_internal(
             project_id=project_id,
             slug=derivation.slug,
             title=derivation.slug,
@@ -444,7 +447,7 @@ class EditionTrackingService:
             tracking_params=derivation.tracking_params,
             alternate_name=derivation.tracking_params.get("alternate_name"),
         )
-        self._logger.info(
+        self._deps.logger.info(
             "Auto-created edition",
             slug=edition.slug,
             kind=edition.kind,
@@ -476,11 +479,11 @@ class EditionTrackingService:
 
         # --- semver_major ---
         major_slug = str(sv.major)
-        major_edition = await self._edition_store.get_by_slug(
+        major_edition = await self._deps.edition_store.get_by_slug(
             project_id=project_id, slug=major_slug
         )
         if major_edition is None:
-            major_edition = await self._edition_store.create_internal(
+            major_edition = await self._deps.edition_store.create_internal(
                 project_id=project_id,
                 slug=major_slug,
                 title=f"Latest {sv.major}.x",
@@ -488,7 +491,7 @@ class EditionTrackingService:
                 tracking_mode=TrackingMode.semver_major,
                 tracking_params={"major_version": sv.major},
             )
-            self._logger.info(
+            self._deps.logger.info(
                 "Auto-created semver_major edition",
                 slug=major_slug,
                 project_id=project_id,
@@ -500,11 +503,11 @@ class EditionTrackingService:
 
         # --- semver_minor ---
         minor_slug = f"{sv.major}.{sv.minor}"
-        minor_edition = await self._edition_store.get_by_slug(
+        minor_edition = await self._deps.edition_store.get_by_slug(
             project_id=project_id, slug=minor_slug
         )
         if minor_edition is None:
-            minor_edition = await self._edition_store.create_internal(
+            minor_edition = await self._deps.edition_store.create_internal(
                 project_id=project_id,
                 slug=minor_slug,
                 title=f"Latest {sv.major}.{sv.minor}.x",
@@ -515,7 +518,7 @@ class EditionTrackingService:
                     "minor_version": sv.minor,
                 },
             )
-            self._logger.info(
+            self._deps.logger.info(
                 "Auto-created semver_minor edition",
                 slug=minor_slug,
                 project_id=project_id,

--- a/src/docverse/services/edition_tracking.py
+++ b/src/docverse/services/edition_tracking.py
@@ -24,6 +24,7 @@ from docverse.domain.version import (
     SemverVersion,
     parse_version_for_mode,
 )
+from docverse.services.lock_service import LockKey, LockService
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
 )
@@ -53,19 +54,25 @@ class EditionTrackingService:
     stale-build guard), and records build history.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         edition_store: EditionStore,
         history_store: EditionBuildHistoryStore,
         project_store: ProjectStore,
         org_store: OrganizationStore,
         logger: structlog.stdlib.BoundLogger,
+        lock_service: LockService | None = None,
     ) -> None:
         self._edition_store = edition_store
         self._history_store = history_store
         self._project_store = project_store
         self._org_store = org_store
         self._logger = logger
+        # Optional: when set (workers), each set_current_build call is
+        # wrapped in an EDITION_UPDATE advisory lock so it serializes
+        # against concurrent publish_edition jobs and admin-triggered
+        # edition pointer changes. None for non-worker call paths.
+        self._lock_service = lock_service
 
     async def track_build(self, build: Build) -> EditionTrackingResult:
         """Evaluate tracking rules for a completed build.
@@ -172,7 +179,11 @@ class EditionTrackingService:
 
         # 8. Update each edition
         outcomes = await self._update_editions(
-            editions, build, created_ids=created_ids
+            editions,
+            build,
+            created_ids=created_ids,
+            org_id=org.id,
+            project_id=project.id,
         )
 
         return EditionTrackingResult(
@@ -187,6 +198,8 @@ class EditionTrackingService:
         build: Build,
         *,
         created_ids: set[int],
+        org_id: int,
+        project_id: int,
     ) -> list[EditionTrackingOutcome]:
         """Apply build to each matched edition, returning outcomes."""
         outcomes: list[EditionTrackingOutcome] = []
@@ -195,6 +208,8 @@ class EditionTrackingService:
                 edition,
                 build,
                 auto_created=edition.id in created_ids,
+                org_id=org_id,
+                project_id=project_id,
             )
             outcomes.append(outcome)
         return outcomes
@@ -205,6 +220,8 @@ class EditionTrackingService:
         build: Build,
         *,
         auto_created: bool,
+        org_id: int,
+        project_id: int,
     ) -> EditionTrackingOutcome:
         """Attempt to update a single edition's build pointer."""
         if not self._should_update(edition, build):
@@ -227,7 +244,9 @@ class EditionTrackingService:
             and build.git_ref == "main"
             and edition.current_build_git_ref == "main"
         )
-        updated = await self._edition_store.set_current_build(
+        updated = await self._set_current_build_locked(
+            org_id=org_id,
+            project_id=project_id,
             edition_id=edition.id,
             build_id=build.id,
             skip_date_guard=skip_date_guard,
@@ -278,6 +297,42 @@ class EditionTrackingService:
             build_id=build.id,
             action=action,
         )
+
+    async def _set_current_build_locked(
+        self,
+        *,
+        org_id: int,
+        project_id: int,
+        edition_id: int,
+        build_id: int,
+        skip_date_guard: bool,
+    ) -> Edition | None:
+        """Update the edition pointer under an EDITION_UPDATE lock.
+
+        When ``self._lock_service`` is configured (worker call paths),
+        the call serializes against concurrent ``publish_edition`` jobs
+        and admin-triggered edition pointer changes for the same
+        edition. With no lock service (unit-test call paths), the
+        update runs unwrapped — non-worker callers are explicitly
+        out of scope per the design (SQR-112).
+        """
+        if self._lock_service is None:
+            return await self._edition_store.set_current_build(
+                edition_id=edition_id,
+                build_id=build_id,
+                skip_date_guard=skip_date_guard,
+            )
+        lock_key = LockKey.for_edition_update(
+            org_id=org_id,
+            project_id=project_id,
+            edition_id=edition_id,
+        )
+        async with self._lock_service.acquire(lock_key):
+            return await self._edition_store.set_current_build(
+                edition_id=edition_id,
+                build_id=build_id,
+                skip_date_guard=skip_date_guard,
+            )
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/src/docverse/services/lock_service.py
+++ b/src/docverse/services/lock_service.py
@@ -66,9 +66,7 @@ def compute_lock_id(lock_class: LockClass, **parts: Any) -> int:
         A signed 64-bit int suitable for ``pg_advisory_lock(bigint)``.
     """
     joined = "|".join(str(value) for value in parts.values())
-    digest = hashlib.blake2b(
-        joined.encode("utf-8"), digest_size=6
-    ).digest()
+    digest = hashlib.blake2b(joined.encode("utf-8"), digest_size=6).digest()
     hash_int = int.from_bytes(digest, "big")
     unsigned = (int(lock_class.value) << 48) | hash_int
     if unsigned >= (1 << 63):
@@ -165,9 +163,7 @@ class LockService:
         self._logger = logger
 
     @asynccontextmanager
-    async def acquire(
-        self, lock_key: LockKey
-    ) -> AsyncGenerator[None]:
+    async def acquire(self, lock_key: LockKey) -> AsyncGenerator[None]:
         """Acquire ``lock_key`` for the lifetime of the context block.
 
         Blocks the caller until the lock is granted via
@@ -200,7 +196,7 @@ class LockService:
                     text("SELECT pg_advisory_unlock(:lock_id)"),
                     {"lock_id": lock_key.lock_id},
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 # Unlock is best-effort: on session or connection
                 # failure the DB releases the lock when the connection
                 # closes. Log and continue so the original exception

--- a/src/docverse/services/lock_service.py
+++ b/src/docverse/services/lock_service.py
@@ -1,0 +1,219 @@
+"""Service for cross-job serialization via Postgres advisory locks.
+
+Docverse background jobs coordinate on shared resources (a project's
+builds, an edition's pointer, a project's dashboard render) using
+``pg_advisory_lock`` on a 64-bit lock id. The high 16 bits encode a
+:class:`LockClass` so a project-level lock cannot collide with an
+edition-level lock that happens to hash to the same 48-bit value; the
+low 48 bits are a ``blake2b`` digest of the resource tuple, so the id
+is deterministic across Python processes and worker replicas.
+
+See SQR-112 §Cross-job serialization for the design rationale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class LockClass(IntEnum):
+    """Advisory-lock class prefixes encoded in the high 16 bits.
+
+    Values are stable on-disk identifiers: changing them would
+    repartition the lock ID space and collide with locks held by
+    already-running workers.
+    """
+
+    BUILD_PROCESSING = 0x0000
+    EDITION_UPDATE = 0x0001
+    PROJECT = 0x0002
+
+
+def compute_lock_id(lock_class: LockClass, **parts: Any) -> int:
+    """Compute a deterministic signed 64-bit advisory-lock id.
+
+    ``parts`` values are ``|``-joined as UTF-8 and hashed with
+    ``blake2b(digest_size=6)``; the 48-bit digest is OR'd with
+    ``lock_class.value << 48`` and the resulting unsigned 64-bit value
+    is reinterpreted as a signed ``bigint`` compatible with
+    ``pg_advisory_lock``. blake2b is chosen over the built-in ``hash()``
+    because it is deterministic across interpreter restarts and worker
+    replicas.
+
+    Parts are serialized in kwargs insertion order, so callers must
+    pass them in a stable canonical order.
+
+    Parameters
+    ----------
+    lock_class
+        The class prefix to encode in the high 16 bits.
+    **parts
+        Resource-identifying fields (ints/strings) to hash into the
+        low 48 bits, in a stable canonical order.
+
+    Returns
+    -------
+    int
+        A signed 64-bit int suitable for ``pg_advisory_lock(bigint)``.
+    """
+    joined = "|".join(str(value) for value in parts.values())
+    digest = hashlib.blake2b(
+        joined.encode("utf-8"), digest_size=6
+    ).digest()
+    hash_int = int.from_bytes(digest, "big")
+    unsigned = (int(lock_class.value) << 48) | hash_int
+    if unsigned >= (1 << 63):
+        return unsigned - (1 << 64)
+    return unsigned
+
+
+@dataclass(frozen=True, slots=True)
+class LockKey:
+    """A resolved advisory-lock identifier.
+
+    Attributes
+    ----------
+    lock_class
+        The :class:`LockClass` encoded in the high 16 bits.
+    lock_id
+        The signed 64-bit id suitable for ``pg_advisory_lock(bigint)``.
+    label
+        A short human-readable label used in log messages.
+    """
+
+    lock_class: LockClass
+    lock_id: int
+    label: str
+
+    @classmethod
+    def for_build_processing(
+        cls, org_id: int, project_id: int, git_ref: str
+    ) -> LockKey:
+        """Build the lock key for a ``build_processing`` job.
+
+        Serializes builds sharing the same ``(org, project, git_ref)``.
+        """
+        lock_class = LockClass.BUILD_PROCESSING
+        lock_id = compute_lock_id(
+            lock_class,
+            org_id=org_id,
+            project_id=project_id,
+            git_ref=git_ref,
+        )
+        label = (
+            f"build_processing(org={org_id},project={project_id},"
+            f"ref={git_ref})"
+        )
+        return cls(lock_class=lock_class, lock_id=lock_id, label=label)
+
+    @classmethod
+    def for_edition_update(
+        cls, org_id: int, project_id: int, edition_id: int
+    ) -> LockKey:
+        """Build the lock key for an edition-pointer update.
+
+        Serializes updates to a single edition (the edition's pointer
+        and its per-edition metadata JSON).
+        """
+        lock_class = LockClass.EDITION_UPDATE
+        lock_id = compute_lock_id(
+            lock_class,
+            org_id=org_id,
+            project_id=project_id,
+            edition_id=edition_id,
+        )
+        label = (
+            f"edition_update(org={org_id},project={project_id},"
+            f"edition={edition_id})"
+        )
+        return cls(lock_class=lock_class, lock_id=lock_id, label=label)
+
+    @classmethod
+    def for_project(cls, org_id: int, project_id: int) -> LockKey:
+        """Build the lock key for a project-scoped job.
+
+        Serializes per-project work such as dashboard renders.
+        """
+        lock_class = LockClass.PROJECT
+        lock_id = compute_lock_id(
+            lock_class,
+            org_id=org_id,
+            project_id=project_id,
+        )
+        label = f"project(org={org_id},project={project_id})"
+        return cls(lock_class=lock_class, lock_id=lock_id, label=label)
+
+
+class LockService:
+    """Acquire and release Postgres advisory locks for a session."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._session = session
+        self._logger = logger
+
+    @asynccontextmanager
+    async def acquire(
+        self, lock_key: LockKey
+    ) -> AsyncGenerator[None]:
+        """Acquire ``lock_key`` for the lifetime of the context block.
+
+        Blocks the caller until the lock is granted via
+        ``SELECT pg_advisory_lock(:lock_id)``. On exit (normal or
+        exceptional) issues ``SELECT pg_advisory_unlock(:lock_id)``. If
+        the session's underlying connection dies before unlock runs
+        (e.g. a crashed worker), Postgres releases the lock when the
+        connection closes — session lifetime is the ultimate owner.
+        """
+        self._logger.debug(
+            "Acquiring advisory lock",
+            lock_id=lock_key.lock_id,
+            lock_label=lock_key.label,
+            lock_class=lock_key.lock_class.name,
+        )
+        await self._session.execute(
+            text("SELECT pg_advisory_lock(:lock_id)"),
+            {"lock_id": lock_key.lock_id},
+        )
+        self._logger.debug(
+            "Acquired advisory lock",
+            lock_id=lock_key.lock_id,
+            lock_label=lock_key.label,
+        )
+        try:
+            yield
+        finally:
+            try:
+                await self._session.execute(
+                    text("SELECT pg_advisory_unlock(:lock_id)"),
+                    {"lock_id": lock_key.lock_id},
+                )
+            except Exception:
+                # Unlock is best-effort: on session or connection
+                # failure the DB releases the lock when the connection
+                # closes. Log and continue so the original exception
+                # (if any) still propagates.
+                self._logger.warning(
+                    "Failed to release advisory lock",
+                    lock_id=lock_key.lock_id,
+                    lock_label=lock_key.label,
+                    exc_info=True,
+                )
+            else:
+                self._logger.debug(
+                    "Released advisory lock",
+                    lock_id=lock_key.lock_id,
+                    lock_label=lock_key.label,
+                )

--- a/src/docverse/services/lock_service.py
+++ b/src/docverse/services/lock_service.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import structlog
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 
 class LockClass(IntEnum):
@@ -168,48 +168,82 @@ class LockService:
 
         Blocks the caller until the lock is granted via
         ``SELECT pg_advisory_lock(:lock_id)``. On exit (normal or
-        exceptional) issues ``SELECT pg_advisory_unlock(:lock_id)``. If
-        the session's underlying connection dies before unlock runs
+        exceptional) issues ``SELECT pg_advisory_unlock(:lock_id)``
+        and returns the lock's connection to the pool.
+
+        The lock is held on a **dedicated** connection checked out from
+        the engine for the duration of the block, not on the caller's
+        session. This insulates the lock from the caller's pool
+        lifecycle: ``session.commit()`` inside the caller returns the
+        session's connection to the pool, and a concurrent sibling
+        session that picks up that connection would see the lock
+        re-entrantly — a silent mutex leak. With a dedicated
+        connection, the lock stays pinned for the whole block, and the
+        caller's session.begin() blocks work unmodified because
+        ``acquire`` never auto-begins on the caller's session. If the
+        dedicated connection dies before ``pg_advisory_unlock`` runs
         (e.g. a crashed worker), Postgres releases the lock when the
-        connection closes — session lifetime is the ultimate owner.
+        TCP connection closes.
         """
+        engine: AsyncEngine = self._session.bind  # type: ignore[assignment]
         self._logger.debug(
             "Acquiring advisory lock",
             lock_id=lock_key.lock_id,
             lock_label=lock_key.label,
             lock_class=lock_key.lock_class.name,
         )
-        await self._session.execute(
-            text("SELECT pg_advisory_lock(:lock_id)"),
-            {"lock_id": lock_key.lock_id},
-        )
-        self._logger.debug(
-            "Acquired advisory lock",
-            lock_id=lock_key.lock_id,
-            lock_label=lock_key.label,
-        )
-        try:
-            yield
-        finally:
+        async with engine.connect() as lock_conn:
+            await lock_conn.execute(
+                text("SELECT pg_advisory_lock(:lock_id)"),
+                {"lock_id": lock_key.lock_id},
+            )
+            # Commit the lock_conn transaction so the connection is
+            # clean for the unlock path; the advisory lock itself is
+            # connection-scoped (not transaction-scoped) so it
+            # survives the commit until unlock runs or the connection
+            # closes.
+            await lock_conn.commit()
+            self._logger.debug(
+                "Acquired advisory lock",
+                lock_id=lock_key.lock_id,
+                lock_label=lock_key.label,
+            )
             try:
-                await self._session.execute(
-                    text("SELECT pg_advisory_unlock(:lock_id)"),
-                    {"lock_id": lock_key.lock_id},
-                )
-            except Exception:  # noqa: BLE001
-                # Unlock is best-effort: on session or connection
-                # failure the DB releases the lock when the connection
-                # closes. Log and continue so the original exception
-                # (if any) still propagates.
-                self._logger.warning(
-                    "Failed to release advisory lock",
-                    lock_id=lock_key.lock_id,
-                    lock_label=lock_key.label,
-                    exc_info=True,
-                )
-            else:
-                self._logger.debug(
-                    "Released advisory lock",
-                    lock_id=lock_key.lock_id,
-                    lock_label=lock_key.label,
-                )
+                yield
+            finally:
+                try:
+                    await lock_conn.execute(
+                        text("SELECT pg_advisory_unlock(:lock_id)"),
+                        {"lock_id": lock_key.lock_id},
+                    )
+                    await lock_conn.commit()
+                except Exception:
+                    # A stuck unlock leaks the lock onto this pooled
+                    # connection; invalidate so the pool discards it
+                    # and the DB releases the lock on close. Raising
+                    # ``error`` (not ``warning``) because every
+                    # subsequent job on this key is blocked until the
+                    # connection is actually closed. The original
+                    # exception from the lock body (if any) still
+                    # propagates because this branch swallows only
+                    # the unlock failure.
+                    self._logger.exception(
+                        "Failed to release advisory lock",
+                        lock_id=lock_key.lock_id,
+                        lock_label=lock_key.label,
+                    )
+                    try:
+                        await lock_conn.invalidate()
+                    except Exception:  # noqa: BLE001
+                        self._logger.warning(
+                            "Failed to invalidate stuck lock connection",
+                            lock_id=lock_key.lock_id,
+                            lock_label=lock_key.label,
+                            exc_info=True,
+                        )
+                else:
+                    self._logger.debug(
+                        "Released advisory lock",
+                        lock_id=lock_key.lock_id,
+                        lock_label=lock_key.label,
+                    )

--- a/src/docverse/services/lock_service.py
+++ b/src/docverse/services/lock_service.py
@@ -101,6 +101,7 @@ class LockKey:
         Serializes builds sharing the same ``(org, project, git_ref)``.
         """
         lock_class = LockClass.BUILD_PROCESSING
+        # kwarg order is load-bearing; do not reorder (see compute_lock_id).
         lock_id = compute_lock_id(
             lock_class,
             org_id=org_id,
@@ -123,6 +124,7 @@ class LockKey:
         and its per-edition metadata JSON).
         """
         lock_class = LockClass.EDITION_UPDATE
+        # kwarg order is load-bearing; do not reorder (see compute_lock_id).
         lock_id = compute_lock_id(
             lock_class,
             org_id=org_id,
@@ -142,6 +144,7 @@ class LockKey:
         Serializes per-project work such as dashboard renders.
         """
         lock_class = LockClass.PROJECT
+        # kwarg order is load-bearing; do not reorder (see compute_lock_id).
         lock_id = compute_lock_id(
             lock_class,
             org_id=org_id,

--- a/src/docverse/storage/build_store.py
+++ b/src/docverse/storage/build_store.py
@@ -99,6 +99,25 @@ class BuildStore:
             return None
         return Build.model_validate(row)
 
+    async def get_latest_build_id_for_ref(
+        self, *, project_id: int, git_ref: str
+    ) -> int | None:
+        """Return the max build id for a ``(project_id, git_ref)`` pair.
+
+        Used by the ``build_processing`` stale-build guard: a job whose
+        build id is less than the latest known id for the same ref has
+        been superseded and must skip its expensive work. Includes
+        soft-deleted rows so a deletion mid-processing cannot make a
+        superseded build look current.
+        """
+        result = await self._session.execute(
+            select(func.max(SqlBuild.id)).where(
+                SqlBuild.project_id == project_id,
+                SqlBuild.git_ref == git_ref,
+            )
+        )
+        return result.scalar_one_or_none()
+
     async def list_by_project(
         self,
         project_id: int,

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -110,14 +110,6 @@ async def build_processing(  # noqa: PLR0915
             git_ref=build.git_ref,
         )
         async with lock_service.acquire(lock_key):
-            # The pg_advisory_lock SELECT auto-began a transaction on
-            # the session; commit it so the explicit session.begin()
-            # blocks below don't trip "transaction already begun".
-            # The advisory lock is connection-scoped so it survives
-            # the commit until pg_advisory_unlock runs (or the worker
-            # connection closes).
-            await session.commit()
-
             # Stale-build guard runs *inside* the lock so two
             # concurrent supersession checks cannot race: only the
             # newest build for (project, git_ref) does any work; any

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -121,6 +121,10 @@ async def build_processing(  # noqa: PLR0915
                         git_ref=build.git_ref,
                     )
                 )
+            # A newer build landing between this read and _mark_stale_skipped
+            # is benign: the BUILD_PROCESSING lock serializes supersession
+            # checks, so the newer build's own check will discard this
+            # build's "stale" verdict and proceed correctly.
             if latest_build_id is not None and latest_build_id != build_id:
                 await _mark_stale_skipped(
                     session=session,

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -48,7 +48,7 @@ _UPLOAD_CONCURRENCY = 50
 config = Configuration()
 
 
-async def build_processing(  # noqa: PLR0915
+async def build_processing(
     ctx: dict[str, Any], payload: dict[str, Any]
 ) -> str:
     """Process a build: download tarball, unpack, upload files.
@@ -110,98 +110,157 @@ async def build_processing(  # noqa: PLR0915
             git_ref=build.git_ref,
         )
         async with lock_service.acquire(lock_key):
-            # Stale-build guard runs *inside* the lock so two
-            # concurrent supersession checks cannot race: only the
-            # newest build for (project, git_ref) does any work; any
-            # older build observes a higher latest id and skips.
-            async with session.begin():
-                latest_build_id = (
-                    await build_store.get_latest_build_id_for_ref(
-                        project_id=build.project_id,
-                        git_ref=build.git_ref,
-                    )
-                )
-            # A newer build landing between this read and _mark_stale_skipped
-            # is benign: the BUILD_PROCESSING lock serializes supersession
-            # checks, so the newer build's own check will discard this
-            # build's "stale" verdict and proceed correctly.
-            if latest_build_id is not None and latest_build_id != build_id:
-                await _mark_stale_skipped(
-                    session=session,
-                    ctx=ctx,
-                    queue_job_store=queue_job_store,
-                    build_id=build_id,
-                    latest_build_id=latest_build_id,
-                    logger=logger,
-                )
+            if await _guard_stale_build(
+                session=session,
+                ctx=ctx,
+                build_store=build_store,
+                queue_job_store=queue_job_store,
+                build=build,
+                build_id=build_id,
+                logger=logger,
+            ):
                 return "completed"
-
-            # Phase 1: Load metadata and mark QueueJob as in_progress
-            async with session.begin():
-                org = await org_store.get_by_id(org_id)
-                if org is None:
-                    msg = f"Organization {org_id} not found"
-                    raise NotFoundError(msg)
-
-                service_label = org.resolved_staging_store_label
-                if service_label is None:
-                    msg = (
-                        f"No object store service configured for org {org_id}"
-                    )
-                    raise RuntimeError(msg)
-
-                object_store = await factory.create_objectstore_for_org(
-                    org_id=org_id, service_label=service_label
-                )
-
-                queue_job_id = await _start_queue_job(ctx, queue_job_store)
-                if queue_job_id is not None:
-                    await queue_job_store.update_phase(
-                        queue_job_id,
-                        "unpacking",
-                        progress={
-                            "message": "Unpacking build into object store",
-                        },
-                    )
-
-            # Phase 2: Upload files and mark build complete
-            try:
-                async with object_store, session.begin():
-                    object_count, total_size_bytes = await _process_build(
-                        object_store=object_store,
-                        build=build,
-                        build_store=build_store,
-                        logger=logger,
-                    )
-            except Exception:
-                # Phase 3a: Mark build and queue job as failed
-                logger.exception("Build processing failed")
-                async with session.begin():
-                    build_service = factory.create_build_service()
-                    await build_service.fail(build_id=build_id)
-                    if queue_job_id is not None:
-                        await queue_job_store.fail(queue_job_id)
-                return "failed"
-            else:
-                await _finalize_success(
-                    session=session,
-                    factory=factory,
-                    build_store=build_store,
-                    queue_job_store=queue_job_store,
-                    org_id=org_id,
-                    project_id=build.project_id,
-                    project_slug=project_slug,
-                    build_id=build_id,
-                    build_public_id=build_public_id,
-                    queue_job_id=queue_job_id,
-                    object_count=object_count,
-                    total_size_bytes=total_size_bytes,
-                    logger=logger,
-                )
-                return "completed"
+            return await _process_build_locked(
+                session=session,
+                factory=factory,
+                build_store=build_store,
+                org_store=org_store,
+                queue_job_store=queue_job_store,
+                ctx=ctx,
+                build=build,
+                org_id=org_id,
+                project_slug=project_slug,
+                build_id=build_id,
+                build_public_id=build_public_id,
+                logger=logger,
+            )
 
     msg = "No database session available"
     raise RuntimeError(msg)
+
+
+async def _guard_stale_build(  # noqa: PLR0913
+    *,
+    session: AsyncSession,
+    ctx: dict[str, Any],
+    build_store: BuildStore,
+    queue_job_store: QueueJobStore,
+    build: Build,
+    build_id: int,
+    logger: structlog.stdlib.BoundLogger,
+) -> bool:
+    """Skip and mark stale if a newer build exists for ``(project, git_ref)``.
+
+    Runs *inside* the BUILD_PROCESSING lock so two concurrent supersession
+    checks cannot race: only the newest build for ``(project, git_ref)``
+    does any work; any older build observes a higher latest id and skips.
+
+    Returns ``True`` when this build was marked stale-skipped and the
+    caller should return ``"completed"`` immediately.
+    """
+    async with session.begin():
+        latest_build_id = await build_store.get_latest_build_id_for_ref(
+            project_id=build.project_id,
+            git_ref=build.git_ref,
+        )
+    # A newer build landing between this read and _mark_stale_skipped
+    # is benign: the BUILD_PROCESSING lock serializes supersession
+    # checks, so the newer build's own check will discard this
+    # build's "stale" verdict and proceed correctly.
+    if latest_build_id is not None and latest_build_id != build_id:
+        await _mark_stale_skipped(
+            session=session,
+            ctx=ctx,
+            queue_job_store=queue_job_store,
+            build_id=build_id,
+            latest_build_id=latest_build_id,
+            logger=logger,
+        )
+        return True
+    return False
+
+
+async def _process_build_locked(  # noqa: PLR0913
+    *,
+    session: AsyncSession,
+    factory: Factory,
+    build_store: BuildStore,
+    org_store: OrganizationStore,
+    queue_job_store: QueueJobStore,
+    ctx: dict[str, Any],
+    build: Build,
+    org_id: int,
+    project_slug: str,
+    build_id: int,
+    build_public_id: str,
+    logger: structlog.stdlib.BoundLogger,
+) -> str:
+    """Unpack, upload, and finalize a non-stale build under the lock.
+
+    Assumes the caller holds the BUILD_PROCESSING advisory lock and has
+    already confirmed this build is the latest for ``(project, git_ref)``.
+    """
+    # Phase 1: Load metadata and mark QueueJob as in_progress
+    async with session.begin():
+        org = await org_store.get_by_id(org_id)
+        if org is None:
+            msg = f"Organization {org_id} not found"
+            raise NotFoundError(msg)
+
+        service_label = org.resolved_staging_store_label
+        if service_label is None:
+            msg = f"No object store service configured for org {org_id}"
+            raise RuntimeError(msg)
+
+        object_store = await factory.create_objectstore_for_org(
+            org_id=org_id, service_label=service_label
+        )
+
+        queue_job_id = await _start_queue_job(ctx, queue_job_store)
+        if queue_job_id is not None:
+            await queue_job_store.update_phase(
+                queue_job_id,
+                "unpacking",
+                progress={
+                    "message": "Unpacking build into object store",
+                },
+            )
+
+    # Phase 2: Upload files and mark build complete
+    try:
+        async with object_store, session.begin():
+            object_count, total_size_bytes = await _process_build(
+                object_store=object_store,
+                build=build,
+                build_store=build_store,
+                logger=logger,
+            )
+    except Exception:
+        # Phase 3a: Mark build and queue job as failed
+        logger.exception("Build processing failed")
+        async with session.begin():
+            build_service = factory.create_build_service()
+            await build_service.fail(build_id=build_id)
+            if queue_job_id is not None:
+                await queue_job_store.fail(queue_job_id)
+        return "failed"
+    else:
+        await _finalize_success(
+            session=session,
+            factory=factory,
+            build_store=build_store,
+            queue_job_store=queue_job_store,
+            org_id=org_id,
+            project_id=build.project_id,
+            project_slug=project_slug,
+            build_id=build_id,
+            build_public_id=build_public_id,
+            queue_job_id=queue_job_id,
+            object_count=object_count,
+            total_size_bytes=total_size_bytes,
+            logger=logger,
+        )
+        return "completed"
 
 
 async def _mark_stale_skipped(  # noqa: PLR0913

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -32,6 +32,7 @@ from docverse.domain.edition_tracking import (
 from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
+from docverse.services.lock_service import LockKey
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -47,7 +48,7 @@ _UPLOAD_CONCURRENCY = 50
 config = Configuration()
 
 
-async def build_processing(
+async def build_processing(  # noqa: PLR0915
     ctx: dict[str, Any], payload: dict[str, Any]
 ) -> str:
     """Process a build: download tarball, unpack, upload files.
@@ -92,76 +93,158 @@ async def build_processing(
         build_store = BuildStore(session=session, logger=logger)
         org_store = OrganizationStore(session=session, logger=logger)
         queue_job_store = QueueJobStore(session=session, logger=logger)
+        lock_service = factory.create_lock_service()
 
-        # Phase 1: Load metadata and mark QueueJob as in_progress
+        # Pre-lock: load just enough build metadata to compute the
+        # BUILD_PROCESSING lock key. Acquired below before any tarball
+        # work so two jobs sharing (project, git_ref) serialize.
         async with session.begin():
             build = await build_store.get_by_id(build_id)
             if build is None:
                 msg = f"Build {build_id} not found"
                 raise NotFoundError(msg)
 
-            org = await org_store.get_by_id(org_id)
-            if org is None:
-                msg = f"Organization {org_id} not found"
-                raise NotFoundError(msg)
+        lock_key = LockKey.for_build_processing(
+            org_id=org_id,
+            project_id=build.project_id,
+            git_ref=build.git_ref,
+        )
+        async with lock_service.acquire(lock_key):
+            # The pg_advisory_lock SELECT auto-began a transaction on
+            # the session; commit it so the explicit session.begin()
+            # blocks below don't trip "transaction already begun".
+            # The advisory lock is connection-scoped so it survives
+            # the commit until pg_advisory_unlock runs (or the worker
+            # connection closes).
+            await session.commit()
 
-            service_label = org.resolved_staging_store_label
-            if service_label is None:
-                msg = f"No object store service configured for org {org_id}"
-                raise RuntimeError(msg)
-
-            object_store = await factory.create_objectstore_for_org(
-                org_id=org_id, service_label=service_label
-            )
-
-            queue_job_id = await _start_queue_job(ctx, queue_job_store)
-            if queue_job_id is not None:
-                await queue_job_store.update_phase(
-                    queue_job_id,
-                    "unpacking",
-                    progress={
-                        "message": "Unpacking build into object store",
-                    },
+            # Stale-build guard runs *inside* the lock so two
+            # concurrent supersession checks cannot race: only the
+            # newest build for (project, git_ref) does any work; any
+            # older build observes a higher latest id and skips.
+            async with session.begin():
+                latest_build_id = (
+                    await build_store.get_latest_build_id_for_ref(
+                        project_id=build.project_id,
+                        git_ref=build.git_ref,
+                    )
                 )
-
-        # Phase 2: Upload files and mark build complete
-        try:
-            async with object_store, session.begin():
-                object_count, total_size_bytes = await _process_build(
-                    object_store=object_store,
-                    build=build,
-                    build_store=build_store,
+            if latest_build_id is not None and latest_build_id != build_id:
+                await _mark_stale_skipped(
+                    session=session,
+                    ctx=ctx,
+                    queue_job_store=queue_job_store,
+                    build_id=build_id,
+                    latest_build_id=latest_build_id,
                     logger=logger,
                 )
-        except Exception:
-            # Phase 3a: Mark build and queue job as failed
-            logger.exception("Build processing failed")
+                return "completed"
+
+            # Phase 1: Load metadata and mark QueueJob as in_progress
             async with session.begin():
-                build_service = factory.create_build_service()
-                await build_service.fail(build_id=build_id)
+                org = await org_store.get_by_id(org_id)
+                if org is None:
+                    msg = f"Organization {org_id} not found"
+                    raise NotFoundError(msg)
+
+                service_label = org.resolved_staging_store_label
+                if service_label is None:
+                    msg = (
+                        f"No object store service configured for org {org_id}"
+                    )
+                    raise RuntimeError(msg)
+
+                object_store = await factory.create_objectstore_for_org(
+                    org_id=org_id, service_label=service_label
+                )
+
+                queue_job_id = await _start_queue_job(ctx, queue_job_store)
                 if queue_job_id is not None:
-                    await queue_job_store.fail(queue_job_id)
-            return "failed"
-        else:
-            await _finalize_success(
-                session=session,
-                factory=factory,
-                build_store=build_store,
-                queue_job_store=queue_job_store,
-                org_id=org_id,
-                project_id=build.project_id,
-                project_slug=project_slug,
-                build_id=build_id,
-                build_public_id=build_public_id,
-                queue_job_id=queue_job_id,
-                object_count=object_count,
-                total_size_bytes=total_size_bytes,
-                logger=logger,
-            )
-            return "completed"
+                    await queue_job_store.update_phase(
+                        queue_job_id,
+                        "unpacking",
+                        progress={
+                            "message": "Unpacking build into object store",
+                        },
+                    )
+
+            # Phase 2: Upload files and mark build complete
+            try:
+                async with object_store, session.begin():
+                    object_count, total_size_bytes = await _process_build(
+                        object_store=object_store,
+                        build=build,
+                        build_store=build_store,
+                        logger=logger,
+                    )
+            except Exception:
+                # Phase 3a: Mark build and queue job as failed
+                logger.exception("Build processing failed")
+                async with session.begin():
+                    build_service = factory.create_build_service()
+                    await build_service.fail(build_id=build_id)
+                    if queue_job_id is not None:
+                        await queue_job_store.fail(queue_job_id)
+                return "failed"
+            else:
+                await _finalize_success(
+                    session=session,
+                    factory=factory,
+                    build_store=build_store,
+                    queue_job_store=queue_job_store,
+                    org_id=org_id,
+                    project_id=build.project_id,
+                    project_slug=project_slug,
+                    build_id=build_id,
+                    build_public_id=build_public_id,
+                    queue_job_id=queue_job_id,
+                    object_count=object_count,
+                    total_size_bytes=total_size_bytes,
+                    logger=logger,
+                )
+                return "completed"
 
     msg = "No database session available"
     raise RuntimeError(msg)
+
+
+async def _mark_stale_skipped(  # noqa: PLR0913
+    *,
+    session: AsyncSession,
+    ctx: dict[str, Any],
+    queue_job_store: QueueJobStore,
+    build_id: int,
+    latest_build_id: int,
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    """Mark a superseded build's QueueJob complete with a stale-skip flag.
+
+    Operators identify these runs by ``progress["stale_skipped"]`` plus
+    the dedicated log line; the QueueJob status stays ``completed``
+    because nothing was wrong with the build itself — a newer build
+    for the same ``(project, git_ref)`` simply took over.
+    """
+    logger.info(
+        "Stale build skipped",
+        build_id=build_id,
+        latest_build_id=latest_build_id,
+    )
+    async with session.begin():
+        queue_job_id = await _start_queue_job(ctx, queue_job_store)
+        if queue_job_id is not None:
+            await queue_job_store.update_phase(
+                queue_job_id,
+                "complete",
+                progress={
+                    "message": (
+                        "Stale build skipped; superseded by "
+                        f"build id {latest_build_id}"
+                    ),
+                    "stale_skipped": True,
+                    "latest_build_id": latest_build_id,
+                },
+            )
+            await queue_job_store.complete(queue_job_id)
 
 
 async def _start_queue_job(

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -20,6 +20,7 @@ from docverse.config import Configuration
 from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
+from docverse.services.lock_service import LockKey
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.queue_job_store import QueueJobStore
 
@@ -68,79 +69,91 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
         )
         queue_job_store = QueueJobStore(session=session, logger=logger)
         org_store = OrganizationStore(session=session, logger=logger)
+        lock_service = factory.create_lock_service()
 
-        async with session.begin():
-            await queue_job_store.start(queue_job_id)
-            await queue_job_store.update_phase(
-                queue_job_id,
-                "rendering",
-                progress={"message": "Rendering dashboard artifacts"},
-            )
+        lock_key = LockKey.for_project(org_id=org_id, project_id=project_id)
+        async with lock_service.acquire(lock_key):
+            # The pg_advisory_lock SELECT auto-began a transaction on
+            # the session; commit it so the explicit session.begin()
+            # blocks below don't trip "transaction already begun".
+            # The advisory lock is connection-scoped so it survives
+            # the commit until pg_advisory_unlock runs (or the worker
+            # connection closes).
+            await session.commit()
 
-        try:
             async with session.begin():
-                org = await org_store.get_by_id(org_id)
-                if org is None:
-                    msg = f"Organization {org_id} not found"
-                    raise NotFoundError(msg)  # noqa: TRY301
-                service_label = org.resolved_staging_store_label
-                if service_label is None:
-                    msg = (
-                        f"No object store service configured for org {org_id}"
-                    )
-                    raise RuntimeError(msg)  # noqa: TRY301
+                await queue_job_store.start(queue_job_id)
+                await queue_job_store.update_phase(
+                    queue_job_id,
+                    "rendering",
+                    progress={"message": "Rendering dashboard artifacts"},
+                )
 
-                publisher = factory.create_dashboard_publisher()
-                rendered_at = datetime.now(tz=UTC)
-                context = await publisher.build_context(
-                    org_id=org_id,
-                    project_id=project_id,
-                    rendered_at=rendered_at,
-                )
-                object_store = await factory.create_objectstore_for_org(
-                    org_id=org_id, service_label=service_label
-                )
+            try:
+                async with session.begin():
+                    org = await org_store.get_by_id(org_id)
+                    if org is None:
+                        msg = f"Organization {org_id} not found"
+                        raise NotFoundError(msg)  # noqa: TRY301
+                    service_label = org.resolved_staging_store_label
+                    if service_label is None:
+                        msg = (
+                            f"No object store service configured for "
+                            f"org {org_id}"
+                        )
+                        raise RuntimeError(msg)  # noqa: TRY301
+
+                    publisher = factory.create_dashboard_publisher()
+                    rendered_at = datetime.now(tz=UTC)
+                    context = await publisher.build_context(
+                        org_id=org_id,
+                        project_id=project_id,
+                        rendered_at=rendered_at,
+                    )
+                    object_store = await factory.create_objectstore_for_org(
+                        org_id=org_id, service_label=service_label
+                    )
+
+                async with session.begin():
+                    await queue_job_store.update_phase(
+                        queue_job_id,
+                        "uploading",
+                        progress={
+                            "message": "Uploading dashboard artifacts",
+                            "object_count": 0,
+                        },
+                    )
+                async with object_store:
+                    progress = await publisher.render_and_upload(
+                        context=context, object_store=object_store
+                    )
+            except Exception as exc:
+                logger.exception("Dashboard build failed")
+                async with session.begin():
+                    await queue_job_store.fail(
+                        queue_job_id,
+                        errors={
+                            "message": str(exc),
+                            "type": type(exc).__name__,
+                            "traceback": traceback.format_exc(),
+                        },
+                    )
+                return "failed"
 
             async with session.begin():
                 await queue_job_store.update_phase(
                     queue_job_id,
-                    "uploading",
+                    "complete",
                     progress={
-                        "message": "Uploading dashboard artifacts",
-                        "object_count": 0,
+                        "message": "Dashboard build complete",
+                        "object_count": progress.object_count,
+                        "total_size_bytes": progress.total_size_bytes,
+                        "rendered_at": context.rendered_at.isoformat(),
                     },
                 )
-            async with object_store:
-                progress = await publisher.render_and_upload(
-                    context=context, object_store=object_store
-                )
-        except Exception as exc:
-            logger.exception("Dashboard build failed")
-            async with session.begin():
-                await queue_job_store.fail(
-                    queue_job_id,
-                    errors={
-                        "message": str(exc),
-                        "type": type(exc).__name__,
-                        "traceback": traceback.format_exc(),
-                    },
-                )
-            return "failed"
-
-        async with session.begin():
-            await queue_job_store.update_phase(
-                queue_job_id,
-                "complete",
-                progress={
-                    "message": "Dashboard build complete",
-                    "object_count": progress.object_count,
-                    "total_size_bytes": progress.total_size_bytes,
-                    "rendered_at": context.rendered_at.isoformat(),
-                },
-            )
-            await queue_job_store.complete(queue_job_id)
-        logger.info("Dashboard build completed")
-        return "completed"
+                await queue_job_store.complete(queue_job_id)
+            logger.info("Dashboard build completed")
+            return "completed"
 
     msg = "No database session available"
     raise RuntimeError(msg)

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -73,14 +73,6 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
 
         lock_key = LockKey.for_project(org_id=org_id, project_id=project_id)
         async with lock_service.acquire(lock_key):
-            # The pg_advisory_lock SELECT auto-began a transaction on
-            # the session; commit it so the explicit session.begin()
-            # blocks below don't trip "transaction already begun".
-            # The advisory lock is connection-scoped so it survives
-            # the commit until pg_advisory_unlock runs (or the worker
-            # connection closes).
-            await session.commit()
-
             async with session.begin():
                 await queue_job_store.start(queue_job_id)
                 await queue_job_store.update_phase(

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -117,14 +117,6 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
             edition_id=payload["edition_id"],
         )
         async with lock_service.acquire(lock_key):
-            # The pg_advisory_lock SELECT auto-began a transaction on
-            # the session; commit it so the explicit session.begin()
-            # blocks below don't trip "transaction already begun".
-            # The advisory lock is connection-scoped so it survives
-            # the commit until pg_advisory_unlock runs (or the worker
-            # connection closes).
-            await session.commit()
-
             async with session.begin():
                 resources = await _load_resources(
                     session=session, logger=logger, payload=payload

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -29,6 +29,7 @@ from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_id,
 )
+from docverse.services.lock_service import LockKey
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -92,51 +93,82 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
             session=session, logger=logger
         )
         queue_job_store = QueueJobStore(session=session, logger=logger)
+        project_store = ProjectStore(session=session, logger=logger)
+        lock_service = factory.create_lock_service()
 
+        # Pre-lock: resolve project_id from the payload's project_slug so
+        # the EDITION_UPDATE lock key can be computed. The arq payload
+        # carries project_slug rather than project_id, so a small SELECT
+        # is required before the lock is acquired.
         async with session.begin():
-            resources = await _load_resources(
-                session=session, logger=logger, payload=payload
+            project = await project_store.get_by_slug(
+                org_id=payload["org_id"], slug=payload["project_slug"]
             )
-            await _mark_publishing(
-                queue_job_store=queue_job_store,
-                edition_store=edition_store,
-                history_store=history_store,
-                resources=resources,
-                queue_job_id=queue_job_id,
-            )
-
-        try:
-            async with session.begin():
-                await factory.create_edition_publishing_service().publish(
-                    org_id=payload["org_id"],
-                    project_slug=payload["project_slug"],
-                    edition=resources.edition,
-                    build=resources.build,
-                    history_entry=resources.history_entry,
+            if project is None:
+                msg = (
+                    f"Project {payload['project_slug']!r} not found "
+                    f"for org {payload['org_id']}"
                 )
-        except Exception as exc:
-            logger.exception("Edition publish failed")
+                raise NotFoundError(msg)
+
+        lock_key = LockKey.for_edition_update(
+            org_id=payload["org_id"],
+            project_id=project.id,
+            edition_id=payload["edition_id"],
+        )
+        async with lock_service.acquire(lock_key):
+            # The pg_advisory_lock SELECT auto-began a transaction on
+            # the session; commit it so the explicit session.begin()
+            # blocks below don't trip "transaction already begun".
+            # The advisory lock is connection-scoped so it survives
+            # the commit until pg_advisory_unlock runs (or the worker
+            # connection closes).
+            await session.commit()
+
             async with session.begin():
-                await _mark_failed(
+                resources = await _load_resources(
+                    session=session, logger=logger, payload=payload
+                )
+                await _mark_publishing(
+                    queue_job_store=queue_job_store,
                     edition_store=edition_store,
                     history_store=history_store,
-                    queue_job_store=queue_job_store,
                     resources=resources,
                     queue_job_id=queue_job_id,
-                    exc=exc,
                 )
-            return "failed"
-        async with session.begin():
-            await queue_job_store.complete(queue_job_id)
-        logger.info("Edition publish completed")
-        await try_enqueue_dashboard_build_by_id(
-            factory=factory,
-            session=session,
-            logger=logger,
-            org_id=payload["org_id"],
-            project_id=resources.edition.project_id,
-        )
-        return "completed"
+
+            try:
+                async with session.begin():
+                    await factory.create_edition_publishing_service().publish(
+                        org_id=payload["org_id"],
+                        project_slug=payload["project_slug"],
+                        edition=resources.edition,
+                        build=resources.build,
+                        history_entry=resources.history_entry,
+                    )
+            except Exception as exc:
+                logger.exception("Edition publish failed")
+                async with session.begin():
+                    await _mark_failed(
+                        edition_store=edition_store,
+                        history_store=history_store,
+                        queue_job_store=queue_job_store,
+                        resources=resources,
+                        queue_job_id=queue_job_id,
+                        exc=exc,
+                    )
+                return "failed"
+            async with session.begin():
+                await queue_job_store.complete(queue_job_id)
+            logger.info("Edition publish completed")
+            await try_enqueue_dashboard_build_by_id(
+                factory=factory,
+                session=session,
+                logger=logger,
+                org_id=payload["org_id"],
+                project_id=resources.edition.project_id,
+            )
+            return "completed"
 
     msg = "No database session available"
     raise RuntimeError(msg)

--- a/tests/services/edition_tracking_test.py
+++ b/tests/services/edition_tracking_test.py
@@ -24,7 +24,10 @@ from docverse.dbschema.project import SqlProject
 from docverse.domain.build import Build
 from docverse.domain.organization import Organization
 from docverse.domain.project import Project
-from docverse.services.edition_tracking import EditionTrackingService
+from docverse.services.edition_tracking import (
+    EditionTrackingDeps,
+    EditionTrackingService,
+)
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -44,7 +47,7 @@ def _make_service(
     db_session: AsyncSession,
 ) -> EditionTrackingService:
     logger = _logger()
-    return EditionTrackingService(
+    deps = EditionTrackingDeps(
         edition_store=EditionStore(session=db_session, logger=logger),
         history_store=EditionBuildHistoryStore(
             session=db_session, logger=logger
@@ -53,6 +56,7 @@ def _make_service(
         org_store=OrganizationStore(session=db_session, logger=logger),
         logger=logger,
     )
+    return EditionTrackingService(deps)
 
 
 async def _setup(

--- a/tests/services/locks_integration_test.py
+++ b/tests/services/locks_integration_test.py
@@ -116,6 +116,34 @@ async def test_different_classes_do_not_block(
 
 
 @pytest.mark.asyncio
+async def test_connection_identity_stable_across_lock_block(
+    lock_engine: AsyncEngine,
+) -> None:
+    """The session's connection is preserved across ``acquire`` + exit.
+
+    ``acquire`` holds the advisory lock on a dedicated pooled
+    connection, not the caller's session — so the session's bookkeeping
+    must be untouched by entering, running, and exiting the lock
+    block. A regression that accidentally committed or closed the
+    session inside ``acquire`` would swap its connection and trip this
+    test.
+    """
+    maker = async_sessionmaker(lock_engine, expire_on_commit=False)
+    lock_key = LockKey.for_project(org_id=7, project_id=11)
+
+    async with maker() as session:
+        svc = LockService(session=session, logger=_logger())
+
+        conn_before = await session.connection()
+        async with svc.acquire(lock_key):
+            conn_inside = await session.connection()
+        conn_after = await session.connection()
+
+        assert id(conn_before) == id(conn_inside)
+        assert id(conn_inside) == id(conn_after)
+
+
+@pytest.mark.asyncio
 async def test_session_close_releases_lock_on_crash(
     app: FastAPI,
 ) -> None:

--- a/tests/services/locks_integration_test.py
+++ b/tests/services/locks_integration_test.py
@@ -1,0 +1,180 @@
+"""Integration tests for ``LockService`` against a real Postgres.
+
+These tests exercise ``pg_advisory_lock`` behaviour end-to-end rather
+than mocking SQL strings: two concurrent sessions against the same
+engine must serialize on the same key, run in parallel on different
+classes, and release locks when the underlying connection dies
+without a clean ``pg_advisory_unlock``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+import structlog
+from fastapi import FastAPI
+from safir.database import create_database_engine
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
+
+from docverse.config import config
+from docverse.services.lock_service import LockKey, LockService
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    logger: structlog.stdlib.BoundLogger = structlog.get_logger("docverse")
+    return logger
+
+
+@pytest_asyncio.fixture
+async def lock_engine(
+    app: FastAPI,  # noqa: ARG001
+) -> AsyncGenerator[AsyncEngine]:
+    """A dedicated engine so the test controls connection disposal.
+
+    Requests the ``app`` fixture so the database schema is initialised
+    before this engine connects. Disposed at teardown so locks from a
+    failed test never leak into another test.
+    """
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_same_lock_serializes_concurrent_sessions(
+    lock_engine: AsyncEngine,
+) -> None:
+    """Two sessions acquiring the same lock must serialize."""
+    maker = async_sessionmaker(lock_engine, expire_on_commit=False)
+    lock_key = LockKey.for_project(org_id=42, project_id=99)
+
+    async with maker() as holder_session, maker() as waiter_session:
+        holder = LockService(
+            session=holder_session, logger=_logger()
+        )
+        waiter = LockService(
+            session=waiter_session, logger=_logger()
+        )
+
+        acquired = asyncio.Event()
+        release = asyncio.Event()
+
+        async def hold() -> None:
+            async with holder.acquire(lock_key):
+                acquired.set()
+                await release.wait()
+
+        async def wait_for_lock() -> None:
+            async with waiter.acquire(lock_key):
+                pass
+
+        hold_task = asyncio.create_task(hold())
+        await asyncio.wait_for(acquired.wait(), timeout=5.0)
+
+        wait_task = asyncio.create_task(wait_for_lock())
+
+        # The waiter must block while the holder has the lock.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                asyncio.shield(wait_task), timeout=0.5
+            )
+        assert not wait_task.done()
+
+        # Releasing the holder unblocks the waiter.
+        release.set()
+        await asyncio.wait_for(hold_task, timeout=5.0)
+        await asyncio.wait_for(wait_task, timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_different_classes_do_not_block(
+    lock_engine: AsyncEngine,
+) -> None:
+    """Same ``(org, project)`` under different classes stays parallel."""
+    maker = async_sessionmaker(lock_engine, expire_on_commit=False)
+
+    project_key = LockKey.for_project(org_id=42, project_id=99)
+    build_key = LockKey.for_build_processing(
+        org_id=42, project_id=99, git_ref="main"
+    )
+
+    async with maker() as s1, maker() as s2:
+        svc1 = LockService(session=s1, logger=_logger())
+        svc2 = LockService(session=s2, logger=_logger())
+
+        # Both locks must be acquirable simultaneously without either
+        # blocking — a short timeout trips the test if they collide.
+        async with asyncio.timeout(5.0):
+            async with (
+                svc1.acquire(project_key),
+                svc2.acquire(build_key),
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_session_close_releases_lock_on_crash(
+    app: FastAPI,  # noqa: ARG001
+) -> None:
+    """Connection death releases the lock even without ``__aexit__``.
+
+    Simulates a worker crash by cancelling the task while it holds a
+    raw ``pg_advisory_lock`` — so no ``pg_advisory_unlock`` is issued
+    — and disposing the engine to close the pooled connection. A
+    fresh engine must then acquire the same lock without blocking.
+    """
+    engine_a = create_database_engine(
+        config.database_url, config.database_password
+    )
+    engine_b = create_database_engine(
+        config.database_url, config.database_password
+    )
+    maker_a = async_sessionmaker(engine_a, expire_on_commit=False)
+    maker_b = async_sessionmaker(engine_b, expire_on_commit=False)
+    lock_key = LockKey.for_project(org_id=123, project_id=456)
+
+    try:
+        acquired = asyncio.Event()
+
+        async def crashing_holder() -> None:
+            # Acquire the lock *without* going through
+            # LockService.acquire's context manager, so cancellation
+            # of this task doesn't trigger pg_advisory_unlock.
+            async with maker_a() as session:
+                await session.execute(
+                    text("SELECT pg_advisory_lock(:id)"),
+                    {"id": lock_key.lock_id},
+                )
+                acquired.set()
+                await asyncio.sleep(60.0)
+
+        task = asyncio.create_task(crashing_holder())
+        await asyncio.wait_for(acquired.wait(), timeout=5.0)
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        # Closing the pool's connections is what actually releases
+        # the lock in Postgres — the cancelled task's rollback alone
+        # does not unlock, because advisory locks are session-scoped
+        # at the connection level, not transaction-scoped.
+        await engine_a.dispose()
+
+        async with maker_b() as s2:
+            svc = LockService(session=s2, logger=_logger())
+            async with asyncio.timeout(5.0):
+                async with svc.acquire(lock_key):
+                    pass
+    finally:
+        await engine_a.dispose()
+        await engine_b.dispose()

--- a/tests/services/locks_integration_test.py
+++ b/tests/services/locks_integration_test.py
@@ -32,9 +32,9 @@ def _logger() -> structlog.stdlib.BoundLogger:
 
 @pytest_asyncio.fixture
 async def lock_engine(
-    app: FastAPI,  # noqa: ARG001
+    app: FastAPI,
 ) -> AsyncGenerator[AsyncEngine]:
-    """A dedicated engine so the test controls connection disposal.
+    """Yield a dedicated engine so the test controls connection disposal.
 
     Requests the ``app`` fixture so the database schema is initialised
     before this engine connects. Disposed at teardown so locks from a
@@ -58,12 +58,8 @@ async def test_same_lock_serializes_concurrent_sessions(
     lock_key = LockKey.for_project(org_id=42, project_id=99)
 
     async with maker() as holder_session, maker() as waiter_session:
-        holder = LockService(
-            session=holder_session, logger=_logger()
-        )
-        waiter = LockService(
-            session=waiter_session, logger=_logger()
-        )
+        holder = LockService(session=holder_session, logger=_logger())
+        waiter = LockService(session=waiter_session, logger=_logger())
 
         acquired = asyncio.Event()
         release = asyncio.Event()
@@ -84,9 +80,7 @@ async def test_same_lock_serializes_concurrent_sessions(
 
         # The waiter must block while the holder has the lock.
         with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(
-                asyncio.shield(wait_task), timeout=0.5
-            )
+            await asyncio.wait_for(asyncio.shield(wait_task), timeout=0.5)
         assert not wait_task.done()
 
         # Releasing the holder unblocks the waiter.
@@ -123,7 +117,7 @@ async def test_different_classes_do_not_block(
 
 @pytest.mark.asyncio
 async def test_session_close_releases_lock_on_crash(
-    app: FastAPI,  # noqa: ARG001
+    app: FastAPI,
 ) -> None:
     """Connection death releases the lock even without ``__aexit__``.
 

--- a/tests/services/locks_test.py
+++ b/tests/services/locks_test.py
@@ -1,0 +1,135 @@
+"""Unit tests for ``docverse.services.lock_service``.
+
+These tests pin the lock-id computation to hard-coded expected
+integers so that two worker replicas computing the same
+``LockKey`` always agree — a regression in the hashing scheme (wrong
+``digest_size``, wrong join separator, forgotten class prefix) would
+otherwise only be caught by the integration tests at runtime.
+"""
+
+from __future__ import annotations
+
+from docverse.services.lock_service import (
+    LockClass,
+    LockKey,
+    compute_lock_id,
+)
+
+SIGNED_INT64_MIN = -(1 << 63)
+SIGNED_INT64_MAX = (1 << 63) - 1
+
+
+def _high_16_bits(lock_id: int) -> int:
+    """Return the high 16 bits of a signed 64-bit lock id."""
+    unsigned = lock_id if lock_id >= 0 else lock_id + (1 << 64)
+    return (unsigned >> 48) & 0xFFFF
+
+
+def test_compute_lock_id_is_deterministic() -> None:
+    """Hard-coded expected ids pin the hashing scheme across runs."""
+    build_id = compute_lock_id(
+        LockClass.BUILD_PROCESSING,
+        org_id=1,
+        project_id=2,
+        git_ref="main",
+    )
+    edition_id = compute_lock_id(
+        LockClass.EDITION_UPDATE,
+        org_id=1,
+        project_id=2,
+        edition_id=3,
+    )
+    project_id = compute_lock_id(
+        LockClass.PROJECT,
+        org_id=1,
+        project_id=2,
+    )
+
+    assert build_id == 136049745188599
+    assert edition_id == 510729122043644
+    assert project_id == 792169873651098
+
+
+def test_lock_key_constructors_match_compute_lock_id() -> None:
+    """``LockKey`` constructors delegate to ``compute_lock_id``."""
+    assert LockKey.for_build_processing(1, 2, "main").lock_id == (
+        136049745188599
+    )
+    assert LockKey.for_edition_update(1, 2, 3).lock_id == (
+        510729122043644
+    )
+    assert LockKey.for_project(1, 2).lock_id == 792169873651098
+
+
+def test_high_16_bits_match_lock_class() -> None:
+    """Every constructor tags the high 16 bits with its class value."""
+    build_key = LockKey.for_build_processing(
+        org_id=42, project_id=99, git_ref="release/v1"
+    )
+    edition_key = LockKey.for_edition_update(
+        org_id=42, project_id=99, edition_id=7
+    )
+    project_key = LockKey.for_project(org_id=42, project_id=99)
+
+    assert _high_16_bits(build_key.lock_id) == (
+        LockClass.BUILD_PROCESSING.value
+    )
+    assert _high_16_bits(edition_key.lock_id) == (
+        LockClass.EDITION_UPDATE.value
+    )
+    assert _high_16_bits(project_key.lock_id) == LockClass.PROJECT.value
+
+
+def test_different_classes_with_same_fields_differ() -> None:
+    """Class prefix prevents cross-class lock-id collisions."""
+    # Same underlying (org_id, project_id) fields — different classes.
+    build = compute_lock_id(
+        LockClass.BUILD_PROCESSING, org_id=1, project_id=2
+    )
+    edition = compute_lock_id(
+        LockClass.EDITION_UPDATE, org_id=1, project_id=2
+    )
+    project = compute_lock_id(
+        LockClass.PROJECT, org_id=1, project_id=2
+    )
+
+    assert build != edition
+    assert build != project
+    assert edition != project
+
+
+def test_result_fits_in_signed_int64() -> None:
+    """Results never overflow Postgres ``bigint``."""
+    samples = [
+        LockKey.for_build_processing(1, 2, "main").lock_id,
+        LockKey.for_build_processing(
+            2**31 - 1, 2**31 - 1, "x" * 256
+        ).lock_id,
+        LockKey.for_edition_update(1, 2, 3).lock_id,
+        LockKey.for_edition_update(
+            2**31 - 1, 2**31 - 1, 2**31 - 1
+        ).lock_id,
+        LockKey.for_project(1, 2).lock_id,
+        LockKey.for_project(2**31 - 1, 2**31 - 1).lock_id,
+    ]
+    for value in samples:
+        assert SIGNED_INT64_MIN <= value <= SIGNED_INT64_MAX
+
+
+def test_lock_key_carries_label_and_class() -> None:
+    """``LockKey`` exposes a human label and its ``LockClass``."""
+    key = LockKey.for_edition_update(
+        org_id=1, project_id=2, edition_id=3
+    )
+    assert key.lock_class is LockClass.EDITION_UPDATE
+    assert "edition" in key.label
+    assert "1" in key.label and "2" in key.label and "3" in key.label
+
+
+def test_build_processing_differs_across_git_refs() -> None:
+    """Two refs on the same project produce distinct lock ids."""
+    main = LockKey.for_build_processing(1, 2, "main").lock_id
+    release = LockKey.for_build_processing(
+        1, 2, "release/v1"
+    ).lock_id
+    assert main != release

--- a/tests/services/locks_test.py
+++ b/tests/services/locks_test.py
@@ -9,11 +9,7 @@ otherwise only be caught by the integration tests at runtime.
 
 from __future__ import annotations
 
-from docverse.services.lock_service import (
-    LockClass,
-    LockKey,
-    compute_lock_id,
-)
+from docverse.services.lock_service import LockClass, LockKey, compute_lock_id
 
 SIGNED_INT64_MIN = -(1 << 63)
 SIGNED_INT64_MAX = (1 << 63) - 1
@@ -55,9 +51,7 @@ def test_lock_key_constructors_match_compute_lock_id() -> None:
     assert LockKey.for_build_processing(1, 2, "main").lock_id == (
         136049745188599
     )
-    assert LockKey.for_edition_update(1, 2, 3).lock_id == (
-        510729122043644
-    )
+    assert LockKey.for_edition_update(1, 2, 3).lock_id == (510729122043644)
     assert LockKey.for_project(1, 2).lock_id == 792169873651098
 
 
@@ -83,15 +77,9 @@ def test_high_16_bits_match_lock_class() -> None:
 def test_different_classes_with_same_fields_differ() -> None:
     """Class prefix prevents cross-class lock-id collisions."""
     # Same underlying (org_id, project_id) fields — different classes.
-    build = compute_lock_id(
-        LockClass.BUILD_PROCESSING, org_id=1, project_id=2
-    )
-    edition = compute_lock_id(
-        LockClass.EDITION_UPDATE, org_id=1, project_id=2
-    )
-    project = compute_lock_id(
-        LockClass.PROJECT, org_id=1, project_id=2
-    )
+    build = compute_lock_id(LockClass.BUILD_PROCESSING, org_id=1, project_id=2)
+    edition = compute_lock_id(LockClass.EDITION_UPDATE, org_id=1, project_id=2)
+    project = compute_lock_id(LockClass.PROJECT, org_id=1, project_id=2)
 
     assert build != edition
     assert build != project
@@ -102,13 +90,9 @@ def test_result_fits_in_signed_int64() -> None:
     """Results never overflow Postgres ``bigint``."""
     samples = [
         LockKey.for_build_processing(1, 2, "main").lock_id,
-        LockKey.for_build_processing(
-            2**31 - 1, 2**31 - 1, "x" * 256
-        ).lock_id,
+        LockKey.for_build_processing(2**31 - 1, 2**31 - 1, "x" * 256).lock_id,
         LockKey.for_edition_update(1, 2, 3).lock_id,
-        LockKey.for_edition_update(
-            2**31 - 1, 2**31 - 1, 2**31 - 1
-        ).lock_id,
+        LockKey.for_edition_update(2**31 - 1, 2**31 - 1, 2**31 - 1).lock_id,
         LockKey.for_project(1, 2).lock_id,
         LockKey.for_project(2**31 - 1, 2**31 - 1).lock_id,
     ]
@@ -118,18 +102,16 @@ def test_result_fits_in_signed_int64() -> None:
 
 def test_lock_key_carries_label_and_class() -> None:
     """``LockKey`` exposes a human label and its ``LockClass``."""
-    key = LockKey.for_edition_update(
-        org_id=1, project_id=2, edition_id=3
-    )
+    key = LockKey.for_edition_update(org_id=1, project_id=2, edition_id=3)
     assert key.lock_class is LockClass.EDITION_UPDATE
     assert "edition" in key.label
-    assert "1" in key.label and "2" in key.label and "3" in key.label
+    assert "1" in key.label
+    assert "2" in key.label
+    assert "3" in key.label
 
 
 def test_build_processing_differs_across_git_refs() -> None:
     """Two refs on the same project produce distinct lock ids."""
     main = LockKey.for_build_processing(1, 2, "main").lock_id
-    release = LockKey.for_build_processing(
-        1, 2, "release/v1"
-    ).lock_id
+    release = LockKey.for_build_processing(1, 2, "release/v1").lock_id
     assert main != release

--- a/tests/storage/build_store_test.py
+++ b/tests/storage/build_store_test.py
@@ -279,3 +279,69 @@ async def test_update_inventory(
         await db_session.commit()
     assert updated.object_count == 42
     assert updated.total_size_bytes == 1024000
+
+
+@pytest.mark.asyncio
+async def test_get_latest_build_id_for_ref(
+    db_session: AsyncSession,
+    build_store: BuildStore,
+) -> None:
+    """Returns the max build id for a (project, git_ref) pair.
+
+    A second build on the same ref supersedes the first; a build on a
+    different ref does not influence the answer; an unknown ref or
+    project returns ``None``.
+    """
+    async with db_session.begin():
+        _, project_id = await _create_org_and_project(db_session)
+
+        first_main = await build_store.create(
+            project_id=project_id,
+            project_slug="build-proj",
+            data=BuildCreate(
+                git_ref="main",
+                content_hash="sha256:" + "1" * 64,
+            ),
+            uploader="testuser",
+        )
+        second_main = await build_store.create(
+            project_id=project_id,
+            project_slug="build-proj",
+            data=BuildCreate(
+                git_ref="main",
+                content_hash="sha256:" + "2" * 64,
+            ),
+            uploader="testuser",
+        )
+        other_ref = await build_store.create(
+            project_id=project_id,
+            project_slug="build-proj",
+            data=BuildCreate(
+                git_ref="release/v1",
+                content_hash="sha256:" + "3" * 64,
+            ),
+            uploader="testuser",
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        latest_main = await build_store.get_latest_build_id_for_ref(
+            project_id=project_id, git_ref="main"
+        )
+        assert latest_main == second_main.id
+        assert latest_main != first_main.id
+
+        latest_release = await build_store.get_latest_build_id_for_ref(
+            project_id=project_id, git_ref="release/v1"
+        )
+        assert latest_release == other_ref.id
+
+        missing_ref = await build_store.get_latest_build_id_for_ref(
+            project_id=project_id, git_ref="does-not-exist"
+        )
+        assert missing_ref is None
+
+        missing_project = await build_store.get_latest_build_id_for_ref(
+            project_id=project_id + 9999, git_ref="main"
+        )
+        assert missing_project is None

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test support code (spies, recorders) for the docverse test suite."""

--- a/tests/support/lock_service_spy.py
+++ b/tests/support/lock_service_spy.py
@@ -25,7 +25,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.factory import Factory
 from docverse.services.lock_service import LockKey, LockService
 
-__all__ = ["LockEvent", "RecordingLockService", "install_recording_lock_service"]
+__all__ = [
+    "LockEvent",
+    "RecordingLockService",
+    "install_recording_lock_service",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,7 +66,9 @@ class RecordingLockService(LockService):
         async with super().acquire(lock_key):
             self._events.append(
                 LockEvent(
-                    event="enter", lock_key=lock_key, timestamp=time.monotonic()
+                    event="enter",
+                    lock_key=lock_key,
+                    timestamp=time.monotonic(),
                 )
             )
             try:
@@ -91,8 +97,8 @@ def install_recording_lock_service(
 
     def _create(self: Factory) -> RecordingLockService:
         return RecordingLockService(
-            session=self._session,  # noqa: SLF001
-            logger=self._logger,  # noqa: SLF001
+            session=self._session,
+            logger=self._logger,
             events=events,
         )
 

--- a/tests/support/lock_service_spy.py
+++ b/tests/support/lock_service_spy.py
@@ -1,0 +1,100 @@
+"""Recording spy for ``LockService`` used by worker-level lock tests.
+
+The spy subclasses :class:`docverse.services.lock_service.LockService` so
+worker code paths that go through ``Factory.create_lock_service`` keep
+their real Postgres advisory-lock behaviour, while each ``acquire``
+records an ``("enter" | "exit", lock_key)`` pair into a shared event
+list. Tests assert the recorded sequence to verify *which* lock keys
+each worker acquires and *in what order* (e.g. the
+``BUILD_PROCESSING -> EDITION_UPDATE`` nesting inside
+``build_processing``).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.factory import Factory
+from docverse.services.lock_service import LockKey, LockService
+
+__all__ = ["LockEvent", "RecordingLockService", "install_recording_lock_service"]
+
+
+@dataclass(frozen=True, slots=True)
+class LockEvent:
+    """One observed lock acquire/release event."""
+
+    event: Literal["enter", "exit"]
+    lock_key: LockKey
+    timestamp: float
+
+
+class RecordingLockService(LockService):
+    """``LockService`` that records every acquire/release event.
+
+    Delegates to the real ``LockService.acquire`` so the worker still
+    serializes against concurrent jobs in tests that need it. The
+    recorded events live on the shared list passed at construction so
+    multiple ``RecordingLockService`` instances created from the same
+    factory share one event log.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        logger: structlog.stdlib.BoundLogger,
+        events: list[LockEvent],
+    ) -> None:
+        super().__init__(session=session, logger=logger)
+        self._events = events
+
+    @asynccontextmanager
+    async def acquire(self, lock_key: LockKey) -> AsyncGenerator[None]:
+        """Acquire ``lock_key`` and record entry/exit on the shared list."""
+        async with super().acquire(lock_key):
+            self._events.append(
+                LockEvent(
+                    event="enter", lock_key=lock_key, timestamp=time.monotonic()
+                )
+            )
+            try:
+                yield
+            finally:
+                self._events.append(
+                    LockEvent(
+                        event="exit",
+                        lock_key=lock_key,
+                        timestamp=time.monotonic(),
+                    )
+                )
+
+
+def install_recording_lock_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[LockEvent]:
+    """Patch ``Factory.create_lock_service`` to return a recording spy.
+
+    Returns a list that accumulates :class:`LockEvent` records as
+    workers acquire and release advisory locks. All ``LockService``
+    instances built by the patched factory share the same list so a
+    single end-to-end run produces one ordered event log.
+    """
+    events: list[LockEvent] = []
+
+    def _create(self: Factory) -> RecordingLockService:
+        return RecordingLockService(
+            session=self._session,  # noqa: SLF001
+            logger=self._logger,  # noqa: SLF001
+            events=events,
+        )
+
+    monkeypatch.setattr(Factory, "create_lock_service", _create)
+    return events

--- a/tests/worker/build_processing_test.py
+++ b/tests/worker/build_processing_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import tarfile
+import time
 from typing import Any
 
 import httpx
@@ -33,6 +34,7 @@ from docverse.domain.queue import JobKind, JobStatus
 from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.edition_tracking import EditionTrackingService
+from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -44,6 +46,7 @@ from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_backend import ArqQueueBackend
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.build_processing import build_processing
+from tests.support.lock_service_spy import install_recording_lock_service
 
 _HASH = "sha256:" + "a" * 64
 
@@ -139,6 +142,35 @@ def _mock_create_objectstore(
         return mock_store
 
     return _create
+
+
+class _RecordingMockObjectStore(MockObjectStore):
+    """``MockObjectStore`` that timestamps every mutating call.
+
+    Tests use this to verify that worker-issued object-store ops happen
+    *after* an advisory-lock acquisition, by comparing the recorded
+    timestamps against the lock-event timestamps.
+    """
+
+    def __init__(self, op_timestamps: list[float]) -> None:
+        super().__init__()
+        self._op_timestamps = op_timestamps
+
+    async def upload_object(
+        self, *, key: str, data: bytes, content_type: str
+    ) -> None:
+        self._op_timestamps.append(time.monotonic())
+        await super().upload_object(
+            key=key, data=data, content_type=content_type
+        )
+
+    async def download_object(self, *, key: str) -> bytes:
+        self._op_timestamps.append(time.monotonic())
+        return await super().download_object(key=key)
+
+    async def delete_object(self, *, key: str) -> None:
+        self._op_timestamps.append(time.monotonic())
+        await super().delete_object(key=key)
 
 
 @pytest.mark.asyncio
@@ -750,3 +782,196 @@ async def test_build_processing_publish_enqueue_failure_leaves_db_consistent(
                 .all()
             )
             assert len(child_rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_build_processing_acquires_build_lock_before_object_store(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """build_processing acquires BUILD_PROCESSING before any obj-store op.
+
+    Verifies the worker wires the lock to the correct key — the
+    integration tests in ``tests/services/locks_integration_test.py``
+    already prove the mechanism works, but they do not pin which key
+    each worker uses. A spy ``LockService`` records every acquire
+    timestamp; a spy ``MockObjectStore`` records every mutating call's
+    timestamp. The first BUILD_PROCESSING acquire must precede every
+    worker-issued upload/download/delete.
+    """
+    logger = _logger()
+    op_timestamps: list[float] = []
+    mock_store = _RecordingMockObjectStore(op_timestamps=op_timestamps)
+
+    async with db_session.begin():
+        org, project = await _setup_org_and_project(db_session)
+        build = await _create_build_in_processing(
+            db_session, project.id, git_ref="main"
+        )
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        await queue_job_store.create(
+            kind=JobKind.build_processing,
+            org_id=org.id,
+            project_id=project.id,
+            build_id=build.id,
+            backend_job_id="test-arq-lock-bp",
+        )
+
+    tarball = _make_tarball({"index.html": b"<html>hello</html>"})
+    await mock_store.upload_object(
+        key=build.staging_key,
+        data=tarball,
+        content_type="application/gzip",
+    )
+    # Discard the staging-upload bookkeeping so only worker-issued ops
+    # are compared against the lock-event timestamps.
+    op_timestamps.clear()
+
+    monkeypatch.setattr(
+        Factory,
+        "create_objectstore_for_org",
+        _mock_create_objectstore(mock_store),
+    )
+    events = install_recording_lock_service(monkeypatch)
+
+    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
+    ctx: dict[str, Any] = {
+        "encryptor": encryptor,
+        "http_client": httpx.AsyncClient(),
+        "job_id": "test-arq-lock-bp",
+        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
+    }
+    payload: dict[str, Any] = {
+        "org_id": org.id,
+        "org_slug": org.slug,
+        "project_slug": project.slug,
+        "build_id": build.id,
+        "build_public_id": serialize_base32_id(build.public_id),
+    }
+
+    result = await build_processing(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    expected = LockKey.for_build_processing(
+        org_id=org.id, project_id=project.id, git_ref="main"
+    )
+    bp_enters = [
+        e
+        for e in events
+        if e.event == "enter"
+        and e.lock_key.lock_class == LockClass.BUILD_PROCESSING
+    ]
+    assert len(bp_enters) == 1
+    assert bp_enters[0].lock_key == expected
+
+    assert op_timestamps, "expected at least one worker object-store call"
+    bp_enter_ts = bp_enters[0].timestamp
+    assert all(ts > bp_enter_ts for ts in op_timestamps)
+
+
+@pytest.mark.asyncio
+async def test_build_processing_nested_lock_sequence(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """EDITION_UPDATE acquisitions nest inside the BUILD_PROCESSING block.
+
+    The ``main`` git_ref auto-creates a ``main`` edition and updates its
+    pointer via ``EditionTrackingService.set_current_build``, which
+    acquires an EDITION_UPDATE lock. The recorded event sequence must
+    be ``BUILD_PROCESSING.enter -> EDITION_UPDATE.enter ->
+    EDITION_UPDATE.exit -> BUILD_PROCESSING.exit`` so the per-edition
+    pointer cannot diverge from the build-level state mid-flight.
+    """
+    logger = _logger()
+    mock_store = MockObjectStore()
+
+    async with db_session.begin():
+        org, project = await _setup_org_and_project(db_session)
+        build = await _create_build_in_processing(
+            db_session, project.id, git_ref="main"
+        )
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        await queue_job_store.create(
+            kind=JobKind.build_processing,
+            org_id=org.id,
+            project_id=project.id,
+            build_id=build.id,
+            backend_job_id="test-arq-lock-nested",
+        )
+
+    tarball = _make_tarball({"index.html": b"<html>hello</html>"})
+    await mock_store.upload_object(
+        key=build.staging_key,
+        data=tarball,
+        content_type="application/gzip",
+    )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_objectstore_for_org",
+        _mock_create_objectstore(mock_store),
+    )
+    events = install_recording_lock_service(monkeypatch)
+
+    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
+    ctx: dict[str, Any] = {
+        "encryptor": encryptor,
+        "http_client": httpx.AsyncClient(),
+        "job_id": "test-arq-lock-nested",
+        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
+    }
+    payload: dict[str, Any] = {
+        "org_id": org.id,
+        "org_slug": org.slug,
+        "project_slug": project.slug,
+        "build_id": build.id,
+        "build_public_id": serialize_base32_id(build.public_id),
+    }
+
+    result = await build_processing(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    # Outer brackets: the BUILD_PROCESSING enter must be the very first
+    # recorded event and its exit the very last.
+    expected_bp = LockKey.for_build_processing(
+        org_id=org.id, project_id=project.id, git_ref="main"
+    )
+    assert len(events) >= 4
+    assert events[0].event == "enter"
+    assert events[0].lock_key == expected_bp
+    assert events[-1].event == "exit"
+    assert events[-1].lock_key == expected_bp
+
+    # At least one EDITION_UPDATE acquire/release pair is fully nested
+    # inside the BUILD_PROCESSING block. Each pair's enter precedes its
+    # exit, and both indices fall strictly between the outer brackets.
+    inner = events[1:-1]
+    eu_enter_idx = [
+        i
+        for i, e in enumerate(inner)
+        if e.event == "enter"
+        and e.lock_key.lock_class == LockClass.EDITION_UPDATE
+    ]
+    eu_exit_idx = [
+        i
+        for i, e in enumerate(inner)
+        if e.event == "exit"
+        and e.lock_key.lock_class == LockClass.EDITION_UPDATE
+    ]
+    assert len(eu_enter_idx) >= 1
+    assert len(eu_enter_idx) == len(eu_exit_idx)
+    for enter_i, exit_i in zip(eu_enter_idx, eu_exit_idx, strict=True):
+        assert enter_i < exit_i
+        assert inner[enter_i].lock_key == inner[exit_i].lock_key
+
+    # No BUILD_PROCESSING events fire inside the outer brackets — the
+    # outer lock is taken once and released once.
+    inner_bp = [
+        e for e in inner if e.lock_key.lock_class == LockClass.BUILD_PROCESSING
+    ]
+    assert inner_bp == []

--- a/tests/worker/build_processing_test.py
+++ b/tests/worker/build_processing_test.py
@@ -501,6 +501,113 @@ async def test_build_processing_enqueues_publish_edition(  # noqa: PLR0915
 
 
 @pytest.mark.asyncio
+async def test_build_processing_skips_stale_build(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A superseded build skips before any object-store interaction.
+
+    Two builds exist for the same ``(project, git_ref)``. The older
+    build is dispatched after the newer one. The stale-build guard
+    inside the BUILD_PROCESSING lock detects that the incoming
+    ``build_id`` is not the max for the ``(project_id, git_ref)``
+    pair, marks the parent ``QueueJob`` ``completed`` with
+    ``progress["stale_skipped"] = True`` and the latest id, and
+    returns without invoking any uploads or touching edition state.
+    """
+    logger = _logger()
+    mock_store = MockObjectStore()
+
+    async with db_session.begin():
+        org, project = await _setup_org_and_project(db_session)
+        older_build = await _create_build_in_processing(
+            db_session, project.id, git_ref="main"
+        )
+        newer_build = await _create_build_in_processing(
+            db_session, project.id, git_ref="main"
+        )
+        # Pre-create the edition with no current_build so we can later
+        # assert the pointer was never moved by the stale dispatch.
+        edition_store = EditionStore(session=db_session, logger=logger)
+        await edition_store.create(
+            project_id=project.id,
+            data=EditionCreate(
+                slug="main",
+                title="Main",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "main"},
+            ),
+        )
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        await queue_job_store.create(
+            kind=JobKind.build_processing,
+            org_id=org.id,
+            project_id=project.id,
+            build_id=older_build.id,
+            backend_job_id="test-arq-stale",
+        )
+
+    # Intentionally do NOT stage a tarball: the stale-build guard
+    # must short-circuit before any download or upload is attempted.
+
+    monkeypatch.setattr(
+        Factory,
+        "create_objectstore_for_org",
+        _mock_create_objectstore(mock_store),
+    )
+
+    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
+    ctx: dict[str, Any] = {
+        "encryptor": encryptor,
+        "http_client": httpx.AsyncClient(),
+        "job_id": "test-arq-stale",
+        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
+    }
+    payload: dict[str, Any] = {
+        "org_id": org.id,
+        "org_slug": org.slug,
+        "project_slug": project.slug,
+        "build_id": older_build.id,
+        "build_public_id": serialize_base32_id(older_build.public_id),
+    }
+
+    result = await build_processing(ctx, payload)
+    await ctx["http_client"].aclose()
+
+    assert result == "completed"
+
+    # No uploads or downloads occurred — the mock store stayed empty.
+    assert mock_store.objects == {}
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            qjs = QueueJobStore(session=session, logger=_logger())
+            job = await qjs.get_by_backend_job_id("test-arq-stale")
+            assert job is not None
+            assert job.status == JobStatus.completed
+            assert job.progress is not None
+            assert job.progress.get("stale_skipped") is True
+            assert job.progress.get("latest_build_id") == newer_build.id
+
+            # The pre-created edition's pointer must be untouched.
+            edition_store = EditionStore(session=session, logger=_logger())
+            edition = await edition_store.get_by_slug(
+                project_id=project.id, slug="main"
+            )
+            assert edition is not None
+            assert edition.current_build_id is None
+
+            # The older build's status was not transitioned by the
+            # stale-skip path; it stays in ``processing``.
+            build_store = BuildStore(session=session, logger=_logger())
+            refreshed_older = await build_store.get_by_id(older_build.id)
+            assert refreshed_older is not None
+            assert refreshed_older.status == BuildStatus.processing
+
+
+@pytest.mark.asyncio
 async def test_build_processing_publish_enqueue_failure_leaves_db_consistent(
     app: None,
     db_session: AsyncSession,

--- a/tests/worker/dashboard_build_test.py
+++ b/tests/worker/dashboard_build_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 import httpx
@@ -27,12 +28,14 @@ from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.queue import JobKind, JobStatus
 from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
+from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.objectstore import MockObjectStore
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.dashboard_build import dashboard_build
+from tests.support.lock_service_spy import install_recording_lock_service
 
 _config = Configuration()
 
@@ -243,3 +246,88 @@ async def test_dashboard_build_marks_failed_on_render_exception(
             assert job.status == JobStatus.failed
             assert job.errors is not None
             assert "Simulated objectstore" in job.errors["message"]
+
+
+class _RecordingMockObjectStore(MockObjectStore):
+    """``MockObjectStore`` that timestamps every upload."""
+
+    def __init__(self, op_timestamps: list[float]) -> None:
+        super().__init__()
+        self._op_timestamps = op_timestamps
+
+    async def upload_object(
+        self, *, key: str, data: bytes, content_type: str
+    ) -> None:
+        self._op_timestamps.append(time.monotonic())
+        await super().upload_object(
+            key=key, data=data, content_type=content_type
+        )
+
+
+@pytest.mark.asyncio
+async def test_dashboard_build_acquires_project_lock_before_render(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dashboard_build acquires PROJECT before any render upload.
+
+    Verifies the worker wires the lock to ``LockKey.for_project`` for
+    the payload's ``(org_id, project_id)`` and that no render upload
+    happens before the lock is held.
+    """
+    logger = _logger()
+    op_timestamps: list[float] = []
+    mock_store = _RecordingMockObjectStore(op_timestamps=op_timestamps)
+
+    async with db_session.begin():
+        org, project = await _setup_org_and_project(db_session)
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        queue_job = await queue_job_store.create(
+            kind=JobKind.dashboard_build,
+            org_id=org.id,
+            project_id=project.id,
+            backend_job_id="test-arq-dash-lock",
+        )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_objectstore_for_org",
+        _mock_create_objectstore(mock_store),
+    )
+    events = install_recording_lock_service(monkeypatch)
+
+    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
+    http_client = httpx.AsyncClient()
+    ctx: dict[str, Any] = {
+        "encryptor": encryptor,
+        "http_client": http_client,
+        "discovery": DiscoveryClient(http_client),
+        "job_id": "test-arq-dash-lock",
+        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
+    }
+    payload: dict[str, Any] = {
+        "org_id": org.id,
+        "org_slug": org.slug,
+        "project_id": project.id,
+        "project_slug": project.slug,
+        "queue_job_id": queue_job.id,
+        "queue_job_public_id": serialize_base32_id(queue_job.public_id),
+    }
+
+    result = await dashboard_build(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    expected = LockKey.for_project(org_id=org.id, project_id=project.id)
+    proj_enters = [
+        e
+        for e in events
+        if e.event == "enter" and e.lock_key.lock_class == LockClass.PROJECT
+    ]
+    assert len(proj_enters) == 1
+    assert proj_enters[0].lock_key == expected
+
+    assert op_timestamps, "expected dashboard render uploads"
+    proj_enter_ts = proj_enters[0].timestamp
+    assert all(ts > proj_enter_ts for ts in op_timestamps)

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from types import TracebackType
 from typing import Any, Self
 
@@ -37,6 +38,7 @@ from docverse.domain.project import Project
 from docverse.domain.queue import JobKind, JobStatus, QueueJob
 from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
+from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -50,6 +52,7 @@ from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.publish_edition import publish_edition
+from tests.support.lock_service_spy import install_recording_lock_service
 
 _HASH = "sha256:" + "a" * 64
 
@@ -601,3 +604,103 @@ async def test_publish_edition_failure_does_not_enqueue_dashboard(
     ]
     dashboard_jobs = [j for j in enqueued if j.name == "dashboard_build"]
     assert dashboard_jobs == []
+
+
+class _RecordingMockEditionPublisher(MockEditionPublisher):
+    """``MockEditionPublisher`` that timestamps each ``publish`` call."""
+
+    def __init__(self, publish_timestamps: list[float]) -> None:
+        super().__init__()
+        self._publish_timestamps = publish_timestamps
+
+    async def publish(
+        self,
+        *,
+        project_slug: str,
+        edition_slug: str,
+        build_public_id: str,
+        object_key_prefix: str,
+    ) -> None:
+        self._publish_timestamps.append(time.monotonic())
+        await super().publish(
+            project_slug=project_slug,
+            edition_slug=edition_slug,
+            build_public_id=build_public_id,
+            object_key_prefix=object_key_prefix,
+        )
+
+
+@pytest.mark.asyncio
+async def test_publish_edition_acquires_edition_update_lock(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """publish_edition takes EDITION_UPDATE before invoking the publisher.
+
+    Verifies the worker wires the lock to the correct
+    ``LockKey.for_edition_update`` for the resolved
+    ``(org_id, project_id, edition_id)`` tuple, and that the spy
+    publisher's ``publish`` call (the externally observable CDN
+    mutation) happens strictly after the EDITION_UPDATE acquire.
+    """
+    publish_timestamps: list[float] = []
+    mock_publisher = _RecordingMockEditionPublisher(
+        publish_timestamps=publish_timestamps
+    )
+
+    async with db_session.begin():
+        (
+            org,
+            project,
+            edition,
+            build,
+            _history_entry,
+            queue_job,
+        ) = await _setup_publish_scenario(
+            db_session,
+            org_slug="pub-lock-org",
+            cdn_service_label="cdn-prod",
+            backend_job_id="test-publish-arq-lock",
+        )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_edition_publisher_for_org",
+        _mock_create_edition_publisher(mock_publisher),
+    )
+    events = install_recording_lock_service(monkeypatch)
+
+    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
+    ctx: dict[str, Any] = {
+        "encryptor": encryptor,
+        "http_client": httpx.AsyncClient(),
+        "job_id": "test-publish-arq-lock",
+    }
+    payload = _make_payload(
+        org=org,
+        project=project,
+        edition=edition,
+        build=build,
+        queue_job=queue_job,
+    )
+
+    result = await publish_edition(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    expected = LockKey.for_edition_update(
+        org_id=org.id, project_id=project.id, edition_id=edition.id
+    )
+    eu_enters = [
+        e
+        for e in events
+        if e.event == "enter"
+        and e.lock_key.lock_class == LockClass.EDITION_UPDATE
+    ]
+    assert len(eu_enters) == 1
+    assert eu_enters[0].lock_key == expected
+
+    assert publish_timestamps, "expected publisher.publish to be called"
+    eu_enter_ts = eu_enters[0].timestamp
+    assert all(ts > eu_enter_ts for ts in publish_timestamps)


### PR DESCRIPTION
## Summary

Implements all four slices of PRD #219 — the LockService primitive plus its wiring into every arq worker that mutates shared object-store state.

- **LockService primitive** (999441b, closes #220): `docverse.services.lock_service` with `LockClass`, `LockKey`, `compute_lock_id`, and `LockService`. Deterministic 64-bit lock ids (high 16 bits = class prefix, low 48 bits = blake2b digest of the resource tuple) so two worker replicas in different processes agree on the lock for the same resource — a guarantee CPython's salted `hash()` cannot give. `acquire()` is an async context manager over `pg_advisory_lock` / `pg_advisory_unlock`, with connection-close as the ultimate release guarantee.
- **`build_processing` wiring + stale-build guard** (f9ab830, closes #221): two jobs sharing `(project, git_ref)` serialize on a `BUILD_PROCESSING` lock; inside the lock, a superseded build (not max id for its `(project, git_ref)`) marks its `QueueJob` completed with `progress["stale_skipped"] = True` and returns without uploading. `EditionTrackingService.set_current_build` calls inside this path are wrapped in `EDITION_UPDATE` locks; the date-based guard in `EditionStore.set_current_build` stays as defence in depth.
- **`publish_edition` wiring** (8e0824c, closes #222): two jobs sharing `(org, project, edition)` serialize on an `EDITION_UPDATE` lock. A pre-lock `ProjectStore.get_by_slug` resolves `project_id` for the lock key (arq payload carries `project_slug`, not id). Combined with `build_processing`'s `EDITION_UPDATE` wrapping, the per-edition pointer and metadata JSON cannot diverge from CDN state regardless of which job updates them.
- **`dashboard_build` wiring** (bf43507, closes #223): two jobs sharing `(org, project)` serialize on a `PROJECT` lock; the arq payload already carries both ids so no pre-lock SELECT is needed. The lock spans the full render + upload lifetime so concurrent renders cannot overwrite each other's `__dashboard.html`, `__switcher.json`, `__404.html`, or `__editions/<slug>.json`.

Lock ordering: `BUILD_PROCESSING` is always outermost, `EDITION_UPDATE` inner. `PROJECT` never nests with the other two (only `dashboard_build` takes it, and it takes nothing else). No cycles possible.

The autobegin-then-commit dance after `acquire()` is repeated across all three workers and is load-bearing: the advisory lock is connection-scoped, not transaction-scoped, so the commit releases the autobegun transaction (avoiding SQLAlchemy's "transaction already begun" guard) without releasing the lock. An earlier attempt to absorb the `begin()` into `LockService` broke `test_same_lock_serializes_concurrent_sessions`; see f9ab830's next-iteration notes.

## Validation steps

- [ ] `tests/services/locks_test.py` — inspect the hard-coded expected ids and confirm the unit tests pin the hashing scheme (a `digest_size` / class-shift regression would have changed them).
- [ ] `tests/services/locks_integration_test.py` — confirm the three scenarios are covered: same lock serializes across two sessions, different classes on the same `(org, project)` run in parallel, and a cancelled task's session releases its lock once the engine is disposed.
- [ ] `tests/storage/build_store_test.py` — confirm `get_latest_build_id_for_ref` returns the max id even when a newer build is soft-deleted (supersession marker must still count).
- [ ] `tests/worker/build_processing_test.py` — confirm the stale-skip path marks the `QueueJob` completed with `progress["stale_skipped"] = True` and performs no uploads or edition-pointer updates.
- [ ] `src/docverse/worker/functions/build_processing.py`, `publish_edition.py`, `dashboard_build.py` — confirm each acquires its lock at the top of the function and holds it for the entire job lifetime (per PRD user-stories 1 / 6 / 9), not just the upload phase.
- [ ] `src/docverse/services/edition_tracking.py` — confirm `lock_service` is optional so direct unit-test constructions continue to work, and `Factory.create_edition_tracking_service` always wires it in for production / worker paths.
- [ ] `src/docverse/factory.py` — confirm `create_lock_service()` follows the existing `create_*_service()` conventions.

## References

- Closes #220
- Closes #221
- Closes #222
- Closes #223
- Closes #226
- Closes #227
- Closes #228
- Closes #229
- Closes #230
- Closes #231
- PRD: #219
- Jira: https://rubinobs.atlassian.net/browse/DM-54693


