### PR TITLE
DM-54689: Add GitHub App infrastructure (sync + webhook foundation)

### DIFF
--- a/src/docverse/config.py
+++ b/src/docverse/config.py
@@ -47,6 +47,35 @@ class Configuration(BaseSettings):
         description="If set, alerts will be posted to this Slack webhook",
     )
 
+    github_app_id: int | None = Field(
+        None,
+        title="GitHub App ID",
+        description=(
+            "Numeric ID of the GitHub App installed by Docverse tenants."
+            " Leave unset to disable the GitHub App feature. All three"
+            " ``github_app_*`` / ``github_webhook_*`` values must be set"
+            " together for the feature to be enabled."
+        ),
+    )
+
+    github_app_private_key: SecretStr | None = Field(
+        None,
+        title="GitHub App private key (PEM)",
+        description=(
+            "PEM-encoded private key for the GitHub App. Used to sign"
+            " JWTs when exchanging for installation access tokens."
+        ),
+    )
+
+    github_webhook_secret: SecretStr | None = Field(
+        None,
+        title="GitHub webhook shared secret",
+        description=(
+            "Shared secret used to verify the HMAC signature on incoming"
+            " GitHub webhooks."
+        ),
+    )
+
     database_url: str = Field(
         title="URL of the PostgreSQL database",
         description=(

--- a/src/docverse/dependencies/context.py
+++ b/src/docverse/dependencies/context.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Annotated, Any
 
+import httpx
 from fastapi import Depends, Request, Response
+from pydantic import SecretStr
 from rubin.repertoire import DiscoveryClient
 from safir.arq import ArqQueue
 from safir.dependencies.arq import arq_dependency
@@ -83,6 +85,10 @@ class ContextDependency:
         self._superadmin_usernames: list[str] = []
         self._arq_queue_name: str = "arq:queue"
         self._discovery: DiscoveryClient | None = None
+        self._http_client: httpx.AsyncClient | None = None
+        self._github_app_id: int | None = None
+        self._github_app_private_key: SecretStr | None = None
+        self._github_webhook_secret: SecretStr | None = None
 
     async def __call__(
         self,
@@ -112,17 +118,25 @@ class ContextDependency:
                 credential_encryptor=self._credential_encryptor,
                 superadmin_usernames=self._superadmin_usernames,
                 discovery=self._discovery,
+                http_client=self._http_client,
+                github_app_id=self._github_app_id,
+                github_app_private_key=self._github_app_private_key,
+                github_webhook_secret=self._github_webhook_secret,
                 default_queue_name=self._arq_queue_name,
             ),
         )
 
-    async def initialize(
+    async def initialize(  # noqa: PLR0913
         self,
         user_info_store: UserInfoStore | None = None,
         credential_encryptor: CredentialEncryptor | None = None,
         superadmin_usernames: list[str] | None = None,
         arq_queue_name: str | None = None,
         discovery: DiscoveryClient | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        github_app_id: int | None = None,
+        github_app_private_key: SecretStr | None = None,
+        github_webhook_secret: SecretStr | None = None,
     ) -> None:
         """Initialize the process-wide shared context."""
         self._initialized = True
@@ -136,6 +150,14 @@ class ContextDependency:
             self._arq_queue_name = arq_queue_name
         if discovery is not None:
             self._discovery = discovery
+        if http_client is not None:
+            self._http_client = http_client
+        if github_app_id is not None:
+            self._github_app_id = github_app_id
+        if github_app_private_key is not None:
+            self._github_app_private_key = github_app_private_key
+        if github_webhook_secret is not None:
+            self._github_webhook_secret = github_webhook_secret
 
     async def aclose(self) -> None:
         """Clean up the per-process configuration."""

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -270,6 +270,12 @@ class Factory:
     def create_github_app_client(self) -> GitHubAppClient:
         """Create a GitHubAppClient from the configured GitHub App secrets.
 
+        The returned :class:`GitHubAppClient` exposes installation-token
+        exchange and a :class:`InstallationAuth` factory; downstream
+        helpers (tree fetcher, compare API helper) attach that auth to
+        the shared ``httpx.AsyncClient`` per request rather than
+        receiving a pre-authenticated client of their own.
+
         Raises
         ------
         GitHubAppNotConfiguredError

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import httpx
 import structlog
+from pydantic import SecretStr
 from rubin.repertoire import DiscoveryClient
 from safir.arq import ArqQueue
+from safir.github import GitHubAppClientFactory
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .services.authorization import AuthorizationService
@@ -39,6 +41,7 @@ from .storage.editionpublisher import (
     EditionPublisher,
     create_edition_publisher,
 )
+from .storage.github import GitHubAppClient, GitHubAppNotConfiguredError
 from .storage.membership_store import OrgMembershipStore
 from .storage.objectstore import ObjectStore, create_objectstore
 from .storage.organization_credential_store import OrganizationCredentialStore
@@ -66,6 +69,10 @@ class Factory:
         http_client: httpx.AsyncClient | None = None,
         arq_queue: ArqQueue | None = None,
         discovery: DiscoveryClient | None = None,
+        github_app_id: int | None = None,
+        github_app_private_key: SecretStr | None = None,
+        github_webhook_secret: SecretStr | None = None,
+        github_app_name: str = "lsst-sqre/docverse",
         *,
         default_queue_name: str,
     ) -> None:
@@ -76,6 +83,10 @@ class Factory:
         self._http_client = http_client
         self._arq_queue = arq_queue
         self._discovery = discovery
+        self._github_app_id = github_app_id
+        self._github_app_private_key = github_app_private_key
+        self._github_webhook_secret = github_webhook_secret
+        self._github_app_name = github_app_name
         self._default_queue_name = default_queue_name
 
     def set_logger(self, logger: structlog.stdlib.BoundLogger) -> None:
@@ -255,6 +266,42 @@ class Factory:
     def create_lock_service(self) -> LockService:
         """Create a LockService bound to this factory's session."""
         return LockService(session=self._session, logger=self._logger)
+
+    def create_github_app_client(self) -> GitHubAppClient:
+        """Create a GitHubAppClient from the configured GitHub App secrets.
+
+        Raises
+        ------
+        GitHubAppNotConfiguredError
+            If any of ``github_app_id``, ``github_app_private_key``, or
+            ``github_webhook_secret`` is unset. Callers at HTTP
+            boundaries translate this to a feature-disabled response
+            (503 for admin endpoints, 404 for the webhook endpoint).
+        RuntimeError
+            If no shared ``httpx.AsyncClient`` is configured on the
+            factory — the GitHub REST calls need one.
+        """
+        if (
+            self._github_app_id is None
+            or self._github_app_private_key is None
+            or self._github_webhook_secret is None
+        ):
+            msg = "GitHub App is not configured"
+            raise GitHubAppNotConfiguredError(msg)
+        if self._http_client is None:
+            msg = "HTTP client is required to build a GitHubAppClient"
+            raise RuntimeError(msg)
+        factory = GitHubAppClientFactory(
+            id=self._github_app_id,
+            key=self._github_app_private_key.get_secret_value(),
+            name=self._github_app_name,
+            http_client=self._http_client,
+        )
+        return GitHubAppClient(
+            factory=factory,
+            http_client=self._http_client,
+            logger=self._logger,
+        )
 
     def create_edition_publishing_service(self) -> EditionPublishingService:
         """Create an EditionPublishingService."""
@@ -446,6 +493,10 @@ class HandlerFactory(Factory):
         credential_encryptor: CredentialEncryptor | None = None,
         superadmin_usernames: list[str] | None = None,
         discovery: DiscoveryClient | None = None,
+        http_client: httpx.AsyncClient | None = None,
+        github_app_id: int | None = None,
+        github_app_private_key: SecretStr | None = None,
+        github_webhook_secret: SecretStr | None = None,
         *,
         default_queue_name: str,
     ) -> None:
@@ -456,6 +507,10 @@ class HandlerFactory(Factory):
             superadmin_usernames=superadmin_usernames,
             arq_queue=arq_queue,
             discovery=discovery,
+            http_client=http_client,
+            github_app_id=github_app_id,
+            github_app_private_key=github_app_private_key,
+            github_webhook_secret=github_webhook_secret,
             default_queue_name=default_queue_name,
         )
         self._user_info_store = user_info_store

--- a/src/docverse/main.py
+++ b/src/docverse/main.py
@@ -94,6 +94,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
         user_info_store=user_info_store,
         arq_queue_name=config.arq_queue_name,
         discovery=discovery,
+        http_client=http_client,
+        github_app_id=config.github_app_id,
+        github_app_private_key=config.github_app_private_key,
+        github_webhook_secret=config.github_webhook_secret,
     )
     yield
     await context_dependency.aclose()

