### PR TITLE
DM-54689: Add dashboard-template binding CRUD handlers

### DIFF
--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -18,6 +18,10 @@ from .credentials import (
     S3Credentials,
 )
 from .dashboard import DashboardRebuildResponse, OrgDashboardRebuildEntry
+from .dashboard_template import (
+    DashboardTemplateBinding,
+    DashboardTemplateBindingCreate,
+)
 from .editions import (
     DefaultEditionConfig,
     Edition,
@@ -67,6 +71,8 @@ __all__ = [
     "CredentialPayload",
     "CredentialProvider",
     "DashboardRebuildResponse",
+    "DashboardTemplateBinding",
+    "DashboardTemplateBindingCreate",
     "DefaultEditionConfig",
     "Edition",
     "EditionBuildHistoryEntry",

--- a/client/src/docverse/client/models/dashboard_template.py
+++ b/client/src/docverse/client/models/dashboard_template.py
@@ -1,0 +1,93 @@
+"""Pydantic models for dashboard-template binding resources."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "DashboardTemplateBinding",
+    "DashboardTemplateBindingCreate",
+]
+
+
+class DashboardTemplateBindingCreate(BaseModel):
+    """Request model for creating or updating a dashboard-template binding."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    github_owner: Annotated[
+        str,
+        Field(
+            min_length=1,
+            max_length=256,
+            description="GitHub owner (user or organization login).",
+        ),
+    ]
+
+    github_repo: Annotated[
+        str,
+        Field(
+            min_length=1,
+            max_length=256,
+            description="GitHub repository name.",
+        ),
+    ]
+
+    github_ref: Annotated[
+        str,
+        Field(
+            min_length=1,
+            max_length=256,
+            description="Git ref (branch, tag, or commit SHA) to sync from.",
+        ),
+    ]
+
+    root_path: Annotated[
+        str,
+        Field(
+            min_length=1,
+            max_length=512,
+            description=(
+                "Path within the repository where the template lives."
+                " Defaults to ``/`` (repo root)."
+            ),
+        ),
+    ] = "/"
+
+
+class DashboardTemplateBinding(BaseModel):
+    """Response model for a dashboard-template binding."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    self_url: str = Field(description="URL to this binding resource.")
+
+    github_owner: str = Field(description="GitHub owner (user or org).")
+
+    github_repo: str = Field(description="GitHub repository name.")
+
+    github_ref: str = Field(description="Git ref (branch, tag, or SHA).")
+
+    root_path: str = Field(
+        description="Path within the repo where the template lives."
+    )
+
+    last_sync_status: str = Field(
+        description="One of ``pending``, ``succeeded``, ``failed``."
+    )
+
+    last_sync_error: str | None = Field(
+        default=None,
+        description="Operator-readable error from the most recent sync.",
+    )
+
+    date_created: datetime = Field(
+        description="Timestamp when the binding was created."
+    )
+
+    date_updated: datetime = Field(
+        description="Timestamp of the most recent update."
+    )

--- a/client/src/docverse/client/models/dashboard_template.py
+++ b/client/src/docverse/client/models/dashboard_template.py
@@ -22,7 +22,8 @@ class DashboardTemplateBindingCreate(BaseModel):
         str,
         Field(
             min_length=1,
-            max_length=256,
+            max_length=39,
+            pattern=r"^[A-Za-z0-9](?:-?[A-Za-z0-9])*$",
             description="GitHub owner (user or organization login).",
         ),
     ]
@@ -31,7 +32,8 @@ class DashboardTemplateBindingCreate(BaseModel):
         str,
         Field(
             min_length=1,
-            max_length=256,
+            max_length=100,
+            pattern=r"^[A-Za-z0-9._-]+$",
             description="GitHub repository name.",
         ),
     ]

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -270,14 +270,19 @@ class Factory:
             logger=self._logger,
         )
 
+    def _create_dashboard_github_template_binding_store(
+        self,
+    ) -> DashboardGitHubTemplateBindingStore:
+        return DashboardGitHubTemplateBindingStore(
+            session=self._session, logger=self._logger
+        )
+
     def create_dashboard_template_binding_service(
         self,
     ) -> DashboardTemplateBindingService:
         """Create a :class:`DashboardTemplateBindingService`."""
         return DashboardTemplateBindingService(
-            binding_store=DashboardGitHubTemplateBindingStore(
-                session=self._session, logger=self._logger
-            ),
+            binding_store=self._create_dashboard_github_template_binding_store(),
             org_store=self._create_org_store(),
             project_store=self._create_project_store(),
             logger=self._logger,

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -14,7 +14,10 @@ from .services.credential import CredentialService
 from .services.credential_encryptor import CredentialEncryptor
 from .services.dashboard.enqueue import DashboardBuildEnqueuer
 from .services.dashboard.publisher import DashboardPublisher
-from .services.dashboard_templates import TemplateResolver
+from .services.dashboard_templates import (
+    DashboardTemplateBindingService,
+    TemplateResolver,
+)
 from .services.edition import EditionService
 from .services.edition_publishing import EditionPublishingService
 from .services.edition_tracking import (
@@ -264,6 +267,19 @@ class Factory:
                 session=self._session, logger=self._logger
             ),
             publisher_provider=self.create_edition_publisher_for_org,
+            logger=self._logger,
+        )
+
+    def create_dashboard_template_binding_service(
+        self,
+    ) -> DashboardTemplateBindingService:
+        """Create a :class:`DashboardTemplateBindingService`."""
+        return DashboardTemplateBindingService(
+            binding_store=DashboardGitHubTemplateBindingStore(
+                session=self._session, logger=self._logger
+            ),
+            org_store=self._create_org_store(),
+            project_store=self._create_project_store(),
             logger=self._logger,
         )
 

--- a/src/docverse/handlers/orgs/__init__.py
+++ b/src/docverse/handlers/orgs/__init__.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter
 from .builds import router as builds_router
 from .credentials import router as credentials_router
 from .dashboard import router as dashboard_router
+from .dashboard_template import router as dashboard_template_router
 from .editions import router as editions_router
 from .members import router as members_router
 from .organizations import router as organizations_router
@@ -20,5 +21,6 @@ orgs_router.include_router(members_router, tags=["orgs"])
 orgs_router.include_router(credentials_router, tags=["orgs"])
 orgs_router.include_router(services_router, tags=["orgs"])
 orgs_router.include_router(dashboard_router, tags=["projects"])
+orgs_router.include_router(dashboard_template_router, tags=["projects"])
 
 __all__ = ["orgs_router"]

--- a/src/docverse/handlers/orgs/dashboard_template.py
+++ b/src/docverse/handlers/orgs/dashboard_template.py
@@ -1,0 +1,165 @@
+"""Dashboard-template binding endpoints within an organization."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Response, status
+
+from docverse.client.models import DashboardTemplateBindingCreate
+from docverse.dependencies.auth import AuthenticatedUser, require_admin
+from docverse.dependencies.context import RequestContext, context_dependency
+from docverse.handlers.params import OrgSlugParam, ProjectSlugParam
+
+from .models import DashboardTemplateBindingResponse
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Org-default binding
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/orgs/{org}/dashboard-template",
+    response_model=DashboardTemplateBindingResponse,
+    summary="Get the organization's default dashboard-template binding",
+    name="get_org_dashboard_template",
+)
+async def get_org_dashboard_template(
+    org_slug: OrgSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+) -> DashboardTemplateBindingResponse:
+    async with context.session.begin():
+        service = context.factory.create_dashboard_template_binding_service()
+        binding = await service.get_org_default(org_slug=org_slug)
+    return DashboardTemplateBindingResponse.from_domain(
+        binding, context.request, org_slug=org_slug
+    )
+
+
+@router.put(
+    "/orgs/{org}/dashboard-template",
+    response_model=DashboardTemplateBindingResponse,
+    summary="Create or update the org-default dashboard-template binding",
+    name="put_org_dashboard_template",
+)
+async def put_org_dashboard_template(
+    org_slug: OrgSlugParam,
+    data: DashboardTemplateBindingCreate,
+    response: Response,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+) -> DashboardTemplateBindingResponse:
+    async with context.session.begin():
+        service = context.factory.create_dashboard_template_binding_service()
+        result = await service.put_org_default(org_slug=org_slug, data=data)
+        if result.changed:
+            await context.session.commit()
+    response.status_code = (
+        status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
+    )
+    return DashboardTemplateBindingResponse.from_domain(
+        result.binding, context.request, org_slug=org_slug
+    )
+
+
+@router.delete(
+    "/orgs/{org}/dashboard-template",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete the organization's default dashboard-template binding",
+    name="delete_org_dashboard_template",
+)
+async def delete_org_dashboard_template(
+    org_slug: OrgSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+) -> None:
+    async with context.session.begin():
+        service = context.factory.create_dashboard_template_binding_service()
+        await service.delete_org_default(org_slug=org_slug)
+        await context.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Project-override binding
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/orgs/{org}/projects/{project}/dashboard-template",
+    response_model=DashboardTemplateBindingResponse,
+    summary="Get a project's dashboard-template binding override",
+    name="get_project_dashboard_template",
+)
+async def get_project_dashboard_template(
+    org_slug: OrgSlugParam,
+    project_slug: ProjectSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+) -> DashboardTemplateBindingResponse:
+    async with context.session.begin():
+        service = context.factory.create_dashboard_template_binding_service()
+        binding = await service.get_project_override(
+            org_slug=org_slug, project_slug=project_slug
+        )
+    return DashboardTemplateBindingResponse.from_domain(
+        binding,
+        context.request,
+        org_slug=org_slug,
+        project_slug=project_slug,
+    )
+
+
+@router.put(
+    "/orgs/{org}/projects/{project}/dashboard-template",
+    response_model=DashboardTemplateBindingResponse,
+    summary="Create or update a project's dashboard-template binding override",
+    name="put_project_dashboard_template",
+)
+async def put_project_dashboard_template(  # noqa: PLR0913
+    org_slug: OrgSlugParam,
+    project_slug: ProjectSlugParam,
+    data: DashboardTemplateBindingCreate,
+    response: Response,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+) -> DashboardTemplateBindingResponse:
+    async with context.session.begin():
+        service = context.factory.create_dashboard_template_binding_service()
+        result = await service.put_project_override(
+            org_slug=org_slug, project_slug=project_slug, data=data
+        )
+        if result.changed:
+            await context.session.commit()
+    response.status_code = (
+        status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
+    )
+    return DashboardTemplateBindingResponse.from_domain(
+        result.binding,
+        context.request,
+        org_slug=org_slug,
+        project_slug=project_slug,
+    )
+
+
+@router.delete(
+    "/orgs/{org}/projects/{project}/dashboard-template",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a project's dashboard-template binding override",
+    name="delete_project_dashboard_template",
+)
+async def delete_project_dashboard_template(
+    org_slug: OrgSlugParam,
+    project_slug: ProjectSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+) -> None:
+    async with context.session.begin():
+        service = context.factory.create_dashboard_template_binding_service()
+        await service.delete_project_override(
+            org_slug=org_slug, project_slug=project_slug
+        )
+        await context.session.commit()

