### PR TITLE
DM-54689: Render-time TemplateResolver for dashboard rendering

### DIFF
--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -14,6 +14,7 @@ from .services.credential import CredentialService
 from .services.credential_encryptor import CredentialEncryptor
 from .services.dashboard.enqueue import DashboardBuildEnqueuer
 from .services.dashboard.publisher import DashboardPublisher
+from .services.dashboard_templates import TemplateResolver
 from .services.edition import EditionService
 from .services.edition_publishing import EditionPublishingService
 from .services.edition_tracking import (
@@ -25,6 +26,9 @@ from .services.lock_service import LockService
 from .services.organization import OrganizationService
 from .services.project import ProjectService
 from .storage.build_store import BuildStore
+from .storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+)
 from .storage.edition_build_history_store import EditionBuildHistoryStore
 from .storage.edition_store import EditionStore
 from .storage.editionpublisher import (
@@ -274,6 +278,17 @@ class Factory:
             logger=self._logger,
         )
 
+    def create_template_resolver(self) -> TemplateResolver:
+        """Create a TemplateResolver for render-time template lookup."""
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=self._session, logger=self._logger
+        )
+        return TemplateResolver(
+            binding_store=binding_store,
+            session=self._session,
+            logger=self._logger,
+        )
+
     def create_dashboard_publisher(self) -> DashboardPublisher:
         """Create a DashboardPublisher for one render.
 
@@ -294,6 +309,7 @@ class Factory:
             build_store=BuildStore(session=self._session, logger=self._logger),
             discovery=self._discovery,
             logger=self._logger,
+            template_resolver=self.create_template_resolver(),
         )
 
     async def create_edition_publisher_for_org(

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -28,6 +28,7 @@ from .services.project import ProjectService
 from .storage.build_store import BuildStore
 from .storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
 )
 from .storage.edition_build_history_store import EditionBuildHistoryStore
 from .storage.edition_store import EditionStore
@@ -283,9 +284,12 @@ class Factory:
         binding_store = DashboardGitHubTemplateBindingStore(
             session=self._session, logger=self._logger
         )
+        template_store = DashboardGitHubTemplateStore(
+            session=self._session, logger=self._logger
+        )
         return TemplateResolver(
             binding_store=binding_store,
-            session=self._session,
+            template_store=template_store,
             logger=self._logger,
         )
 

--- a/src/docverse/services/dashboard/publisher.py
+++ b/src/docverse/services/dashboard/publisher.py
@@ -10,7 +10,6 @@ import structlog
 from rubin.repertoire import DiscoveryClient
 
 from docverse.domain.dashboard_context import DashboardContext, EditionContext
-from docverse.exceptions import NotFoundError
 from docverse.services.dashboard_templates.resolver import TemplateResolver
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_store import EditionStore
@@ -112,6 +111,7 @@ class DashboardPublisher:
         *,
         context: DashboardContext,
         object_store: ObjectStore,
+        org_id: int,
         project_id: int,
     ) -> DashboardUploadProgress:
         """Render the artifacts and upload them to the object store.
@@ -119,17 +119,10 @@ class DashboardPublisher:
         The :class:`TemplateSource` is resolved here (not at construction
         time) so the per-project override / org default / built-in
         fallback chain is evaluated freshly for each render.
-
-        Raises
-        ------
-        NotFoundError
-            If ``project_id`` does not correspond to an existing project.
         """
-        project = await self._project_store.get_by_id(project_id)
-        if project is None:
-            msg = f"Project {project_id} not found"
-            raise NotFoundError(msg)
-        resolved = await self._template_resolver.resolve_for_project(project)
+        resolved = await self._template_resolver.resolve(
+            org_id=org_id, project_id=project_id
+        )
         template_source = resolved.source
         logger = self._logger.bind(template_origin=resolved.origin.value)
 
@@ -243,6 +236,7 @@ class DashboardPublisher:
             progress = await self.render_and_upload(
                 context=context,
                 object_store=object_store,
+                org_id=org_id,
                 project_id=project_id,
             )
         return context, progress

--- a/src/docverse/services/dashboard/publisher.py
+++ b/src/docverse/services/dashboard/publisher.py
@@ -10,9 +10,9 @@ import structlog
 from rubin.repertoire import DiscoveryClient
 
 from docverse.domain.dashboard_context import DashboardContext, EditionContext
+from docverse.exceptions import NotFoundError
+from docverse.services.dashboard_templates.resolver import TemplateResolver
 from docverse.storage.build_store import BuildStore
-from docverse.storage.dashboard_templates.builtin import BuiltInTemplateSource
-from docverse.storage.dashboard_templates.template_source import TemplateSource
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.objectstore import ObjectStore
 from docverse.storage.organization_store import OrganizationStore
@@ -75,7 +75,7 @@ class DashboardPublisher:
         build_store: BuildStore,
         discovery: DiscoveryClient,
         logger: structlog.stdlib.BoundLogger,
-        template_source: TemplateSource | None = None,
+        template_resolver: TemplateResolver,
     ) -> None:
         self._org_store = org_store
         self._project_store = project_store
@@ -83,7 +83,7 @@ class DashboardPublisher:
         self._build_store = build_store
         self._discovery = discovery
         self._logger = logger
-        self._template_source = template_source or BuiltInTemplateSource()
+        self._template_resolver = template_resolver
 
     async def build_context(
         self,
@@ -112,11 +112,29 @@ class DashboardPublisher:
         *,
         context: DashboardContext,
         object_store: ObjectStore,
+        project_id: int,
     ) -> DashboardUploadProgress:
-        """Render the artifacts and upload them to the object store."""
-        config = self._template_source.load_config()
+        """Render the artifacts and upload them to the object store.
 
