### PR TITLE
Improve Ralph afk.sh script for PR blockers

### DIFF
--- a/ralph/afk.sh
+++ b/ralph/afk.sh
@@ -249,7 +249,9 @@ build_shortlist() {
                 state=$(container_exec gh issue view "$b" \
                     --repo lsst-sqre/docverse \
                     --json state --jq .state 2>/dev/null || echo "OPEN")
-                if [ "$state" != "CLOSED" ]; then ok=0; break; fi
+                # gh issue view works on PR numbers too; merged PRs report state=MERGED.
+                # Treat anything other than OPEN as "blocker resolved".
+                if [ "$state" = "OPEN" ]; then ok=0; break; fi
             done
             if [ "$ok" = "1" ]; then
                 filtered=$(jq -c --argjson e "$entry" '. + [$e]' <<<"$filtered")


### PR DESCRIPTION
## Summary

- `ralph/afk.sh` treats a PR-number blocker (e.g. `| Blocked by | #224 |`) as unresolved forever because merged PRs report state `MERGED`, not `CLOSED`. The old `!= "CLOSED"` check filtered these tasks out of every shortlist.
- Invert the comparison to `= "OPEN"` so `MERGED`, `CLOSED`, and the `OPEN`-fallback on a failed `gh` lookup all behave correctly. Only `OPEN` blocks now.
- Added a two-line rationale comment above the check noting that `gh issue view` works transparently on PR numbers and that merged PRs report `MERGED`.

## Test plan

- [x] Unit check: `gh issue view 224 --repo lsst-sqre/docverse --json state --jq .state` returns `MERGED`; an open issue returns `OPEN`. The new comparison handles both correctly.
- [ ] End-to-end: rerun `ralph/afk.sh <n>` without `--issue` against docverse#236 (which has `| Blocked by | PR #224 |` where #224 is merged) and confirm #236 appears in `iter-01.shortlist.json`.