--- a/src/docverse/handlers/orgs/models.py
+++ b/src/docverse/handlers/orgs/models.py
@@ -11,6 +11,9 @@ from docverse.client.models import (
     DashboardRebuildResponse as _DashboardRebuildResponseBase,
 )
 from docverse.client.models import (
+    DashboardTemplateBinding as _DashboardTemplateBindingBase,
+)
+from docverse.client.models import (
     DefaultEditionConfig,
     OrganizationServiceSummary,
 )
@@ -32,6 +35,9 @@ from docverse.client.models import OrgMembership as _OrgMembershipBase
 from docverse.client.models import Project as _ProjectBase
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.build import Build as BuildDomain
+from docverse.domain.dashboard_github_template import (
+    DashboardGitHubTemplateBinding as DashboardGitHubTemplateBindingDomain,
+)
 from docverse.domain.edition import Edition as EditionDomain
 from docverse.domain.edition_build_history import (
     EditionBuildHistoryWithBuild as EditionBuildHistoryWithBuildDomain,
@@ -437,6 +443,44 @@ class OrgDashboardRebuildEntry(_OrgDashboardRebuildEntryBase):
             queue_job_url=str(
                 request.url_for("get_queue_job", job=queue_job_id)
             ),
+        )
+
+
+class DashboardTemplateBindingResponse(_DashboardTemplateBindingBase):
+    """Dashboard-template binding response with HATEOAS URL."""
+
+    @classmethod
+    def from_domain(
+        cls,
+        domain: DashboardGitHubTemplateBindingDomain,
+        request: Request,
+        *,
+        org_slug: str,
+        project_slug: str | None = None,
+    ) -> Self:
+        """Create from a domain binding, adding the ``self_url``."""
+        if project_slug is None:
+            self_url = str(
+                request.url_for("get_org_dashboard_template", org=org_slug)
+            )
+        else:
+            self_url = str(
+                request.url_for(
+                    "get_project_dashboard_template",
+                    org=org_slug,
+                    project=project_slug,
+                )
+            )
+        return cls(
+            self_url=self_url,
+            github_owner=domain.github_owner,
+            github_repo=domain.github_repo,
+            github_ref=domain.github_ref,
+            root_path=domain.root_path,
+            last_sync_status=domain.last_sync_status,
+            last_sync_error=domain.last_sync_error,
+            date_created=domain.date_created,
+            date_updated=domain.date_updated,
         )
 
 