-        inliner = AssetInliner(template_source=self._template_source)
+        The :class:`TemplateSource` is resolved here (not at construction
+        time) so the per-project override / org default / built-in
+        fallback chain is evaluated freshly for each render.
+
+        Raises
+        ------
+        NotFoundError
+            If ``project_id`` does not correspond to an existing project.
+        """
+        project = await self._project_store.get_by_id(project_id)
+        if project is None:
+            msg = f"Project {project_id} not found"
+            raise NotFoundError(msg)
+        resolved = await self._template_resolver.resolve_for_project(project)
+        template_source = resolved.source
+
+        config = template_source.load_config()
+
+        inliner = AssetInliner(template_source=template_source)
         dashboard_assets = inliner.inline(
             css=config.dashboard.css,
             js=config.dashboard.js,
@@ -124,13 +142,9 @@ class DashboardPublisher:
         )
         dashboard_context = replace(context, assets=dashboard_assets)
 
-        html_renderer = DashboardHtmlRenderer(
-            template_source=self._template_source
-        )
+        html_renderer = DashboardHtmlRenderer(template_source=template_source)
         switcher_renderer = SwitcherJsonRenderer()
-        error_renderer = ErrorPageRenderer(
-            template_source=self._template_source
-        )
+        error_renderer = ErrorPageRenderer(template_source=template_source)
         edition_renderer = EditionJsonRenderer()
 
         html_bytes = html_renderer.render(dashboard_context)
@@ -226,6 +240,8 @@ class DashboardPublisher:
         object_store = await object_store_provider()
         async with object_store:
             progress = await self.render_and_upload(
-                context=context, object_store=object_store
+                context=context,
+                object_store=object_store,
+                project_id=project_id,
             )
         return context, progress

--- a/src/docverse/services/dashboard/publisher.py
+++ b/src/docverse/services/dashboard/publisher.py
@@ -131,6 +131,7 @@ class DashboardPublisher:
             raise NotFoundError(msg)
         resolved = await self._template_resolver.resolve_for_project(project)
         template_source = resolved.source
+        logger = self._logger.bind(template_origin=resolved.origin.value)
 
         config = template_source.load_config()
 
@@ -203,7 +204,7 @@ class DashboardPublisher:
             )
             total += len(data)
 
-        self._logger.info(
+        logger.info(
             "Uploaded dashboard artifacts",
             project=project_slug,
             object_count=len(artifacts),

--- a/src/docverse/services/dashboard/publisher.py
+++ b/src/docverse/services/dashboard/publisher.py
@@ -10,7 +10,10 @@ import structlog
 from rubin.repertoire import DiscoveryClient
 
 from docverse.domain.dashboard_context import DashboardContext, EditionContext
-from docverse.services.dashboard_templates.resolver import TemplateResolver
+from docverse.services.dashboard_templates.resolver import (
+    ResolvedTemplate,
+    TemplateResolver,
+)
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.objectstore import ObjectStore
@@ -106,23 +109,35 @@ class DashboardPublisher:
             rendered_at=rendered_at,
         )
 
+    async def resolve_template(
+        self, *, org_id: int, project_id: int
+    ) -> ResolvedTemplate:
+        """Resolve the effective template for one project render.
+
+        Callers that want to split the resolve (DB-bound) and
+        render-and-upload (pure CPU + object store) steps across separate
+        transaction scopes can call this first and then pass the result
+        into :meth:`render_and_upload`.
+        """
+        return await self._template_resolver.resolve(
+            org_id=org_id, project_id=project_id
+        )
+
     async def render_and_upload(
         self,
         *,
         context: DashboardContext,
         object_store: ObjectStore,
-        org_id: int,
-        project_id: int,
+        resolved: ResolvedTemplate,
     ) -> DashboardUploadProgress:
         """Render the artifacts and upload them to the object store.
 
-        The :class:`TemplateSource` is resolved here (not at construction
-        time) so the per-project override / org default / built-in
-        fallback chain is evaluated freshly for each render.
+        Accepts a pre-resolved :class:`ResolvedTemplate` so callers can
+        close their resolve-time DB transaction before the upload loop
+        opens the object store. ``resolved.source`` is expected to be
+        fully preloaded (GitHub-backed sources are preloaded by
+        :class:`TemplateResolver`), so no DB reads run here.
         """
-        resolved = await self._template_resolver.resolve(
-            org_id=org_id, project_id=project_id
-        )
         template_source = resolved.source
         logger = self._logger.bind(template_origin=resolved.origin.value)
 
@@ -231,12 +246,14 @@ class DashboardPublisher:
             project_id=project_id,
             rendered_at=rendered_at,
         )
+        resolved = await self.resolve_template(
+            org_id=org_id, project_id=project_id
+        )
         object_store = await object_store_provider()
         async with object_store:
             progress = await self.render_and_upload(
                 context=context,
                 object_store=object_store,
-                org_id=org_id,
-                project_id=project_id,
+                resolved=resolved,
             )
         return context, progress

--- a/src/docverse/services/dashboard_templates/__init__.py
+++ b/src/docverse/services/dashboard_templates/__init__.py
@@ -1,0 +1,15 @@
+"""Dashboard-template services (resolution, sync, fan-out)."""
+
+from __future__ import annotations
+
+from .resolver import (
+    ResolvedTemplate,
+    ResolvedTemplateOrigin,
+    TemplateResolver,
+)
+
+__all__ = [
+    "ResolvedTemplate",
+    "ResolvedTemplateOrigin",
+    "TemplateResolver",
+]

--- a/src/docverse/services/dashboard_templates/resolver.py
+++ b/src/docverse/services/dashboard_templates/resolver.py
@@ -8,7 +8,6 @@ from enum import StrEnum
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from docverse.domain.project import Project
 from docverse.storage.dashboard_templates.builtin import BuiltInTemplateSource
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
@@ -75,10 +74,12 @@ class TemplateResolver:
         self._session = session
         self._logger = logger
 
-    async def resolve_for_project(self, project: Project) -> ResolvedTemplate:
-        """Return the template source for rendering ``project``."""
+    async def resolve(
+        self, *, org_id: int, project_id: int
+    ) -> ResolvedTemplate:
+        """Return the template source for rendering the given project."""
         override = await self._binding_store.get_project_override(
-            org_id=project.org_id, project_id=project.id
+            org_id=org_id, project_id=project_id
         )
         if override is not None and override.github_template_id is not None:
             source = await self._load_github_source(
@@ -89,7 +90,7 @@ class TemplateResolver:
                 origin=ResolvedTemplateOrigin.project_override,
             )
 
-        default = await self._binding_store.get_org_default(project.org_id)
+        default = await self._binding_store.get_org_default(org_id)
         if default is not None and default.github_template_id is not None:
             source = await self._load_github_source(default.github_template_id)
             return ResolvedTemplate(

--- a/src/docverse/services/dashboard_templates/resolver.py
+++ b/src/docverse/services/dashboard_templates/resolver.py
@@ -38,7 +38,10 @@ class ResolvedTemplate:
     ``source`` is a :class:`TemplateSource` ready for synchronous reads
     by the renderer pipeline. :class:`GitHubTemplateSource` instances
     returned here have already been ``preload``-ed so the sync read
-    methods do not raise.
+    methods do not raise. ``preload`` loads the template's
+    ``template.toml`` bytes plus every template-file row into an
+    in-memory cache keyed by relative path, so synchronous
+    ``read_template`` / ``read_asset`` calls never raise.
     """
 
     source: TemplateSource