--- a/src/docverse/storage/github/__init__.py
+++ b/src/docverse/storage/github/__init__.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from .app_client import GitHubAppClient, GitHubAppNotConfiguredError
+from .app_client import (
+    GITHUB_API_BASE_URL,
+    GitHubAppClient,
+    GitHubAppNotConfiguredError,
+    InstallationAuth,
+)
 from .changed_paths import (
     extract_changed_paths_from_push,
     fetch_changed_paths_from_compare,
@@ -10,11 +15,13 @@ from .changed_paths import (
 from .tree_fetcher import FetchedTree, FetchedTreeFile, GitHubTreeFetcher
 
 __all__ = [
+    "GITHUB_API_BASE_URL",
     "FetchedTree",
     "FetchedTreeFile",
     "GitHubAppClient",
     "GitHubAppNotConfiguredError",
     "GitHubTreeFetcher",
+    "InstallationAuth",
     "extract_changed_paths_from_push",
     "fetch_changed_paths_from_compare",
 ]

--- a/src/docverse/storage/github/__init__.py
+++ b/src/docverse/storage/github/__init__.py
@@ -1,0 +1,20 @@
+"""GitHub App infrastructure shared by the sync worker and webhooks."""
+
+from __future__ import annotations
+
+from .app_client import GitHubAppClient, GitHubAppNotConfiguredError
+from .changed_paths import (
+    extract_changed_paths_from_push,
+    fetch_changed_paths_from_compare,
+)
+from .tree_fetcher import FetchedTree, FetchedTreeFile, GitHubTreeFetcher
+
+__all__ = [
+    "FetchedTree",
+    "FetchedTreeFile",
+    "GitHubAppClient",
+    "GitHubAppNotConfiguredError",
+    "GitHubTreeFetcher",
+    "extract_changed_paths_from_push",
+    "fetch_changed_paths_from_compare",
+]

--- a/src/docverse/storage/github/app_client.py
+++ b/src/docverse/storage/github/app_client.py
@@ -2,16 +2,37 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import httpx
 import structlog
 from gidgethub.apps import get_installation_access_token
 from gidgethub.httpx import GitHubAPI
 from safir.github import GitHubAppClientFactory
 
-__all__ = ["GitHubAppClient", "GitHubAppNotConfiguredError"]
+__all__ = [
+    "GITHUB_API_BASE_URL",
+    "GitHubAppClient",
+    "GitHubAppNotConfiguredError",
+    "InstallationAuth",
+]
 
 
-_GITHUB_API_BASE = "https://api.github.com"
+GITHUB_API_BASE_URL = "https://api.github.com"
+
+
+@dataclass(frozen=True, slots=True)
+class InstallationAuth:
+    """Per-installation GitHub auth applied to the shared HTTP client.
+
+    Callers (tree fetcher, compare API helper) build absolute URLs from
+    ``base_url`` and attach ``Authorization: Bearer {token}`` on each
+    request so the process-wide ``httpx.AsyncClient`` defaults stay
+    untouched.
+    """
+
+    token: str
+    base_url: str = GITHUB_API_BASE_URL
 
 
 class GitHubAppNotConfiguredError(Exception):
@@ -29,10 +50,11 @@ class GitHubAppClient:
     """Installation-scoped access to the GitHub REST API.
 
     Thin wrapper over :class:`safir.github.GitHubAppClientFactory`.
-    Exposes installation-token exchange and a ready-to-use
-    :class:`httpx.AsyncClient` pre-authenticated as a given installation,
-    for downstream helpers (tree fetcher, compare API calls) that need
-    raw REST access, including response headers such as ``ETag``.
+    Exposes installation-token exchange and a small
+    :class:`InstallationAuth` record that downstream helpers (tree
+    fetcher, compare API calls) attach to the shared
+    ``httpx.AsyncClient`` on every request — the wrapper never mints
+    its own client, so process-wide default headers stay untouched.
     """
 
     def __init__(
@@ -81,15 +103,19 @@ class GitHubAppClient:
         )
         return str(token_info["token"])
 
-    async def create_installation_http_client(
+    async def get_installation_auth(
         self, *, owner: str, repo: str
-    ) -> httpx.AsyncClient:
-        """Return a new ``httpx.AsyncClient`` scoped to an installation.
+    ) -> InstallationAuth:
+        """Return the per-installation auth record for ``owner/repo``.
 
-        The returned client has ``base_url`` set to the GitHub API and
-        an ``Authorization: Bearer <token>`` header pre-configured.
-        The caller owns the client and MUST close it (typically via
-        ``async with``).
+        Resolves the installation ID, exchanges it for a short-lived
+        installation token, and returns an :class:`InstallationAuth` the
+        caller attaches to the shared ``httpx.AsyncClient`` on each
+        request. The wrapper does not construct an
+        :class:`httpx.AsyncClient` of its own — the process-wide client
+        from the ``main.py`` lifespan is reused so its default headers
+        (used by Gafaelfawr/Repertoire/CDN calls) cannot leak the
+        installation token.
 
         Parameters
         ----------
@@ -100,11 +126,4 @@ class GitHubAppClient:
         """
         installation_id = await self.get_installation_id(owner, repo)
         token = await self.exchange_installation_token(installation_id)
-        return httpx.AsyncClient(
-            base_url=_GITHUB_API_BASE,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
-        )
+        return InstallationAuth(token=token)

--- a/src/docverse/storage/github/app_client.py
+++ b/src/docverse/storage/github/app_client.py
@@ -1,0 +1,110 @@
+"""GitHub App client wrapper over ``safir.github.GitHubAppClientFactory``."""
+
+from __future__ import annotations
+
+import httpx
+import structlog
+from gidgethub.apps import get_installation_access_token
+from gidgethub.httpx import GitHubAPI
+from safir.github import GitHubAppClientFactory
+
+__all__ = ["GitHubAppClient", "GitHubAppNotConfiguredError"]
+
+
+_GITHUB_API_BASE = "https://api.github.com"
+
+
+class GitHubAppNotConfiguredError(Exception):
+    """The GitHub App feature is not configured in ``Config``.
+
+    Raised when ``Factory.create_github_app_client()`` is called but any
+    of ``github_app_id``, ``github_app_private_key``, or
+    ``github_webhook_secret`` is unset. Callers at HTTP boundaries
+    translate this to a feature-disabled response (503 for admin
+    endpoints, 404 for the webhook endpoint).
+    """
+
+
+class GitHubAppClient:
+    """Installation-scoped access to the GitHub REST API.
+
+    Thin wrapper over :class:`safir.github.GitHubAppClientFactory`.
+    Exposes installation-token exchange and a ready-to-use
+    :class:`httpx.AsyncClient` pre-authenticated as a given installation,
+    for downstream helpers (tree fetcher, compare API calls) that need
+    raw REST access, including response headers such as ``ETag``.
+    """
+
+    def __init__(
+        self,
+        *,
+        factory: GitHubAppClientFactory,
+        http_client: httpx.AsyncClient,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._factory = factory
+        self._http_client = http_client
+        self._logger = logger
+
+    async def get_installation_id(self, owner: str, repo: str) -> int:
+        """Resolve the installation ID for a repository.
+
+        Uses the app JWT to call
+        ``GET /repos/{owner}/{repo}/installation``. Returns the
+        ``installation.id`` value, which is stable across GitHub repo
+        renames / transfers and is therefore the preferred internal key
+        for later lookups.
+        """
+        jwt = self._factory.get_app_jwt()
+        anon = GitHubAPI(self._http_client, self._factory.app_name)
+        data = await anon.getitem(
+            "/repos/{owner}/{repo}/installation",
+            url_vars={"owner": owner, "repo": repo},
+            jwt=jwt,
+        )
+        return int(data["id"])
+
+    async def exchange_installation_token(self, installation_id: int) -> str:
+        """Exchange the app JWT for a short-lived installation token.
+
+        Delegates to :func:`gidgethub.apps.get_installation_access_token`
+        so token minting stays in one tested code path. Returns only the
+        token string — callers that need the expiry should call
+        gidgethub directly.
+        """
+        anon = GitHubAPI(self._http_client, self._factory.app_name)
+        token_info = await get_installation_access_token(
+            anon,
+            installation_id=str(installation_id),
+            app_id=str(self._factory.app_id),
+            private_key=self._factory.app_key,
+        )
+        return str(token_info["token"])
+
+    async def create_installation_http_client(
+        self, *, owner: str, repo: str
+    ) -> httpx.AsyncClient:
+        """Return a new ``httpx.AsyncClient`` scoped to an installation.
+
+        The returned client has ``base_url`` set to the GitHub API and
+        an ``Authorization: Bearer <token>`` header pre-configured.
+        The caller owns the client and MUST close it (typically via
+        ``async with``).
+
+        Parameters
+        ----------
+        owner
+            The repository owner (org or user login).
+        repo
+            The repository name.
+        """
+        installation_id = await self.get_installation_id(owner, repo)
+        token = await self.exchange_installation_token(installation_id)
+        return httpx.AsyncClient(
+            base_url=_GITHUB_API_BASE,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )

--- a/src/docverse/storage/github/changed_paths.py
+++ b/src/docverse/storage/github/changed_paths.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import httpx
 
+from .app_client import InstallationAuth
+
 __all__ = [
     "extract_changed_paths_from_push",
     "fetch_changed_paths_from_compare",
@@ -68,9 +70,10 @@ def extract_changed_paths_from_push(
     return sorted(paths)
 
 
-async def fetch_changed_paths_from_compare(
+async def fetch_changed_paths_from_compare(  # noqa: PLR0913
     client: httpx.AsyncClient,
     *,
+    auth: InstallationAuth,
     owner: str,
     repo: str,
     before: str,
@@ -78,15 +81,21 @@ async def fetch_changed_paths_from_compare(
 ) -> list[str]:
     """Return the sorted set of paths changed between two commits.
 
-    Calls ``GET /repos/{owner}/{repo}/compare/{before}...{after}`` and
-    unions each entry's ``filename`` (new path) with any
-    ``previous_filename`` (old path on renames). Both sides are needed
-    so a rename whose new path is outside the binding's ``root_path``
-    but whose old path was inside still triggers a resync.
+    Calls ``GET /repos/{owner}/{repo}/compare/{before}...{after}`` on
+    the shared ``client`` with ``auth.base_url`` + an
+    ``Authorization: Bearer {auth.token}`` header attached per request,
+    so the client's defaults stay untouched. Unions each entry's
+    ``filename`` (new path) with any ``previous_filename`` (old path on
+    renames). Both sides are needed so a rename whose new path is
+    outside the binding's ``root_path`` but whose old path was inside
+    still triggers a resync.
     """
     response = await client.get(
-        f"/repos/{owner}/{repo}/compare/{before}...{after}",
-        headers={"Accept": "application/vnd.github+json"},
+        f"{auth.base_url}/repos/{owner}/{repo}/compare/{before}...{after}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {auth.token}",
+        },
     )
     response.raise_for_status()
     data = response.json()

--- a/src/docverse/storage/github/changed_paths.py
+++ b/src/docverse/storage/github/changed_paths.py
@@ -1,0 +1,105 @@
+"""Extract the set of changed paths from a GitHub push event.
+
+The webhook path (in-payload) and the API fallback (compare API) live
+side-by-side so the webhook handler can try the cheap path first and
+fall back to the API only when it can prove the payload is truncated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+__all__ = [
+    "extract_changed_paths_from_push",
+    "fetch_changed_paths_from_compare",
+]
+
+
+_MAX_PUSH_COMMITS = 20
+"""GitHub delivers at most 20 commits per push webhook payload.
+
+If a push has more than 20 commits, the ``commits`` array is truncated
+and the payload's ``size`` field tells us the true count. The ``>= 20``
+boundary is a defensive upper bound; ``size > len(commits)`` is the
+authoritative signal.
+"""
+
+
+def extract_changed_paths_from_push(
+    payload: Mapping[str, Any],
+) -> list[str] | None:
+    """Return the sorted set of paths touched by a push payload.
+
+    Returns ``None`` if the payload's ``commits`` array is (or may be)
+    truncated. The caller MUST then fall back to
+    :func:`fetch_changed_paths_from_compare` using ``payload["before"]``
+    and ``payload["after"]`` — the compare API is authoritative for
+    pushes that exceed the webhook size limits.
+
+    GitHub truncates at 20 commits per push and 3000 files per commit.
+    The 20-commit truncation is detectable via ``size > len(commits)``;
+    the per-commit 3000-file truncation has no explicit signal, so
+    touching that limit is rare enough that the compare fallback is
+    wired by the caller when it has other reason to suspect truncation.
+    """
+    commits = payload.get("commits")
+    if commits is None:
+        return None
+    size = payload.get("size")
+    if isinstance(size, int) and size > len(commits):
+        return None
+    if len(commits) >= _MAX_PUSH_COMMITS:
+        return None
+
+    paths: set[str] = set()
+    for commit in commits:
+        if not isinstance(commit, Mapping):
+            continue
+        for key in ("added", "modified", "removed"):
+            entries = commit.get(key)
+            if not entries:
+                continue
+            for path in entries:
+                if isinstance(path, str):
+                    paths.add(path)
+    return sorted(paths)
+
+
+async def fetch_changed_paths_from_compare(
+    client: httpx.AsyncClient,
+    *,
+    owner: str,
+    repo: str,
+    before: str,
+    after: str,
+) -> list[str]:
+    """Return the sorted set of paths changed between two commits.
+
+    Calls ``GET /repos/{owner}/{repo}/compare/{before}...{after}`` and
+    unions each entry's ``filename`` (new path) with any
+    ``previous_filename`` (old path on renames). Both sides are needed
+    so a rename whose new path is outside the binding's ``root_path``
+    but whose old path was inside still triggers a resync.
+    """
+    response = await client.get(
+        f"/repos/{owner}/{repo}/compare/{before}...{after}",
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    response.raise_for_status()
+    data = response.json()
+    files = data.get("files") or []
+
+    paths: set[str] = set()
+    for entry in files:
+        if not isinstance(entry, Mapping):
+            continue
+        filename = entry.get("filename")
+        if isinstance(filename, str):
+            paths.add(filename)
+        previous = entry.get("previous_filename")
+        if isinstance(previous, str):
+            paths.add(previous)
+    return sorted(paths)

--- a/src/docverse/storage/github/tree_fetcher.py
+++ b/src/docverse/storage/github/tree_fetcher.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import structlog
@@ -11,6 +12,14 @@ import structlog
 from .app_client import InstallationAuth
 
 __all__ = ["FetchedTree", "FetchedTreeFile", "GitHubTreeFetcher"]
+
+# Cap on concurrent blob fetches per ``GitHubTreeFetcher.fetch`` call.
+# Mid-point of the 8-16 range reviewers pinned on PR #246: enough to
+# hide per-blob round-trip latency for a realistic template tree while
+# leaving headroom under GitHub's secondary rate-limits for the ref +
+# tree calls and any other sync worker running in parallel. Bumping
+# further is deferred until GraphQL blob-batching is evaluated.
+_BLOB_FETCH_CONCURRENCY = 12
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,7 +111,7 @@ class GitHubTreeFetcher:
         normalized_root = _normalize_root(root_path)
         prefix = f"{normalized_root}/" if normalized_root else ""
 
-        files: list[FetchedTreeFile] = []
+        kept: list[tuple[str, dict[str, Any]]] = []
         for entry in tree_entries:
             if entry.get("type") != "blob":
                 continue
@@ -110,16 +119,30 @@ class GitHubTreeFetcher:
             if prefix and not path.startswith(prefix):
                 continue
             rel_path = path[len(prefix) :] if prefix else path
+            kept.append((rel_path, entry))
+
+        files: list[FetchedTreeFile | None] = [None] * len(kept)
+        semaphore = asyncio.Semaphore(_BLOB_FETCH_CONCURRENCY)
+
+        async def _fetch_into(
+            slot: int, rel_path: str, entry: dict[str, Any]
+        ) -> None:
             blob_sha = entry["sha"]
-            data = await self._fetch_blob(owner, repo, blob_sha)
-            files.append(
-                FetchedTreeFile(
-                    path=rel_path,
-                    blob_sha=blob_sha,
-                    size=int(entry.get("size", len(data))),
-                    data=data,
-                )
+            async with semaphore:
+                data = await self._fetch_blob(owner, repo, blob_sha)
+            files[slot] = FetchedTreeFile(
+                path=rel_path,
+                blob_sha=blob_sha,
+                size=int(entry.get("size", len(data))),
+                data=data,
             )
+
+        await asyncio.gather(
+            *(
+                asyncio.create_task(_fetch_into(i, rel_path, entry))
+                for i, (rel_path, entry) in enumerate(kept)
+            )
+        )
 
         return FetchedTree(
             owner=owner,
@@ -129,7 +152,7 @@ class GitHubTreeFetcher:
             commit_sha=commit_sha,
             tree_sha=tree_sha,
             etag=etag,
-            files=tuple(files),
+            files=tuple(cast("list[FetchedTreeFile]", files)),
         )
 
     def _auth_headers(self, accept: str) -> dict[str, str]:

--- a/src/docverse/storage/github/tree_fetcher.py
+++ b/src/docverse/storage/github/tree_fetcher.py
@@ -1,0 +1,158 @@
+"""Fetch a subtree of a GitHub repository at a given ref."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import structlog
+
+__all__ = ["FetchedTree", "FetchedTreeFile", "GitHubTreeFetcher"]
+
+
+@dataclass(frozen=True, slots=True)
+class FetchedTreeFile:
+    """A single blob inside a ``FetchedTree``.
+
+    ``path`` is relative to the fetcher's ``root_path`` argument. For
+    ``root_path="/"`` that matches the repository-relative path; for
+    ``root_path="templates/default"`` it strips the prefix so downstream
+    storage keys are invariant across template layouts.
+    """
+
+    path: str
+    blob_sha: str
+    size: int
+    data: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class FetchedTree:
+    """A GitHub tree scoped to ``root_path``, plus identity/cache metadata.
+
+    ``etag`` is captured from the git-trees response so the syncer can
+    short-circuit a subsequent unchanged fetch via ``If-None-Match``.
+    ``commit_sha`` is the resolved commit the ref pointed at when the
+    tree was read, independent of whether ``ref`` was a branch, tag, or
+    raw SHA.
+    """
+
+    owner: str
+    repo: str
+    ref: str
+    root_path: str
+    commit_sha: str
+    tree_sha: str
+    etag: str | None
+    files: tuple[FetchedTreeFile, ...]
+
+
+def _normalize_root(root_path: str) -> str:
+    """Strip leading/trailing slashes; ``"/"`` and ``""`` both mean root."""
+    return root_path.strip("/")
+
+
+class GitHubTreeFetcher:
+    """Fetch a subtree of a repo using the GitHub REST API.
+
+    Uses a raw :class:`httpx.AsyncClient` (pre-authenticated as an
+    installation) rather than gidgethub so callers see response headers
+    — specifically ``ETag`` on the tree response — which we need to
+    deduplicate unchanged syncs.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._client = client
+        self._logger = logger
+
+    async def fetch(
+        self, *, owner: str, repo: str, ref: str, root_path: str
+    ) -> FetchedTree:
+        """Fetch the tree under ``root_path`` at ``ref`` for ``owner/repo``.
+
+        Steps: resolve the ref to a commit (giving us ``commit_sha`` +
+        the top-level tree SHA), list the recursive tree, keep only
+        blobs inside ``root_path``, then fetch each blob's bytes.
+        """
+        commit_sha, tree_sha = await self._resolve_ref(owner, repo, ref)
+        tree_entries, etag = await self._list_tree(owner, repo, tree_sha)
+
+        normalized_root = _normalize_root(root_path)
+        prefix = f"{normalized_root}/" if normalized_root else ""
+
+        files: list[FetchedTreeFile] = []
+        for entry in tree_entries:
+            if entry.get("type") != "blob":
+                continue
+            path = entry["path"]
+            if prefix and not path.startswith(prefix):
+                continue
+            rel_path = path[len(prefix) :] if prefix else path
+            blob_sha = entry["sha"]
+            data = await self._fetch_blob(owner, repo, blob_sha)
+            files.append(
+                FetchedTreeFile(
+                    path=rel_path,
+                    blob_sha=blob_sha,
+                    size=int(entry.get("size", len(data))),
+                    data=data,
+                )
+            )
+
+        return FetchedTree(
+            owner=owner,
+            repo=repo,
+            ref=ref,
+            root_path=normalized_root,
+            commit_sha=commit_sha,
+            tree_sha=tree_sha,
+            etag=etag,
+            files=tuple(files),
+        )
+
+    async def _resolve_ref(
+        self, owner: str, repo: str, ref: str
+    ) -> tuple[str, str]:
+        """Resolve a ref (branch/tag/SHA) to (commit_sha, tree_sha)."""
+        response = await self._client.get(
+            f"/repos/{owner}/{repo}/commits/{ref}",
+            headers={"Accept": "application/vnd.github+json"},
+        )
+        response.raise_for_status()
+        data = response.json()
+        return str(data["sha"]), str(data["commit"]["tree"]["sha"])
+
+    async def _list_tree(
+        self, owner: str, repo: str, tree_sha: str
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Return the recursive tree entries and the response ETag."""
+        response = await self._client.get(
+            f"/repos/{owner}/{repo}/git/trees/{tree_sha}",
+            params={"recursive": "1"},
+            headers={"Accept": "application/vnd.github+json"},
+        )
+        response.raise_for_status()
+        data = response.json()
+        entries: list[dict[str, Any]] = list(data.get("tree") or [])
+        etag = response.headers.get("etag")
+        return entries, etag
+
+    async def _fetch_blob(self, owner: str, repo: str, blob_sha: str) -> bytes:
+        """Fetch a blob's raw bytes.
+
+        Uses ``Accept: application/vnd.github.raw`` so the response body
+        is the file bytes verbatim — no base64 round-trip, which matters
+        for binary assets (images, fonts) referenced by templates.
+        """
+        response = await self._client.get(
+            f"/repos/{owner}/{repo}/git/blobs/{blob_sha}",
+            headers={"Accept": "application/vnd.github.raw"},
+        )
+        response.raise_for_status()
+        return response.content

--- a/src/docverse/storage/github/tree_fetcher.py
+++ b/src/docverse/storage/github/tree_fetcher.py
@@ -8,6 +8,8 @@ from typing import Any
 import httpx
 import structlog
 
+from .app_client import InstallationAuth
+
 __all__ = ["FetchedTree", "FetchedTreeFile", "GitHubTreeFetcher"]
 
 
@@ -31,8 +33,16 @@ class FetchedTreeFile:
 class FetchedTree:
     """A GitHub tree scoped to ``root_path``, plus identity/cache metadata.
 
-    ``etag`` is captured from the git-trees response so the syncer can
-    short-circuit a subsequent unchanged fetch via ``If-None-Match``.
+    ``etag`` is the value of the git-trees response's ``ETag`` header,
+    captured so the syncer can use it as a content cache key: after a
+    full fetch, comparing the new ETag against the previously-stored
+    one lets the syncer skip the no-op upsert + dashboard rebuild
+    fan-out when nothing under ``root_path`` actually changed. The
+    fetcher itself does not perform a conditional ``If-None-Match``
+    request — issuing the conditional GET to skip the body fetch
+    entirely is a possible future optimisation tracked alongside
+    the dashboard sync worker (#237).
+
     ``commit_sha`` is the resolved commit the ref pointed at when the
     tree was read, independent of whether ``ref`` was a branch, tag, or
     raw SHA.
@@ -56,19 +66,25 @@ def _normalize_root(root_path: str) -> str:
 class GitHubTreeFetcher:
     """Fetch a subtree of a repo using the GitHub REST API.
 
-    Uses a raw :class:`httpx.AsyncClient` (pre-authenticated as an
-    installation) rather than gidgethub so callers see response headers
-    — specifically ``ETag`` on the tree response — which we need to
-    deduplicate unchanged syncs.
+    Uses the shared :class:`httpx.AsyncClient` from the application
+    lifespan and attaches an ``Authorization: Bearer {token}`` header
+    per request from a caller-supplied :class:`InstallationAuth`. The
+    client's default headers and ``base_url`` are deliberately not
+    mutated so the same client can serve Gafaelfawr / Repertoire / CDN
+    calls without leaking installation tokens or re-rooting their URLs.
+    Reading raw HTTP responses (rather than going through gidgethub)
+    keeps the ``ETag`` header and raw blob bytes accessible.
     """
 
     def __init__(
         self,
         *,
-        client: httpx.AsyncClient,
+        http_client: httpx.AsyncClient,
+        auth: InstallationAuth,
         logger: structlog.stdlib.BoundLogger,
     ) -> None:
-        self._client = client
+        self._http_client = http_client
+        self._auth = auth
         self._logger = logger
 
     async def fetch(
@@ -116,13 +132,19 @@ class GitHubTreeFetcher:
             files=tuple(files),
         )
 
+    def _auth_headers(self, accept: str) -> dict[str, str]:
+        return {
+            "Accept": accept,
+            "Authorization": f"Bearer {self._auth.token}",
+        }
+
     async def _resolve_ref(
         self, owner: str, repo: str, ref: str
     ) -> tuple[str, str]:
         """Resolve a ref (branch/tag/SHA) to (commit_sha, tree_sha)."""
-        response = await self._client.get(
-            f"/repos/{owner}/{repo}/commits/{ref}",
-            headers={"Accept": "application/vnd.github+json"},
+        response = await self._http_client.get(
+            f"{self._auth.base_url}/repos/{owner}/{repo}/commits/{ref}",
+            headers=self._auth_headers("application/vnd.github+json"),
         )
         response.raise_for_status()
         data = response.json()
@@ -132,10 +154,10 @@ class GitHubTreeFetcher:
         self, owner: str, repo: str, tree_sha: str
     ) -> tuple[list[dict[str, Any]], str | None]:
         """Return the recursive tree entries and the response ETag."""
-        response = await self._client.get(
-            f"/repos/{owner}/{repo}/git/trees/{tree_sha}",
+        response = await self._http_client.get(
+            f"{self._auth.base_url}/repos/{owner}/{repo}/git/trees/{tree_sha}",
             params={"recursive": "1"},
-            headers={"Accept": "application/vnd.github+json"},
+            headers=self._auth_headers("application/vnd.github+json"),
         )
         response.raise_for_status()
         data = response.json()
@@ -150,9 +172,9 @@ class GitHubTreeFetcher:
         is the file bytes verbatim — no base64 round-trip, which matters
         for binary assets (images, fonts) referenced by templates.
         """
-        response = await self._client.get(
-            f"/repos/{owner}/{repo}/git/blobs/{blob_sha}",
-            headers={"Accept": "application/vnd.github.raw"},
+        response = await self._http_client.get(
+            f"{self._auth.base_url}/repos/{owner}/{repo}/git/blobs/{blob_sha}",
+            headers=self._auth_headers("application/vnd.github.raw"),
         )
         response.raise_for_status()
         return response.content

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,10 @@ from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from docverse.storage.user_info_store import StubUserInfoStore
 
+from .support.github_mock import GitHubMock, make_rsa_pem
+
 __all__ = [
+    "GitHubMock",
     "seed_build",
     "seed_group_member",
     "seed_member",
@@ -64,6 +67,28 @@ def mock_discovery() -> Iterator[respx.Router]:
     with respx.mock(assert_all_called=False, assert_all_mocked=False) as mock:
         register_mock_discovery(mock, _DISCOVERY_FIXTURE)
         yield mock
+
+
+@pytest.fixture(scope="session")
+def github_app_private_key_pem() -> str:
+    """Session-scoped RSA PEM so the 2048-bit keygen only runs once."""
+    return make_rsa_pem()
+
+
+@pytest.fixture
+def mock_github(
+    mock_discovery: respx.Router,
+    github_app_private_key_pem: str,
+) -> GitHubMock:
+    """Seeder for GitHub REST API responses on the autouse respx router.
+
+    Composes with ``mock_discovery`` by sharing its router, so a single
+    ``respx.mock`` context covers both mocks. Tests that need GitHub
+    fakes depend on this fixture; tests that don't are unaffected.
+    """
+    return GitHubMock(
+        router=mock_discovery, private_key_pem=github_app_private_key_pem
+    )
 
 
 @pytest_asyncio.fixture

--- a/tests/dependencies/context_test.py
+++ b/tests/dependencies/context_test.py
@@ -1,0 +1,75 @@
+"""Tests for the ContextDependency plumbing of GitHub App secrets."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import httpx
+import pytest
+import structlog
+from fastapi import Request, Response
+from pydantic import SecretStr
+from safir.arq import MockArqQueue
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.dependencies.context import ContextDependency
+from docverse.storage.github import (
+    GitHubAppClient,
+    GitHubAppNotConfiguredError,
+)
+from tests.support.github_mock import GitHubMock
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+@pytest.mark.asyncio
+async def test_request_context_creates_github_app_client_when_configured(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """With all three secrets set, the factory builds a GitHubAppClient."""
+    dep = ContextDependency()
+    async with httpx.AsyncClient() as http_client:
+        await dep.initialize(
+            http_client=http_client,
+            github_app_id=mock_github.app_id,
+            github_app_private_key=SecretStr(mock_github.private_key_pem),
+            github_webhook_secret=SecretStr("webhook-secret"),
+        )
+        context = await dep(
+            request=Mock(spec=Request),
+            response=Mock(spec=Response),
+            session=db_session,
+            logger=_logger(),
+            arq_queue=MockArqQueue(default_queue_name="docverse:queue"),
+        )
+        client = context.factory.create_github_app_client()
+
+    assert isinstance(client, GitHubAppClient)
+
+
+@pytest.mark.asyncio
+async def test_request_context_raises_when_github_secret_missing(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A single missing secret makes ``create_github_app_client`` raise."""
+    dep = ContextDependency()
+    async with httpx.AsyncClient() as http_client:
+        await dep.initialize(
+            http_client=http_client,
+            github_app_id=mock_github.app_id,
+            github_app_private_key=SecretStr(mock_github.private_key_pem),
+            # github_webhook_secret intentionally unset
+        )
+        context = await dep(
+            request=Mock(spec=Request),
+            response=Mock(spec=Response),
+            session=db_session,
+            logger=_logger(),
+            arq_queue=MockArqQueue(default_queue_name="docverse:queue"),
+        )
+        with pytest.raises(GitHubAppNotConfiguredError):
+            context.factory.create_github_app_client()

--- a/tests/storage/github/__init__.py
+++ b/tests/storage/github/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the docverse.storage.github module."""

--- a/tests/storage/github/app_client_test.py
+++ b/tests/storage/github/app_client_test.py
@@ -103,7 +103,18 @@ async def test_factory_create_github_app_client_all_set(
     db_session: AsyncSession,
     mock_github: GitHubMock,
 ) -> None:
-    """With all three secrets set, the helper returns a GitHubAppClient."""
+    """With all three secrets set, the helper returns a usable client.
+
+    Exercises an actual installation-token round-trip through the shared
+    http_client to prove the returned client is wired end-to-end, not
+    just type-checks. ``isinstance`` would still pass against a client
+    whose internal ``_http_client`` had already been closed by the
+    surrounding ``async with`` block.
+    """
+    mock_github.seed_installation(
+        "acme", "templates", installation_id=42, token="ghs_factory_test"
+    )
+
     async with httpx.AsyncClient() as http_client:
         factory = Factory(
             session=db_session,
@@ -115,8 +126,17 @@ async def test_factory_create_github_app_client_all_set(
             default_queue_name="docverse:queue",
         )
         client = factory.create_github_app_client()
-
-    assert isinstance(client, GitHubAppClient)
+        assert isinstance(client, GitHubAppClient)
+        installation_client = await client.create_installation_http_client(
+            owner="acme", repo="templates"
+        )
+        try:
+            assert (
+                installation_client.headers["authorization"]
+                == "Bearer ghs_factory_test"
+            )
+        finally:
+            await installation_client.aclose()
 
 
 @pytest.mark.parametrize(

--- a/tests/storage/github/app_client_test.py
+++ b/tests/storage/github/app_client_test.py
@@ -11,8 +11,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.factory import Factory
 from docverse.storage.github import (
+    GITHUB_API_BASE_URL,
     GitHubAppClient,
     GitHubAppNotConfiguredError,
+    InstallationAuth,
 )
 from tests.support.github_mock import DEFAULT_APP_NAME, GitHubMock
 
@@ -66,10 +68,16 @@ async def test_exchange_installation_token(mock_github: GitHubMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_installation_http_client_sets_auth_header(
+async def test_get_installation_auth_returns_token_record(
     mock_github: GitHubMock,
 ) -> None:
-    """Returned client carries ``Authorization: Bearer <token>``."""
+    """``get_installation_auth`` round-trips through both endpoints.
+
+    Pins that the wrapper resolves the installation ID then exchanges
+    it for a token, returning an :class:`InstallationAuth` with the
+    seeded token and the default GitHub API base URL — without minting
+    any per-call ``httpx.AsyncClient``.
+    """
     mock_github.seed_installation(
         "acme", "templates", installation_id=42, token="ghs_installtok"
     )
@@ -84,18 +92,13 @@ async def test_create_installation_http_client_sets_auth_header(
         client = GitHubAppClient(
             factory=factory, http_client=http_client, logger=_logger()
         )
-        installation_client = await client.create_installation_http_client(
+        auth = await client.get_installation_auth(
             owner="acme", repo="templates"
         )
 
-    try:
-        assert (
-            installation_client.headers["authorization"]
-            == "Bearer ghs_installtok"
-        )
-        assert str(installation_client.base_url) == "https://api.github.com"
-    finally:
-        await installation_client.aclose()
+    assert isinstance(auth, InstallationAuth)
+    assert auth.token == "ghs_installtok"  # noqa: S105
+    assert auth.base_url == GITHUB_API_BASE_URL
 
 
 @pytest.mark.asyncio
@@ -107,9 +110,9 @@ async def test_factory_create_github_app_client_all_set(
 
     Exercises an actual installation-token round-trip through the shared
     http_client to prove the returned client is wired end-to-end, not
-    just type-checks. ``isinstance`` would still pass against a client
-    whose internal ``_http_client`` had already been closed by the
-    surrounding ``async with`` block.
+    just type-checks. Asserting on ``InstallationAuth.token`` (rather
+    than ``isinstance``) catches the case where the shared client is
+    closed or otherwise unusable by the time the helper runs.
     """
     mock_github.seed_installation(
         "acme", "templates", installation_id=42, token="ghs_factory_test"
@@ -127,16 +130,11 @@ async def test_factory_create_github_app_client_all_set(
         )
         client = factory.create_github_app_client()
         assert isinstance(client, GitHubAppClient)
-        installation_client = await client.create_installation_http_client(
+        auth = await client.get_installation_auth(
             owner="acme", repo="templates"
         )
-        try:
-            assert (
-                installation_client.headers["authorization"]
-                == "Bearer ghs_factory_test"
-            )
-        finally:
-            await installation_client.aclose()
+
+    assert auth.token == "ghs_factory_test"  # noqa: S105
 
 
 @pytest.mark.parametrize(

--- a/tests/storage/github/app_client_test.py
+++ b/tests/storage/github/app_client_test.py
@@ -1,0 +1,166 @@
+"""Tests for the GitHubAppClient wrapper and the Factory helper."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import structlog
+from pydantic import SecretStr
+from safir.github import GitHubAppClientFactory
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.factory import Factory
+from docverse.storage.github import (
+    GitHubAppClient,
+    GitHubAppNotConfiguredError,
+)
+from tests.support.github_mock import DEFAULT_APP_NAME, GitHubMock
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+@pytest.mark.asyncio
+async def test_get_installation_id_uses_app_jwt(
+    mock_github: GitHubMock,
+) -> None:
+    """``get_installation_id`` returns the mocked installation ID."""
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+
+    async with httpx.AsyncClient() as http_client:
+        factory = GitHubAppClientFactory(
+            id=mock_github.app_id,
+            key=mock_github.private_key_pem,
+            name=DEFAULT_APP_NAME,
+            http_client=http_client,
+        )
+        client = GitHubAppClient(
+            factory=factory, http_client=http_client, logger=_logger()
+        )
+        installation_id = await client.get_installation_id("acme", "templates")
+
+    assert installation_id == 42
+
+
+@pytest.mark.asyncio
+async def test_exchange_installation_token(mock_github: GitHubMock) -> None:
+    """``exchange_installation_token`` returns the mocked bearer token."""
+    mock_github.seed_installation(
+        "acme", "templates", installation_id=42, token="ghs_test_abc"
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        factory = GitHubAppClientFactory(
+            id=mock_github.app_id,
+            key=mock_github.private_key_pem,
+            name=DEFAULT_APP_NAME,
+            http_client=http_client,
+        )
+        client = GitHubAppClient(
+            factory=factory, http_client=http_client, logger=_logger()
+        )
+        token = await client.exchange_installation_token(42)
+
+    assert token == "ghs_test_abc"  # noqa: S105
+
+
+@pytest.mark.asyncio
+async def test_create_installation_http_client_sets_auth_header(
+    mock_github: GitHubMock,
+) -> None:
+    """Returned client carries ``Authorization: Bearer <token>``."""
+    mock_github.seed_installation(
+        "acme", "templates", installation_id=42, token="ghs_installtok"
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        factory = GitHubAppClientFactory(
+            id=mock_github.app_id,
+            key=mock_github.private_key_pem,
+            name=DEFAULT_APP_NAME,
+            http_client=http_client,
+        )
+        client = GitHubAppClient(
+            factory=factory, http_client=http_client, logger=_logger()
+        )
+        installation_client = await client.create_installation_http_client(
+            owner="acme", repo="templates"
+        )
+
+    try:
+        assert (
+            installation_client.headers["authorization"]
+            == "Bearer ghs_installtok"
+        )
+        assert str(installation_client.base_url) == "https://api.github.com"
+    finally:
+        await installation_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_factory_create_github_app_client_all_set(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """With all three secrets set, the helper returns a GitHubAppClient."""
+    async with httpx.AsyncClient() as http_client:
+        factory = Factory(
+            session=db_session,
+            logger=_logger(),
+            http_client=http_client,
+            github_app_id=mock_github.app_id,
+            github_app_private_key=SecretStr(mock_github.private_key_pem),
+            github_webhook_secret=SecretStr("webhook-secret"),
+            default_queue_name="docverse:queue",
+        )
+        client = factory.create_github_app_client()
+
+    assert isinstance(client, GitHubAppClient)
+
+
+@pytest.mark.parametrize(
+    ("app_id", "private_key", "webhook_secret"),
+    [
+        (None, SecretStr("key"), SecretStr("wh")),
+        (12345, None, SecretStr("wh")),
+        (12345, SecretStr("key"), None),
+    ],
+    ids=["missing_app_id", "missing_private_key", "missing_webhook_secret"],
+)
+@pytest.mark.asyncio
+async def test_factory_create_github_app_client_one_missing_raises(
+    db_session: AsyncSession,
+    app_id: int | None,
+    private_key: SecretStr | None,
+    webhook_secret: SecretStr | None,
+) -> None:
+    """Any single missing secret disables the feature."""
+    async with httpx.AsyncClient() as http_client:
+        factory = Factory(
+            session=db_session,
+            logger=_logger(),
+            http_client=http_client,
+            github_app_id=app_id,
+            github_app_private_key=private_key,
+            github_webhook_secret=webhook_secret,
+            default_queue_name="docverse:queue",
+        )
+        with pytest.raises(GitHubAppNotConfiguredError):
+            factory.create_github_app_client()
+
+
+@pytest.mark.asyncio
+async def test_factory_create_github_app_client_all_missing_raises(
+    db_session: AsyncSession,
+) -> None:
+    """Default (no GitHub config) raises ``GitHubAppNotConfiguredError``."""
+    async with httpx.AsyncClient() as http_client:
+        factory = Factory(
+            session=db_session,
+            logger=_logger(),
+            http_client=http_client,
+            default_queue_name="docverse:queue",
+        )
+        with pytest.raises(GitHubAppNotConfiguredError):
+            factory.create_github_app_client()

--- a/tests/storage/github/changed_paths_test.py
+++ b/tests/storage/github/changed_paths_test.py
@@ -115,3 +115,49 @@ async def test_fetch_changed_paths_from_compare_includes_rename_source(
         )
 
     assert paths == ["templates/new.html", "templates/old.html"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_changed_paths_from_compare_with_null_files(
+    mock_github: GitHubMock,
+) -> None:
+    """``{"files": null}`` from GitHub coerces to an empty list, not a crash.
+
+    Pins the ``data.get("files") or []`` defence in
+    :func:`fetch_changed_paths_from_compare` against an upstream
+    refactor that might switch to ``data["files"] or []`` (KeyError) or
+    ``data.get("files", [])`` (TypeError on ``None``).
+    """
+    mock_github.router.get(
+        "https://api.github.com/repos/acme/repo/compare/aaaa...bbbb"
+    ).mock(return_value=httpx.Response(200, json={"files": None}))
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        paths = await fetch_changed_paths_from_compare(
+            client, owner="acme", repo="repo", before="aaaa", after="bbbb"
+        )
+
+    assert paths == []
+
+
+@pytest.mark.parametrize("status", [404, 429, 500], ids=["404", "429", "500"])
+@pytest.mark.asyncio
+async def test_fetch_changed_paths_from_compare_raises_on_non_2xx(
+    mock_github: GitHubMock,
+    status: int,
+) -> None:
+    """Non-2xx GitHub responses surface as ``httpx.HTTPStatusError``.
+
+    Pins today's bare ``raise_for_status`` behaviour so when the sync
+    worker (#237) layers a richer typed-exception taxonomy on top, the
+    regression fence catches an accidental swallow.
+    """
+    mock_github.router.get(
+        "https://api.github.com/repos/acme/repo/compare/aaaa...bbbb"
+    ).mock(return_value=httpx.Response(status))
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            await fetch_changed_paths_from_compare(
+                client, owner="acme", repo="repo", before="aaaa", after="bbbb"
+            )

--- a/tests/storage/github/changed_paths_test.py
+++ b/tests/storage/github/changed_paths_test.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 
 from docverse.storage.github import (
+    InstallationAuth,
     extract_changed_paths_from_push,
     fetch_changed_paths_from_compare,
 )
@@ -86,10 +87,16 @@ async def test_fetch_changed_paths_from_compare(
         after="bbbb",
         changed_paths=["templates/a.html", "templates/b.html", "docs/c.md"],
     )
+    auth = mock_github.installation_auth("acme", "repo")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+    async with httpx.AsyncClient() as http_client:
         paths = await fetch_changed_paths_from_compare(
-            client, owner="acme", repo="repo", before="aaaa", after="bbbb"
+            http_client,
+            auth=auth,
+            owner="acme",
+            repo="repo",
+            before="aaaa",
+            after="bbbb",
         )
 
     assert paths == ["docs/c.md", "templates/a.html", "templates/b.html"]
@@ -108,10 +115,16 @@ async def test_fetch_changed_paths_from_compare_includes_rename_source(
         changed_paths=["templates/new.html"],
         renamed={"templates/new.html": "templates/old.html"},
     )
+    auth = mock_github.installation_auth("acme", "repo")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+    async with httpx.AsyncClient() as http_client:
         paths = await fetch_changed_paths_from_compare(
-            client, owner="acme", repo="repo", before="aaaa", after="bbbb"
+            http_client,
+            auth=auth,
+            owner="acme",
+            repo="repo",
+            before="aaaa",
+            after="bbbb",
         )
 
     assert paths == ["templates/new.html", "templates/old.html"]
@@ -131,13 +144,60 @@ async def test_fetch_changed_paths_from_compare_with_null_files(
     mock_github.router.get(
         "https://api.github.com/repos/acme/repo/compare/aaaa...bbbb"
     ).mock(return_value=httpx.Response(200, json={"files": None}))
+    auth = InstallationAuth(token="ghs_test")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+    async with httpx.AsyncClient() as http_client:
         paths = await fetch_changed_paths_from_compare(
-            client, owner="acme", repo="repo", before="aaaa", after="bbbb"
+            http_client,
+            auth=auth,
+            owner="acme",
+            repo="repo",
+            before="aaaa",
+            after="bbbb",
         )
 
     assert paths == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_changed_paths_from_compare_attaches_authorization(
+    mock_github: GitHubMock,
+) -> None:
+    """Compare call carries ``Authorization: Bearer <token>`` per request.
+
+    Mirrors the no-mutation contract on the tree fetcher: the helper
+    must not rely on the shared client's defaults for either base URL
+    or auth, since the same client also serves Gafaelfawr / Repertoire
+    / CDN traffic.
+    """
+    mock_github.seed_compare(
+        "acme",
+        "repo",
+        before="aaaa",
+        after="bbbb",
+        changed_paths=["templates/a.html"],
+    )
+    auth = InstallationAuth(token="ghs_compare_attach")
+
+    async with httpx.AsyncClient() as http_client:
+        assert "authorization" not in http_client.headers
+        await fetch_changed_paths_from_compare(
+            http_client,
+            auth=auth,
+            owner="acme",
+            repo="repo",
+            before="aaaa",
+            after="bbbb",
+        )
+        assert "authorization" not in http_client.headers
+
+    sent = [
+        call.request
+        for call in mock_github.router.calls
+        if call.request.url.path == "/repos/acme/repo/compare/aaaa...bbbb"
+    ]
+    assert sent, "expected the compare endpoint to be called"
+    assert sent[-1].headers["authorization"] == "Bearer ghs_compare_attach"
 
 
 @pytest.mark.parametrize("status", [404, 429, 500], ids=["404", "429", "500"])
@@ -155,9 +215,15 @@ async def test_fetch_changed_paths_from_compare_raises_on_non_2xx(
     mock_github.router.get(
         "https://api.github.com/repos/acme/repo/compare/aaaa...bbbb"
     ).mock(return_value=httpx.Response(status))
+    auth = InstallationAuth(token="ghs_test")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+    async with httpx.AsyncClient() as http_client:
         with pytest.raises(httpx.HTTPStatusError):
             await fetch_changed_paths_from_compare(
-                client, owner="acme", repo="repo", before="aaaa", after="bbbb"
+                http_client,
+                auth=auth,
+                owner="acme",
+                repo="repo",
+                before="aaaa",
+                after="bbbb",
             )

--- a/tests/storage/github/changed_paths_test.py
+++ b/tests/storage/github/changed_paths_test.py
@@ -1,0 +1,117 @@
+"""Tests for the changed-paths helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from docverse.storage.github import (
+    extract_changed_paths_from_push,
+    fetch_changed_paths_from_compare,
+)
+from tests.support.github_mock import GitHubMock
+
+
+def _commit(
+    *,
+    added: list[str] | None = None,
+    modified: list[str] | None = None,
+    removed: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "added": added or [],
+        "modified": modified or [],
+        "removed": removed or [],
+    }
+
+
+def test_extract_changed_paths_flat_list() -> None:
+    """In-payload commits yield the union of added/modified/removed paths."""
+    payload = {
+        "before": "aaaa",
+        "after": "bbbb",
+        "size": 2,
+        "commits": [
+            _commit(added=["a.txt"], modified=["b.txt"]),
+            _commit(modified=["b.txt"], removed=["c.txt"]),
+        ],
+    }
+    result = extract_changed_paths_from_push(payload)
+    assert result == ["a.txt", "b.txt", "c.txt"]
+
+
+def test_extract_changed_paths_truncated_by_size_returns_none() -> None:
+    """If size > len(commits), payload is truncated; return None."""
+    payload = {
+        "before": "aaaa",
+        "after": "bbbb",
+        "size": 5,
+        "commits": [_commit(added=["a.txt"])],
+    }
+    assert extract_changed_paths_from_push(payload) is None
+
+
+def test_extract_changed_paths_twenty_commits_returns_none() -> None:
+    """20 commits is GitHub's ceiling; treat as possibly truncated."""
+    payload = {
+        "commits": [_commit(added=[f"f{i}.txt"]) for i in range(20)],
+        "size": 20,
+    }
+    assert extract_changed_paths_from_push(payload) is None
+
+
+def test_extract_changed_paths_missing_commits_returns_none() -> None:
+    """Payloads without a ``commits`` array (e.g. tag-delete) fall back."""
+    payload = {"before": "aaaa", "after": "bbbb"}
+    assert extract_changed_paths_from_push(payload) is None
+
+
+def test_extract_changed_paths_empty_commits_returns_empty_list() -> None:
+    """A push with zero non-merge commits yields zero changed paths."""
+    payload = {"commits": [], "size": 0}
+    assert extract_changed_paths_from_push(payload) == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_changed_paths_from_compare(
+    mock_github: GitHubMock,
+) -> None:
+    """Compare-API response parses into a deduped, sorted list of paths."""
+    mock_github.seed_compare(
+        "acme",
+        "repo",
+        before="aaaa",
+        after="bbbb",
+        changed_paths=["templates/a.html", "templates/b.html", "docs/c.md"],
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        paths = await fetch_changed_paths_from_compare(
+            client, owner="acme", repo="repo", before="aaaa", after="bbbb"
+        )
+
+    assert paths == ["docs/c.md", "templates/a.html", "templates/b.html"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_changed_paths_from_compare_includes_rename_source(
+    mock_github: GitHubMock,
+) -> None:
+    """Renames contribute both the new and the previous path to the set."""
+    mock_github.seed_compare(
+        "acme",
+        "repo",
+        before="aaaa",
+        after="bbbb",
+        changed_paths=["templates/new.html"],
+        renamed={"templates/new.html": "templates/old.html"},
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        paths = await fetch_changed_paths_from_compare(
+            client, owner="acme", repo="repo", before="aaaa", after="bbbb"
+        )
+
+    assert paths == ["templates/new.html", "templates/old.html"]

--- a/tests/storage/github/tree_fetcher_test.py
+++ b/tests/storage/github/tree_fetcher_test.py
@@ -7,7 +7,11 @@ import pytest
 import structlog
 from safir.github import GitHubAppClientFactory
 
-from docverse.storage.github import GitHubAppClient, GitHubTreeFetcher
+from docverse.storage.github import (
+    GitHubAppClient,
+    GitHubTreeFetcher,
+    InstallationAuth,
+)
 from tests.support.github_mock import DEFAULT_APP_NAME, GitHubMock
 
 
@@ -32,9 +36,12 @@ async def test_tree_fetcher_scoped_to_root_path(
         },
         etag='W/"abc"',
     )
+    auth = mock_github.installation_auth("acme", "templates")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
-        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+    async with httpx.AsyncClient() as http_client:
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
         tree = await fetcher.fetch(
             owner="acme",
             repo="templates",
@@ -60,9 +67,12 @@ async def test_tree_fetcher_captures_etag_and_commit_sha(
         tree_sha="treecafe",
         etag='W/"tree-etag-1"',
     )
+    auth = mock_github.installation_auth("acme", "templates")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
-        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+    async with httpx.AsyncClient() as http_client:
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
         tree = await fetcher.fetch(
             owner="acme", repo="templates", ref="main", root_path="/"
         )
@@ -84,9 +94,12 @@ async def test_tree_fetcher_blob_bytes_are_verbatim(
         "main",
         files={"assets/logo.png": logo_bytes},
     )
+    auth = mock_github.installation_auth("acme", "templates")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
-        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+    async with httpx.AsyncClient() as http_client:
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
         tree = await fetcher.fetch(
             owner="acme", repo="templates", ref="main", root_path="/"
         )
@@ -107,9 +120,12 @@ async def test_tree_fetcher_empty_when_root_path_missing(
         "main",
         files={"README.md": b"# readme\n"},
     )
+    auth = mock_github.installation_auth("acme", "templates")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
-        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+    async with httpx.AsyncClient() as http_client:
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
         tree = await fetcher.fetch(
             owner="acme",
             repo="templates",
@@ -141,14 +157,60 @@ async def test_tree_fetcher_ignores_non_blob_entries(
             }
         ],
     )
+    auth = mock_github.installation_auth("acme", "templates")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
-        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+    async with httpx.AsyncClient() as http_client:
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
         tree = await fetcher.fetch(
             owner="acme", repo="templates", ref="main", root_path="/"
         )
 
     assert {f.path for f in tree.files} == {"template.toml"}
+
+
+@pytest.mark.asyncio
+async def test_tree_fetcher_attaches_authorization_header(
+    mock_github: GitHubMock,
+) -> None:
+    """Each GitHub call carries ``Authorization: Bearer <token>``.
+
+    Pins the no-mutation contract: the fetcher attaches auth per
+    request rather than mutating the shared client's defaults. Without
+    this guarantee, the lifespan client could leak the installation
+    token onto unrelated requests (Gafaelfawr/Repertoire/CDN).
+    """
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"template.toml": b"[dashboard]\n"},
+    )
+    auth = InstallationAuth(token="ghs_attach_test")
+
+    async with httpx.AsyncClient() as http_client:
+        # The shared client must not be configured with a base_url or an
+        # Authorization header — those would defeat the per-request
+        # attachment the fetcher under test is supposed to perform.
+        assert "authorization" not in http_client.headers
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
+        await fetcher.fetch(
+            owner="acme", repo="templates", ref="main", root_path="/"
+        )
+        # Defaults still untouched after the fetch returns.
+        assert "authorization" not in http_client.headers
+
+    sent_requests = [
+        call.request
+        for call in mock_github.router.calls
+        if call.request.url.path.startswith("/repos/acme/templates")
+    ]
+    assert sent_requests, "expected at least one GitHub call"
+    for request in sent_requests:
+        assert request.headers["authorization"] == "Bearer ghs_attach_test"
 
 
 @pytest.mark.parametrize("status", [404, 429, 500], ids=["404", "429", "500"])
@@ -168,9 +230,12 @@ async def test_tree_fetcher_raises_on_non_2xx_ref_resolution(
     mock_github.router.get(
         "https://api.github.com/repos/acme/templates/commits/main"
     ).mock(return_value=httpx.Response(status))
+    auth = InstallationAuth(token="ghs_test")
 
-    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
-        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+    async with httpx.AsyncClient() as http_client:
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
         with pytest.raises(httpx.HTTPStatusError):
             await fetcher.fetch(
                 owner="acme", repo="templates", ref="main", root_path="/"
@@ -181,7 +246,7 @@ async def test_tree_fetcher_raises_on_non_2xx_ref_resolution(
 async def test_mock_github_composes_with_app_client_end_to_end(
     mock_github: GitHubMock,
 ) -> None:
-    """Full flow: app JWT → install-token exchange → install client → tree.
+    """Full flow: app JWT → install-token exchange → InstallationAuth → tree.
 
     Exercises both fixture helpers (``seed_installation`` +
     ``seed_tree``) on the same ``mock_discovery`` router in a single
@@ -208,20 +273,17 @@ async def test_mock_github_composes_with_app_client_end_to_end(
             http_client=http_client,
             logger=_logger(),
         )
-        installation_client = await app_client.create_installation_http_client(
+        auth = await app_client.get_installation_auth(
             owner="acme", repo="templates"
         )
-        try:
-            fetcher = GitHubTreeFetcher(
-                client=installation_client, logger=_logger()
-            )
-            tree = await fetcher.fetch(
-                owner="acme",
-                repo="templates",
-                ref="main",
-                root_path="/",
-            )
-        finally:
-            await installation_client.aclose()
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
+        tree = await fetcher.fetch(
+            owner="acme",
+            repo="templates",
+            ref="main",
+            root_path="/",
+        )
 
     assert {f.path for f in tree.files} == {"template.toml"}

--- a/tests/storage/github/tree_fetcher_test.py
+++ b/tests/storage/github/tree_fetcher_test.py
@@ -151,6 +151,32 @@ async def test_tree_fetcher_ignores_non_blob_entries(
     assert {f.path for f in tree.files} == {"template.toml"}
 
 
+@pytest.mark.parametrize("status", [404, 429, 500], ids=["404", "429", "500"])
+@pytest.mark.asyncio
+async def test_tree_fetcher_raises_on_non_2xx_ref_resolution(
+    mock_github: GitHubMock,
+    status: int,
+) -> None:
+    """Non-2xx responses on ref resolution raise ``httpx.HTTPStatusError``.
+
+    Seeds the failing status on ``commits/{ref}`` (the first call in
+    :meth:`GitHubTreeFetcher.fetch`) — sufficient to pin the
+    ``raise_for_status`` behaviour without permuting every sub-call.
+    The sync worker (#237) will layer typed exceptions on top; this
+    test fences against an accidental swallow at the storage layer.
+    """
+    mock_github.router.get(
+        "https://api.github.com/repos/acme/templates/commits/main"
+    ).mock(return_value=httpx.Response(status))
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+        with pytest.raises(httpx.HTTPStatusError):
+            await fetcher.fetch(
+                owner="acme", repo="templates", ref="main", root_path="/"
+            )
+
+
 @pytest.mark.asyncio
 async def test_mock_github_composes_with_app_client_end_to_end(
     mock_github: GitHubMock,

--- a/tests/storage/github/tree_fetcher_test.py
+++ b/tests/storage/github/tree_fetcher_test.py
@@ -1,0 +1,201 @@
+"""Tests for GitHubTreeFetcher end-to-end against the mock_github fixture."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import structlog
+from safir.github import GitHubAppClientFactory
+
+from docverse.storage.github import GitHubAppClient, GitHubTreeFetcher
+from tests.support.github_mock import DEFAULT_APP_NAME, GitHubMock
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+@pytest.mark.asyncio
+async def test_tree_fetcher_scoped_to_root_path(
+    mock_github: GitHubMock,
+) -> None:
+    """Only blobs under ``root_path`` are returned; paths are re-rooted."""
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "templates/default/template.toml": b"[dashboard]\n",
+            "templates/default/assets/logo.svg": b"<svg/>",
+            "templates/other/template.toml": b"[dashboard]\n",
+            "README.md": b"# readme\n",
+        },
+        etag='W/"abc"',
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+        tree = await fetcher.fetch(
+            owner="acme",
+            repo="templates",
+            ref="main",
+            root_path="templates/default",
+        )
+
+    returned_paths = {f.path for f in tree.files}
+    assert returned_paths == {"template.toml", "assets/logo.svg"}
+
+
+@pytest.mark.asyncio
+async def test_tree_fetcher_captures_etag_and_commit_sha(
+    mock_github: GitHubMock,
+) -> None:
+    """ETag and commit SHA surface on ``FetchedTree`` for dedup/cache."""
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"template.toml": b"[dashboard]\n"},
+        commit_sha="deadbeef",
+        tree_sha="treecafe",
+        etag='W/"tree-etag-1"',
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+        tree = await fetcher.fetch(
+            owner="acme", repo="templates", ref="main", root_path="/"
+        )
+
+    assert tree.commit_sha == "deadbeef"
+    assert tree.tree_sha == "treecafe"
+    assert tree.etag == 'W/"tree-etag-1"'
+
+
+@pytest.mark.asyncio
+async def test_tree_fetcher_blob_bytes_are_verbatim(
+    mock_github: GitHubMock,
+) -> None:
+    """Binary blob bytes round-trip unchanged (no base64 smear)."""
+    logo_bytes = b"\x89PNG\r\n\x1a\n\x00\x01\x02\x03fake-png"
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"assets/logo.png": logo_bytes},
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+        tree = await fetcher.fetch(
+            owner="acme", repo="templates", ref="main", root_path="/"
+        )
+
+    assert len(tree.files) == 1
+    assert tree.files[0].data == logo_bytes
+    assert tree.files[0].size == len(logo_bytes)
+
+
+@pytest.mark.asyncio
+async def test_tree_fetcher_empty_when_root_path_missing(
+    mock_github: GitHubMock,
+) -> None:
+    """``root_path`` with no blobs returns ``files=()`` but keeps metadata."""
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"README.md": b"# readme\n"},
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+        tree = await fetcher.fetch(
+            owner="acme",
+            repo="templates",
+            ref="main",
+            root_path="does/not/exist",
+        )
+
+    assert tree.files == ()
+    assert tree.commit_sha  # still resolved
+    assert tree.root_path == "does/not/exist"
+
+
+@pytest.mark.asyncio
+async def test_tree_fetcher_ignores_non_blob_entries(
+    mock_github: GitHubMock,
+) -> None:
+    """Subdirectory (``type: tree``) entries are not fetched as blobs."""
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"template.toml": b"[dashboard]\n"},
+        extra_tree_entries=[
+            {
+                "path": "assets",
+                "mode": "040000",
+                "type": "tree",
+                "sha": "tree-subdir",
+            }
+        ],
+    )
+
+    async with httpx.AsyncClient(base_url="https://api.github.com") as client:
+        fetcher = GitHubTreeFetcher(client=client, logger=_logger())
+        tree = await fetcher.fetch(
+            owner="acme", repo="templates", ref="main", root_path="/"
+        )
+
+    assert {f.path for f in tree.files} == {"template.toml"}
+
+
+@pytest.mark.asyncio
+async def test_mock_github_composes_with_app_client_end_to_end(
+    mock_github: GitHubMock,
+) -> None:
+    """Full flow: app JWT → install-token exchange → install client → tree.
+
+    Exercises both fixture helpers (``seed_installation`` +
+    ``seed_tree``) on the same ``mock_discovery`` router in a single
+    test, demonstrating the composition requirement from the task
+    acceptance criteria.
+    """
+    mock_github.seed_installation("acme", "templates", installation_id=77)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"template.toml": b"[dashboard]\n"},
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        safir_factory = GitHubAppClientFactory(
+            id=mock_github.app_id,
+            key=mock_github.private_key_pem,
+            name=DEFAULT_APP_NAME,
+            http_client=http_client,
+        )
+        app_client = GitHubAppClient(
+            factory=safir_factory,
+            http_client=http_client,
+            logger=_logger(),
+        )
+        installation_client = await app_client.create_installation_http_client(
+            owner="acme", repo="templates"
+        )
+        try:
+            fetcher = GitHubTreeFetcher(
+                client=installation_client, logger=_logger()
+            )
+            tree = await fetcher.fetch(
+                owner="acme",
+                repo="templates",
+                ref="main",
+                root_path="/",
+            )
+        finally:
+            await installation_client.aclose()
+
+    assert {f.path for f in tree.files} == {"template.toml"}

--- a/tests/storage/github/tree_fetcher_test.py
+++ b/tests/storage/github/tree_fetcher_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import httpx
 import pytest
 import structlog
@@ -12,6 +14,7 @@ from docverse.storage.github import (
     GitHubTreeFetcher,
     InstallationAuth,
 )
+from docverse.storage.github import tree_fetcher as tree_fetcher_module
 from tests.support.github_mock import DEFAULT_APP_NAME, GitHubMock
 
 
@@ -240,6 +243,105 @@ async def test_tree_fetcher_raises_on_non_2xx_ref_resolution(
             await fetcher.fetch(
                 owner="acme", repo="templates", ref="main", root_path="/"
             )
+
+
+@pytest.mark.asyncio
+async def test_tree_fetcher_runs_blob_fetches_concurrently(
+    mock_github: GitHubMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blob fetches overlap in-flight, bounded by the module concurrency.
+
+    Monkeypatches ``_fetch_blob`` to record the peak in-flight count.
+    With the default constant (12) and eight kept files, peak must be
+    strictly greater than 1 — a serial loop would pin it to 1.
+    """
+    assert tree_fetcher_module._BLOB_FETCH_CONCURRENCY == 12
+    file_count = 8
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            f"file-{i}.txt": f"data-{i}".encode() for i in range(file_count)
+        },
+    )
+    auth = mock_github.installation_auth("acme", "templates")
+
+    in_flight = 0
+    peak = 0
+
+    async with httpx.AsyncClient() as http_client:
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
+        original = fetcher._fetch_blob
+
+        async def spy(owner: str, repo: str, blob_sha: str) -> bytes:
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            try:
+                await asyncio.sleep(0.01)
+                return await original(owner, repo, blob_sha)
+            finally:
+                in_flight -= 1
+
+        monkeypatch.setattr(fetcher, "_fetch_blob", spy)
+        tree = await fetcher.fetch(
+            owner="acme", repo="templates", ref="main", root_path="/"
+        )
+
+    assert len(tree.files) == file_count
+    assert peak > 1
+
+
+@pytest.mark.asyncio
+async def test_tree_fetcher_preserves_tree_entry_order(
+    mock_github: GitHubMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``FetchedTree.files`` order matches filtered tree-entry order.
+
+    Makes the first-scheduled blob the slowest to complete so completion
+    order is inverted from entry order; slot pre-allocation is what
+    keeps ``files[0]`` pointing at the first entry.
+    """
+    expected_paths = [f"file-{i}.txt" for i in range(6)]
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            path: f"data-{i}".encode() for i, path in enumerate(expected_paths)
+        },
+    )
+    auth = mock_github.installation_auth("acme", "templates")
+
+    async with httpx.AsyncClient() as http_client:
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
+        original = fetcher._fetch_blob
+        call_count = 0
+
+        async def invert_completion_order(
+            owner: str, repo: str, blob_sha: str
+        ) -> bytes:
+            nonlocal call_count
+            call_count += 1
+            # The first task scheduled waits longest, so completion
+            # order is the reverse of entry order.
+            delay = max(0.0, 0.02 - 0.003 * (call_count - 1))
+            await asyncio.sleep(delay)
+            return await original(owner, repo, blob_sha)
+
+        monkeypatch.setattr(fetcher, "_fetch_blob", invert_completion_order)
+        tree = await fetcher.fetch(
+            owner="acme", repo="templates", ref="main", root_path="/"
+        )
+
+    assert [f.path for f in tree.files] == expected_paths
 
 
 @pytest.mark.asyncio

--- a/tests/support/github_mock.py
+++ b/tests/support/github_mock.py
@@ -18,6 +18,8 @@ import respx
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+from docverse.storage.github import GITHUB_API_BASE_URL, InstallationAuth
+
 __all__ = ["DEFAULT_APP_ID", "DEFAULT_APP_NAME", "GitHubMock", "make_rsa_pem"]
 
 
@@ -75,6 +77,9 @@ class GitHubMock:
     default_installation_id: int = 99
     default_token: str = "ghs_test_installation_token"  # noqa: S105
     _installation_ids: dict[tuple[str, str], int] = field(default_factory=dict)
+    _installation_tokens: dict[tuple[str, str], str] = field(
+        default_factory=dict
+    )
 
     @cached_property
     def installation_token(self) -> str:
@@ -92,13 +97,17 @@ class GitHubMock:
         """Wire (repo → installation id) lookup and (id → token) exchange.
 
         Both endpoints are needed for
-        ``GitHubAppClient.create_installation_http_client`` to succeed;
-        seed them together so callers only write one line. Returns the
-        installation id for downstream assertions.
+        ``GitHubAppClient.get_installation_auth`` to succeed; seed them
+        together so callers only write one line. Returns the
+        installation id for downstream assertions; pair with
+        :meth:`installation_auth` when the test needs the
+        ``InstallationAuth`` record without round-tripping the app
+        client.
         """
         iid = installation_id or self.default_installation_id
         bearer_token = token or self.default_token
         self._installation_ids[(owner, repo)] = iid
+        self._installation_tokens[(owner, repo)] = bearer_token
 
         self.router.get(
             f"{_GITHUB_API}/repos/{owner}/{repo}/installation"
@@ -119,6 +128,27 @@ class GitHubMock:
             )
         )
         return iid
+
+    def installation_auth(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        base_url: str = GITHUB_API_BASE_URL,
+    ) -> InstallationAuth:
+        """Return an :class:`InstallationAuth` for a previously-seeded repo.
+
+        Tests that exercise the tree fetcher / compare helper directly
+        — without going through ``GitHubAppClient.get_installation_auth``
+        — call this to grab the same token they seeded on the router.
+        Falls back to ``default_token`` when ``seed_installation`` was
+        not called for ``(owner, repo)``, which mirrors what the live
+        client would have minted from a default installation.
+        """
+        token = self._installation_tokens.get(
+            (owner, repo), self.default_token
+        )
+        return InstallationAuth(token=token, base_url=base_url)
 
     def seed_tree(
         self,

--- a/tests/support/github_mock.py
+++ b/tests/support/github_mock.py
@@ -1,0 +1,239 @@
+"""Helpers to seed GitHub REST API responses on a respx router.
+
+Used by the ``mock_github`` fixture in ``tests/conftest.py`` to stand in
+for the live GitHub API when exercising the sync worker, webhook
+handler, and any unit test that drives the GitHub-facing storage
+helpers (``GitHubAppClient``, ``GitHubTreeFetcher``, ``changed_paths``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from functools import cached_property
+
+import httpx
+import respx
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+__all__ = ["DEFAULT_APP_ID", "DEFAULT_APP_NAME", "GitHubMock", "make_rsa_pem"]
+
+
+DEFAULT_APP_ID = 12345
+DEFAULT_APP_NAME = "lsst-sqre/docverse"
+_GITHUB_API = "https://api.github.com"
+
+
+def make_rsa_pem() -> str:
+    """Generate a fresh PKCS#8 PEM RSA private key for test JWT signing.
+
+    Session-scoped in the fixture so the 2048-bit keygen cost only pays
+    once per ``nox -s test`` run.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem.decode("utf-8")
+
+
+def _blob_sha(data: bytes) -> str:
+    r"""Git blob SHA-1 (matches ``git hash-object``).
+
+    Blob header is ``blob <size>\0`` prepended to the bytes. Using the
+    real scheme lets tests assert that a known file's SHA matches what a
+    real repo would produce, if they care — and gives the mock
+    deterministic SHAs without callers having to invent them.
+    """
+    header = f"blob {len(data)}\0".encode()
+    return hashlib.sha1(header + data, usedforsecurity=False).hexdigest()
+
+
+@dataclass(slots=True)
+class GitHubMock:
+    """respx seeder for the GitHub REST endpoints the GitHub App touches.
+
+    One instance per test; each seed_* method registers the handful of
+    routes that together let a given helper (tree fetcher, webhook
+    processor, app client) execute its flow without hitting the
+    network.
+
+    The fixture wires this onto the same autouse ``mock_discovery``
+    router so both the Repertoire-discovery mocks and the GitHub mocks
+    live in one respx context — tests that need both compose cleanly
+    without juggling two context managers.
+    """
+
+    router: respx.Router
+    private_key_pem: str
+    app_id: int = DEFAULT_APP_ID
+    app_name: str = DEFAULT_APP_NAME
+    default_installation_id: int = 99
+    default_token: str = "ghs_test_installation_token"  # noqa: S105
+    _installation_ids: dict[tuple[str, str], int] = field(default_factory=dict)
+
+    @cached_property
+    def installation_token(self) -> str:
+        """Installation token returned by the mocked exchange endpoint."""
+        return self.default_token
+
+    def seed_installation(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        installation_id: int | None = None,
+        token: str | None = None,
+    ) -> int:
+        """Wire (repo → installation id) lookup and (id → token) exchange.
+
+        Both endpoints are needed for
+        ``GitHubAppClient.create_installation_http_client`` to succeed;
+        seed them together so callers only write one line. Returns the
+        installation id for downstream assertions.
+        """
+        iid = installation_id or self.default_installation_id
+        bearer_token = token or self.default_token
+        self._installation_ids[(owner, repo)] = iid
+
+        self.router.get(
+            f"{_GITHUB_API}/repos/{owner}/{repo}/installation"
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"id": iid, "account": {"login": owner}}
+            )
+        )
+        self.router.post(
+            f"{_GITHUB_API}/app/installations/{iid}/access_tokens"
+        ).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "token": bearer_token,
+                    "expires_at": "2099-01-01T00:00:00Z",
+                },
+            )
+        )
+        return iid
+
+    def seed_tree(
+        self,
+        owner: str,
+        repo: str,
+        ref: str,
+        *,
+        files: Mapping[str, bytes],
+        commit_sha: str | None = None,
+        tree_sha: str | None = None,
+        etag: str = 'W/"test-etag"',
+        extra_tree_entries: list[dict[str, object]] | None = None,
+    ) -> tuple[str, str]:
+        """Register the commit, tree, and blob endpoints for a fetch.
+
+        ``files`` maps *repo-absolute* paths to blob bytes. Callers
+        passing a nested ``root_path`` to the fetcher must pre-prefix
+        accordingly — this matches how real repositories are keyed and
+        keeps the helper honest about the structure under test.
+
+        ``extra_tree_entries`` lets a test add non-blob entries (``tree``
+        subdirs) or blobs outside ``root_path`` to verify the fetcher's
+        filtering.
+
+        Returns ``(commit_sha, tree_sha)`` for cross-asserting.
+        """
+        csha = commit_sha or f"commit-{owner}-{repo}-{ref}"
+        tsha = tree_sha or f"tree-{owner}-{repo}-{ref}"
+
+        self.router.get(
+            f"{_GITHUB_API}/repos/{owner}/{repo}/commits/{ref}"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sha": csha,
+                    "commit": {"tree": {"sha": tsha}},
+                },
+            )
+        )
+
+        tree_entries: list[dict[str, object]] = []
+        for path, data in files.items():
+            blob_sha = _blob_sha(data)
+            tree_entries.append(
+                {
+                    "path": path,
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": blob_sha,
+                    "size": len(data),
+                }
+            )
+            self.router.get(
+                f"{_GITHUB_API}/repos/{owner}/{repo}/git/blobs/{blob_sha}"
+            ).mock(return_value=httpx.Response(200, content=data))
+
+        if extra_tree_entries:
+            tree_entries.extend(extra_tree_entries)
+
+        self.router.get(
+            f"{_GITHUB_API}/repos/{owner}/{repo}/git/trees/{tsha}",
+            params={"recursive": "1"},
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "sha": tsha,
+                    "tree": tree_entries,
+                    "truncated": False,
+                },
+                headers={"ETag": etag},
+            )
+        )
+
+        return csha, tsha
+
+    def seed_compare(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        before: str,
+        after: str,
+        changed_paths: list[str],
+        renamed: Mapping[str, str] | None = None,
+    ) -> None:
+        """Register a compare-API response listing ``changed_paths``.
+
+        ``renamed`` maps new filename → previous filename so callers can
+        exercise the rename branch of ``fetch_changed_paths_from_compare``
+        without flattening the rename into two independent entries.
+        """
+        renamed = renamed or {}
+        files: list[dict[str, object]] = []
+        for path in changed_paths:
+            entry: dict[str, object] = {
+                "filename": path,
+                "status": "renamed" if path in renamed else "modified",
+            }
+            if path in renamed:
+                entry["previous_filename"] = renamed[path]
+            files.append(entry)
+
+        self.router.get(
+            f"{_GITHUB_API}/repos/{owner}/{repo}/compare/{before}...{after}"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "status": "ahead",
+                    "ahead_by": len(changed_paths),
+                    "behind_by": 0,
+                    "total_commits": 1,
+                    "files": files,
+                },
+            )
+        )


### PR DESCRIPTION
## Summary

- Add `github_app_id`, `github_app_private_key`, `github_webhook_secret` to `Config` following the `slack_webhook: SecretStr | None` pattern; the feature stays disabled until all three are set, and partial configuration raises `GitHubAppNotConfiguredError` at the Factory layer.
- New `src/docverse/storage/github/` module — `GitHubAppClient` (gidgethub JWT + installation-token exchange, plus a per-request-auth `InstallationAuth(token, base_url)` record that piggy-backs on the lifespan `http_client` rather than spinning up per-installation pools), `GitHubTreeFetcher` with verbatim blob bytes + ETag capture and bounded concurrent blob fetches (`asyncio.Semaphore` capped at a named `_BLOB_FETCH_CONCURRENCY = 12` so realistic template trees are not bottlenecked on per-blob round-trip latency while staying within GitHub's secondary rate-limits), and pure `changed_paths` helpers with compare-API fallback.
- Wire the three `github_*` Config values and the shared `http_client` from `main.py`'s lifespan through `ContextDependency.initialize` into the per-request `HandlerFactory`, so request-path handlers can call `Factory.create_github_app_client()` instead of silently receiving `None` defaults.
- New `mock_github` respx fixture (`tests/support/github_mock.py`) seeds installation-token exchange, tree + blob fetches, and the compare API with real SHA-1 git-object blob SHAs; composes with the existing autouse `mock_discovery` so later slices exercise the flow without network calls.
- Tighten test coverage in response to PR #246 review: factory-helper test now exercises a real installation-token round-trip on the shared `http_client` (was asserting against an already-closed client), the compare API helper has a `{"files": null}` regression test, and both the compare helper and the tree fetcher's ref-resolution path have 404 / 429 / 500 tests pinning today's `httpx.HTTPStatusError` surface for the sync worker (#237) to layer typed exceptions on top of.

## Validation steps

- [ ] With all three `DOCVERSE_GITHUB_APP_*` / `DOCVERSE_GITHUB_WEBHOOK_SECRET` env vars set, `Factory(..., github_app_id=..., github_app_private_key=..., github_webhook_secret=...).create_github_app_client()` returns a `GitHubAppClient` without raising.
- [ ] With any one of the three unset, the same call raises `GitHubAppNotConfiguredError` (spot-check each of the three missing cases against the parametrized test in `tests/storage/github/app_client_test.py`).
- [ ] Startup in a clean environment with none of the three set still boots — confirm `uv run docverse-admin --help` or the server lifespan does not reference the new config eagerly.
- [ ] Existing admin / build / dashboard flows are unaffected (no new env requirements surfaced to ops).
- [ ] With all three env vars set, spin up a `RequestContext` via `ContextDependency.__call__` and verify `context.factory.create_github_app_client()` returns a `GitHubAppClient`; with one env var unset, the same call raises `GitHubAppNotConfiguredError` (see `tests/dependencies/context_test.py`).

## References

- Closes #236
- Closes #254
- Closes #255
- Closes #256
- Closes #257
- PRD: #232
- Jira: https://rubinobs.atlassian.net/browse/DM-54689