--- a/src/docverse/services/dashboard_templates/__init__.py
+++ b/src/docverse/services/dashboard_templates/__init__.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from .binding import (
+    DashboardTemplateBindingResult,
+    DashboardTemplateBindingService,
+)
 from .resolver import (
     ResolvedTemplate,
     ResolvedTemplateOrigin,
@@ -9,6 +13,8 @@ from .resolver import (
 )
 
 __all__ = [
+    "DashboardTemplateBindingResult",
+    "DashboardTemplateBindingService",
     "ResolvedTemplate",
     "ResolvedTemplateOrigin",
     "TemplateResolver",

--- a/src/docverse/services/dashboard_templates/binding.py
+++ b/src/docverse/services/dashboard_templates/binding.py
@@ -1,0 +1,253 @@
+"""Business logic for dashboard-template binding CRUD."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import structlog
+
+from docverse.client.models import DashboardTemplateBindingCreate
+from docverse.domain.dashboard_github_template import (
+    DashboardGitHubTemplateBinding,
+)
+from docverse.exceptions import NotFoundError
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.dashboard_templates.github.binding_store import (
+    DashboardGitHubTemplateBindingCreate as _BindingCreate,
+)
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+
+__all__ = [
+    "DashboardTemplateBindingResult",
+    "DashboardTemplateBindingService",
+]
+
+
+@dataclass(frozen=True)
+class DashboardTemplateBindingResult:
+    """Outcome of a PUT binding call.
+
+    ``created`` distinguishes a brand-new row from an in-place update so
+    the handler can return 201 vs. 200. ``changed`` is ``False`` when
+    the PUT was a no-op because every source field already matched the
+    stored row — in that case, no write happened and ``date_updated``
+    is unchanged.
+    """
+
+    binding: DashboardGitHubTemplateBinding
+    created: bool
+    changed: bool
+
+
+class DashboardTemplateBindingService:
+    """CRUD for dashboard-template bindings scoped to an organization.
+
+    The service owns slug → ID resolution and the create-vs-update
+    branching so handlers stay a thin HTTP layer. It deliberately does
+    *not* enqueue a sync on PUT — that wiring lands with the worker
+    slice (see PRD #232).
+    """
+
+    def __init__(
+        self,
+        binding_store: DashboardGitHubTemplateBindingStore,
+        org_store: OrganizationStore,
+        project_store: ProjectStore,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._binding_store = binding_store
+        self._org_store = org_store
+        self._project_store = project_store
+        self._logger = logger
+
+    async def _resolve_org_id(self, org_slug: str) -> int:
+        org = await self._org_store.get_by_slug(org_slug)
+        if org is None:
+            msg = f"Organization {org_slug!r} not found"
+            raise NotFoundError(msg)
+        return org.id
+
+    async def _resolve_project_id(
+        self, *, org_id: int, project_slug: str
+    ) -> int:
+        project = await self._project_store.get_by_slug(
+            org_id=org_id, slug=project_slug
+        )
+        if project is None:
+            msg = f"Project {project_slug!r} not found"
+            raise NotFoundError(msg)
+        return project.id
+
+    async def get_org_default(
+        self, *, org_slug: str
+    ) -> DashboardGitHubTemplateBinding:
+        """Fetch the org's default binding or raise :class:`NotFoundError`."""
+        org_id = await self._resolve_org_id(org_slug)
+        binding = await self._binding_store.get_org_default(org_id)
+        if binding is None:
+            msg = (
+                f"No dashboard-template binding for organization {org_slug!r}"
+            )
+            raise NotFoundError(msg)
+        return binding
+
+    async def put_org_default(
+        self,
+        *,
+        org_slug: str,
+        data: DashboardTemplateBindingCreate,
+    ) -> DashboardTemplateBindingResult:
+        """Create or update the org-default binding."""
+        org_id = await self._resolve_org_id(org_slug)
+        existing = await self._binding_store.get_org_default(org_id)
+        return await self._upsert(
+            org_id=org_id,
+            project_id=None,
+            existing=existing,
+            data=data,
+        )
+
+    async def delete_org_default(self, *, org_slug: str) -> None:
+        """Delete the org-default binding or raise :class:`NotFoundError`."""
+        org_id = await self._resolve_org_id(org_slug)
+        existing = await self._binding_store.get_org_default(org_id)
+        if existing is None:
+            msg = (
+                f"No dashboard-template binding for organization {org_slug!r}"
+            )
+            raise NotFoundError(msg)
+        await self._binding_store.delete(existing.id)
+        self._logger.info(
+            "Deleted org-default dashboard-template binding",
+            org_slug=org_slug,
+            binding_id=existing.id,
+        )
+
+    async def get_project_override(
+        self, *, org_slug: str, project_slug: str
+    ) -> DashboardGitHubTemplateBinding:
+        """Fetch a project override or raise :class:`NotFoundError`."""
+        org_id = await self._resolve_org_id(org_slug)
+        project_id = await self._resolve_project_id(
+            org_id=org_id, project_slug=project_slug
+        )
+        binding = await self._binding_store.get_project_override(
+            org_id=org_id, project_id=project_id
+        )
+        if binding is None:
+            msg = (
+                f"No dashboard-template binding for project {project_slug!r}"
+                f" in organization {org_slug!r}"
+            )
+            raise NotFoundError(msg)
+        return binding
+
+    async def put_project_override(
+        self,
+        *,
+        org_slug: str,
+        project_slug: str,
+        data: DashboardTemplateBindingCreate,
+    ) -> DashboardTemplateBindingResult:
+        """Create or update a project-override binding."""
+        org_id = await self._resolve_org_id(org_slug)
+        project_id = await self._resolve_project_id(
+            org_id=org_id, project_slug=project_slug
+        )
+        existing = await self._binding_store.get_project_override(
+            org_id=org_id, project_id=project_id
+        )
+        return await self._upsert(
+            org_id=org_id,
+            project_id=project_id,
+            existing=existing,
+            data=data,
+        )
+
+    async def delete_project_override(
+        self, *, org_slug: str, project_slug: str
+    ) -> None:
+        """Delete a project override or raise :class:`NotFoundError`."""
+        org_id = await self._resolve_org_id(org_slug)
+        project_id = await self._resolve_project_id(
+            org_id=org_id, project_slug=project_slug
+        )
+        existing = await self._binding_store.get_project_override(
+            org_id=org_id, project_id=project_id
+        )
+        if existing is None:
+            msg = (
+                f"No dashboard-template binding for project {project_slug!r}"
+                f" in organization {org_slug!r}"
+            )
+            raise NotFoundError(msg)
+        await self._binding_store.delete(existing.id)
+        self._logger.info(
+            "Deleted project dashboard-template binding",
+            org_slug=org_slug,
+            project_slug=project_slug,
+            binding_id=existing.id,
+        )
+
+    async def _upsert(
+        self,
+        *,
+        org_id: int,
+        project_id: int | None,
+        existing: DashboardGitHubTemplateBinding | None,
+        data: DashboardTemplateBindingCreate,
+    ) -> DashboardTemplateBindingResult:
+        if existing is None:
+            binding = await self._binding_store.create(
+                _BindingCreate(
+                    org_id=org_id,
+                    project_id=project_id,
+                    github_owner=data.github_owner,
+                    github_repo=data.github_repo,
+                    github_ref=data.github_ref,
+                    root_path=data.root_path,
+                )
+            )
+            self._logger.info(
+                "Created dashboard-template binding",
+                binding_id=binding.id,
+                org_id=org_id,
+                project_id=project_id,
+            )
+            return DashboardTemplateBindingResult(
+                binding=binding, created=True, changed=True
+            )
+
+        # Idempotent no-op when every source field already matches.
+        if (
+            existing.github_owner == data.github_owner
+            and existing.github_repo == data.github_repo
+            and existing.github_ref == data.github_ref
+            and existing.root_path == data.root_path
+        ):
+            return DashboardTemplateBindingResult(
+                binding=existing, created=False, changed=False
+            )
+
+        updated = await self._binding_store.update_source(
+            binding_id=existing.id,
+            github_owner=data.github_owner,
+            github_repo=data.github_repo,
+            github_ref=data.github_ref,
+            root_path=data.root_path,
+        )
+        # ``update_source`` only returns ``None`` if the row disappeared
+        # between our read and write — impossible inside one transaction.
+        assert updated is not None
+        self._logger.info(
+            "Updated dashboard-template binding",
+            binding_id=updated.id,
+            org_id=org_id,
+            project_id=project_id,
+        )
+        return DashboardTemplateBindingResult(
+            binding=updated, created=False, changed=True
+        )

--- a/src/docverse/services/dashboard_templates/binding.py
+++ b/src/docverse/services/dashboard_templates/binding.py
@@ -239,9 +239,12 @@ class DashboardTemplateBindingService:
             github_ref=data.github_ref,
             root_path=data.root_path,
         )
-        # ``update_source`` only returns ``None`` if the row disappeared
-        # between our read and write — impossible inside one transaction.
-        assert updated is not None
+        if updated is None:
+            msg = (
+                f"Binding {existing.id} disappeared mid-transaction during "
+                "dashboard-template binding update"
+            )
+            raise RuntimeError(msg)
         self._logger.info(
             "Updated dashboard-template binding",
             binding_id=updated.id,

--- a/tests/handlers/dashboard_template_test.py
+++ b/tests/handlers/dashboard_template_test.py
@@ -1,0 +1,494 @@
+"""Tests for the dashboard-template binding handlers."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from httpx import AsyncClient
+from safir.dependencies.db_session import db_session_dependency
+
+from docverse.client.models import OrgRole
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
+    GitHubTemplateFileInput,
+    GitHubTemplateKey,
+)
+from docverse.storage.organization_store import OrganizationStore
+from tests.conftest import seed_member, seed_org_with_admin
+
+_ADMIN = "admin-user"
+_ORG = "tmpl-org"
+_PROJECT = "tmpl-proj"
+
+_VALID_BODY = {
+    "github_owner": "lsst-sqre",
+    "github_repo": "docverse-templates",
+    "github_ref": "main",
+    "root_path": "/",
+}
+
+
+async def _setup_org(client: AsyncClient) -> None:
+    await seed_org_with_admin(client, _ORG, _ADMIN)
+
+
+async def _setup_org_and_project(client: AsyncClient) -> None:
+    await _setup_org(client)
+    response = await client.post(
+        f"/docverse/orgs/{_ORG}/projects",
+        json={
+            "slug": _PROJECT,
+            "title": "Tmpl Project",
+            "doc_repo": "https://github.com/example/tmpl",
+        },
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# Org-default binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_org_put_creates_binding(client: AsyncClient) -> None:
+    await _setup_org(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["github_owner"] == "lsst-sqre"
+    assert body["github_repo"] == "docverse-templates"
+    assert body["github_ref"] == "main"
+    assert body["root_path"] == "/"
+    assert body["last_sync_status"] == "pending"
+    assert body["last_sync_error"] is None
+    assert "date_created" in body
+    assert "date_updated" in body
+    assert body["self_url"].endswith(f"/orgs/{_ORG}/dashboard-template")
+
+
+@pytest.mark.asyncio
+async def test_org_put_defaults_root_path(client: AsyncClient) -> None:
+    await _setup_org(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json={
+            "github_owner": "lsst-sqre",
+            "github_repo": "docverse-templates",
+            "github_ref": "main",
+        },
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+    assert response.json()["root_path"] == "/"
+
+
+@pytest.mark.asyncio
+async def test_org_get_returns_existing_binding(client: AsyncClient) -> None:
+    await _setup_org(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["github_owner"] == "lsst-sqre"
+    assert body["github_ref"] == "main"
+    assert body["last_sync_status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_org_get_404_when_unset(client: AsyncClient) -> None:
+    await _setup_org(client)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_org_delete_removes_binding(client: AsyncClient) -> None:
+    await _setup_org(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 204
+
+    follow_up = await client.get(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert follow_up.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_org_delete_404_when_unset(client: AsyncClient) -> None:
+    await _setup_org(client)
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_org_put_is_idempotent_no_op(client: AsyncClient) -> None:
+    """Re-PUT with identical values leaves date_updated/status unchanged."""
+    await _setup_org(client)
+    first = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert first.status_code == 201
+    first_body = first.json()
+
+    second = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+
+    assert second_body["date_created"] == first_body["date_created"]
+    assert second_body["date_updated"] == first_body["date_updated"]
+    assert second_body["last_sync_status"] == first_body["last_sync_status"]
+
+
+@pytest.mark.asyncio
+async def test_org_put_updates_existing_binding(client: AsyncClient) -> None:
+    await _setup_org(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    changed = {**_VALID_BODY, "github_ref": "release"}
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=changed,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["github_ref"] == "release"
+
+
+@pytest.mark.asyncio
+async def test_org_put_unauthenticated_returns_403(
+    client: AsyncClient,
+) -> None:
+    await _setup_org(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_org_put_non_admin_returns_403(client: AsyncClient) -> None:
+    await _setup_org(client)
+    await seed_member(_ORG, "reader-user", OrgRole.reader)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_org_get_non_admin_returns_403(client: AsyncClient) -> None:
+    await _setup_org(client)
+    await seed_member(_ORG, "reader-user", OrgRole.reader)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_org_put_unknown_org_returns_404(client: AsyncClient) -> None:
+    response = await client.put(
+        "/docverse/orgs/no-such-org/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_org_put_does_not_auto_link_github_template(
+    client: AsyncClient,
+) -> None:
+    """Re-PUT after a template row exists does not auto-link it.
+
+    Even if a synced template row exists for the same key, PUT leaves
+    ``github_template_id`` NULL — the sync worker owns that linkage.
+    """
+    await _setup_org(client)
+
+    logger = structlog.get_logger("docverse")
+    async for session in db_session_dependency():
+        async with session.begin():
+            tstore = DashboardGitHubTemplateStore(
+                session=session, logger=logger
+            )
+            await tstore.upsert(
+                key=GitHubTemplateKey(
+                    github_owner="lsst-sqre",
+                    github_repo="docverse-templates",
+                    github_ref="main",
+                    root_path="/",
+                ),
+                commit_sha="deadbeef",
+                etag='W/"etag1"',
+                template_toml=b"[meta]\nname='t'\n",
+                files=[
+                    GitHubTemplateFileInput(
+                        relative_path="template.toml",
+                        is_text=True,
+                        data=b"[meta]\nname='t'\n",
+                    )
+                ],
+            )
+            await session.commit()
+        break
+
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            ostore = OrganizationStore(session=session, logger=logger)
+            org = await ostore.get_by_slug(_ORG)
+            assert org is not None
+            bstore = DashboardGitHubTemplateBindingStore(
+                session=session, logger=logger
+            )
+            binding = await bstore.get_org_default(org.id)
+            assert binding is not None
+            assert binding.github_template_id is None
+            assert binding.last_sync_status == "pending"
+        break
+
+
+# ---------------------------------------------------------------------------
+# Project-override binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_project_put_creates_binding(client: AsyncClient) -> None:
+    await _setup_org_and_project(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["github_owner"] == "lsst-sqre"
+    assert body["root_path"] == "/"
+    assert body["last_sync_status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_project_get_returns_existing_binding(
+    client: AsyncClient,
+) -> None:
+    await _setup_org_and_project(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["github_ref"] == "main"
+
+
+@pytest.mark.asyncio
+async def test_project_get_404_when_unset(client: AsyncClient) -> None:
+    await _setup_org_and_project(client)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_project_delete_removes_binding(client: AsyncClient) -> None:
+    await _setup_org_and_project(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 204
+
+    follow_up = await client.get(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert follow_up.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_project_put_is_idempotent_no_op(client: AsyncClient) -> None:
+    await _setup_org_and_project(client)
+    first = await client.put(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert first.status_code == 201
+    first_body = first.json()
+
+    second = await client.put(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert second.status_code == 200
+    second_body = second.json()
+    assert second_body["date_updated"] == first_body["date_updated"]
+    assert second_body["date_created"] == first_body["date_created"]
+
+
+@pytest.mark.asyncio
+async def test_project_put_unknown_project_returns_404(
+    client: AsyncClient,
+) -> None:
+    """PUT on a non-existent project must not leave a dangling binding."""
+    await _setup_org(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/projects/no-such-proj/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+    logger = structlog.get_logger("docverse")
+    async for session in db_session_dependency():
+        async with session.begin():
+            ostore = OrganizationStore(session=session, logger=logger)
+            org = await ostore.get_by_slug(_ORG)
+            assert org is not None
+            bstore = DashboardGitHubTemplateBindingStore(
+                session=session, logger=logger
+            )
+            default = await bstore.get_org_default(org.id)
+            assert default is None
+        break
+
+
+@pytest.mark.asyncio
+async def test_project_delete_unknown_project_returns_404(
+    client: AsyncClient,
+) -> None:
+    await _setup_org(client)
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/projects/no-such-proj/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_project_put_unauthenticated_returns_403(
+    client: AsyncClient,
+) -> None:
+    await _setup_org_and_project(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        json=_VALID_BODY,
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_project_put_non_admin_returns_403(client: AsyncClient) -> None:
+    await _setup_org_and_project(client)
+    await seed_member(_ORG, "reader-user", OrgRole.reader)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_org_default_and_project_override_are_independent(
+    client: AsyncClient,
+) -> None:
+    """Setting org default and project override are independent rows."""
+    await _setup_org_and_project(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    project_body = {**_VALID_BODY, "github_ref": "project-branch"}
+    await client.put(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        json=project_body,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    org_response = await client.get(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    project_response = await client.get(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert org_response.json()["github_ref"] == "main"
+    assert project_response.json()["github_ref"] == "project-branch"
+
+    # Deleting the project override leaves the org default in place.
+    await client.delete(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    org_after = await client.get(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert org_after.status_code == 200
+    assert org_after.json()["github_ref"] == "main"

--- a/tests/handlers/dashboard_template_test.py
+++ b/tests/handlers/dashboard_template_test.py
@@ -299,6 +299,94 @@ async def test_org_put_does_not_auto_link_github_template(
 
 
 # ---------------------------------------------------------------------------
+# Payload validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "invalid_owner",
+    [
+        "../evil",
+        "foo/bar",
+        "-foo",
+        "foo--",
+        "",
+        "a" * 40,
+    ],
+)
+async def test_put_rejects_invalid_github_owner(
+    client: AsyncClient, invalid_owner: str
+) -> None:
+    await _setup_org(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json={**_VALID_BODY, "github_owner": invalid_owner},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "valid_owner",
+    ["lsst-sqre", "Org1", "a"],
+)
+async def test_put_accepts_valid_github_owner(
+    client: AsyncClient, valid_owner: str
+) -> None:
+    await _setup_org(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json={**_VALID_BODY, "github_owner": valid_owner},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+    assert response.json()["github_owner"] == valid_owner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "invalid_repo",
+    [
+        "../evil",
+        "foo/bar",
+        "foo bar",
+        "",
+        "a" * 101,
+    ],
+)
+async def test_put_rejects_invalid_github_repo(
+    client: AsyncClient, invalid_repo: str
+) -> None:
+    await _setup_org(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json={**_VALID_BODY, "github_repo": invalid_repo},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "valid_repo",
+    ["docverse-templates", "my.repo", "_repo"],
+)
+async def test_put_accepts_valid_github_repo(
+    client: AsyncClient, valid_repo: str
+) -> None:
+    await _setup_org(client)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json={**_VALID_BODY, "github_repo": valid_repo},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+    assert response.json()["github_repo"] == valid_repo
+
+
+# ---------------------------------------------------------------------------
 # Project-override binding
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds six org-admin-scoped HTTP endpoints for dashboard-template bindings: `GET/PUT/DELETE /orgs/{org}/dashboard-template` (org default) and `GET/PUT/DELETE /orgs/{org}/projects/{project}/dashboard-template` (project override).
- PUT writes a binding row with `last_sync_status="pending"` and `github_template_id=NULL`; the sync worker (follow-up #237) owns the actual GitHub fetch and content-row linkage, so the resolver (#234) continues to fall through for bindings in this state.
- PUT is idempotent: re-PUT with identical source fields is a no-op (no commit, no `date_updated` churn) and returns 200 instead of 201 so clients can distinguish create from update.

## Validation steps

- [ ] `PUT /orgs/{org}/dashboard-template` with a fresh org returns 201 and the expected `last_sync_status="pending"` / `last_sync_error=null` shape.
- [ ] Re-PUT with identical body returns 200 and the response's `date_updated` matches the first PUT's value.
- [ ] `PUT /orgs/{org}/projects/{project}/dashboard-template` with a non-existent project slug returns 404 and does not leave a dangling binding row (spot-check the `dashboard_github_template_bindings` table).
- [ ] `DELETE` on an existing binding returns 204; subsequent `GET` returns 404.
- [ ] Non-admin member receives 403 on every verb; missing `X-Auth-Request-User` header receives 403.

## References

- Closes #235
- Closes #253
- PRD: #232
- Jira: https://rubinobs.atlassian.net/browse/DM-54689