### PR TITLE
Ralph preflight considers state of blocking issue PRs

### DIFF
--- a/ralph/README.md
+++ b/ralph/README.md
@@ -119,7 +119,9 @@ A task is eligible when all of these are true:
 
 - Labeled `prd-task`, state `open`.
 - Metadata `Type` is `AFK`.
-- Every issue number in the Metadata `Blocked by` row is `CLOSED`.
+- Every issue number in the Metadata `Blocked by` row is resolved: open PRs
+  still block, and a closed issue is only resolved once its closing PR is
+  merged (or if it has no closing PR).
 - Not labeled `agent-stuck`.
 - If `--prd N` is passed, Metadata `Parent PRD` references `#N`.
 

--- a/ralph/afk.sh
+++ b/ralph/afk.sh
@@ -158,6 +158,60 @@ container_exec() {
     fi
 }
 
+# ---- Helper: decide whether a blocker ref is still blocking ----
+# Args: issue_or_pr_number
+# Return code: 0 if still blocking, 1 if resolved.
+#
+# The AFK flow closes task issues at PR-creation time (see README.md), so an
+# issue being CLOSED alone does not mean the code has landed — we must follow
+# it to its closing PR and require that PR to be MERGED. For refs that are
+# themselves PR numbers, any non-OPEN state (CLOSED or MERGED) counts as
+# resolved. Query failures fall back to "blocked" so transient ratelimit or
+# network blips don't silently unblock a task.
+blocker_is_open() {
+    local num="$1"
+    local payload
+    # shellcheck disable=SC2016  # $num is a GraphQL variable, not a shell var
+    payload=$(container_exec gh api graphql -F num="$num" -f query='
+        query($num: Int!) {
+          repository(owner: "lsst-sqre", name: "docverse") {
+            issueOrPullRequest(number: $num) {
+              __typename
+              ... on Issue {
+                state
+                closedByPullRequestsReferences(first: 10, includeClosedPrs: true) {
+                  nodes { state }
+                }
+              }
+              ... on PullRequest { state }
+            }
+          }
+        }
+    ' --jq .data.repository.issueOrPullRequest 2>/dev/null || echo '{}')
+
+    local tn st any_merged pr_count
+    tn=$(echo "$payload" | jq -r '.__typename // ""')
+    st=$(echo "$payload" | jq -r '.state // ""')
+    any_merged=$(echo "$payload" \
+        | jq -r '[.closedByPullRequestsReferences.nodes[]?.state] | any(. == "MERGED")')
+    pr_count=$(echo "$payload" \
+        | jq -r '[.closedByPullRequestsReferences.nodes[]?] | length')
+
+    # Query failed or ref not found → treat as blocked (conservative).
+    if [ -z "$tn" ] || [ "$tn" = "null" ]; then
+        return 0
+    fi
+    # Still open → blocked.
+    if [ "$st" = "OPEN" ]; then
+        return 0
+    fi
+    # Closed issue with closing PRs, none merged → blocked.
+    if [ "$tn" = "Issue" ] && [ "$pr_count" -gt 0 ] && [ "$any_merged" != "true" ]; then
+        return 0
+    fi
+    return 1
+}
+
 # ---- Loop-start fetch so we see other humans' merges ----
 echo "Fetching origin inside container..."
 container_exec git -C /workspace/docverse fetch --prune origin \
@@ -245,13 +299,7 @@ build_shortlist() {
                 | grep -oE '#[0-9]+' \
                 | tr -d '#' || true)
             for b in $blockers; do
-                local state
-                state=$(container_exec gh issue view "$b" \
-                    --repo lsst-sqre/docverse \
-                    --json state --jq .state 2>/dev/null || echo "OPEN")
-                # gh issue view works on PR numbers too; merged PRs report state=MERGED.
-                # Treat anything other than OPEN as "blocker resolved".
-                if [ "$state" = "OPEN" ]; then ok=0; break; fi
+                if blocker_is_open "$b"; then ok=0; break; fi
             done
             if [ "$ok" = "1" ]; then
                 filtered=$(jq -c --argjson e "$entry" '. + [$e]' <<<"$filtered")


### PR DESCRIPTION
## Summary

- Ralph's AFK flow closes task issues at PR-creation time, so treating any non-OPEN blocker as resolved let the implement phase run against `main` without the blocker code (this is how PRD #237 got stuck).
- Added a `blocker_is_open` helper in `ralph/afk.sh` that follows each blocker via a single `issueOrPullRequest` GraphQL query: a `CLOSED` issue only counts as resolved once its closing PR is `MERGED` (or it has no closing PR). PR refs keep the prior behaviour — any non-OPEN state is resolved.
- Query failures still fall back to "blocked" so ratelimit / network blips can't silently unblock a task. README eligibility bullet updated to match.

## Test plan

- [x] `shellcheck ralph/afk.sh` — new helper is clean; only pre-existing warnings remain.
- [x] `uv run --only-group=lint pre-commit run --all-files` — passes.
- [x] Probed real GitHub data for the plan's verification table (#234 blocked / #233 resolved / #244 blocked / #239 resolved) — all four match.
- [ ] Once PRs #244/#245/#246 merge, confirm `ralph/afk.sh 1 --prd 237` accepts #237 on the next run without manual intervention.