--- a/src/docverse/services/dashboard_templates/resolver.py
+++ b/src/docverse/services/dashboard_templates/resolver.py
@@ -1,0 +1,109 @@
+"""Resolve a project's effective dashboard template at render time."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.domain.project import Project
+from docverse.storage.dashboard_templates.builtin import BuiltInTemplateSource
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+    GitHubTemplateSource,
+)
+from docverse.storage.dashboard_templates.template_source import TemplateSource
+
+__all__ = [
+    "ResolvedTemplate",
+    "ResolvedTemplateOrigin",
+    "TemplateResolver",
+]
+
+
+class ResolvedTemplateOrigin(StrEnum):
+    """Which resolution layer produced a :class:`ResolvedTemplate`."""
+
+    project_override = "project_override"
+    org_default = "org_default"
+    builtin = "builtin"
+
+
+@dataclass(frozen=True)
+class ResolvedTemplate:
+    """The template source selected for a single project's render.
+
+    ``source`` is a :class:`TemplateSource` ready for synchronous reads
+    by the renderer pipeline. :class:`GitHubTemplateSource` instances
+    returned here have already been ``preload``-ed so the sync read
+    methods do not raise.
+    """
+
+    source: TemplateSource
+    origin: ResolvedTemplateOrigin
+
+
+class TemplateResolver:
+    """Resolve a project's effective dashboard template.
+
+    The resolution order, per PRD #232, is:
+
+    1. Project override binding (if it has a synced template).
+    2. Org default binding (if it has a synced template).
+    3. :class:`BuiltInTemplateSource` as the universal last-resort
+       fallback.
+
+    A binding whose ``github_template_id`` is ``None`` is treated as
+    "not found" for resolution purposes — initial-sync-pending bindings
+    fall through to the next layer so dashboards keep rendering while
+    the first sync is still in flight (or has failed outright).
+    """
+
+    def __init__(
+        self,
+        *,
+        binding_store: DashboardGitHubTemplateBindingStore,
+        session: AsyncSession,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._binding_store = binding_store
+        self._session = session
+        self._logger = logger
+
+    async def resolve_for_project(self, project: Project) -> ResolvedTemplate:
+        """Return the template source for rendering ``project``."""
+        override = await self._binding_store.get_project_override(
+            org_id=project.org_id, project_id=project.id
+        )
+        if override is not None and override.github_template_id is not None:
+            source = await self._load_github_source(
+                override.github_template_id
+            )
+            return ResolvedTemplate(
+                source=source,
+                origin=ResolvedTemplateOrigin.project_override,
+            )
+
+        default = await self._binding_store.get_org_default(project.org_id)
+        if default is not None and default.github_template_id is not None:
+            source = await self._load_github_source(default.github_template_id)
+            return ResolvedTemplate(
+                source=source,
+                origin=ResolvedTemplateOrigin.org_default,
+            )
+
+        return ResolvedTemplate(
+            source=BuiltInTemplateSource(),
+            origin=ResolvedTemplateOrigin.builtin,
+        )
+
+    async def _load_github_source(
+        self, template_id: int
+    ) -> GitHubTemplateSource:
+        source = GitHubTemplateSource(
+            template_id=template_id, session=self._session
+        )
+        await source.preload()
+        return source

--- a/src/docverse/services/dashboard_templates/resolver.py
+++ b/src/docverse/services/dashboard_templates/resolver.py
@@ -6,12 +6,11 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 import structlog
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.storage.dashboard_templates.builtin import BuiltInTemplateSource
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
-    GitHubTemplateSource,
+    DashboardGitHubTemplateStore,
 )
 from docverse.storage.dashboard_templates.template_source import TemplateSource
 
@@ -61,17 +60,29 @@ class TemplateResolver:
     "not found" for resolution purposes — initial-sync-pending bindings
     fall through to the next layer so dashboards keep rendering while
     the first sync is still in flight (or has failed outright).
+
+    The FK
+    ``dashboard_github_template_bindings.github_template_id ->
+    dashboard_github_templates.id`` uses ``ON DELETE SET NULL``
+    (see ``src/docverse/dbschema/dashboard_github_template_binding.py``),
+    so within a single transaction a binding with a non-null
+    ``github_template_id`` always points at an existing template row.
+    Across transaction boundaries, a concurrent template delete
+    transitions the binding's ``github_template_id`` to ``NULL`` rather
+    than leaving a dangling reference, so the next resolve call simply
+    falls through to the null-handling branch instead of raising on a
+    missing row.
     """
 
     def __init__(
         self,
         *,
         binding_store: DashboardGitHubTemplateBindingStore,
-        session: AsyncSession,
+        template_store: DashboardGitHubTemplateStore,
         logger: structlog.stdlib.BoundLogger,
     ) -> None:
         self._binding_store = binding_store
-        self._session = session
+        self._template_store = template_store
         self._logger = logger
 
     async def resolve(
@@ -82,7 +93,7 @@ class TemplateResolver:
             org_id=org_id, project_id=project_id
         )
         if override is not None and override.github_template_id is not None:
-            source = await self._load_github_source(
+            source = await self._template_store.load_preloaded_source(
                 override.github_template_id
             )
             return ResolvedTemplate(
@@ -92,7 +103,9 @@ class TemplateResolver:
 
         default = await self._binding_store.get_org_default(org_id)
         if default is not None and default.github_template_id is not None:
-            source = await self._load_github_source(default.github_template_id)
+            source = await self._template_store.load_preloaded_source(
+                default.github_template_id
+            )
             return ResolvedTemplate(
                 source=source,
                 origin=ResolvedTemplateOrigin.org_default,
@@ -102,12 +115,3 @@ class TemplateResolver:
             source=BuiltInTemplateSource(),
             origin=ResolvedTemplateOrigin.builtin,
         )
-
-    async def _load_github_source(
-        self, template_id: int
-    ) -> GitHubTemplateSource:
-        source = GitHubTemplateSource(
-            template_id=template_id, session=self._session
-        )
-        await source.preload()
-        return source

--- a/src/docverse/storage/dashboard_templates/github/template_store.py
+++ b/src/docverse/storage/dashboard_templates/github/template_store.py
@@ -25,6 +25,8 @@ from docverse.domain.dashboard_github_template import (
     DashboardGitHubTemplateFile,
 )
 
+from .source import GitHubTemplateSource
+
 __all__ = [
     "DashboardGitHubTemplateStore",
     "GitHubTemplateFileInput",
@@ -173,6 +175,34 @@ class DashboardGitHubTemplateStore:
             template=DashboardGitHubTemplate.model_validate(row),
             changed=True,
         )
+
+    async def load_preloaded_source(
+        self, template_id: int
+    ) -> GitHubTemplateSource:
+        """Construct and preload a :class:`GitHubTemplateSource`.
+
+        The returned source has already had its async ``preload`` step
+        run, so the synchronous :class:`TemplateSource` reads
+        (``load_config`` / ``read_template`` / ``read_asset``) serve
+        from the in-memory cache without further I/O.
+
+        Raises
+        ------
+        LookupError
+            If no template row exists for ``template_id``.
+        """
+        source = GitHubTemplateSource(
+            template_id=template_id, session=self._session
+        )
+        try:
+            await source.preload()
+        except LookupError as exc:
+            msg = (
+                f"DashboardGitHubTemplate {template_id} not found while "
+                "loading preloaded source"
+            )
+            raise LookupError(msg) from exc
+        return source
 
     async def list_files(
         self, template_id: int

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -124,6 +124,7 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                     progress = await publisher.render_and_upload(
                         context=context,
                         object_store=object_store,
+                        org_id=org_id,
                         project_id=project_id,
                     )
             except Exception as exc:

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -115,9 +115,16 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                             "object_count": 0,
                         },
                     )
-                async with object_store:
+                async with object_store, session.begin():
+                    # render_and_upload resolves the TemplateSource at
+                    # render time (project override → org default →
+                    # built-in), so the DB reads live inside a
+                    # session.begin() that commits before the next
+                    # phase update opens its own transaction.
                     progress = await publisher.render_and_upload(
-                        context=context, object_store=object_store
+                        context=context,
+                        object_store=object_store,
+                        project_id=project_id,
                     )
             except Exception as exc:
                 logger.exception("Dashboard build failed")

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -105,6 +105,13 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                     object_store = await factory.create_objectstore_for_org(
                         org_id=org_id, service_label=service_label
                     )
+                    # Preload the template source in the same short
+                    # transaction so the upload loop below runs with no
+                    # open DB transaction — GitHub-backed sources cache
+                    # their bytes at resolve time.
+                    resolved = await publisher.resolve_template(
+                        org_id=org_id, project_id=project_id
+                    )
 
                 async with session.begin():
                     await queue_job_store.update_phase(
@@ -115,17 +122,11 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                             "object_count": 0,
                         },
                     )
