### PR TITLE
Make pre-commit cache writable in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,6 +54,7 @@ RUN { \
     echo "node ALL=(root) NOPASSWD: /usr/sbin/cron"; \
     echo "node ALL=(root) NOPASSWD: /bin/mkdir -p /run/docverse-sandbox"; \
     echo "node ALL=(root) NOPASSWD: /bin/chown node\\:node /run/docverse-sandbox"; \
+    echo "node ALL=(root) NOPASSWD: /bin/chown node\\:node /home/node/.cache"; \
     echo "node ALL=(root) NOPASSWD: /bin/chown -R node\\:node /workspace /home/node/.claude /commandhistory /home/node/.cache/uv"; \
     } > /etc/sudoers.d/firewall \
     && chmod 0440 /etc/sudoers.d/firewall

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
     "CLAUDE_CODE_USE_BEDROCK": "",
     "CLAUDE_CODE_USE_VERTEX": ""
   },
-  "postCreateCommand": "sudo chown -R node:node /workspace /home/node/.claude /commandhistory /home/node/.cache/uv",
+  "postCreateCommand": "sudo chown node:node /home/node/.cache && sudo chown -R node:node /workspace /home/node/.claude /commandhistory /home/node/.cache/uv",
   "postStartCommand": "sudo /usr/local/bin/init-firewall.sh && sudo cron",
   "waitFor": "postStartCommand",
   "containerUser": "root",

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,13 @@ coverage.xml
 # Ruff
 .ruff_cache/
 
+# pre-commit (fallback when $HOME/.cache/pre-commit isn't writable)
+.pre-commit-cache/
+
+# Linux core dumps
+core
+core.*
+
 # Sphinx documentation
 docs/_build/
 


### PR DESCRIPTION
## Summary

- Fix root cause: chown `/home/node/.cache` to node in the devcontainer `postCreateCommand` (plus matching sudoers entry) so pre-commit's default store at `/home/node/.cache/pre-commit` is writable. The parent directory was being materialized as `root:root` when the `docverse-uv-cache` volume mounted at `/home/node/.cache/uv`, and the existing chown only touched the `uv` subdir.
- Defense-in-depth: gitignore `.pre-commit-cache/` (the in-repo fallback path a ralph-implement agent picked on 2026-04-22, which tripped the next iteration's dirty-tree pre-flight) and Linux `core` / `core.*` dumps.

## Why now

Ralph-implement agents have been silently working around the broken default cache since at least 2026-04-17 by picking various out-of-tree paths (`/tmp/pc-cache`, `$HOME/.local/share/pre-commit`, etc.). The 2026-04-22 run was the first to pick an in-repo path, which caused the next iteration's pre-flight (`ralph/afk.sh:597-601`) to abort with `dirty tree at start of iter 2: ?? .pre-commit-cache/`.

## Test plan

- [ ] Rebuild the devcontainer and confirm `ls -ld /home/node/.cache` shows `node node`.
- [ ] Run `uv run --only-group=lint pre-commit run --all-files` in a fresh container without `PRE_COMMIT_HOME` — should succeed and populate `/home/node/.cache/pre-commit/`.
- [ ] Kick off `ralph/afk.sh 2` and confirm iter 2's pre-flight doesn't abort.
- [ ] `git check-ignore -v .pre-commit-cache/ core core.12345` resolves all three to the new gitignore lines.