-                async with object_store, session.begin():
-                    # render_and_upload resolves the TemplateSource at
-                    # render time (project override → org default →
-                    # built-in), so the DB reads live inside a
-                    # session.begin() that commits before the next
-                    # phase update opens its own transaction.
+                async with object_store:
                     progress = await publisher.render_and_upload(
                         context=context,
                         object_store=object_store,
-                        org_id=org_id,
-                        project_id=project_id,
+                        resolved=resolved,
                     )
             except Exception as exc:
                 logger.exception("Dashboard build failed")

--- a/tests/services/dashboard/publisher_test.py
+++ b/tests/services/dashboard/publisher_test.py
@@ -8,6 +8,7 @@ import pytest
 import structlog
 from rubin.repertoire import DiscoveryClient
 from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
 
 from docverse.client.models import (
     BuildCreate,
@@ -20,7 +21,11 @@ from docverse.services.dashboard.publisher import DashboardPublisher
 from docverse.services.dashboard_templates.resolver import TemplateResolver
 from docverse.storage.build_store import BuildStore
 from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
     DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
+    GitHubTemplateFileInput,
+    GitHubTemplateKey,
 )
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.objectstore import MockObjectStore
@@ -286,3 +291,168 @@ async def test_publisher_handles_empty_project(
         key.startswith("empty-pub-proj/__editions/")
         for key in mock_store.objects
     )
+
+
+_CUSTOM_TEMPLATE_TOML = b"""\
+[dashboard]
+template = "dashboard.html.jinja"
+
+[dashboard.assets]
+css = []
+js = []
+images = []
+
+[switcher]
+include_kinds = ["main", "release"]
+"""
+
+_CUSTOM_DASHBOARD_JINJA = b"""\
+<!DOCTYPE html>
+<html lang="en">
+<head><title>{{ project.title }}</title></head>
+<body>
+<div id="custom-marker">GITHUB-TEMPLATE-RENDERED-{{ project.slug }}</div>
+</body>
+</html>
+"""
+
+
+@pytest.mark.asyncio
+async def test_publisher_logs_builtin_template_origin(
+    db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
+) -> None:
+    """``template_origin='builtin'`` is bound on unbound-project uploads."""
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+
+    async with db_session.begin():
+        org = await org_store.create(
+            OrganizationCreate(
+                slug="origin-builtin-org",
+                title="Origin Builtin Org",
+                base_domain="origin-builtin.example.com",
+            )
+        )
+        project = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug="origin-builtin-proj",
+                title="Origin Builtin Project",
+                doc_repo="https://github.com/example/origin-builtin",
+            ),
+        )
+        await db_session.commit()
+
+    publisher = _make_publisher(db_session, discovery_client)
+    mock_store = MockObjectStore()
+
+    async def _provider() -> MockObjectStore:
+        return mock_store
+
+    with capture_logs() as captured:
+        async with db_session.begin():
+            await publisher.publish(
+                org_id=org.id,
+                project_id=project.id,
+                object_store_provider=_provider,
+            )
+
+    upload_events = [
+        event
+        for event in captured
+        if event.get("event") == "Uploaded dashboard artifacts"
+    ]
+    assert len(upload_events) == 1
+    assert upload_events[0]["template_origin"] == "builtin"
+
+
+@pytest.mark.asyncio
+async def test_publisher_logs_github_template_origin(
+    db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
+) -> None:
+    """A GitHub-bound render logs ``template_origin='org_default'``."""
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+    template_store = DashboardGitHubTemplateStore(
+        session=db_session, logger=logger
+    )
+    binding_store = DashboardGitHubTemplateBindingStore(
+        session=db_session, logger=logger
+    )
+
+    async with db_session.begin():
+        org = await org_store.create(
+            OrganizationCreate(
+                slug="origin-github-org",
+                title="Origin GitHub Org",
+                base_domain="origin-github.example.com",
+            )
+        )
+        project = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug="origin-github-proj",
+                title="Origin GitHub Project",
+                doc_repo="https://github.com/example/origin-github",
+            ),
+        )
+        template_result = await template_store.upsert(
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+            commit_sha="deadbeef",
+            etag="etag-1",
+            template_toml=_CUSTOM_TEMPLATE_TOML,
+            files=[
+                GitHubTemplateFileInput(
+                    relative_path="dashboard.html.jinja",
+                    is_text=True,
+                    data=_CUSTOM_DASHBOARD_JINJA,
+                ),
+            ],
+        )
+        binding = await binding_store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org.id,
+                project_id=None,
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            )
+        )
+        await binding_store.update_sync_state(
+            binding_id=binding.id,
+            last_sync_status="succeeded",
+            github_template_id=template_result.template.id,
+        )
+        await db_session.commit()
+
+    publisher = _make_publisher(db_session, discovery_client)
+    mock_store = MockObjectStore()
+
+    async def _provider() -> MockObjectStore:
+        return mock_store
+
+    with capture_logs() as captured:
+        async with db_session.begin():
+            await publisher.publish(
+                org_id=org.id,
+                project_id=project.id,
+                object_store_provider=_provider,
+            )
+
+    upload_events = [
+        event
+        for event in captured
+        if event.get("event") == "Uploaded dashboard artifacts"
+    ]
+    assert len(upload_events) == 1
+    assert upload_events[0]["template_origin"] == "org_default"

--- a/tests/services/dashboard/publisher_test.py
+++ b/tests/services/dashboard/publisher_test.py
@@ -18,7 +18,11 @@ from docverse.client.models import (
     TrackingMode,
 )
 from docverse.services.dashboard.publisher import DashboardPublisher
-from docverse.services.dashboard_templates.resolver import TemplateResolver
+from docverse.services.dashboard_templates.resolver import (
+    ResolvedTemplate,
+    ResolvedTemplateOrigin,
+    TemplateResolver,
+)
 from docverse.storage.build_store import BuildStore
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingCreate,
@@ -317,6 +321,148 @@ _CUSTOM_DASHBOARD_JINJA = b"""\
 </body>
 </html>
 """
+
+
+@pytest.mark.asyncio
+async def test_publisher_resolve_template_returns_builtin_when_unbound(
+    db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
+) -> None:
+    """``resolve_template`` returns a ``builtin`` ResolvedTemplate.
+
+    Exercises the no-binding path: a project without an override or
+    org-default binding resolves through to ``BuiltInTemplateSource``.
+    """
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+
+    async with db_session.begin():
+        org = await org_store.create(
+            OrganizationCreate(
+                slug="resolve-builtin-org",
+                title="Resolve Builtin Org",
+                base_domain="resolve-builtin.example.com",
+            )
+        )
+        project = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug="resolve-builtin-proj",
+                title="Resolve Builtin Project",
+                doc_repo="https://github.com/example/resolve-builtin",
+            ),
+        )
+        await db_session.commit()
+
+    publisher = _make_publisher(db_session, discovery_client)
+
+    async with db_session.begin():
+        resolved = await publisher.resolve_template(
+            org_id=org.id, project_id=project.id
+        )
+
+    assert isinstance(resolved, ResolvedTemplate)
+    assert resolved.origin is ResolvedTemplateOrigin.builtin
+
+
+@pytest.mark.asyncio
+async def test_publisher_render_and_upload_uses_provided_resolved_template(
+    db_session: AsyncSession,
+    discovery_client: DiscoveryClient,
+) -> None:
+    """``render_and_upload`` renders from the caller-supplied ``resolved``.
+
+    Pins the contract that the upload loop is a pure consumer of the
+    pre-resolved template: no DB reads happen inside ``render_and_upload``
+    itself, so the worker can commit its resolve-time transaction before
+    entering the object-store context.
+    """
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+    template_store = DashboardGitHubTemplateStore(
+        session=db_session, logger=logger
+    )
+    binding_store = DashboardGitHubTemplateBindingStore(
+        session=db_session, logger=logger
+    )
+
+    async with db_session.begin():
+        org = await org_store.create(
+            OrganizationCreate(
+                slug="render-provided-org",
+                title="Render Provided Org",
+                base_domain="render-provided.example.com",
+            )
+        )
+        project = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug="render-provided-proj",
+                title="Render Provided Project",
+                doc_repo="https://github.com/example/render-provided",
+            ),
+        )
+        template_result = await template_store.upsert(
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+            commit_sha="deadbeef",
+            etag="etag-1",
+            template_toml=_CUSTOM_TEMPLATE_TOML,
+            files=[
+                GitHubTemplateFileInput(
+                    relative_path="dashboard.html.jinja",
+                    is_text=True,
+                    data=_CUSTOM_DASHBOARD_JINJA,
+                ),
+            ],
+        )
+        binding = await binding_store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org.id,
+                project_id=None,
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            )
+        )
+        await binding_store.update_sync_state(
+            binding_id=binding.id,
+            last_sync_status="succeeded",
+            github_template_id=template_result.template.id,
+        )
+        await db_session.commit()
+
+    publisher = _make_publisher(db_session, discovery_client)
+    mock_store = MockObjectStore()
+
+    async with db_session.begin():
+        context = await publisher.build_context(
+            org_id=org.id, project_id=project.id
+        )
+        resolved = await publisher.resolve_template(
+            org_id=org.id, project_id=project.id
+        )
+
+    # Upload loop runs outside any DB transaction: the preloaded
+    # GitHub template source must satisfy every renderer read.
+    async with mock_store:
+        await publisher.render_and_upload(
+            context=context,
+            object_store=mock_store,
+            resolved=resolved,
+        )
+
+    html_obj = mock_store.objects["render-provided-proj/__dashboard.html"]
+    html_text = html_obj.data.decode("utf-8")
+    assert "GITHUB-TEMPLATE-RENDERED-render-provided-proj" in html_text
+    assert resolved.origin is ResolvedTemplateOrigin.org_default
 
 
 @pytest.mark.asyncio

--- a/tests/services/dashboard/publisher_test.py
+++ b/tests/services/dashboard/publisher_test.py
@@ -47,7 +47,9 @@ def _make_publisher(
         binding_store=DashboardGitHubTemplateBindingStore(
             session=session, logger=logger
         ),
-        session=session,
+        template_store=DashboardGitHubTemplateStore(
+            session=session, logger=logger
+        ),
         logger=logger,
     )
     return DashboardPublisher(

--- a/tests/services/dashboard/publisher_test.py
+++ b/tests/services/dashboard/publisher_test.py
@@ -17,7 +17,11 @@ from docverse.client.models import (
     TrackingMode,
 )
 from docverse.services.dashboard.publisher import DashboardPublisher
+from docverse.services.dashboard_templates.resolver import TemplateResolver
 from docverse.storage.build_store import BuildStore
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+)
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.objectstore import MockObjectStore
 from docverse.storage.organization_store import OrganizationStore
@@ -34,6 +38,13 @@ def _make_publisher(
     session: AsyncSession, discovery_client: DiscoveryClient
 ) -> DashboardPublisher:
     logger = _logger()
+    resolver = TemplateResolver(
+        binding_store=DashboardGitHubTemplateBindingStore(
+            session=session, logger=logger
+        ),
+        session=session,
+        logger=logger,
+    )
     return DashboardPublisher(
         org_store=OrganizationStore(session=session, logger=logger),
         project_store=ProjectStore(session=session, logger=logger),
@@ -41,6 +52,7 @@ def _make_publisher(
         build_store=BuildStore(session=session, logger=logger),
         discovery=discovery_client,
         logger=logger,
+        template_resolver=resolver,
     )
 
 

--- a/tests/services/dashboard_templates/resolver_test.py
+++ b/tests/services/dashboard_templates/resolver_test.py
@@ -110,9 +110,12 @@ def _make_resolver(session: AsyncSession) -> TemplateResolver:
     binding_store = DashboardGitHubTemplateBindingStore(
         session=session, logger=logger
     )
+    template_store = DashboardGitHubTemplateStore(
+        session=session, logger=logger
+    )
     return TemplateResolver(
         binding_store=binding_store,
-        session=session,
+        template_store=template_store,
         logger=logger,
     )
 

--- a/tests/services/dashboard_templates/resolver_test.py
+++ b/tests/services/dashboard_templates/resolver_test.py
@@ -130,7 +130,9 @@ async def test_resolve_returns_builtin_when_no_bindings_exist(
 
     resolver = _make_resolver(db_session)
     async with db_session.begin():
-        resolved = await resolver.resolve_for_project(project)
+        resolved = await resolver.resolve(
+            org_id=project.org_id, project_id=project.id
+        )
         await db_session.rollback()
 
     assert resolved.origin is ResolvedTemplateOrigin.builtin
@@ -170,7 +172,9 @@ async def test_resolve_returns_org_default_when_only_default_synced(
 
     resolver = _make_resolver(db_session)
     async with db_session.begin():
-        resolved = await resolver.resolve_for_project(project)
+        resolved = await resolver.resolve(
+            org_id=project.org_id, project_id=project.id
+        )
         await db_session.rollback()
 
     assert resolved.origin is ResolvedTemplateOrigin.org_default
@@ -232,7 +236,9 @@ async def test_resolve_returns_project_override_when_override_synced(
 
     resolver = _make_resolver(db_session)
     async with db_session.begin():
-        resolved = await resolver.resolve_for_project(project)
+        resolved = await resolver.resolve(
+            org_id=project.org_id, project_id=project.id
+        )
         await db_session.rollback()
 
     assert resolved.origin is ResolvedTemplateOrigin.project_override
@@ -280,7 +286,9 @@ async def test_resolve_falls_through_when_override_template_id_is_null(
 
     resolver = _make_resolver(db_session)
     async with db_session.begin():
-        resolved = await resolver.resolve_for_project(project)
+        resolved = await resolver.resolve(
+            org_id=project.org_id, project_id=project.id
+        )
         await db_session.rollback()
 
     assert resolved.origin is ResolvedTemplateOrigin.org_default
@@ -313,7 +321,9 @@ async def test_resolve_falls_through_to_builtin_when_both_template_ids_null(
 
     resolver = _make_resolver(db_session)
     async with db_session.begin():
-        resolved = await resolver.resolve_for_project(project)
+        resolved = await resolver.resolve(
+            org_id=project.org_id, project_id=project.id
+        )
         await db_session.rollback()
 
     assert resolved.origin is ResolvedTemplateOrigin.builtin
@@ -339,7 +349,9 @@ async def test_resolve_returns_builtin_when_only_org_default_is_null(
 
     resolver = _make_resolver(db_session)
     async with db_session.begin():
-        resolved = await resolver.resolve_for_project(project)
+        resolved = await resolver.resolve(
+            org_id=project.org_id, project_id=project.id
+        )
         await db_session.rollback()
 
     assert resolved.origin is ResolvedTemplateOrigin.builtin
@@ -365,7 +377,9 @@ async def test_resolve_returns_builtin_when_only_override_is_null(
 
     resolver = _make_resolver(db_session)
     async with db_session.begin():
-        resolved = await resolver.resolve_for_project(project)
+        resolved = await resolver.resolve(
+            org_id=project.org_id, project_id=project.id
+        )
         await db_session.rollback()
 
     assert resolved.origin is ResolvedTemplateOrigin.builtin
@@ -411,7 +425,9 @@ async def test_resolve_preloads_github_source_so_reads_are_cache_hits(
 
     resolver = _make_resolver(db_session)
     async with db_session.begin():
-        resolved = await resolver.resolve_for_project(project)
+        resolved = await resolver.resolve(
+            org_id=project.org_id, project_id=project.id
+        )
         # Reading template contents should succeed synchronously.
         text = resolved.source.read_template("dashboard.html.jinja")
         await db_session.rollback()

--- a/tests/services/dashboard_templates/resolver_test.py
+++ b/tests/services/dashboard_templates/resolver_test.py
@@ -1,0 +1,419 @@
+"""Tests for TemplateResolver."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import OrganizationCreate, ProjectCreate
+from docverse.domain.project import Project
+from docverse.services.dashboard_templates.resolver import (
+    ResolvedTemplateOrigin,
+    TemplateResolver,
+)
+from docverse.storage.dashboard_templates.builtin import BuiltInTemplateSource
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
+    DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
+    GitHubTemplateFileInput,
+    GitHubTemplateKey,
+    GitHubTemplateSource,
+)
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+
+_TEMPLATE_TOML = b"""\
+[dashboard]
+template = "dashboard.html.jinja"
+"""
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("test")  # type: ignore[no-any-return]
+
+
+async def _seed_org_and_project(
+    session: AsyncSession,
+    *,
+    org_slug: str,
+    project_slug: str = "resolver-proj",
+) -> tuple[int, Project]:
+    logger = _logger()
+    org_store = OrganizationStore(session=session, logger=logger)
+    proj_store = ProjectStore(session=session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=org_slug,
+            title=f"Org {org_slug}",
+            base_domain=f"{org_slug}.example.com",
+        )
+    )
+    project = await proj_store.create(
+        org_id=org.id,
+        data=ProjectCreate(
+            slug=project_slug,
+            title="Resolver Project",
+            doc_repo="https://github.com/example/repo",
+        ),
+    )
+    return org.id, project
+
+
+async def _seed_template(
+    session: AsyncSession,
+    *,
+    key: GitHubTemplateKey,
+    template_toml: bytes = _TEMPLATE_TOML,
+) -> int:
+    template_store = DashboardGitHubTemplateStore(
+        session=session, logger=_logger()
+    )
+    result = await template_store.upsert(
+        key=key,
+        commit_sha="deadbeef",
+        etag="etag-1",
+        template_toml=template_toml,
+        files=[
+            GitHubTemplateFileInput(
+                relative_path="dashboard.html.jinja",
+                is_text=True,
+                data=b"<html>custom</html>",
+            ),
+        ],
+    )
+    return result.template.id
+
+
+def _binding_create(
+    *,
+    org_id: int,
+    project_id: int | None,
+    github_owner: str = "acme",
+    github_repo: str = "dashboard-templates",
+    github_ref: str = "main",
+    root_path: str = "/",
+) -> DashboardGitHubTemplateBindingCreate:
+    return DashboardGitHubTemplateBindingCreate(
+        org_id=org_id,
+        project_id=project_id,
+        github_owner=github_owner,
+        github_repo=github_repo,
+        github_ref=github_ref,
+        root_path=root_path,
+    )
+
+
+def _make_resolver(session: AsyncSession) -> TemplateResolver:
+    logger = _logger()
+    binding_store = DashboardGitHubTemplateBindingStore(
+        session=session, logger=logger
+    )
+    return TemplateResolver(
+        binding_store=binding_store,
+        session=session,
+        logger=logger,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_builtin_when_no_bindings_exist(
+    db_session: AsyncSession,
+) -> None:
+    """With zero binding rows, the built-in template serves every project."""
+    async with db_session.begin():
+        _, project = await _seed_org_and_project(
+            db_session, org_slug="resolver-empty"
+        )
+        await db_session.commit()
+
+    resolver = _make_resolver(db_session)
+    async with db_session.begin():
+        resolved = await resolver.resolve_for_project(project)
+        await db_session.rollback()
+
+    assert resolved.origin is ResolvedTemplateOrigin.builtin
+    assert isinstance(resolved.source, BuiltInTemplateSource)
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_org_default_when_only_default_synced(
+    db_session: AsyncSession,
+) -> None:
+    """With an org default binding that has a synced template, use it."""
+    async with db_session.begin():
+        org_id, project = await _seed_org_and_project(
+            db_session, org_slug="resolver-org"
+        )
+        template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await binding_store.create(
+            _binding_create(org_id=org_id, project_id=None)
+        )
+        await binding_store.update_sync_state(
+            binding_id=binding.id,
+            last_sync_status="succeeded",
+            github_template_id=template_id,
+        )
+        await db_session.commit()
+
+    resolver = _make_resolver(db_session)
+    async with db_session.begin():
+        resolved = await resolver.resolve_for_project(project)
+        await db_session.rollback()
+
+    assert resolved.origin is ResolvedTemplateOrigin.org_default
+    assert isinstance(resolved.source, GitHubTemplateSource)
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_project_override_when_override_synced(
+    db_session: AsyncSession,
+) -> None:
+    """A synced project override shadows any other binding layer."""
+    async with db_session.begin():
+        org_id, project = await _seed_org_and_project(
+            db_session, org_slug="resolver-override"
+        )
+        # Seed an org default too, to prove the override wins.
+        default_template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+        )
+        override_template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="override-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        default_binding = await binding_store.create(
+            _binding_create(org_id=org_id, project_id=None)
+        )
+        await binding_store.update_sync_state(
+            binding_id=default_binding.id,
+            last_sync_status="succeeded",
+            github_template_id=default_template_id,
+        )
+        override_binding = await binding_store.create(
+            _binding_create(
+                org_id=org_id,
+                project_id=project.id,
+                github_repo="override-templates",
+            )
+        )
+        await binding_store.update_sync_state(
+            binding_id=override_binding.id,
+            last_sync_status="succeeded",
+            github_template_id=override_template_id,
+        )
+        await db_session.commit()
+
+    resolver = _make_resolver(db_session)
+    async with db_session.begin():
+        resolved = await resolver.resolve_for_project(project)
+        await db_session.rollback()
+
+    assert resolved.origin is ResolvedTemplateOrigin.project_override
+    assert isinstance(resolved.source, GitHubTemplateSource)
+
+
+@pytest.mark.asyncio
+async def test_resolve_falls_through_when_override_template_id_is_null(
+    db_session: AsyncSession,
+) -> None:
+    """A project override pending initial sync falls through to org default."""
+    async with db_session.begin():
+        org_id, project = await _seed_org_and_project(
+            db_session, org_slug="resolver-override-null"
+        )
+        default_template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        default_binding = await binding_store.create(
+            _binding_create(org_id=org_id, project_id=None)
+        )
+        await binding_store.update_sync_state(
+            binding_id=default_binding.id,
+            last_sync_status="succeeded",
+            github_template_id=default_template_id,
+        )
+        # Override exists but has NEVER completed a sync.
+        await binding_store.create(
+            _binding_create(
+                org_id=org_id,
+                project_id=project.id,
+                github_repo="override-templates",
+            )
+        )
+        await db_session.commit()
+
+    resolver = _make_resolver(db_session)
+    async with db_session.begin():
+        resolved = await resolver.resolve_for_project(project)
+        await db_session.rollback()
+
+    assert resolved.origin is ResolvedTemplateOrigin.org_default
+    assert isinstance(resolved.source, GitHubTemplateSource)
+
+
+@pytest.mark.asyncio
+async def test_resolve_falls_through_to_builtin_when_both_template_ids_null(
+    db_session: AsyncSession,
+) -> None:
+    """Override AND default both pending-sync ⇒ built-in fallback."""
+    async with db_session.begin():
+        org_id, project = await _seed_org_and_project(
+            db_session, org_slug="resolver-both-null"
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        await binding_store.create(
+            _binding_create(org_id=org_id, project_id=None)
+        )
+        await binding_store.create(
+            _binding_create(
+                org_id=org_id,
+                project_id=project.id,
+                github_repo="override-templates",
+            )
+        )
+        await db_session.commit()
+
+    resolver = _make_resolver(db_session)
+    async with db_session.begin():
+        resolved = await resolver.resolve_for_project(project)
+        await db_session.rollback()
+
+    assert resolved.origin is ResolvedTemplateOrigin.builtin
+    assert isinstance(resolved.source, BuiltInTemplateSource)
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_builtin_when_only_org_default_is_null(
+    db_session: AsyncSession,
+) -> None:
+    """Org default pending-sync with no override ⇒ built-in fallback."""
+    async with db_session.begin():
+        org_id, project = await _seed_org_and_project(
+            db_session, org_slug="resolver-default-null"
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        await binding_store.create(
+            _binding_create(org_id=org_id, project_id=None)
+        )
+        await db_session.commit()
+
+    resolver = _make_resolver(db_session)
+    async with db_session.begin():
+        resolved = await resolver.resolve_for_project(project)
+        await db_session.rollback()
+
+    assert resolved.origin is ResolvedTemplateOrigin.builtin
+    assert isinstance(resolved.source, BuiltInTemplateSource)
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_builtin_when_only_override_is_null(
+    db_session: AsyncSession,
+) -> None:
+    """Override pending-sync with no default ⇒ built-in fallback."""
+    async with db_session.begin():
+        org_id, project = await _seed_org_and_project(
+            db_session, org_slug="resolver-override-only-null"
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        await binding_store.create(
+            _binding_create(org_id=org_id, project_id=project.id)
+        )
+        await db_session.commit()
+
+    resolver = _make_resolver(db_session)
+    async with db_session.begin():
+        resolved = await resolver.resolve_for_project(project)
+        await db_session.rollback()
+
+    assert resolved.origin is ResolvedTemplateOrigin.builtin
+    assert isinstance(resolved.source, BuiltInTemplateSource)
+
+
+@pytest.mark.asyncio
+async def test_resolve_preloads_github_source_so_reads_are_cache_hits(
+    db_session: AsyncSession,
+) -> None:
+    """Resolver returns a preloaded GitHubTemplateSource.
+
+    Callers (renderers) invoke ``load_config`` / ``read_template`` /
+    ``read_asset`` synchronously on the ``TemplateSource`` protocol, so
+    the resolver must do the async ``preload`` itself — otherwise those
+    sync reads would raise ``RuntimeError``.
+    """
+    async with db_session.begin():
+        org_id, project = await _seed_org_and_project(
+            db_session, org_slug="resolver-preload"
+        )
+        template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await binding_store.create(
+            _binding_create(org_id=org_id, project_id=None)
+        )
+        await binding_store.update_sync_state(
+            binding_id=binding.id,
+            last_sync_status="succeeded",
+            github_template_id=template_id,
+        )
+        await db_session.commit()
+
+    resolver = _make_resolver(db_session)
+    async with db_session.begin():
+        resolved = await resolver.resolve_for_project(project)
+        # Reading template contents should succeed synchronously.
+        text = resolved.source.read_template("dashboard.html.jinja")
+        await db_session.rollback()
+
+    assert text == "<html>custom</html>"

--- a/tests/storage/dashboard_templates/github/template_store_test.py
+++ b/tests/storage/dashboard_templates/github/template_store_test.py
@@ -311,6 +311,44 @@ async def test_get_file_returns_single_row(
 
 
 @pytest.mark.asyncio
+async def test_load_preloaded_source_round_trips_synced_files(
+    db_session: AsyncSession,
+) -> None:
+    """The store hands back a preloaded source whose sync reads hit cache."""
+    async with db_session.begin():
+        store = _store(db_session)
+        upsert = await store.upsert(
+            key=_KEY,
+            commit_sha="deadbeef",
+            etag="etag-1",
+            template_toml=_TEMPLATE_TOML,
+            files=_files(),
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = _store(db_session)
+        source = await store.load_preloaded_source(upsert.template.id)
+        html = source.read_template("dashboard.html.jinja")
+        css = source.read_asset("dashboard.css")
+        await db_session.rollback()
+    assert html == "<html></html>"
+    assert css == b"body { color: red; }"
+
+
+@pytest.mark.asyncio
+async def test_load_preloaded_source_raises_lookup_error_for_missing_id(
+    db_session: AsyncSession,
+) -> None:
+    """A non-existent template id surfaces as ``LookupError``."""
+    async with db_session.begin():
+        store = _store(db_session)
+        with pytest.raises(LookupError):
+            await store.load_preloaded_source(999_999)
+        await db_session.rollback()
+
+
+@pytest.mark.asyncio
 async def test_unique_template_key_blocks_direct_duplicate(
     db_session: AsyncSession,
 ) -> None:

--- a/tests/worker/dashboard_build_test.py
+++ b/tests/worker/dashboard_build_test.py
@@ -29,6 +29,13 @@ from docverse.domain.queue import JobKind, JobStatus
 from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.lock_service import LockClass, LockKey
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
+    DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
+    GitHubTemplateFileInput,
+    GitHubTemplateKey,
+)
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.objectstore import MockObjectStore
 from docverse.storage.organization_store import OrganizationStore
@@ -331,3 +338,135 @@ async def test_dashboard_build_acquires_project_lock_before_render(
     assert op_timestamps, "expected dashboard render uploads"
     proj_enter_ts = proj_enters[0].timestamp
     assert all(ts > proj_enter_ts for ts in op_timestamps)
+
+
+_CUSTOM_TEMPLATE_TOML = b"""\
+[dashboard]
+template = "dashboard.html.jinja"
+
+[dashboard.assets]
+css = []
+js = []
+images = []
+
+[switcher]
+include_kinds = ["main", "release"]
+"""
+
+# Intentionally distinctive so we can tell this template rendered vs. the
+# packaged built-in. The built-in dashboard renders a <main> element; ours
+# renders a single <div id="custom-marker"> with a well-known token.
+_CUSTOM_DASHBOARD_JINJA = b"""\
+<!DOCTYPE html>
+<html lang="en">
+<head><title>{{ project.title }}</title></head>
+<body>
+<div id="custom-marker">GITHUB-TEMPLATE-RENDERED-{{ project.slug }}</div>
+</body>
+</html>
+"""
+
+
+@pytest.mark.asyncio
+async def test_dashboard_build_uses_github_template_when_bound(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bound GitHub template is used for the render instead of built-in.
+
+    Seeds a synced GitHub template with distinctive bytes and an
+    org-default binding pointing at it, then runs ``dashboard_build``
+    and asserts the rendered HTML reflects the synced bytes rather than
+    the packaged ``BuiltInTemplateSource`` defaults.
+    """
+    logger = _logger()
+    mock_store = MockObjectStore()
+
+    async with db_session.begin():
+        org, project = await _setup_org_and_project(db_session)
+        # Seed a synced GitHub template + bind it as the org default so
+        # TemplateResolver returns it for this project's render.
+        template_store = DashboardGitHubTemplateStore(
+            session=db_session, logger=logger
+        )
+        template_result = await template_store.upsert(
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+            commit_sha="deadbeef",
+            etag="etag-1",
+            template_toml=_CUSTOM_TEMPLATE_TOML,
+            files=[
+                GitHubTemplateFileInput(
+                    relative_path="dashboard.html.jinja",
+                    is_text=True,
+                    data=_CUSTOM_DASHBOARD_JINJA,
+                ),
+            ],
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=logger
+        )
+        binding = await binding_store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org.id,
+                project_id=None,
+                github_owner="acme",
+                github_repo="dashboard-templates",
+                github_ref="main",
+                root_path="/",
+            )
+        )
+        await binding_store.update_sync_state(
+            binding_id=binding.id,
+            last_sync_status="succeeded",
+            github_template_id=template_result.template.id,
+        )
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        queue_job = await queue_job_store.create(
+            kind=JobKind.dashboard_build,
+            org_id=org.id,
+            project_id=project.id,
+            backend_job_id="test-arq-dash-github",
+        )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_objectstore_for_org",
+        _mock_create_objectstore(mock_store),
+    )
+
+    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
+    http_client = httpx.AsyncClient()
+    ctx: dict[str, Any] = {
+        "encryptor": encryptor,
+        "http_client": http_client,
+        "discovery": DiscoveryClient(http_client),
+        "job_id": "test-arq-dash-github",
+        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
+    }
+    payload: dict[str, Any] = {
+        "org_id": org.id,
+        "org_slug": org.slug,
+        "project_id": project.id,
+        "project_slug": project.slug,
+        "queue_job_id": queue_job.id,
+        "queue_job_public_id": serialize_base32_id(queue_job.public_id),
+    }
+
+    result = await dashboard_build(ctx, payload)
+    await ctx["http_client"].aclose()
+
+    assert result == "completed"
+    html_obj = mock_store.objects["dash-proj/__dashboard.html"]
+    html_text = html_obj.data.decode("utf-8")
+    # Marker proves the GitHub-synced template rendered.
+    assert "GITHUB-TEMPLATE-RENDERED-dash-proj" in html_text
+    assert 'id="custom-marker"' in html_text
+    # Built-in template's <main> element must not appear — if it does
+    # we resolved to BuiltInTemplateSource, which would be a regression.
+    assert "<main>" not in html_text


### PR DESCRIPTION
## Summary

- Add `TemplateResolver` + frozen `ResolvedTemplate(source, origin)` implementing the PRD's project override → org default → `BuiltInTemplateSource` chain; bindings with `github_template_id IS NULL` (pre-first-sync or failed) fall through so dashboards keep rendering while a first sync is pending.
- Shift `DashboardPublisher` to render-time template resolution: `__init__` takes a `TemplateResolver` (replacing the construction-time `template_source`), `render_and_upload` selects the source per render, and the "Uploaded dashboard artifacts" log line carries `template_origin` so operators can see which layer served each build.
- Clean up the resolver surface: keyword-only `resolve(*, org_id, project_id)` drops the render-time `Project` re-fetch, and `DashboardGitHubTemplateStore.load_preloaded_source` moves session-bound construct-and-preload off the resolver so `TemplateResolver` depends only on storage collaborators.
- Split `dashboard_build` so template resolution + preload commit in a short DB transaction before the object-store upload loop opens; the upload loop no longer holds a DB transaction while streaming to the object store.

## Validation steps

- [ ] Confirm an existing install with zero `dashboard_github_template_bindings` rows still renders dashboards via `BuiltInTemplateSource` (the integration test covers this, but also spot-check a real dashboard build in dev).
- [ ] Seed a `dashboard_github_template_bindings` row pointing at a synced `dashboard_github_templates` row for a test project and run `dashboard_build`; confirm the rendered HTML reflects the synced template bytes rather than the packaged defaults.
- [ ] Verify a binding with `github_template_id = NULL` (pre-first-sync) does not blow up `dashboard_build` — the resolver falls through to the org default or built-in.
- [ ] Observe a real `dashboard_build` run: the Postgres connection pool should not show a transaction held open during the object-store upload phase (the per-project DB transaction now closes before uploads begin).

## References

- Closes #234
- Closes #249
- Closes #250
- Closes #251
- Closes #252
- PRD: #232
- Jira: https://rubinobs.atlassian.net/browse/DM-54689