### PR TITLE
DM-54689: Add dashboard_sync worker, syncer, fanout + force-sync endpoint

### DIFF
--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -105,15 +105,25 @@ class Factory:
             default_queue_name=self._default_queue_name,
         )
 
-    def _create_org_store(self) -> OrganizationStore:
+    def create_org_store(self) -> OrganizationStore:
+        """Create an :class:`OrganizationStore`."""
         return OrganizationStore(session=self._session, logger=self._logger)
 
-    def _create_project_store(self) -> ProjectStore:
+    def create_project_store(self) -> ProjectStore:
+        """Create a :class:`ProjectStore`."""
         return ProjectStore(session=self._session, logger=self._logger)
+
+    def create_build_store(self) -> BuildStore:
+        """Create a :class:`BuildStore`."""
+        return BuildStore(session=self._session, logger=self._logger)
+
+    def create_edition_store(self) -> EditionStore:
+        """Create an :class:`EditionStore`."""
+        return EditionStore(session=self._session, logger=self._logger)
 
     def create_organization_service(self) -> OrganizationService:
         """Create an OrganizationService."""
-        store = self._create_org_store()
+        store = self.create_org_store()
         return OrganizationService(
             store=store,
             service_store=self.create_service_store(),
@@ -122,11 +132,9 @@ class Factory:
 
     def create_project_service(self) -> ProjectService:
         """Create a ProjectService."""
-        store = self._create_project_store()
-        org_store = self._create_org_store()
-        edition_store = EditionStore(
-            session=self._session, logger=self._logger
-        )
+        store = self.create_project_store()
+        org_store = self.create_org_store()
+        edition_store = self.create_edition_store()
         return ProjectService(
             store=store,
             org_store=org_store,
@@ -136,9 +144,9 @@ class Factory:
 
     def create_build_service(self) -> BuildService:
         """Create a BuildService."""
-        store = BuildStore(session=self._session, logger=self._logger)
-        org_store = self._create_org_store()
-        project_store = self._create_project_store()
+        store = self.create_build_store()
+        org_store = self.create_org_store()
+        project_store = self.create_project_store()
         queue_backend = self.create_queue_backend()
         queue_job_store = QueueJobStore(
             session=self._session, logger=self._logger
@@ -170,14 +178,12 @@ class Factory:
         on the :class:`EditionTrackingDeps` dataclass.
         """
         deps = EditionTrackingDeps(
-            edition_store=EditionStore(
-                session=self._session, logger=self._logger
-            ),
+            edition_store=self.create_edition_store(),
             history_store=EditionBuildHistoryStore(
                 session=self._session, logger=self._logger
             ),
-            project_store=self._create_project_store(),
-            org_store=self._create_org_store(),
+            project_store=self.create_project_store(),
+            org_store=self.create_org_store(),
             logger=self._logger,
             lock_service=self.create_lock_service(),
         )
@@ -185,13 +191,13 @@ class Factory:
 
     def create_edition_service(self) -> EditionService:
         """Create an EditionService."""
-        store = EditionStore(session=self._session, logger=self._logger)
-        org_store = self._create_org_store()
-        project_store = self._create_project_store()
+        store = self.create_edition_store()
+        org_store = self.create_org_store()
+        project_store = self.create_project_store()
         history_store = EditionBuildHistoryStore(
             session=self._session, logger=self._logger
         )
-        build_store = BuildStore(session=self._session, logger=self._logger)
+        build_store = self.create_build_store()
         queue_backend = self.create_queue_backend()
         queue_job_store = QueueJobStore(
             session=self._session, logger=self._logger
@@ -251,7 +257,7 @@ class Factory:
             raise RuntimeError(msg)
         return CredentialService(
             store=self.create_credential_store(),
-            org_store=self._create_org_store(),
+            org_store=self.create_org_store(),
             service_store=self.create_service_store(),
             encryptor=self._credential_encryptor,
             logger=self._logger,
@@ -262,7 +268,7 @@ class Factory:
         return InfrastructureService(
             store=self.create_service_store(),
             credential_store=self.create_credential_store(),
-            org_store=self._create_org_store(),
+            org_store=self.create_org_store(),
             logger=self._logger,
         )
 
@@ -315,10 +321,8 @@ class Factory:
     def create_edition_publishing_service(self) -> EditionPublishingService:
         """Create an EditionPublishingService."""
         return EditionPublishingService(
-            org_store=self._create_org_store(),
-            edition_store=EditionStore(
-                session=self._session, logger=self._logger
-            ),
+            org_store=self.create_org_store(),
+            edition_store=self.create_edition_store(),
             history_store=EditionBuildHistoryStore(
                 session=self._session, logger=self._logger
             ),
@@ -326,9 +330,10 @@ class Factory:
             logger=self._logger,
         )
 
-    def _create_dashboard_github_template_binding_store(
+    def create_dashboard_github_template_binding_store(
         self,
     ) -> DashboardGitHubTemplateBindingStore:
+        """Create a :class:`DashboardGitHubTemplateBindingStore`."""
         return DashboardGitHubTemplateBindingStore(
             session=self._session, logger=self._logger
         )
@@ -338,9 +343,9 @@ class Factory:
     ) -> DashboardTemplateBindingService:
         """Create a :class:`DashboardTemplateBindingService`."""
         return DashboardTemplateBindingService(
-            binding_store=self._create_dashboard_github_template_binding_store(),
-            org_store=self._create_org_store(),
-            project_store=self._create_project_store(),
+            binding_store=self.create_dashboard_github_template_binding_store(),
+            org_store=self.create_org_store(),
+            project_store=self.create_project_store(),
             logger=self._logger,
         )
 
@@ -349,8 +354,8 @@ class Factory:
     ) -> DashboardBuildEnqueuer:
         """Create a DashboardBuildEnqueuer."""
         return DashboardBuildEnqueuer(
-            org_store=self._create_org_store(),
-            project_store=self._create_project_store(),
+            org_store=self.create_org_store(),
+            project_store=self.create_project_store(),
             queue_backend=self.create_queue_backend(),
             queue_job_store=self.create_queue_job_store(),
             logger=self._logger,
@@ -373,7 +378,7 @@ class Factory:
     def create_dashboard_sync_enqueuer(self) -> DashboardSyncEnqueuer:
         """Create a :class:`DashboardSyncEnqueuer`."""
         return DashboardSyncEnqueuer(
-            binding_store=self._create_dashboard_github_template_binding_store(),
+            binding_store=self.create_dashboard_github_template_binding_store(),
             queue_backend=self.create_queue_backend(),
             queue_job_store=self.create_queue_job_store(),
             logger=self._logger,
@@ -382,8 +387,8 @@ class Factory:
     def create_dashboard_rebuild_fanout(self) -> DashboardRebuildFanout:
         """Create a :class:`DashboardRebuildFanout`."""
         return DashboardRebuildFanout(
-            binding_store=self._create_dashboard_github_template_binding_store(),
-            project_store=self._create_project_store(),
+            binding_store=self.create_dashboard_github_template_binding_store(),
+            project_store=self.create_project_store(),
             enqueuer=self.create_dashboard_build_enqueuer(),
             logger=self._logger,
         )
@@ -402,7 +407,7 @@ class Factory:
             msg = "HTTP client is required to build a DashboardTemplateSyncer"
             raise RuntimeError(msg)
         return DashboardTemplateSyncer(
-            binding_store=self._create_dashboard_github_template_binding_store(),
+            binding_store=self.create_dashboard_github_template_binding_store(),
             template_store=DashboardGitHubTemplateStore(
                 session=self._session, logger=self._logger
             ),
@@ -423,12 +428,10 @@ class Factory:
             msg = "DiscoveryClient is required to build a DashboardPublisher"
             raise RuntimeError(msg)
         return DashboardPublisher(
-            org_store=self._create_org_store(),
-            project_store=self._create_project_store(),
-            edition_store=EditionStore(
-                session=self._session, logger=self._logger
-            ),
-            build_store=BuildStore(session=self._session, logger=self._logger),
+            org_store=self.create_org_store(),
+            project_store=self.create_project_store(),
+            edition_store=self.create_edition_store(),
+            build_store=self.create_build_store(),
             discovery=self._discovery,
             logger=self._logger,
             template_resolver=self.create_template_resolver(),

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -17,7 +17,10 @@ from .services.credential_encryptor import CredentialEncryptor
 from .services.dashboard.enqueue import DashboardBuildEnqueuer
 from .services.dashboard.publisher import DashboardPublisher
 from .services.dashboard_templates import (
+    DashboardRebuildFanout,
+    DashboardSyncEnqueuer,
     DashboardTemplateBindingService,
+    DashboardTemplateSyncer,
     TemplateResolver,
 )
 from .services.edition import EditionService
@@ -364,6 +367,47 @@ class Factory:
         return TemplateResolver(
             binding_store=binding_store,
             template_store=template_store,
+            logger=self._logger,
+        )
+
+    def create_dashboard_sync_enqueuer(self) -> DashboardSyncEnqueuer:
+        """Create a :class:`DashboardSyncEnqueuer`."""
+        return DashboardSyncEnqueuer(
+            binding_store=self._create_dashboard_github_template_binding_store(),
+            queue_backend=self.create_queue_backend(),
+            queue_job_store=self.create_queue_job_store(),
+            logger=self._logger,
+        )
+
+    def create_dashboard_rebuild_fanout(self) -> DashboardRebuildFanout:
+        """Create a :class:`DashboardRebuildFanout`."""
+        return DashboardRebuildFanout(
+            binding_store=self._create_dashboard_github_template_binding_store(),
+            project_store=self._create_project_store(),
+            enqueuer=self.create_dashboard_build_enqueuer(),
+            logger=self._logger,
+        )
+
+    def create_dashboard_template_syncer(self) -> DashboardTemplateSyncer:
+        """Create a :class:`DashboardTemplateSyncer`.
+
+        Raises
+        ------
+        GitHubAppNotConfiguredError
+            If the GitHub App feature is not configured.
+        RuntimeError
+            If the shared HTTP client is not configured.
+        """
+        if self._http_client is None:
+            msg = "HTTP client is required to build a DashboardTemplateSyncer"
+            raise RuntimeError(msg)
+        return DashboardTemplateSyncer(
+            binding_store=self._create_dashboard_github_template_binding_store(),
+            template_store=DashboardGitHubTemplateStore(
+                session=self._session, logger=self._logger
+            ),
+            app_client=self.create_github_app_client(),
+            http_client=self._http_client,
             logger=self._logger,
         )
 

--- a/src/docverse/handlers/admin/endpoints.py
+++ b/src/docverse/handlers/admin/endpoints.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
 
 from docverse.client.models import OrganizationCreate
 from docverse.dependencies.auth import require_superadmin
 from docverse.dependencies.context import RequestContext, context_dependency
+from docverse.domain.base32id import serialize_base32_id
 from docverse.exceptions import ConflictError, NotFoundError
 from docverse.handlers.params import OrgSlugParam
 
@@ -109,3 +111,33 @@ async def delete_organization(
             msg = f"Organization {org_slug!r} not found"
             raise NotFoundError(msg)
         await context.session.commit()
+
+
+class DashboardTemplateSyncEnqueuedResponse(BaseModel):
+    """Response body for the super-admin force-sync endpoint."""
+
+    binding_id: int = Field(description="ID of the binding that was synced.")
+    queue_job_id: str = Field(
+        description="Base32 public ID of the enqueued ``dashboard_sync`` job."
+    )
+
+
+@router.post(
+    "/admin/dashboard-templates/{binding_id}/sync",
+    response_model=DashboardTemplateSyncEnqueuedResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Force a re-sync of a dashboard-template binding",
+    name="admin_sync_dashboard_template",
+)
+async def sync_dashboard_template(
+    binding_id: int,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> DashboardTemplateSyncEnqueuedResponse:
+    async with context.session.begin():
+        enqueuer = context.factory.create_dashboard_sync_enqueuer()
+        queue_job = await enqueuer.enqueue(binding_id)
+        await context.session.commit()
+    return DashboardTemplateSyncEnqueuedResponse(
+        binding_id=binding_id,
+        queue_job_id=serialize_base32_id(queue_job.public_id),
+    )

--- a/src/docverse/handlers/orgs/dashboard_template.py
+++ b/src/docverse/handlers/orgs/dashboard_template.py
@@ -10,6 +10,9 @@ from docverse.client.models import DashboardTemplateBindingCreate
 from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.handlers.params import OrgSlugParam, ProjectSlugParam
+from docverse.services.dashboard_templates.enqueue import (
+    try_enqueue_dashboard_sync,
+)
 
 from .models import DashboardTemplateBindingResponse
 
@@ -58,6 +61,13 @@ async def put_org_dashboard_template(
         result = await service.put_org_default(org_slug=org_slug, data=data)
         if result.changed:
             await context.session.commit()
+    if result.changed:
+        await try_enqueue_dashboard_sync(
+            factory=context.factory,
+            session=context.session,
+            logger=context.logger,
+            binding_id=result.binding.id,
+        )
     response.status_code = (
         status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
     )
@@ -134,6 +144,13 @@ async def put_project_dashboard_template(  # noqa: PLR0913
         )
         if result.changed:
             await context.session.commit()
+    if result.changed:
+        await try_enqueue_dashboard_sync(
+            factory=context.factory,
+            session=context.session,
+            logger=context.logger,
+            binding_id=result.binding.id,
+        )
     response.status_code = (
         status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
     )

--- a/src/docverse/services/dashboard_templates/__init__.py
+++ b/src/docverse/services/dashboard_templates/__init__.py
@@ -6,15 +6,22 @@ from .binding import (
     DashboardTemplateBindingResult,
     DashboardTemplateBindingService,
 )
+from .enqueue import DashboardSyncEnqueuer
+from .fanout import DashboardRebuildFanout
 from .resolver import (
     ResolvedTemplate,
     ResolvedTemplateOrigin,
     TemplateResolver,
 )
+from .sync import DashboardTemplateSyncer, DashboardTemplateSyncError
 
 __all__ = [
+    "DashboardRebuildFanout",
+    "DashboardSyncEnqueuer",
     "DashboardTemplateBindingResult",
     "DashboardTemplateBindingService",
+    "DashboardTemplateSyncError",
+    "DashboardTemplateSyncer",
     "ResolvedTemplate",
     "ResolvedTemplateOrigin",
     "TemplateResolver",

--- a/src/docverse/services/dashboard_templates/enqueue.py
+++ b/src/docverse/services/dashboard_templates/enqueue.py
@@ -114,8 +114,8 @@ async def try_enqueue_dashboard_sync(
         )
         try:
             async with session.begin():
-                binding_store = DashboardGitHubTemplateBindingStore(
-                    session=session, logger=logger
+                binding_store = (
+                    factory.create_dashboard_github_template_binding_store()
                 )
                 await binding_store.update_sync_state(
                     binding_id=binding_id,

--- a/src/docverse/services/dashboard_templates/enqueue.py
+++ b/src/docverse/services/dashboard_templates/enqueue.py
@@ -95,13 +95,36 @@ async def try_enqueue_dashboard_sync(
     failure. The enqueue runs in a freshly started transaction on
     ``session`` — the caller must have already committed the binding
     write it wants persisted.
+
+    If the enqueue fails, a second transaction flips the binding's
+    ``last_sync_status`` to ``"failed"`` with a descriptive
+    ``last_sync_error``. That way the row does not sit in ``"pending"``
+    forever after a silent enqueue drop — operators see the failure by
+    reading the binding, and the existing force-sync endpoint is the
+    recovery path.
     """
     try:
         async with session.begin():
             service = factory.create_dashboard_sync_enqueuer()
             await service.enqueue(binding_id)
             await session.commit()
-    except Exception:
+    except Exception as exc:
         logger.exception(
             "Failed to enqueue dashboard_sync", binding_id=binding_id
         )
+        try:
+            async with session.begin():
+                binding_store = DashboardGitHubTemplateBindingStore(
+                    session=session, logger=logger
+                )
+                await binding_store.update_sync_state(
+                    binding_id=binding_id,
+                    last_sync_status="failed",
+                    last_sync_error=f"Enqueue failed: {exc}",
+                )
+                await session.commit()
+        except Exception:
+            logger.exception(
+                "Failed to mark binding as enqueue-failed",
+                binding_id=binding_id,
+            )

--- a/src/docverse/services/dashboard_templates/enqueue.py
+++ b/src/docverse/services/dashboard_templates/enqueue.py
@@ -1,0 +1,107 @@
+"""Service that enqueues ``dashboard_sync`` jobs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import structlog
+
+from docverse.client.models.queue_enums import JobKind
+from docverse.domain.base32id import serialize_base32_id
+from docverse.domain.queue import QueueJob
+from docverse.exceptions import NotFoundError
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.queue_backend import QueueBackend
+from docverse.storage.queue_job_store import QueueJobStore
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from docverse.factory import Factory
+
+__all__ = [
+    "DashboardSyncEnqueuer",
+    "try_enqueue_dashboard_sync",
+]
+
+
+class DashboardSyncEnqueuer:
+    """Create the ``QueueJob`` row and enqueue a ``dashboard_sync`` arq job.
+
+    Mirrors :class:`docverse.services.dashboard.enqueue.DashboardBuildEnqueuer`
+    at the enqueue layer — the heavy work (GitHub fetch, upsert,
+    fan-out) lives in the worker function.
+    """
+
+    def __init__(
+        self,
+        *,
+        binding_store: DashboardGitHubTemplateBindingStore,
+        queue_backend: QueueBackend,
+        queue_job_store: QueueJobStore,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._binding_store = binding_store
+        self._queue_backend = queue_backend
+        self._queue_job_store = queue_job_store
+        self._logger = logger
+
+    async def enqueue(self, binding_id: int) -> QueueJob:
+        """Enqueue one ``dashboard_sync`` job for a binding.
+
+        Raises
+        ------
+        NotFoundError
+            If the binding cannot be loaded.
+        """
+        binding = await self._binding_store.get_by_id(binding_id)
+        if binding is None:
+            msg = f"Dashboard template binding {binding_id} not found"
+            raise NotFoundError(msg)
+
+        queue_job = await self._queue_job_store.create(
+            kind=JobKind.dashboard_sync,
+            org_id=binding.org_id,
+            project_id=binding.project_id,
+        )
+        backend_job_id = await self._queue_backend.enqueue(
+            "dashboard_sync",
+            {
+                "binding_id": binding.id,
+                "queue_job_id": queue_job.id,
+                "queue_job_public_id": serialize_base32_id(
+                    queue_job.public_id
+                ),
+            },
+        )
+        return await self._queue_job_store.set_backend_job_id(
+            queue_job.id, backend_job_id
+        )
+
+
+async def try_enqueue_dashboard_sync(
+    *,
+    factory: Factory,
+    session: AsyncSession,
+    logger: structlog.stdlib.BoundLogger,
+    binding_id: int,
+) -> None:
+    """Enqueue one ``dashboard_sync`` job in its own transaction.
+
+    Exceptions are logged but never re-raised, so the caller's flow
+    (typically a binding PUT handler) is not broken by an enqueue
+    failure. The enqueue runs in a freshly started transaction on
+    ``session`` — the caller must have already committed the binding
+    write it wants persisted.
+    """
+    try:
+        async with session.begin():
+            service = factory.create_dashboard_sync_enqueuer()
+            await service.enqueue(binding_id)
+            await session.commit()
+    except Exception:
+        logger.exception(
+            "Failed to enqueue dashboard_sync", binding_id=binding_id
+        )

--- a/src/docverse/services/dashboard_templates/fanout.py
+++ b/src/docverse/services/dashboard_templates/fanout.py
@@ -1,0 +1,98 @@
+"""Fan out dashboard rebuilds for every project using a synced template."""
+
+from __future__ import annotations
+
+import structlog
+
+from docverse.domain.queue import QueueJob
+from docverse.services.dashboard.enqueue import DashboardBuildEnqueuer
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.project_store import ProjectStore
+
+__all__ = ["DashboardRebuildFanout"]
+
+
+class DashboardRebuildFanout:
+    """Enqueue ``dashboard_build`` jobs for projects that use a template.
+
+    The fan-out set is derived from the binding table plus the
+    resolution order (project override → org default → built-in), not
+    from a denormalized reverse-index column on projects. For a given
+    synced template ``T`` the affected projects are:
+
+    - every project whose override binding points at ``T``; and
+    - every project whose org-default binding points at ``T`` and which
+      does not have its own override binding (an override always wins,
+      even one that points elsewhere).
+    """
+
+    def __init__(
+        self,
+        *,
+        binding_store: DashboardGitHubTemplateBindingStore,
+        project_store: ProjectStore,
+        enqueuer: DashboardBuildEnqueuer,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._binding_store = binding_store
+        self._project_store = project_store
+        self._enqueuer = enqueuer
+        self._logger = logger
+
+    async def fan_out(self, github_template_id: int) -> list[QueueJob]:
+        """Enqueue ``dashboard_build`` for every project using the template.
+
+        Returns the enqueued queue jobs in the order they were created.
+        Returns an empty list when no bindings reference the template.
+        """
+        bindings = await self._binding_store.list_by_github_template_id(
+            github_template_id
+        )
+        if not bindings:
+            return []
+
+        affected: list[tuple[int, int]] = []
+        seen: set[tuple[int, int]] = set()
+        for binding in bindings:
+            if binding.project_id is not None:
+                key = (binding.org_id, binding.project_id)
+                if key not in seen:
+                    seen.add(key)
+                    affected.append(key)
+                continue
+
+            # Org-default binding: every non-deleted project in the org
+            # whose override (if any) does not shadow this default.
+            overrides = (
+                await self._binding_store.list_project_overrides_for_org(
+                    binding.org_id
+                )
+            )
+            override_ids = {
+                o.project_id for o in overrides if o.project_id is not None
+            }
+            projects = await self._project_store.list_all_by_org(
+                binding.org_id
+            )
+            for project in projects:
+                if project.id in override_ids:
+                    continue
+                key = (binding.org_id, project.id)
+                if key not in seen:
+                    seen.add(key)
+                    affected.append(key)
+
+        jobs: list[QueueJob] = []
+        for org_id, project_id in affected:
+            job = await self._enqueuer.enqueue_for_project(
+                org_id=org_id, project_id=project_id
+            )
+            jobs.append(job)
+        self._logger.info(
+            "Fanned out dashboard rebuilds",
+            github_template_id=github_template_id,
+            project_count=len(jobs),
+        )
+        return jobs

--- a/src/docverse/services/dashboard_templates/sync.py
+++ b/src/docverse/services/dashboard_templates/sync.py
@@ -1,0 +1,284 @@
+"""Fetch a GitHub dashboard template and upsert it into storage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+import httpx
+import structlog
+
+from docverse.domain.dashboard_github_template import (
+    DashboardGitHubTemplateBinding,
+)
+from docverse.exceptions import NotFoundError
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
+    GitHubTemplateFileInput,
+    GitHubTemplateKey,
+)
+from docverse.storage.dashboard_templates.template_source import (
+    parse_template_toml,
+)
+from docverse.storage.github import GitHubAppClient, GitHubTreeFetcher
+
+__all__ = [
+    "DashboardSyncResult",
+    "DashboardSyncStatus",
+    "DashboardTemplateSyncError",
+    "DashboardTemplateSyncer",
+]
+
+
+_TEMPLATE_TOML_PATH = "template.toml"
+
+
+class DashboardSyncStatus(StrEnum):
+    """Outcome category of a sync attempt.
+
+    ``succeeded`` covers both first-ever syncs and unchanged re-syncs;
+    use :attr:`DashboardSyncResult.changed` to distinguish them.
+    """
+
+    succeeded = "succeeded"
+    failed = "failed"
+
+
+class DashboardTemplateSyncError(Exception):
+    """Convenience exception for callers that prefer to propagate failure.
+
+    The syncer's :meth:`DashboardTemplateSyncer.sync` method itself
+    never raises this — it always returns a :class:`DashboardSyncResult`
+    whose ``status`` is :attr:`DashboardSyncStatus.failed` on failure —
+    so the binding's ``last_sync_status`` / ``last_sync_error`` row
+    update commits with the caller's transaction. This class exists for
+    callers that want to convert a failed result into an exception
+    (e.g. the worker, which needs to mark the queue job failed).
+    """
+
+
+@dataclass(frozen=True)
+class DashboardSyncResult:
+    """Outcome of a :meth:`DashboardTemplateSyncer.sync` call.
+
+    ``changed`` is ``True`` only on a successful sync that actually
+    moved the bytes (first-ever sync or ETag-mismatch rewrite); it is
+    ``False`` for ETag short-circuits and for any failed sync. Failed
+    syncs leave ``github_template_id`` pointing at the previous
+    template row when one was recorded by an earlier successful sync,
+    and ``None`` when the binding has never synced successfully.
+    """
+
+    binding: DashboardGitHubTemplateBinding
+    github_template_id: int | None
+    changed: bool
+    status: DashboardSyncStatus
+    error: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """``True`` when the sync completed without errors."""
+        return self.status is DashboardSyncStatus.succeeded
+
+
+class DashboardTemplateSyncer:
+    """Fetch one binding's GitHub tree and upsert it into storage.
+
+    The syncer owns the fetch + validate + upsert steps. It does not
+    acquire advisory locks or fan out dashboard rebuilds — the worker
+    wraps the call to :meth:`sync` with ``LockKey.for_dashboard_template``
+    and invokes :class:`DashboardRebuildFanout` on success.
+
+    Failure semantics: a sync that cannot complete (GitHub error,
+    missing or invalid ``template.toml``) flips the binding to
+    ``last_sync_status="failed"`` with a non-empty ``last_sync_error``
+    and leaves ``github_template_id`` pointing at the previously-synced
+    template row. Dashboards keep rendering from the last-good bytes.
+    The method *returns* a failed result rather than raising so the
+    caller's surrounding ``session.begin()`` block commits the failure
+    state instead of rolling it back.
+    """
+
+    def __init__(
+        self,
+        *,
+        binding_store: DashboardGitHubTemplateBindingStore,
+        template_store: DashboardGitHubTemplateStore,
+        app_client: GitHubAppClient,
+        http_client: httpx.AsyncClient,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._binding_store = binding_store
+        self._template_store = template_store
+        self._app_client = app_client
+        self._http_client = http_client
+        self._logger = logger
+
+    async def sync(self, binding_id: int) -> DashboardSyncResult:
+        """Fetch the template tree and upsert it into storage.
+
+        Raises
+        ------
+        NotFoundError
+            If ``binding_id`` does not exist.
+        """
+        binding = await self._binding_store.get_by_id(binding_id)
+        if binding is None:
+            msg = f"Dashboard template binding {binding_id} not found"
+            raise NotFoundError(msg)
+
+        logger = self._logger.bind(
+            binding_id=binding.id,
+            github_owner=binding.github_owner,
+            github_repo=binding.github_repo,
+            github_ref=binding.github_ref,
+            root_path=binding.root_path,
+        )
+
+        try:
+            auth = await self._app_client.get_installation_auth(
+                owner=binding.github_owner, repo=binding.github_repo
+            )
+        except Exception as exc:  # noqa: BLE001
+            return await self._record_failure(
+                binding=binding,
+                logger=logger,
+                message=f"GitHub App installation lookup failed: {exc}",
+            )
+
+        fetcher = GitHubTreeFetcher(
+            http_client=self._http_client, auth=auth, logger=logger
+        )
+        try:
+            fetched = await fetcher.fetch(
+                owner=binding.github_owner,
+                repo=binding.github_repo,
+                ref=binding.github_ref,
+                root_path=binding.root_path,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return await self._record_failure(
+                binding=binding,
+                logger=logger,
+                message=f"GitHub tree fetch failed: {exc}",
+            )
+
+        template_toml: bytes | None = None
+        other_files: list[GitHubTemplateFileInput] = []
+        for file in fetched.files:
+            if file.path == _TEMPLATE_TOML_PATH:
+                template_toml = file.data
+                continue
+            other_files.append(
+                GitHubTemplateFileInput(
+                    relative_path=file.path,
+                    is_text=_is_text(file.data),
+                    data=file.data,
+                )
+            )
+
+        if template_toml is None:
+            return await self._record_failure(
+                binding=binding,
+                logger=logger,
+                message=(
+                    "template.toml not found under root_path "
+                    f"{binding.root_path!r}"
+                ),
+            )
+
+        try:
+            parse_template_toml(template_toml)
+        except Exception as exc:  # noqa: BLE001
+            return await self._record_failure(
+                binding=binding,
+                logger=logger,
+                message=f"Invalid template.toml: {exc}",
+            )
+
+        # ETag caching: fall back to the tree SHA when GitHub omits the
+        # ETag header, so the compare-and-upsert step still short-
+        # circuits unchanged re-syncs.
+        etag = fetched.etag or f"tree:{fetched.tree_sha}"
+        upsert = await self._template_store.upsert(
+            key=GitHubTemplateKey(
+                github_owner=binding.github_owner,
+                github_repo=binding.github_repo,
+                github_ref=binding.github_ref,
+                root_path=binding.root_path,
+            ),
+            commit_sha=fetched.commit_sha,
+            etag=etag,
+            template_toml=template_toml,
+            files=other_files,
+        )
+
+        updated = await self._binding_store.update_sync_state(
+            binding_id=binding.id,
+            last_sync_status="succeeded",
+            last_sync_error=None,
+            github_template_id=upsert.template.id,
+        )
+        if updated is None:
+            msg = (
+                f"Binding {binding.id} disappeared mid-sync while recording "
+                "success"
+            )
+            raise RuntimeError(msg)
+
+        logger.info(
+            "Dashboard template synced",
+            github_template_id=upsert.template.id,
+            changed=upsert.changed,
+        )
+        return DashboardSyncResult(
+            binding=updated,
+            github_template_id=upsert.template.id,
+            changed=upsert.changed,
+            status=DashboardSyncStatus.succeeded,
+        )
+
+    async def _record_failure(
+        self,
+        *,
+        binding: DashboardGitHubTemplateBinding,
+        logger: structlog.stdlib.BoundLogger,
+        message: str,
+    ) -> DashboardSyncResult:
+        """Mark the binding failed without clearing ``github_template_id``."""
+        logger.warning("Dashboard template sync failed", reason=message)
+        updated = await self._binding_store.update_sync_state(
+            binding_id=binding.id,
+            last_sync_status="failed",
+            last_sync_error=message,
+        )
+        if updated is None:
+            msg = (
+                f"Binding {binding.id} disappeared mid-sync while recording "
+                "failure"
+            )
+            raise RuntimeError(msg)
+        return DashboardSyncResult(
+            binding=updated,
+            github_template_id=updated.github_template_id,
+            changed=False,
+            status=DashboardSyncStatus.failed,
+            error=message,
+        )
+
+
+def _is_text(data: bytes) -> bool:
+    """Return ``True`` when ``data`` decodes as UTF-8 text.
+
+    Used as a best-effort classifier for the ``is_text`` column on
+    ``dashboard_github_template_files``. Treating anything that
+    round-trips through UTF-8 as text covers Jinja templates, CSS, JS,
+    TOML, and SVG assets; binary images (PNG, WOFF2) fail the decode
+    and land as ``is_text=False``.
+    """
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True

--- a/src/docverse/services/dashboard_templates/sync.py
+++ b/src/docverse/services/dashboard_templates/sync.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import tomllib
 from dataclasses import dataclass
 from enum import StrEnum
 
+import gidgethub
 import httpx
 import structlog
 
@@ -140,7 +142,7 @@ class DashboardTemplateSyncer:
             auth = await self._app_client.get_installation_auth(
                 owner=binding.github_owner, repo=binding.github_repo
             )
-        except Exception as exc:  # noqa: BLE001
+        except (httpx.HTTPError, gidgethub.GitHubException) as exc:
             return await self._record_failure(
                 binding=binding,
                 logger=logger,
@@ -157,7 +159,7 @@ class DashboardTemplateSyncer:
                 ref=binding.github_ref,
                 root_path=binding.root_path,
             )
-        except Exception as exc:  # noqa: BLE001
+        except httpx.HTTPError as exc:
             return await self._record_failure(
                 binding=binding,
                 logger=logger,
@@ -190,7 +192,7 @@ class DashboardTemplateSyncer:
 
         try:
             parse_template_toml(template_toml)
-        except Exception as exc:  # noqa: BLE001
+        except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
             return await self._record_failure(
                 binding=binding,
                 logger=logger,

--- a/src/docverse/services/lock_service.py
+++ b/src/docverse/services/lock_service.py
@@ -36,6 +36,7 @@ class LockClass(IntEnum):
     BUILD_PROCESSING = 0x0000
     EDITION_UPDATE = 0x0001
     PROJECT = 0x0002
+    DASHBOARD_TEMPLATE = 0x0003
 
 
 def compute_lock_id(lock_class: LockClass, **parts: Any) -> int:
@@ -151,6 +152,39 @@ class LockKey:
             project_id=project_id,
         )
         label = f"project(org={org_id},project={project_id})"
+        return cls(lock_class=lock_class, lock_id=lock_id, label=label)
+
+    @classmethod
+    def for_dashboard_template(
+        cls,
+        *,
+        owner: str,
+        repo: str,
+        ref: str,
+        root_path: str,
+    ) -> LockKey:
+        """Build the lock key for a ``dashboard_sync`` job.
+
+        Serializes syncs of the same ``(owner, repo, ref, root_path)``
+        content so the ETag-compare-and-upsert sequence runs under a
+        single hold across workers. Keyed on the content dedup tuple —
+        not on the binding id — because multiple bindings may point at
+        the same upstream template and must not race each other on the
+        shared content row.
+        """
+        lock_class = LockClass.DASHBOARD_TEMPLATE
+        # kwarg order is load-bearing; do not reorder (see compute_lock_id).
+        lock_id = compute_lock_id(
+            lock_class,
+            owner=owner,
+            repo=repo,
+            ref=ref,
+            root_path=root_path,
+        )
+        label = (
+            f"dashboard_template(owner={owner},repo={repo},"
+            f"ref={ref},root={root_path})"
+        )
         return cls(lock_class=lock_class, lock_id=lock_id, label=label)
 
 

--- a/src/docverse/storage/dashboard_templates/github/binding_store.py
+++ b/src/docverse/storage/dashboard_templates/github/binding_store.py
@@ -111,6 +111,36 @@ class DashboardGitHubTemplateBindingStore:
             return None
         return DashboardGitHubTemplateBinding.model_validate(row)
 
+    async def list_by_github_template_id(
+        self, github_template_id: int
+    ) -> list[DashboardGitHubTemplateBinding]:
+        """List every binding that currently points at a template row."""
+        result = await self._session.execute(
+            select(SqlDashboardGitHubTemplateBinding).where(
+                SqlDashboardGitHubTemplateBinding.github_template_id
+                == github_template_id,
+            )
+        )
+        return [
+            DashboardGitHubTemplateBinding.model_validate(row)
+            for row in result.scalars().all()
+        ]
+
+    async def list_project_overrides_for_org(
+        self, org_id: int
+    ) -> list[DashboardGitHubTemplateBinding]:
+        """List every project-override binding within an organization."""
+        result = await self._session.execute(
+            select(SqlDashboardGitHubTemplateBinding).where(
+                SqlDashboardGitHubTemplateBinding.org_id == org_id,
+                SqlDashboardGitHubTemplateBinding.project_id.is_not(None),
+            )
+        )
+        return [
+            DashboardGitHubTemplateBinding.model_validate(row)
+            for row in result.scalars().all()
+        ]
+
     async def update_source(
         self,
         *,

--- a/src/docverse/worker/functions/__init__.py
+++ b/src/docverse/worker/functions/__init__.py
@@ -2,7 +2,14 @@
 
 from .build_processing import build_processing
 from .dashboard_build import dashboard_build
+from .dashboard_sync import dashboard_sync
 from .ping import ping
 from .publish_edition import publish_edition
 
-__all__ = ["build_processing", "dashboard_build", "ping", "publish_edition"]
+__all__ = [
+    "build_processing",
+    "dashboard_build",
+    "dashboard_sync",
+    "ping",
+    "publish_edition",
+]

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -14,15 +14,12 @@ import tarfile
 from dataclasses import dataclass
 from typing import Any
 
-import httpx
 import structlog
-from safir.arq import ArqQueue
 from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import BuildStatus
 from docverse.client.models.queue_enums import JobKind, PublishStatus
-from docverse.config import Configuration
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.build import Build
 from docverse.domain.edition_tracking import (
@@ -31,7 +28,6 @@ from docverse.domain.edition_tracking import (
 )
 from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
-from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.lock_service import LockKey
 from docverse.storage.build_store import BuildStore
 from docverse.storage.objectstore import ObjectStore
@@ -40,8 +36,6 @@ from docverse.storage.queue_job_store import QueueJobStore
 
 #: Maximum number of concurrent upload tasks.
 _UPLOAD_CONCURRENCY = 50
-
-config = Configuration()
 
 
 async def build_processing(
@@ -52,7 +46,8 @@ async def build_processing(
     Parameters
     ----------
     ctx
-        arq worker context (contains encryptor).
+        arq worker context (``factory_builder``, ``http_client``,
+        ``arq_queue``).
     payload
         Job payload with ``org_id``, ``project_id``, ``build_id``.
 
@@ -73,19 +68,8 @@ async def build_processing(
         build=build_public_id,
     )
 
-    encryptor: CredentialEncryptor = ctx["encryptor"]
-    http_client: httpx.AsyncClient = ctx["http_client"]
-    arq_queue: ArqQueue | None = ctx.get("arq_queue")
-
     async for session in db_session_dependency():
-        factory = Factory(
-            session=session,
-            logger=logger,
-            credential_encryptor=encryptor,
-            http_client=http_client,
-            arq_queue=arq_queue,
-            default_queue_name=config.arq_queue_name,
-        )
+        factory = ctx["factory_builder"](session=session, logger=logger)
         build_store = factory.create_build_store()
         org_store = factory.create_org_store()
         queue_job_store = factory.create_queue_job_store()

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -34,10 +34,6 @@ from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.lock_service import LockKey
 from docverse.storage.build_store import BuildStore
-from docverse.storage.edition_build_history_store import (
-    EditionBuildHistoryStore,
-)
-from docverse.storage.edition_store import EditionStore
 from docverse.storage.objectstore import ObjectStore
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.queue_job_store import QueueJobStore
@@ -90,9 +86,9 @@ async def build_processing(
             arq_queue=arq_queue,
             default_queue_name=config.arq_queue_name,
         )
-        build_store = BuildStore(session=session, logger=logger)
-        org_store = OrganizationStore(session=session, logger=logger)
-        queue_job_store = QueueJobStore(session=session, logger=logger)
+        build_store = factory.create_build_store()
+        org_store = factory.create_org_store()
+        queue_job_store = factory.create_queue_job_store()
         lock_service = factory.create_lock_service()
 
         # Pre-lock: load just enough build metadata to compute the
@@ -433,8 +429,8 @@ async def _enqueue_publish_jobs(  # noqa: PLR0913
     Returns a list of ``{edition_slug, publish_queue_job_public_id}``
     entries suitable for embedding in the parent build job's progress.
     """
-    edition_store = EditionStore(session=session, logger=logger)
-    history_store = EditionBuildHistoryStore(session=session, logger=logger)
+    edition_store = factory.create_edition_store()
+    history_store = factory.create_edition_build_history_store()
     queue_backend = factory.create_queue_backend()
 
     pending_enqueues: list[_PendingEnqueue] = []

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -10,19 +10,11 @@ import traceback
 from datetime import UTC, datetime
 from typing import Any
 
-import httpx
 import structlog
-from rubin.repertoire import DiscoveryClient
-from safir.arq import ArqQueue
 from safir.dependencies.db_session import db_session_dependency
 
-from docverse.config import Configuration
 from docverse.exceptions import NotFoundError
-from docverse.factory import Factory
-from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.lock_service import LockKey
-
-config = Configuration()
 
 
 async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
@@ -31,7 +23,8 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
     Parameters
     ----------
     ctx
-        arq worker context (encryptor, http_client, queue).
+        arq worker context (``factory_builder``, ``http_client``,
+        ``arq_queue``).
     payload
         Job payload with ``org_id``, ``org_slug``, ``project_id``,
         ``project_slug``, ``queue_job_id``, ``queue_job_public_id``.
@@ -50,21 +43,8 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
     project_id: int = payload["project_id"]
     queue_job_id: int = payload["queue_job_id"]
 
-    encryptor: CredentialEncryptor = ctx["encryptor"]
-    http_client: httpx.AsyncClient = ctx["http_client"]
-    arq_queue: ArqQueue | None = ctx.get("arq_queue")
-    discovery: DiscoveryClient = ctx["discovery"]
-
     async for session in db_session_dependency():
-        factory = Factory(
-            session=session,
-            logger=logger,
-            credential_encryptor=encryptor,
-            http_client=http_client,
-            arq_queue=arq_queue,
-            discovery=discovery,
-            default_queue_name=config.arq_queue_name,
-        )
+        factory = ctx["factory_builder"](session=session, logger=logger)
         queue_job_store = factory.create_queue_job_store()
         org_store = factory.create_org_store()
         lock_service = factory.create_lock_service()

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -21,8 +21,6 @@ from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.lock_service import LockKey
-from docverse.storage.organization_store import OrganizationStore
-from docverse.storage.queue_job_store import QueueJobStore
 
 config = Configuration()
 
@@ -67,8 +65,8 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
             discovery=discovery,
             default_queue_name=config.arq_queue_name,
         )
-        queue_job_store = QueueJobStore(session=session, logger=logger)
-        org_store = OrganizationStore(session=session, logger=logger)
+        queue_job_store = factory.create_queue_job_store()
+        org_store = factory.create_org_store()
         lock_service = factory.create_lock_service()
 
         lock_key = LockKey.for_project(org_id=org_id, project_id=project_id)

--- a/src/docverse/worker/functions/dashboard_sync.py
+++ b/src/docverse/worker/functions/dashboard_sync.py
@@ -23,10 +23,6 @@ from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.dashboard_templates.sync import DashboardSyncStatus
 from docverse.services.lock_service import LockKey
-from docverse.storage.dashboard_templates.github import (
-    DashboardGitHubTemplateBindingStore,
-)
-from docverse.storage.queue_job_store import QueueJobStore
 
 config = Configuration()
 
@@ -80,9 +76,9 @@ async def dashboard_sync(  # noqa: PLR0915
             github_webhook_secret=github_webhook_secret,
             default_queue_name=config.arq_queue_name,
         )
-        queue_job_store = QueueJobStore(session=session, logger=logger)
-        binding_store = DashboardGitHubTemplateBindingStore(
-            session=session, logger=logger
+        queue_job_store = factory.create_queue_job_store()
+        binding_store = (
+            factory.create_dashboard_github_template_binding_store()
         )
         lock_service = factory.create_lock_service()
 

--- a/src/docverse/worker/functions/dashboard_sync.py
+++ b/src/docverse/worker/functions/dashboard_sync.py
@@ -1,0 +1,209 @@
+"""Dashboard template sync worker function.
+
+Fetches a dashboard-template tree from GitHub, upserts the content +
+files, and fans out ``dashboard_build`` jobs for every project whose
+resolved template points at the synced content.
+"""
+
+from __future__ import annotations
+
+import traceback
+from typing import Any
+
+import httpx
+import structlog
+from pydantic import SecretStr
+from rubin.repertoire import DiscoveryClient
+from safir.arq import ArqQueue
+from safir.dependencies.db_session import db_session_dependency
+
+from docverse.config import Configuration
+from docverse.exceptions import NotFoundError
+from docverse.factory import Factory
+from docverse.services.credential_encryptor import CredentialEncryptor
+from docverse.services.dashboard_templates.sync import DashboardSyncStatus
+from docverse.services.lock_service import LockKey
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.queue_job_store import QueueJobStore
+
+config = Configuration()
+
+
+async def dashboard_sync(  # noqa: PLR0915
+    ctx: dict[str, Any], payload: dict[str, Any]
+) -> str:
+    """Sync one dashboard-template binding from GitHub.
+
+    Parameters
+    ----------
+    ctx
+        arq worker context (encryptor, http_client, discovery, queue,
+        GitHub-App secrets).
+    payload
+        Job payload with ``binding_id``, ``queue_job_id``,
+        ``queue_job_public_id``.
+
+    Returns
+    -------
+    str
+        ``"completed"`` on success or ``"failed"`` if the sync raised.
+    """
+    logger = structlog.get_logger("docverse.worker.dashboard_sync").bind(
+        binding_id=payload["binding_id"],
+        queue_job_id=payload["queue_job_public_id"],
+    )
+    binding_id: int = payload["binding_id"]
+    queue_job_id: int = payload["queue_job_id"]
+
+    encryptor: CredentialEncryptor = ctx["encryptor"]
+    http_client: httpx.AsyncClient = ctx["http_client"]
+    arq_queue: ArqQueue | None = ctx.get("arq_queue")
+    discovery: DiscoveryClient = ctx["discovery"]
+    github_app_id: int | None = ctx.get("github_app_id")
+    github_app_private_key: SecretStr | None = ctx.get(
+        "github_app_private_key"
+    )
+    github_webhook_secret: SecretStr | None = ctx.get("github_webhook_secret")
+
+    async for session in db_session_dependency():
+        factory = Factory(
+            session=session,
+            logger=logger,
+            credential_encryptor=encryptor,
+            http_client=http_client,
+            arq_queue=arq_queue,
+            discovery=discovery,
+            github_app_id=github_app_id,
+            github_app_private_key=github_app_private_key,
+            github_webhook_secret=github_webhook_secret,
+            default_queue_name=config.arq_queue_name,
+        )
+        queue_job_store = QueueJobStore(session=session, logger=logger)
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=session, logger=logger
+        )
+        lock_service = factory.create_lock_service()
+
+        # Load the binding before the lock so we know the content key
+        # to serialize on. A binding that was deleted between enqueue
+        # and dequeue fails fast before we try to acquire anything.
+        async with session.begin():
+            binding = await binding_store.get_by_id(binding_id)
+        if binding is None:
+            async with session.begin():
+                await queue_job_store.start(queue_job_id)
+                await queue_job_store.fail(
+                    queue_job_id,
+                    errors={
+                        "message": (
+                            f"Dashboard template binding {binding_id} "
+                            "not found"
+                        ),
+                        "type": NotFoundError.__name__,
+                    },
+                )
+            logger.warning("Dashboard sync binding missing")
+            return "failed"
+
+        lock_key = LockKey.for_dashboard_template(
+            owner=binding.github_owner,
+            repo=binding.github_repo,
+            ref=binding.github_ref,
+            root_path=binding.root_path,
+        )
+        async with lock_service.acquire(lock_key):
+            # Autobegin-then-commit dance inside the lock mirrors the
+            # pattern from PR #224: the lock is held on a dedicated
+            # connection, but the caller's session needs an explicit
+            # begin/commit around each DB write so progress updates
+            # are visible to observers outside the lock hold.
+            async with session.begin():
+                await queue_job_store.start(queue_job_id)
+                await queue_job_store.update_phase(
+                    queue_job_id,
+                    "fetching",
+                    progress={"message": "Fetching template tree from GitHub"},
+                )
+
+            try:
+                async with session.begin():
+                    await queue_job_store.update_phase(
+                        queue_job_id,
+                        "writing",
+                        progress={
+                            "message": (
+                                "Writing template content to the database"
+                            )
+                        },
+                    )
+                    syncer = factory.create_dashboard_template_syncer()
+                    sync_result = await syncer.sync(binding_id)
+            except Exception as exc:
+                logger.exception("Dashboard sync failed unexpectedly")
+                async with session.begin():
+                    await queue_job_store.fail(
+                        queue_job_id,
+                        errors={
+                            "message": str(exc),
+                            "type": type(exc).__name__,
+                            "traceback": traceback.format_exc(),
+                        },
+                    )
+                return "failed"
+
+            if sync_result.status is DashboardSyncStatus.failed:
+                logger.warning(
+                    "Dashboard sync marked binding failed",
+                    reason=sync_result.error,
+                )
+                async with session.begin():
+                    await queue_job_store.fail(
+                        queue_job_id,
+                        errors={
+                            "message": sync_result.error or "Sync failed",
+                            "type": "DashboardTemplateSyncError",
+                        },
+                    )
+                return "failed"
+
+            fan_out_count = 0
+            template_id = sync_result.github_template_id
+            if sync_result.changed and template_id is not None:
+                async with session.begin():
+                    await queue_job_store.update_phase(
+                        queue_job_id,
+                        "fanning_out",
+                        progress={
+                            "message": (
+                                "Fanning out dashboard rebuilds for dependent "
+                                "projects"
+                            ),
+                        },
+                    )
+                    fanout = factory.create_dashboard_rebuild_fanout()
+                    jobs = await fanout.fan_out(template_id)
+                    fan_out_count = len(jobs)
+
+            async with session.begin():
+                await queue_job_store.update_phase(
+                    queue_job_id,
+                    "complete",
+                    progress={
+                        "message": "Dashboard sync complete",
+                        "changed": sync_result.changed,
+                        "github_template_id": (sync_result.github_template_id),
+                        "fan_out_count": fan_out_count,
+                    },
+                )
+                await queue_job_store.complete(queue_job_id)
+            logger.info(
+                "Dashboard sync completed",
+                changed=sync_result.changed,
+                fan_out_count=fan_out_count,
+            )
+            return "completed"
+
+    msg = "No database session available"
+    raise RuntimeError(msg)

--- a/src/docverse/worker/functions/dashboard_sync.py
+++ b/src/docverse/worker/functions/dashboard_sync.py
@@ -10,33 +10,22 @@ from __future__ import annotations
 import traceback
 from typing import Any
 
-import httpx
 import structlog
-from pydantic import SecretStr
-from rubin.repertoire import DiscoveryClient
-from safir.arq import ArqQueue
 from safir.dependencies.db_session import db_session_dependency
 
-from docverse.config import Configuration
 from docverse.exceptions import NotFoundError
-from docverse.factory import Factory
-from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.dashboard_templates.sync import DashboardSyncStatus
 from docverse.services.lock_service import LockKey
 
-config = Configuration()
 
-
-async def dashboard_sync(  # noqa: PLR0915
-    ctx: dict[str, Any], payload: dict[str, Any]
-) -> str:
+async def dashboard_sync(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
     """Sync one dashboard-template binding from GitHub.
 
     Parameters
     ----------
     ctx
-        arq worker context (encryptor, http_client, discovery, queue,
-        GitHub-App secrets).
+        arq worker context (``factory_builder``, ``http_client``,
+        ``arq_queue``).
     payload
         Job payload with ``binding_id``, ``queue_job_id``,
         ``queue_job_public_id``.
@@ -53,29 +42,8 @@ async def dashboard_sync(  # noqa: PLR0915
     binding_id: int = payload["binding_id"]
     queue_job_id: int = payload["queue_job_id"]
 
-    encryptor: CredentialEncryptor = ctx["encryptor"]
-    http_client: httpx.AsyncClient = ctx["http_client"]
-    arq_queue: ArqQueue | None = ctx.get("arq_queue")
-    discovery: DiscoveryClient = ctx["discovery"]
-    github_app_id: int | None = ctx.get("github_app_id")
-    github_app_private_key: SecretStr | None = ctx.get(
-        "github_app_private_key"
-    )
-    github_webhook_secret: SecretStr | None = ctx.get("github_webhook_secret")
-
     async for session in db_session_dependency():
-        factory = Factory(
-            session=session,
-            logger=logger,
-            credential_encryptor=encryptor,
-            http_client=http_client,
-            arq_queue=arq_queue,
-            discovery=discovery,
-            github_app_id=github_app_id,
-            github_app_private_key=github_app_private_key,
-            github_webhook_secret=github_webhook_secret,
-            default_queue_name=config.arq_queue_name,
-        )
+        factory = ctx["factory_builder"](session=session, logger=logger)
         queue_job_store = factory.create_queue_job_store()
         binding_store = (
             factory.create_dashboard_github_template_binding_store()

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -12,19 +12,15 @@ import traceback
 from dataclasses import dataclass
 from typing import Any
 
-import httpx
 import structlog
-from safir.arq import ArqQueue
 from safir.dependencies.db_session import db_session_dependency
 
 from docverse.client.models.queue_enums import PublishStatus
-from docverse.config import Configuration
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
 from docverse.domain.edition_build_history import EditionBuildHistory
 from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
-from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_id,
 )
@@ -34,8 +30,6 @@ from docverse.storage.edition_build_history_store import (
 )
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.queue_job_store import QueueJobStore
-
-config = Configuration()
 
 
 @dataclass(slots=True)
@@ -51,7 +45,8 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
     Parameters
     ----------
     ctx
-        arq worker context.
+        arq worker context (``factory_builder``, ``http_client``,
+        ``arq_queue``).
     payload
         Job payload with ``org_id``, ``project_slug``, ``edition_id``,
         ``edition_slug``, ``build_id``, ``build_public_id``,
@@ -71,20 +66,10 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
         queue_job_id=payload["queue_job_public_id"],
     )
 
-    encryptor: CredentialEncryptor = ctx["encryptor"]
-    http_client: httpx.AsyncClient = ctx["http_client"]
-    arq_queue: ArqQueue | None = ctx.get("arq_queue")
     queue_job_id: int = payload["queue_job_id"]
 
     async for session in db_session_dependency():
-        factory = Factory(
-            session=session,
-            logger=logger,
-            credential_encryptor=encryptor,
-            http_client=http_client,
-            arq_queue=arq_queue,
-            default_queue_name=config.arq_queue_name,
-        )
+        factory = ctx["factory_builder"](session=session, logger=logger)
         edition_store = factory.create_edition_store()
         history_store = factory.create_edition_build_history_store()
         queue_job_store = factory.create_queue_job_store()

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -16,7 +16,6 @@ import httpx
 import structlog
 from safir.arq import ArqQueue
 from safir.dependencies.db_session import db_session_dependency
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models.queue_enums import PublishStatus
 from docverse.config import Configuration
@@ -30,12 +29,10 @@ from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_id,
 )
 from docverse.services.lock_service import LockKey
-from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
 )
 from docverse.storage.edition_store import EditionStore
-from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
 
 config = Configuration()
@@ -88,12 +85,10 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
             arq_queue=arq_queue,
             default_queue_name=config.arq_queue_name,
         )
-        edition_store = EditionStore(session=session, logger=logger)
-        history_store = EditionBuildHistoryStore(
-            session=session, logger=logger
-        )
-        queue_job_store = QueueJobStore(session=session, logger=logger)
-        project_store = ProjectStore(session=session, logger=logger)
+        edition_store = factory.create_edition_store()
+        history_store = factory.create_edition_build_history_store()
+        queue_job_store = factory.create_queue_job_store()
+        project_store = factory.create_project_store()
         lock_service = factory.create_lock_service()
 
         # Pre-lock: resolve project_id from the payload's project_slug so
@@ -119,7 +114,7 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
         async with lock_service.acquire(lock_key):
             async with session.begin():
                 resources = await _load_resources(
-                    session=session, logger=logger, payload=payload
+                    factory=factory, payload=payload
                 )
                 await _mark_publishing(
                     queue_job_store=queue_job_store,
@@ -168,15 +163,14 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
 
 async def _load_resources(
     *,
-    session: AsyncSession,
-    logger: structlog.stdlib.BoundLogger,
+    factory: Factory,
     payload: dict[str, Any],
 ) -> _PublishResources:
     """Load project, edition, build, and history entry for the job."""
-    project_store = ProjectStore(session=session, logger=logger)
-    edition_store = EditionStore(session=session, logger=logger)
-    build_store = BuildStore(session=session, logger=logger)
-    history_store = EditionBuildHistoryStore(session=session, logger=logger)
+    project_store = factory.create_project_store()
+    edition_store = factory.create_edition_store()
+    build_store = factory.create_build_store()
+    history_store = factory.create_edition_build_history_store()
 
     project = await project_store.get_by_slug(
         org_id=payload["org_id"], slug=payload["project_slug"]

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -10,14 +10,17 @@ from typing import Any
 
 import httpx
 import structlog
+from pydantic import SecretStr
 from rubin.repertoire import DiscoveryClient
-from safir.arq import RedisArqQueue
+from safir.arq import ArqQueue, RedisArqQueue
 from safir.database import create_database_engine, is_database_current
 from safir.dependencies.db_session import db_session_dependency
 from safir.logging import configure_logging
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.config import Configuration
 from docverse.database import get_current_revision
+from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
 
 from .functions import (
@@ -29,6 +32,60 @@ from .functions import (
 )
 
 config = Configuration()
+
+
+class WorkerFactoryBuilder:
+    """Build per-job :class:`Factory` instances inside the arq worker.
+
+    Captures the worker's process-lifetime dependencies once and exposes
+    a ``__call__(session, logger)`` that mints a fresh
+    :class:`docverse.factory.Factory` for the duration of one arq job.
+    Mirrors the request-side pattern in
+    :class:`safir.dependencies.context.ContextDependency`, where the
+    process-lifetime deps are captured once and a per-request
+    ``RequestContext`` is built around them.
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        encryptor: CredentialEncryptor,
+        http_client: httpx.AsyncClient,
+        arq_queue: ArqQueue,
+        discovery: DiscoveryClient,
+        github_app_id: int | None,
+        github_app_private_key: SecretStr | None,
+        github_webhook_secret: SecretStr | None,
+        default_queue_name: str,
+    ) -> None:
+        self._encryptor = encryptor
+        self._http_client = http_client
+        self._arq_queue = arq_queue
+        self._discovery = discovery
+        self._github_app_id = github_app_id
+        self._github_app_private_key = github_app_private_key
+        self._github_webhook_secret = github_webhook_secret
+        self._default_queue_name = default_queue_name
+
+    def __call__(
+        self,
+        *,
+        session: AsyncSession,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> Factory:
+        """Build a :class:`Factory` for one arq job."""
+        return Factory(
+            session=session,
+            logger=logger,
+            credential_encryptor=self._encryptor,
+            http_client=self._http_client,
+            arq_queue=self._arq_queue,
+            discovery=self._discovery,
+            github_app_id=self._github_app_id,
+            github_app_private_key=self._github_app_private_key,
+            github_webhook_secret=self._github_webhook_secret,
+            default_queue_name=self._default_queue_name,
+        )
 
 
 async def startup(ctx: dict[str, Any]) -> None:
@@ -66,26 +123,39 @@ async def startup(ctx: dict[str, Any]) -> None:
         if config.credential_encryption_key_retired
         else None
     )
-    ctx["encryptor"] = CredentialEncryptor(
+    encryptor = CredentialEncryptor(
         current_key=config.credential_encryption_key.get_secret_value(),
         retired_key=retired_key,
     )
 
-    ctx["http_client"] = httpx.AsyncClient()
-    ctx["discovery"] = DiscoveryClient(
-        ctx["http_client"],
+    http_client = httpx.AsyncClient()
+    discovery = DiscoveryClient(
+        http_client,
         base_url=str(config.repertoire_base_url),
         logger=logger,
     )
-    ctx["github_app_id"] = config.github_app_id
-    ctx["github_app_private_key"] = config.github_app_private_key
-    ctx["github_webhook_secret"] = config.github_webhook_secret
 
     if config.arq_redis_settings is None:
         msg = "arq_redis_settings must be configured for the worker"
         raise RuntimeError(msg)
-    ctx["arq_queue"] = await RedisArqQueue.initialize(
+    arq_queue = await RedisArqQueue.initialize(
         config.arq_redis_settings,
+        default_queue_name=config.arq_queue_name,
+    )
+
+    # ``http_client`` and ``arq_queue`` stay in ctx because ``shutdown``
+    # owns their teardown. The factory builder captures them by reference,
+    # so worker functions never need to look them up directly.
+    ctx["http_client"] = http_client
+    ctx["arq_queue"] = arq_queue
+    ctx["factory_builder"] = WorkerFactoryBuilder(
+        encryptor=encryptor,
+        http_client=http_client,
+        arq_queue=arq_queue,
+        discovery=discovery,
+        github_app_id=config.github_app_id,
+        github_app_private_key=config.github_app_private_key,
+        github_webhook_secret=config.github_webhook_secret,
         default_queue_name=config.arq_queue_name,
     )
 

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -20,7 +20,13 @@ from docverse.config import Configuration
 from docverse.database import get_current_revision
 from docverse.services.credential_encryptor import CredentialEncryptor
 
-from .functions import build_processing, dashboard_build, ping, publish_edition
+from .functions import (
+    build_processing,
+    dashboard_build,
+    dashboard_sync,
+    ping,
+    publish_edition,
+)
 
 config = Configuration()
 
@@ -71,6 +77,9 @@ async def startup(ctx: dict[str, Any]) -> None:
         base_url=str(config.repertoire_base_url),
         logger=logger,
     )
+    ctx["github_app_id"] = config.github_app_id
+    ctx["github_app_private_key"] = config.github_app_private_key
+    ctx["github_webhook_secret"] = config.github_webhook_secret
 
     if config.arq_redis_settings is None:
         msg = "arq_redis_settings must be configured for the worker"
@@ -99,7 +108,13 @@ async def shutdown(ctx: dict[str, Any]) -> None:
 class WorkerSettings:
     """arq WorkerSettings for Docverse."""
 
-    functions = [build_processing, dashboard_build, ping, publish_edition]
+    functions = [
+        build_processing,
+        dashboard_build,
+        dashboard_sync,
+        ping,
+        publish_edition,
+    ]
     redis_settings = config.arq_redis_settings
     queue_name = config.arq_queue_name
     on_startup = startup

--- a/tests/handlers/admin_dashboard_template_test.py
+++ b/tests/handlers/admin_dashboard_template_test.py
@@ -1,0 +1,122 @@
+"""Tests for the super-admin ``POST /admin/dashboard-templates/{id}/sync``."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from httpx import AsyncClient
+from safir.arq import JobMetadata, MockArqQueue
+from safir.dependencies.arq import arq_dependency
+from safir.dependencies.db_session import db_session_dependency
+
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.organization_store import OrganizationStore
+from tests.conftest import seed_org_with_admin
+
+_SUPERADMIN = "superadmin"
+_ADMIN = "admin-user"
+_USER = "someone-else"
+_ORG = "admin-sync-org"
+
+_BINDING_BODY = {
+    "github_owner": "lsst-sqre",
+    "github_repo": "docverse-templates",
+    "github_ref": "main",
+    "root_path": "/",
+}
+
+
+async def _create_binding(client: AsyncClient) -> int:
+    """Create an org-default binding via the name-keyed PUT; return its id."""
+    await seed_org_with_admin(client, _ORG, _ADMIN)
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_BINDING_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+
+    logger = structlog.get_logger("test")
+    async for session in db_session_dependency():
+        async with session.begin():
+            org_store = OrganizationStore(session=session, logger=logger)
+            org = await org_store.get_by_slug(_ORG)
+            assert org is not None
+            binding_store = DashboardGitHubTemplateBindingStore(
+                session=session, logger=logger
+            )
+            binding = await binding_store.get_org_default(org.id)
+            assert binding is not None
+            return binding.id
+    msg = "db_session_dependency yielded nothing"
+    raise AssertionError(msg)
+
+
+def _dashboard_sync_enqueues(mock_arq: MockArqQueue) -> list[JobMetadata]:
+    return [
+        j
+        for queue in mock_arq._job_metadata.values()
+        for j in queue.values()
+        if j.name == "dashboard_sync"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_admin_sync_enqueues_dashboard_sync(
+    client: AsyncClient,
+) -> None:
+    """Super-admin POST enqueues a ``dashboard_sync`` for the given binding."""
+    binding_id = await _create_binding(client)
+    mock_arq: MockArqQueue = arq_dependency._arq_queue  # type: ignore[assignment]
+    before = len(_dashboard_sync_enqueues(mock_arq))
+
+    response = await client.post(
+        f"/docverse/admin/dashboard-templates/{binding_id}/sync",
+        headers={"X-Auth-Request-User": _SUPERADMIN},
+    )
+    assert response.status_code == 202
+    body = response.json()
+    assert body["binding_id"] == binding_id
+    assert body["queue_job_id"]
+
+    enqueues = _dashboard_sync_enqueues(mock_arq)
+    assert len(enqueues) == before + 1
+    payload = enqueues[-1].kwargs["payload"]
+    assert payload["binding_id"] == binding_id
+
+
+@pytest.mark.asyncio
+async def test_admin_sync_unknown_binding_returns_404(
+    client: AsyncClient,
+) -> None:
+    """A missing binding id surfaces a 404, not 500."""
+    response = await client.post(
+        "/docverse/admin/dashboard-templates/999999/sync",
+        headers={"X-Auth-Request-User": _SUPERADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_admin_sync_rejects_unauthenticated(client: AsyncClient) -> None:
+    """Callers without an auth header are rejected (401 or 403)."""
+    binding_id = await _create_binding(client)
+    response = await client.post(
+        f"/docverse/admin/dashboard-templates/{binding_id}/sync",
+    )
+    # The router-level ``require_superadmin`` dep raises 403 for missing
+    # or non-superadmin users alike — either code satisfies "rejected".
+    assert response.status_code in {401, 403}
+
+
+@pytest.mark.asyncio
+async def test_admin_sync_rejects_non_superadmin(client: AsyncClient) -> None:
+    """Ordinary users cannot force-sync; the endpoint is super-admin only."""
+    binding_id = await _create_binding(client)
+    response = await client.post(
+        f"/docverse/admin/dashboard-templates/{binding_id}/sync",
+        headers={"X-Auth-Request-User": _USER},
+    )
+    assert response.status_code == 403

--- a/tests/handlers/dashboard_template_test.py
+++ b/tests/handlers/dashboard_template_test.py
@@ -10,6 +10,7 @@ from safir.dependencies.arq import arq_dependency
 from safir.dependencies.db_session import db_session_dependency
 
 from docverse.client.models import OrgRole
+from docverse.services.dashboard_templates.enqueue import DashboardSyncEnqueuer
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
     DashboardGitHubTemplateStore,
@@ -675,3 +676,50 @@ async def test_project_put_enqueues_dashboard_sync(
 
     enqueues = _dashboard_sync_enqueues(mock_arq)
     assert len(enqueues) == before + 1
+
+
+@pytest.mark.asyncio
+async def test_org_put_enqueue_failure_marks_binding_failed(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mark the binding ``failed`` when the fire-and-forget enqueue raises.
+
+    The PUT must still succeed, but the binding must reflect the failure
+    as ``last_sync_status="failed"`` with a descriptive
+    ``last_sync_error`` so operators can detect the stuck row.
+    """
+    await _setup_org(client)
+
+    boom_message = "arq down"
+
+    async def _boom(
+        self: DashboardSyncEnqueuer,
+        binding_id: int,
+    ) -> None:
+        raise RuntimeError(boom_message)
+
+    monkeypatch.setattr(DashboardSyncEnqueuer, "enqueue", _boom)
+
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+
+    logger = structlog.get_logger("docverse")
+    async for session in db_session_dependency():
+        async with session.begin():
+            ostore = OrganizationStore(session=session, logger=logger)
+            org = await ostore.get_by_slug(_ORG)
+            assert org is not None
+            bstore = DashboardGitHubTemplateBindingStore(
+                session=session, logger=logger
+            )
+            binding = await bstore.get_org_default(org.id)
+            assert binding is not None
+            assert binding.last_sync_status == "failed"
+            assert binding.last_sync_error is not None
+            assert "arq down" in binding.last_sync_error
+        break

--- a/tests/handlers/dashboard_template_test.py
+++ b/tests/handlers/dashboard_template_test.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pytest
 import structlog
 from httpx import AsyncClient
+from safir.arq import JobMetadata, MockArqQueue
+from safir.dependencies.arq import arq_dependency
 from safir.dependencies.db_session import db_session_dependency
 
 from docverse.client.models import OrgRole
@@ -580,3 +582,96 @@ async def test_org_default_and_project_override_are_independent(
     )
     assert org_after.status_code == 200
     assert org_after.json()["github_ref"] == "main"
+
+
+def _dashboard_sync_enqueues(mock_arq: MockArqQueue) -> list[JobMetadata]:
+    """Return every ``dashboard_sync`` job recorded on the mock queue."""
+    return [
+        j
+        for queue in mock_arq._job_metadata.values()
+        for j in queue.values()
+        if j.name == "dashboard_sync"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_org_put_enqueues_dashboard_sync_on_create(
+    client: AsyncClient,
+) -> None:
+    """Creating an org-default binding enqueues an initial sync."""
+    await _setup_org(client)
+    mock_arq: MockArqQueue = arq_dependency._arq_queue  # type: ignore[assignment]
+    before = len(_dashboard_sync_enqueues(mock_arq))
+
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+
+    enqueues = _dashboard_sync_enqueues(mock_arq)
+    assert len(enqueues) == before + 1
+
+    # Verify the enqueued job points at the binding the PUT created.
+    binding_id: int | None = None
+    async for session in db_session_dependency():
+        async with session.begin():
+            org_store = OrganizationStore(
+                session=session, logger=structlog.get_logger("test")
+            )
+            org = await org_store.get_by_slug(_ORG)
+            assert org is not None
+            binding_store = DashboardGitHubTemplateBindingStore(
+                session=session, logger=structlog.get_logger("test")
+            )
+            binding = await binding_store.get_org_default(org.id)
+            assert binding is not None
+            binding_id = binding.id
+    assert binding_id is not None
+    payload = enqueues[-1].kwargs["payload"]
+    assert payload["binding_id"] == binding_id
+
+
+@pytest.mark.asyncio
+async def test_org_put_idempotent_noop_does_not_enqueue_dashboard_sync(
+    client: AsyncClient,
+) -> None:
+    """A PUT that writes no changes must not enqueue a new sync."""
+    await _setup_org(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    mock_arq: MockArqQueue = arq_dependency._arq_queue  # type: ignore[assignment]
+    before = len(_dashboard_sync_enqueues(mock_arq))
+
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+
+    assert len(_dashboard_sync_enqueues(mock_arq)) == before
+
+
+@pytest.mark.asyncio
+async def test_project_put_enqueues_dashboard_sync(
+    client: AsyncClient,
+) -> None:
+    """Creating a project override enqueues an initial sync."""
+    await _setup_org_and_project(client)
+    mock_arq: MockArqQueue = arq_dependency._arq_queue  # type: ignore[assignment]
+    before = len(_dashboard_sync_enqueues(mock_arq))
+
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/projects/{_PROJECT}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 201
+
+    enqueues = _dashboard_sync_enqueues(mock_arq)
+    assert len(enqueues) == before + 1

--- a/tests/services/dashboard_templates/fanout_test.py
+++ b/tests/services/dashboard_templates/fanout_test.py
@@ -1,0 +1,337 @@
+"""Tests for DashboardRebuildFanout."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from safir.arq import MockArqQueue
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import OrganizationCreate, ProjectCreate
+from docverse.client.models.queue_enums import JobKind
+from docverse.config import Configuration
+from docverse.services.dashboard.enqueue import DashboardBuildEnqueuer
+from docverse.services.dashboard_templates.fanout import DashboardRebuildFanout
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
+    DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
+    GitHubTemplateFileInput,
+    GitHubTemplateKey,
+)
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+from docverse.storage.queue_backend import ArqQueueBackend
+from docverse.storage.queue_job_store import QueueJobStore
+
+_config = Configuration()
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("test")  # type: ignore[no-any-return]
+
+
+async def _seed_template(
+    session: AsyncSession,
+    *,
+    key: GitHubTemplateKey,
+    etag: str = "etag-1",
+) -> int:
+    store = DashboardGitHubTemplateStore(session=session, logger=_logger())
+    result = await store.upsert(
+        key=key,
+        commit_sha="cafebabe",
+        etag=etag,
+        template_toml=b"[dashboard]\n",
+        files=[
+            GitHubTemplateFileInput(
+                relative_path="dashboard.html.jinja",
+                is_text=True,
+                data=b"<html>ok</html>",
+            ),
+        ],
+    )
+    return result.template.id
+
+
+async def _seed_org_with_projects(
+    session: AsyncSession,
+    *,
+    org_slug: str,
+    project_slugs: list[str],
+) -> tuple[int, list[int]]:
+    logger = _logger()
+    org_store = OrganizationStore(session=session, logger=logger)
+    proj_store = ProjectStore(session=session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=org_slug,
+            title=f"Org {org_slug}",
+            base_domain=f"{org_slug}.example.com",
+        )
+    )
+    project_ids: list[int] = []
+    for slug in project_slugs:
+        project = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug=slug,
+                title=f"Project {slug}",
+                doc_repo=f"https://github.com/example/{slug}",
+            ),
+        )
+        project_ids.append(project.id)
+    return org.id, project_ids
+
+
+def _make_fanout(
+    session: AsyncSession,
+    *,
+    arq_queue: MockArqQueue,
+) -> DashboardRebuildFanout:
+    logger = _logger()
+    org_store = OrganizationStore(session=session, logger=logger)
+    proj_store = ProjectStore(session=session, logger=logger)
+    binding_store = DashboardGitHubTemplateBindingStore(
+        session=session, logger=logger
+    )
+    queue_backend = ArqQueueBackend(
+        arq_queue=arq_queue, default_queue_name=_config.arq_queue_name
+    )
+    queue_job_store = QueueJobStore(session=session, logger=logger)
+    enqueuer = DashboardBuildEnqueuer(
+        org_store=org_store,
+        project_store=proj_store,
+        queue_backend=queue_backend,
+        queue_job_store=queue_job_store,
+        logger=logger,
+    )
+    return DashboardRebuildFanout(
+        binding_store=binding_store,
+        project_store=proj_store,
+        enqueuer=enqueuer,
+        logger=logger,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fanout_from_org_default_hits_every_project_without_override(
+    db_session: AsyncSession,
+) -> None:
+    """Org-default fan-out enqueues one job per project without override."""
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+
+    async with db_session.begin():
+        org_id, project_ids = await _seed_org_with_projects(
+            db_session,
+            org_slug="fanout-org-default",
+            project_slugs=["alpha", "beta", "charlie"],
+        )
+        template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/",
+            ),
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await binding_store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org_id,
+                project_id=None,
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/",
+            )
+        )
+        await binding_store.update_sync_state(
+            binding_id=binding.id,
+            last_sync_status="succeeded",
+            github_template_id=template_id,
+        )
+        await db_session.commit()
+
+    fanout = _make_fanout(db_session, arq_queue=arq_queue)
+    async with db_session.begin():
+        jobs = await fanout.fan_out(template_id)
+        await db_session.commit()
+
+    assert len(jobs) == 3
+    async with db_session.begin():
+        queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+        project_ids_for_jobs = []
+        for job in jobs:
+            loaded = await queue_job_store.get(job.id)
+            assert loaded is not None
+            assert loaded.kind == JobKind.dashboard_build
+            project_ids_for_jobs.append(loaded.project_id)
+    assert set(project_ids_for_jobs) == set(project_ids)
+
+
+@pytest.mark.asyncio
+async def test_fanout_skips_projects_with_override_to_other_template(
+    db_session: AsyncSession,
+) -> None:
+    """A project pinned to a different template is excluded from fan-out."""
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+
+    async with db_session.begin():
+        org_id, project_ids = await _seed_org_with_projects(
+            db_session,
+            org_slug="fanout-org-skip",
+            project_slugs=["keep", "override"],
+        )
+        default_template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/",
+            ),
+            etag="etag-default",
+        )
+        other_template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="other-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+            etag="etag-other",
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        default_binding = await binding_store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org_id,
+                project_id=None,
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/",
+            )
+        )
+        await binding_store.update_sync_state(
+            binding_id=default_binding.id,
+            last_sync_status="succeeded",
+            github_template_id=default_template_id,
+        )
+        override_binding = await binding_store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org_id,
+                project_id=project_ids[1],
+                github_owner="acme",
+                github_repo="other-templates",
+                github_ref="main",
+                root_path="/",
+            )
+        )
+        await binding_store.update_sync_state(
+            binding_id=override_binding.id,
+            last_sync_status="succeeded",
+            github_template_id=other_template_id,
+        )
+        await db_session.commit()
+
+    fanout = _make_fanout(db_session, arq_queue=arq_queue)
+    async with db_session.begin():
+        jobs = await fanout.fan_out(default_template_id)
+        await db_session.commit()
+
+    # Only the non-override project should have been fanned out.
+    assert len(jobs) == 1
+    async with db_session.begin():
+        queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+        loaded = await queue_job_store.get(jobs[0].id)
+        assert loaded is not None
+        assert loaded.project_id == project_ids[0]
+
+
+@pytest.mark.asyncio
+async def test_fanout_project_override_triggers_that_project_only(
+    db_session: AsyncSession,
+) -> None:
+    """Fanning out for a template that only an override uses hits one."""
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+
+    async with db_session.begin():
+        org_id, project_ids = await _seed_org_with_projects(
+            db_session,
+            org_slug="fanout-override",
+            project_slugs=["alpha", "beta"],
+        )
+        template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="override-templates",
+                github_ref="main",
+                root_path="/",
+            ),
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        override = await binding_store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org_id,
+                project_id=project_ids[1],
+                github_owner="acme",
+                github_repo="override-templates",
+                github_ref="main",
+                root_path="/",
+            )
+        )
+        await binding_store.update_sync_state(
+            binding_id=override.id,
+            last_sync_status="succeeded",
+            github_template_id=template_id,
+        )
+        await db_session.commit()
+
+    fanout = _make_fanout(db_session, arq_queue=arq_queue)
+    async with db_session.begin():
+        jobs = await fanout.fan_out(template_id)
+        await db_session.commit()
+
+    assert len(jobs) == 1
+    async with db_session.begin():
+        queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+        loaded = await queue_job_store.get(jobs[0].id)
+        assert loaded is not None
+        assert loaded.project_id == project_ids[1]
+
+
+@pytest.mark.asyncio
+async def test_fanout_returns_empty_when_no_bindings_reference_template(
+    db_session: AsyncSession,
+) -> None:
+    """Unreferenced templates produce no enqueues."""
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+
+    async with db_session.begin():
+        template_id = await _seed_template(
+            db_session,
+            key=GitHubTemplateKey(
+                github_owner="acme",
+                github_repo="orphan",
+                github_ref="main",
+                root_path="/",
+            ),
+        )
+        await db_session.commit()
+
+    fanout = _make_fanout(db_session, arq_queue=arq_queue)
+    async with db_session.begin():
+        jobs = await fanout.fan_out(template_id)
+        await db_session.commit()
+
+    assert jobs == []

--- a/tests/services/dashboard_templates/sync_test.py
+++ b/tests/services/dashboard_templates/sync_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 import httpx
 import pytest
 import structlog
@@ -10,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import OrganizationCreate
 from docverse.exceptions import NotFoundError
+from docverse.services.dashboard_templates import sync as sync_module
 from docverse.services.dashboard_templates.sync import (
     DashboardSyncStatus,
     DashboardTemplateSyncer,
@@ -19,7 +22,7 @@ from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
     DashboardGitHubTemplateStore,
 )
-from docverse.storage.github import GitHubAppClient
+from docverse.storage.github import GitHubAppClient, InstallationAuth
 from docverse.storage.organization_store import OrganizationStore
 from tests.support.github_mock import DEFAULT_APP_NAME, GitHubMock
 
@@ -337,12 +340,14 @@ async def test_sync_github_error_records_failure_without_clearing_content(
         )
         await db_session.commit()
 
-    # Do not seed any tree for owner=acme repo=broken — the fetcher's
-    # HTTP call will 404 because respx is configured with
-    # assert_all_mocked=False and the underlying httpx.AsyncClient
-    # cannot reach the network. Seed only the installation lookup so
-    # we exercise the tree-fetch failure branch.
+    # Seed the installation lookup so auth succeeds, then wire an
+    # explicit 404 on the tree's commit lookup so the fetcher raises
+    # ``httpx.HTTPStatusError`` (a subclass of ``httpx.HTTPError``) and
+    # the syncer records the failure via its narrow catch.
     mock_github.seed_installation("acme", "broken", installation_id=77)
+    mock_github.router.get(
+        "https://api.github.com/repos/acme/broken/commits/main"
+    ).mock(return_value=httpx.Response(404, json={"message": "Not Found"}))
 
     async with httpx.AsyncClient() as http_client:
         syncer = _make_syncer(
@@ -364,3 +369,139 @@ async def test_sync_github_error_records_failure_without_clearing_content(
     assert binding.last_sync_status == "failed"
     assert binding.last_sync_error
     assert binding.github_template_id is None
+
+
+@pytest.mark.asyncio
+async def test_sync_unexpected_auth_error_propagates(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """Unexpected errors from the app-client lookup propagate.
+
+    The syncer's failure-recording catches only the known-bad cases
+    (``httpx.HTTPError``, gidgethub exceptions). A programming bug that
+    surfaces as ``RuntimeError`` must bubble up so the worker's outer
+    ``except Exception`` records it with a full traceback, rather than
+    being hidden as a user-visible sync failure.
+    """
+    async with db_session.begin():
+        binding_id = await _seed_binding(
+            db_session, org_slug="sync-unexpected-auth"
+        )
+        await db_session.commit()
+
+    class _ExplodingAppClient:
+        async def get_installation_auth(
+            self,
+            *,
+            owner: str,  # noqa: ARG002
+            repo: str,  # noqa: ARG002
+        ) -> InstallationAuth:
+            msg = "unexpected bug during auth lookup"
+            raise RuntimeError(msg)
+
+    logger = _logger()
+    async with httpx.AsyncClient() as http_client:
+        syncer = DashboardTemplateSyncer(
+            binding_store=DashboardGitHubTemplateBindingStore(
+                session=db_session, logger=logger
+            ),
+            template_store=DashboardGitHubTemplateStore(
+                session=db_session, logger=logger
+            ),
+            app_client=cast("Any", _ExplodingAppClient()),
+            http_client=http_client,
+            logger=logger,
+        )
+        with pytest.raises(RuntimeError, match="unexpected bug"):
+            async with db_session.begin():
+                await syncer.sync(binding_id)
+
+
+@pytest.mark.asyncio
+async def test_sync_unexpected_fetch_error_propagates(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected error raised during tree fetch propagates.
+
+    The fetch block's catch is narrowed to ``httpx.HTTPError``; a
+    programming bug that surfaces as ``RuntimeError`` must reach the
+    worker's outer handler so it's logged with a traceback instead of
+    being recorded as a generic user-visible sync failure.
+    """
+    async with db_session.begin():
+        binding_id = await _seed_binding(
+            db_session, org_slug="sync-unexpected-fetch"
+        )
+        await db_session.commit()
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+
+    class _ExplodingFetcher:
+        def __init__(
+            self,
+            *args: Any,
+            **kwargs: Any,
+        ) -> None:
+            pass
+
+        async def fetch(self, **kwargs: Any) -> Any:  # noqa: ARG002
+            msg = "unexpected bug during tree fetch"
+            raise RuntimeError(msg)
+
+    monkeypatch.setattr(sync_module, "GitHubTreeFetcher", _ExplodingFetcher)
+
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        with pytest.raises(RuntimeError, match="unexpected bug"):
+            async with db_session.begin():
+                await syncer.sync(binding_id)
+
+
+@pytest.mark.asyncio
+async def test_sync_unexpected_parse_error_propagates(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected error raised during TOML parse propagates.
+
+    The parse block's catch is narrowed to ``tomllib.TOMLDecodeError``
+    and ``UnicodeDecodeError``; programming bugs that surface as
+    ``RuntimeError`` must bubble up so the worker's outer handler
+    records them with a full traceback.
+    """
+    async with db_session.begin():
+        binding_id = await _seed_binding(
+            db_session, org_slug="sync-unexpected-parse"
+        )
+        await db_session.commit()
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "template.toml": _VALID_TEMPLATE_TOML,
+            "dashboard.html.jinja": b"<html>ok</html>",
+        },
+    )
+
+    def _exploding_parse(data: bytes) -> Any:
+        msg = "unexpected bug during template parse"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(sync_module, "parse_template_toml", _exploding_parse)
+
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        with pytest.raises(RuntimeError, match="unexpected bug"):
+            async with db_session.begin():
+                await syncer.sync(binding_id)

--- a/tests/services/dashboard_templates/sync_test.py
+++ b/tests/services/dashboard_templates/sync_test.py
@@ -1,0 +1,366 @@
+"""Tests for DashboardTemplateSyncer."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import structlog
+from safir.github import GitHubAppClientFactory
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import OrganizationCreate
+from docverse.exceptions import NotFoundError
+from docverse.services.dashboard_templates.sync import (
+    DashboardSyncStatus,
+    DashboardTemplateSyncer,
+)
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
+    DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
+)
+from docverse.storage.github import GitHubAppClient
+from docverse.storage.organization_store import OrganizationStore
+from tests.support.github_mock import DEFAULT_APP_NAME, GitHubMock
+
+_VALID_TEMPLATE_TOML = b"""\
+[dashboard]
+template = "dashboard.html.jinja"
+"""
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_binding(
+    session: AsyncSession,
+    *,
+    org_slug: str,
+    github_owner: str = "acme",
+    github_repo: str = "templates",
+    github_ref: str = "main",
+    root_path: str = "/",
+) -> int:
+    logger = _logger()
+    org_store = OrganizationStore(session=session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=org_slug,
+            title=f"Org {org_slug}",
+            base_domain=f"{org_slug}.example.com",
+        )
+    )
+    binding_store = DashboardGitHubTemplateBindingStore(
+        session=session, logger=logger
+    )
+    binding = await binding_store.create(
+        DashboardGitHubTemplateBindingCreate(
+            org_id=org.id,
+            project_id=None,
+            github_owner=github_owner,
+            github_repo=github_repo,
+            github_ref=github_ref,
+            root_path=root_path,
+        )
+    )
+    return binding.id
+
+
+def _make_syncer(
+    session: AsyncSession,
+    *,
+    http_client: httpx.AsyncClient,
+    mock_github: GitHubMock,
+) -> DashboardTemplateSyncer:
+    logger = _logger()
+    factory = GitHubAppClientFactory(
+        id=mock_github.app_id,
+        key=mock_github.private_key_pem,
+        name=DEFAULT_APP_NAME,
+        http_client=http_client,
+    )
+    app_client = GitHubAppClient(
+        factory=factory, http_client=http_client, logger=logger
+    )
+    binding_store = DashboardGitHubTemplateBindingStore(
+        session=session, logger=logger
+    )
+    template_store = DashboardGitHubTemplateStore(
+        session=session, logger=logger
+    )
+    return DashboardTemplateSyncer(
+        binding_store=binding_store,
+        template_store=template_store,
+        app_client=app_client,
+        http_client=http_client,
+        logger=logger,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_writes_content_and_files_on_first_sync(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """Happy path: first sync stores template + files and marks succeeded."""
+    async with db_session.begin():
+        binding_id = await _seed_binding(db_session, org_slug="sync-first")
+        await db_session.commit()
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "template.toml": _VALID_TEMPLATE_TOML,
+            "dashboard.html.jinja": b"<html>dash</html>",
+            "logo.png": b"\x89PNG\r\n\x1a\npng-bytes",
+        },
+        etag='W/"tree-etag-1"',
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        async with db_session.begin():
+            result = await syncer.sync(binding_id)
+            await db_session.commit()
+
+    assert result.changed is True
+    assert result.github_template_id is not None
+    assert result.binding.last_sync_status == "succeeded"
+    assert result.binding.last_sync_error is None
+
+    async with db_session.begin():
+        template_store = DashboardGitHubTemplateStore(
+            session=db_session, logger=_logger()
+        )
+        files = await template_store.list_files(result.github_template_id)
+    file_paths = {f.relative_path for f in files}
+    assert file_paths == {"dashboard.html.jinja", "logo.png"}
+    logo_file = next(f for f in files if f.relative_path == "logo.png")
+    assert logo_file.is_text is False
+    jinja_file = next(
+        f for f in files if f.relative_path == "dashboard.html.jinja"
+    )
+    assert jinja_file.is_text is True
+
+
+@pytest.mark.asyncio
+async def test_sync_etag_unchanged_does_not_rewrite_content(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """Re-sync with same ETag returns ``changed=False`` and no new row."""
+    async with db_session.begin():
+        binding_id = await _seed_binding(db_session, org_slug="sync-etag")
+        await db_session.commit()
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "template.toml": _VALID_TEMPLATE_TOML,
+            "dashboard.html.jinja": b"<html>etag</html>",
+        },
+        commit_sha="sha-1",
+        tree_sha="tree-1",
+        etag='W/"tree-etag-1"',
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        async with db_session.begin():
+            first = await syncer.sync(binding_id)
+            await db_session.commit()
+        async with db_session.begin():
+            second = await syncer.sync(binding_id)
+            await db_session.commit()
+
+    assert first.changed is True
+    assert second.changed is False
+    assert first.github_template_id == second.github_template_id
+    assert second.binding.last_sync_status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_sync_invalid_template_toml_marks_failed_and_keeps_prior_content(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A second sync with bad TOML keeps the binding's github_template_id."""
+    async with db_session.begin():
+        binding_id = await _seed_binding(db_session, org_slug="sync-bad-toml")
+        await db_session.commit()
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "template.toml": _VALID_TEMPLATE_TOML,
+            "dashboard.html.jinja": b"<html>good</html>",
+        },
+        commit_sha="sha-good",
+        tree_sha="tree-good",
+        etag='W/"tree-etag-good"',
+    )
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        async with db_session.begin():
+            first = await syncer.sync(binding_id)
+            await db_session.commit()
+
+    good_template_id = first.github_template_id
+    assert good_template_id is not None
+
+    # Re-seed the same (owner/repo/ref) tuple with broken TOML and a new
+    # tree SHA so the ETag no longer matches — the syncer must attempt
+    # to parse and then record the failure.
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "template.toml": b"[dashboard\n= NOT TOML",
+            "dashboard.html.jinja": b"<html>broken</html>",
+        },
+        commit_sha="sha-bad",
+        tree_sha="tree-bad",
+        etag='W/"tree-etag-bad"',
+    )
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        async with db_session.begin():
+            bad = await syncer.sync(binding_id)
+            await db_session.commit()
+
+    assert bad.status is DashboardSyncStatus.failed
+    assert bad.error
+    assert "template.toml" in bad.error.lower()
+
+    async with db_session.begin():
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await binding_store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "failed"
+    assert binding.last_sync_error
+    assert "template.toml" in binding.last_sync_error.lower()
+    # The last-good template row is still pointed at.
+    assert binding.github_template_id == good_template_id
+
+
+@pytest.mark.asyncio
+async def test_sync_missing_template_toml_marks_failed(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A tree that lacks ``template.toml`` fails with a clear reason."""
+    async with db_session.begin():
+        binding_id = await _seed_binding(
+            db_session, org_slug="sync-no-template"
+        )
+        await db_session.commit()
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"dashboard.html.jinja": b"<html>no toml</html>"},
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        async with db_session.begin():
+            result = await syncer.sync(binding_id)
+            await db_session.commit()
+
+    assert result.status is DashboardSyncStatus.failed
+    assert result.error
+    assert "template.toml" in result.error.lower()
+
+    async with db_session.begin():
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await binding_store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "failed"
+    assert binding.last_sync_error
+    assert "template.toml" in binding.last_sync_error.lower()
+    assert binding.github_template_id is None
+
+
+@pytest.mark.asyncio
+async def test_sync_missing_binding_raises_not_found(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """An unknown binding id raises NotFoundError without a GitHub call."""
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        with pytest.raises(NotFoundError):
+            async with db_session.begin():
+                await syncer.sync(9999)
+
+
+@pytest.mark.asyncio
+async def test_sync_github_error_records_failure_without_clearing_content(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """GitHub fetch errors land as a recorded failure, not a raise."""
+    async with db_session.begin():
+        binding_id = await _seed_binding(
+            db_session,
+            org_slug="sync-gh-error",
+            github_repo="broken",
+        )
+        await db_session.commit()
+
+    # Do not seed any tree for owner=acme repo=broken — the fetcher's
+    # HTTP call will 404 because respx is configured with
+    # assert_all_mocked=False and the underlying httpx.AsyncClient
+    # cannot reach the network. Seed only the installation lookup so
+    # we exercise the tree-fetch failure branch.
+    mock_github.seed_installation("acme", "broken", installation_id=77)
+
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        async with db_session.begin():
+            result = await syncer.sync(binding_id)
+            await db_session.commit()
+
+    assert result.status is DashboardSyncStatus.failed
+    assert result.error
+
+    async with db_session.begin():
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await binding_store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "failed"
+    assert binding.last_sync_error
+    assert binding.github_template_id is None

--- a/tests/services/locks_integration_test.py
+++ b/tests/services/locks_integration_test.py
@@ -116,6 +116,76 @@ async def test_different_classes_do_not_block(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_template_lock_does_not_block_project_lock(
+    lock_engine: AsyncEngine,
+) -> None:
+    """DASHBOARD_TEMPLATE + PROJECT on the same org run in parallel.
+
+    dashboard_sync must not wedge behind dashboard_build (or vice
+    versa) even when both jobs touch the same org — the sync serialises
+    on (owner, repo, ref, root_path) while builds serialise on
+    (org_id, project_id), and the two classes must never contend.
+    """
+    maker = async_sessionmaker(lock_engine, expire_on_commit=False)
+
+    template_key = LockKey.for_dashboard_template(
+        owner="acme", repo="templates", ref="main", root_path="/"
+    )
+    project_key = LockKey.for_project(org_id=42, project_id=99)
+
+    async with maker() as s1, maker() as s2:
+        svc1 = LockService(session=s1, logger=_logger())
+        svc2 = LockService(session=s2, logger=_logger())
+
+        async with asyncio.timeout(5.0):
+            async with (
+                svc1.acquire(template_key),
+                svc2.acquire(project_key),
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_same_dashboard_template_serializes_concurrent_syncs(
+    lock_engine: AsyncEngine,
+) -> None:
+    """Two dashboard_sync jobs on the same content tuple must serialise."""
+    maker = async_sessionmaker(lock_engine, expire_on_commit=False)
+    lock_key = LockKey.for_dashboard_template(
+        owner="acme", repo="templates", ref="main", root_path="/"
+    )
+
+    async with maker() as holder_session, maker() as waiter_session:
+        holder = LockService(session=holder_session, logger=_logger())
+        waiter = LockService(session=waiter_session, logger=_logger())
+
+        acquired = asyncio.Event()
+        release = asyncio.Event()
+
+        async def hold() -> None:
+            async with holder.acquire(lock_key):
+                acquired.set()
+                await release.wait()
+
+        async def wait_for_lock() -> None:
+            async with waiter.acquire(lock_key):
+                pass
+
+        hold_task = asyncio.create_task(hold())
+        await asyncio.wait_for(acquired.wait(), timeout=5.0)
+
+        wait_task = asyncio.create_task(wait_for_lock())
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(wait_task), timeout=0.5)
+        assert not wait_task.done()
+
+        release.set()
+        await asyncio.wait_for(hold_task, timeout=5.0)
+        await asyncio.wait_for(wait_task, timeout=5.0)
+
+
+@pytest.mark.asyncio
 async def test_connection_identity_stable_across_lock_block(
     lock_engine: AsyncEngine,
 ) -> None:

--- a/tests/services/locks_test.py
+++ b/tests/services/locks_test.py
@@ -40,10 +40,18 @@ def test_compute_lock_id_is_deterministic() -> None:
         org_id=1,
         project_id=2,
     )
+    template_id = compute_lock_id(
+        LockClass.DASHBOARD_TEMPLATE,
+        owner="acme",
+        repo="dashboard-templates",
+        ref="main",
+        root_path="/",
+    )
 
     assert build_id == 136049745188599
     assert edition_id == 510729122043644
     assert project_id == 792169873651098
+    assert template_id == 873459670219191
 
 
 def test_lock_key_constructors_match_compute_lock_id() -> None:
@@ -53,6 +61,15 @@ def test_lock_key_constructors_match_compute_lock_id() -> None:
     )
     assert LockKey.for_edition_update(1, 2, 3).lock_id == (510729122043644)
     assert LockKey.for_project(1, 2).lock_id == 792169873651098
+    assert (
+        LockKey.for_dashboard_template(
+            owner="acme",
+            repo="dashboard-templates",
+            ref="main",
+            root_path="/",
+        ).lock_id
+        == 873459670219191
+    )
 
 
 def test_high_16_bits_match_lock_class() -> None:
@@ -64,6 +81,9 @@ def test_high_16_bits_match_lock_class() -> None:
         org_id=42, project_id=99, edition_id=7
     )
     project_key = LockKey.for_project(org_id=42, project_id=99)
+    template_key = LockKey.for_dashboard_template(
+        owner="acme", repo="templates", ref="main", root_path="/"
+    )
 
     assert _high_16_bits(build_key.lock_id) == (
         LockClass.BUILD_PROCESSING.value
@@ -72,6 +92,9 @@ def test_high_16_bits_match_lock_class() -> None:
         LockClass.EDITION_UPDATE.value
     )
     assert _high_16_bits(project_key.lock_id) == LockClass.PROJECT.value
+    assert _high_16_bits(template_key.lock_id) == (
+        LockClass.DASHBOARD_TEMPLATE.value
+    )
 
 
 def test_different_classes_with_same_fields_differ() -> None:
@@ -95,9 +118,23 @@ def test_result_fits_in_signed_int64() -> None:
         LockKey.for_edition_update(2**31 - 1, 2**31 - 1, 2**31 - 1).lock_id,
         LockKey.for_project(1, 2).lock_id,
         LockKey.for_project(2**31 - 1, 2**31 - 1).lock_id,
+        LockKey.for_dashboard_template(
+            owner="a" * 128, repo="b" * 128, ref="c" * 128, root_path="/" * 16
+        ).lock_id,
     ]
     for value in samples:
         assert SIGNED_INT64_MIN <= value <= SIGNED_INT64_MAX
+
+
+def test_dashboard_template_key_distinguishes_root_paths() -> None:
+    """Same repo, different root_path → different lock ids."""
+    root = LockKey.for_dashboard_template(
+        owner="acme", repo="templates", ref="main", root_path="/"
+    )
+    nested = LockKey.for_dashboard_template(
+        owner="acme", repo="templates", ref="main", root_path="sub/dir"
+    )
+    assert root.lock_id != nested.lock_id
 
 
 def test_lock_key_carries_label_and_class() -> None:

--- a/tests/worker/build_processing_test.py
+++ b/tests/worker/build_processing_test.py
@@ -10,7 +10,6 @@ from typing import Any
 import httpx
 import pytest
 import structlog
-from cryptography.fernet import Fernet
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy import select, update
@@ -32,7 +31,6 @@ from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.queue import JobKind, JobStatus
 from docverse.factory import Factory
-from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.edition_tracking import EditionTrackingService
 from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.build_store import BuildStore
@@ -47,6 +45,7 @@ from docverse.storage.queue_backend import ArqQueueBackend
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.build_processing import build_processing
 from tests.support.lock_service_spy import install_recording_lock_service
+from tests.worker.conftest import make_worker_ctx
 
 _HASH = "sha256:" + "a" * 64
 
@@ -212,13 +211,10 @@ async def test_build_processing_updates_edition(
         _mock_create_objectstore(mock_store),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-arq-job-1",
-        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-arq-job-1",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,
@@ -299,13 +295,10 @@ async def test_build_processing_uses_stored_storage_prefix(
         _mock_create_objectstore(mock_store),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-arq-prefix",
-        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-arq-prefix",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,
@@ -373,12 +366,10 @@ async def test_build_processing_edition_failure_no_build_fail(
 
     monkeypatch.setattr(EditionTrackingService, "track_build", _broken_track)
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-arq-job-2",
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-arq-job-2",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,
@@ -452,13 +443,11 @@ async def test_build_processing_enqueues_publish_edition(  # noqa: PLR0915
         _mock_create_objectstore(mock_store),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-arq-publish-1",
-        "arq_queue": mock_arq,
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        arq_queue=mock_arq,
+        job_id="test-arq-publish-1",
+    )
     build_public_id = serialize_base32_id(build.public_id)
     payload: dict[str, Any] = {
         "org_id": org.id,
@@ -590,13 +579,10 @@ async def test_build_processing_skips_stale_build(
         _mock_create_objectstore(mock_store),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-arq-stale",
-        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-arq-stale",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,
@@ -721,13 +707,11 @@ async def test_build_processing_publish_enqueue_failure_leaves_db_consistent(
 
     monkeypatch.setattr(ArqQueueBackend, "enqueue", failing_enqueue)
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-arq-publish-fail",
-        "arq_queue": mock_arq,
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        arq_queue=mock_arq,
+        job_id="test-arq-publish-fail",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,
@@ -835,13 +819,10 @@ async def test_build_processing_acquires_build_lock_before_object_store(
     )
     events = install_recording_lock_service(monkeypatch)
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-arq-lock-bp",
-        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-arq-lock-bp",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,
@@ -917,13 +898,10 @@ async def test_build_processing_nested_lock_sequence(
     )
     events = install_recording_lock_service(monkeypatch)
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-arq-lock-nested",
-        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-arq-lock-nested",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -1,0 +1,74 @@
+"""Shared fixtures and helpers for ``tests/worker``.
+
+The ``make_worker_ctx`` helper here matches the dependency wiring
+``docverse.worker.main.startup`` performs in production: it builds a
+``WorkerFactoryBuilder`` capturing the supplied process-lifetime deps
+(or sensible test defaults) and returns a ctx dict with the same shape
+each worker function expects (``factory_builder`` plus the ``http_client``
+and ``arq_queue`` entries that the production ``shutdown`` would close).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from cryptography.fernet import Fernet
+from pydantic import SecretStr
+from rubin.repertoire import DiscoveryClient
+from safir.arq import MockArqQueue
+
+from docverse.config import Configuration
+from docverse.services.credential_encryptor import CredentialEncryptor
+from docverse.worker.main import WorkerFactoryBuilder
+
+__all__ = ["make_worker_ctx"]
+
+
+_config = Configuration()
+
+
+def make_worker_ctx(
+    *,
+    http_client: httpx.AsyncClient,
+    arq_queue: MockArqQueue | None = None,
+    job_id: str | None = None,
+    encryptor: CredentialEncryptor | None = None,
+    discovery: DiscoveryClient | None = None,
+    github_app_id: int | None = None,
+    github_app_private_key: SecretStr | None = None,
+    github_webhook_secret: SecretStr | None = None,
+) -> dict[str, Any]:
+    """Build a worker ctx dict that mirrors ``worker.main.startup``.
+
+    Defaults are filled in for every dep so individual tests only need
+    to override the ones that drive their assertion (e.g.,
+    ``arq_queue=mock_arq`` to read enqueued jobs back, or the GitHub-App
+    secrets when exercising ``dashboard_sync``).
+    """
+    if encryptor is None:
+        encryptor = CredentialEncryptor(
+            current_key=Fernet.generate_key().decode()
+        )
+    if discovery is None:
+        discovery = DiscoveryClient(http_client)
+    if arq_queue is None:
+        arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+    builder = WorkerFactoryBuilder(
+        encryptor=encryptor,
+        http_client=http_client,
+        arq_queue=arq_queue,
+        discovery=discovery,
+        github_app_id=github_app_id,
+        github_app_private_key=github_app_private_key,
+        github_webhook_secret=github_webhook_secret,
+        default_queue_name=_config.arq_queue_name,
+    )
+    ctx: dict[str, Any] = {
+        "factory_builder": builder,
+        "http_client": http_client,
+        "arq_queue": arq_queue,
+    }
+    if job_id is not None:
+        ctx["job_id"] = job_id
+    return ctx

--- a/tests/worker/dashboard_build_test.py
+++ b/tests/worker/dashboard_build_test.py
@@ -8,9 +8,6 @@ from typing import Any
 import httpx
 import pytest
 import structlog
-from cryptography.fernet import Fernet
-from rubin.repertoire import DiscoveryClient
-from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,12 +19,10 @@ from docverse.client.models import (
     ProjectCreate,
     TrackingMode,
 )
-from docverse.config import Configuration
 from docverse.dbschema.organization import SqlOrganization
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.queue import JobKind, JobStatus
 from docverse.factory import Factory
-from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingCreate,
@@ -43,8 +38,7 @@ from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.dashboard_build import dashboard_build
 from tests.support.lock_service_spy import install_recording_lock_service
-
-_config = Configuration()
+from tests.worker.conftest import make_worker_ctx
 
 
 def _logger() -> structlog.stdlib.BoundLogger:
@@ -135,15 +129,11 @@ async def test_dashboard_build_completes_with_phase_transitions(
         _mock_create_objectstore(mock_store),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
     http_client = httpx.AsyncClient()
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": http_client,
-        "discovery": DiscoveryClient(http_client),
-        "job_id": "test-arq-dashboard",
-        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
-    }
+    ctx = make_worker_ctx(
+        http_client=http_client,
+        job_id="test-arq-dashboard",
+    )
     queue_job_public_id = serialize_base32_id(queue_job.public_id)
     payload: dict[str, Any] = {
         "org_id": org.id,
@@ -222,15 +212,11 @@ async def test_dashboard_build_marks_failed_on_render_exception(
         _broken_create_objectstore,
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
     http_client = httpx.AsyncClient()
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": http_client,
-        "discovery": DiscoveryClient(http_client),
-        "job_id": "test-arq-dash-fail",
-        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
-    }
+    ctx = make_worker_ctx(
+        http_client=http_client,
+        job_id="test-arq-dash-fail",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,
@@ -304,15 +290,11 @@ async def test_dashboard_build_acquires_project_lock_before_render(
     )
     events = install_recording_lock_service(monkeypatch)
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
     http_client = httpx.AsyncClient()
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": http_client,
-        "discovery": DiscoveryClient(http_client),
-        "job_id": "test-arq-dash-lock",
-        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
-    }
+    ctx = make_worker_ctx(
+        http_client=http_client,
+        job_id="test-arq-dash-lock",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,
@@ -440,15 +422,11 @@ async def test_dashboard_build_uses_github_template_when_bound(
         _mock_create_objectstore(mock_store),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
     http_client = httpx.AsyncClient()
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": http_client,
-        "discovery": DiscoveryClient(http_client),
-        "job_id": "test-arq-dash-github",
-        "arq_queue": MockArqQueue(default_queue_name=_config.arq_queue_name),
-    }
+    ctx = make_worker_ctx(
+        http_client=http_client,
+        job_id="test-arq-dash-github",
+    )
     payload: dict[str, Any] = {
         "org_id": org.id,
         "org_slug": org.slug,

--- a/tests/worker/dashboard_sync_test.py
+++ b/tests/worker/dashboard_sync_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import httpx
 import pytest
 import structlog
-from cryptography.fernet import Fernet
 from pydantic import SecretStr
-from rubin.repertoire import DiscoveryClient
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy import update
@@ -20,7 +16,6 @@ from docverse.config import Configuration
 from docverse.dbschema.organization import SqlOrganization
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.queue import JobKind, JobStatus
-from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingCreate,
@@ -32,6 +27,7 @@ from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.dashboard_sync import dashboard_sync
 from tests.support.github_mock import GitHubMock
 from tests.support.lock_service_spy import install_recording_lock_service
+from tests.worker.conftest import make_worker_ctx
 
 _config = Configuration()
 
@@ -112,17 +108,14 @@ def _make_ctx(
     arq_queue: MockArqQueue,
     http_client: httpx.AsyncClient,
     mock_github: GitHubMock,
-) -> dict[str, Any]:
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    return {
-        "encryptor": encryptor,
-        "http_client": http_client,
-        "discovery": DiscoveryClient(http_client),
-        "arq_queue": arq_queue,
-        "github_app_id": mock_github.app_id,
-        "github_app_private_key": SecretStr(mock_github.private_key_pem),
-        "github_webhook_secret": SecretStr("webhook-secret"),
-    }
+) -> dict[str, object]:
+    return make_worker_ctx(
+        http_client=http_client,
+        arq_queue=arq_queue,
+        github_app_id=mock_github.app_id,
+        github_app_private_key=SecretStr(mock_github.private_key_pem),
+        github_webhook_secret=SecretStr("webhook-secret"),
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/worker/dashboard_sync_test.py
+++ b/tests/worker/dashboard_sync_test.py
@@ -1,0 +1,463 @@
+"""Integration tests for the dashboard_sync worker function."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import structlog
+from cryptography.fernet import Fernet
+from pydantic import SecretStr
+from rubin.repertoire import DiscoveryClient
+from safir.arq import MockArqQueue
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import OrganizationCreate, ProjectCreate
+from docverse.config import Configuration
+from docverse.dbschema.organization import SqlOrganization
+from docverse.domain.base32id import serialize_base32_id
+from docverse.domain.queue import JobKind, JobStatus
+from docverse.services.credential_encryptor import CredentialEncryptor
+from docverse.services.lock_service import LockClass, LockKey
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+from docverse.storage.queue_job_store import QueueJobStore
+from docverse.worker.functions.dashboard_sync import dashboard_sync
+from tests.support.github_mock import GitHubMock
+from tests.support.lock_service_spy import install_recording_lock_service
+
+_config = Configuration()
+
+
+_VALID_TEMPLATE_TOML = b"""\
+[dashboard]
+template = "dashboard.html.jinja"
+"""
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _setup_org_and_projects(
+    db_session: AsyncSession,
+    *,
+    org_slug: str = "sync-org",
+    project_slugs: tuple[str, ...] = ("one", "two"),
+) -> tuple[int, list[int]]:
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=org_slug,
+            title=f"Org {org_slug}",
+            base_domain=f"{org_slug}.example.com",
+        )
+    )
+    await db_session.execute(
+        update(SqlOrganization)
+        .where(SqlOrganization.id == org.id)
+        .values(publishing_store_label="mock-store")
+    )
+    await db_session.flush()
+    project_ids: list[int] = []
+    for slug in project_slugs:
+        project = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug=slug,
+                title=f"Project {slug}",
+                doc_repo=f"https://github.com/example/{slug}",
+            ),
+        )
+        project_ids.append(project.id)
+    return org.id, project_ids
+
+
+async def _create_binding(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    github_owner: str = "acme",
+    github_repo: str = "templates",
+    github_ref: str = "main",
+    root_path: str = "/",
+) -> int:
+    binding_store = DashboardGitHubTemplateBindingStore(
+        session=db_session, logger=_logger()
+    )
+    binding = await binding_store.create(
+        DashboardGitHubTemplateBindingCreate(
+            org_id=org_id,
+            project_id=None,
+            github_owner=github_owner,
+            github_repo=github_repo,
+            github_ref=github_ref,
+            root_path=root_path,
+        )
+    )
+    return binding.id
+
+
+def _make_ctx(
+    *,
+    arq_queue: MockArqQueue,
+    http_client: httpx.AsyncClient,
+    mock_github: GitHubMock,
+) -> dict[str, Any]:
+    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
+    return {
+        "encryptor": encryptor,
+        "http_client": http_client,
+        "discovery": DiscoveryClient(http_client),
+        "arq_queue": arq_queue,
+        "github_app_id": mock_github.app_id,
+        "github_app_private_key": SecretStr(mock_github.private_key_pem),
+        "github_webhook_secret": SecretStr("webhook-secret"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_dashboard_sync_happy_path_fans_out_dashboard_builds(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A successful sync upserts content and enqueues one build per project."""
+    logger = _logger()
+    async with db_session.begin():
+        org_id, project_ids = await _setup_org_and_projects(
+            db_session, org_slug="sync-happy", project_slugs=("alpha", "beta")
+        )
+        binding_id = await _create_binding(db_session, org_id=org_id)
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        queue_job = await queue_job_store.create(
+            kind=JobKind.dashboard_sync,
+            org_id=org_id,
+            backend_job_id="arq-sync-1",
+        )
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "template.toml": _VALID_TEMPLATE_TOML,
+            "dashboard.html.jinja": b"<html>dash</html>",
+        },
+        etag='W/"etag-sync-1"',
+    )
+
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(
+            arq_queue=arq_queue,
+            http_client=http_client,
+            mock_github=mock_github,
+        )
+        payload = {
+            "binding_id": binding_id,
+            "queue_job_id": queue_job.id,
+            "queue_job_public_id": serialize_base32_id(queue_job.public_id),
+        }
+        result = await dashboard_sync(ctx, payload)
+
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            qjs = QueueJobStore(session=session, logger=_logger())
+            job = await qjs.get(queue_job.id)
+            assert job is not None
+            assert job.status == JobStatus.completed
+            assert job.phase == "complete"
+            assert job.progress is not None
+            assert job.progress["changed"] is True
+            assert job.progress["fan_out_count"] == len(project_ids)
+
+            binding_store = DashboardGitHubTemplateBindingStore(
+                session=session, logger=_logger()
+            )
+            binding = await binding_store.get_by_id(binding_id)
+            assert binding is not None
+            assert binding.last_sync_status == "succeeded"
+            assert binding.github_template_id is not None
+
+    enqueued = [
+        j for queue in arq_queue._job_metadata.values() for j in queue.values()
+    ]
+    build_jobs = [j for j in enqueued if j.name == "dashboard_build"]
+    assert len(build_jobs) == len(project_ids)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_sync_acquires_dashboard_template_lock(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The worker acquires ``LockKey.for_dashboard_template`` first."""
+    logger = _logger()
+    async with db_session.begin():
+        org_id, _ = await _setup_org_and_projects(
+            db_session, org_slug="sync-lock", project_slugs=("alpha",)
+        )
+        binding_id = await _create_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="acme",
+            github_repo="templates",
+            github_ref="main",
+            root_path="/",
+        )
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        queue_job = await queue_job_store.create(
+            kind=JobKind.dashboard_sync,
+            org_id=org_id,
+            backend_job_id="arq-sync-lock",
+        )
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "template.toml": _VALID_TEMPLATE_TOML,
+            "dashboard.html.jinja": b"<html>dash</html>",
+        },
+    )
+
+    events = install_recording_lock_service(monkeypatch)
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(
+            arq_queue=arq_queue,
+            http_client=http_client,
+            mock_github=mock_github,
+        )
+        payload = {
+            "binding_id": binding_id,
+            "queue_job_id": queue_job.id,
+            "queue_job_public_id": serialize_base32_id(queue_job.public_id),
+        }
+        result = await dashboard_sync(ctx, payload)
+
+    assert result == "completed"
+
+    template_enters = [
+        e
+        for e in events
+        if e.event == "enter"
+        and e.lock_key.lock_class == LockClass.DASHBOARD_TEMPLATE
+    ]
+    assert len(template_enters) == 1
+    expected = LockKey.for_dashboard_template(
+        owner="acme", repo="templates", ref="main", root_path="/"
+    )
+    assert template_enters[0].lock_key == expected
+
+
+@pytest.mark.asyncio
+async def test_dashboard_sync_etag_short_circuit_skips_fanout(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A second sync with the same ETag enqueues no dashboard_build jobs."""
+    logger = _logger()
+    async with db_session.begin():
+        org_id, _ = await _setup_org_and_projects(
+            db_session,
+            org_slug="sync-etag",
+            project_slugs=("alpha", "beta"),
+        )
+        binding_id = await _create_binding(db_session, org_id=org_id)
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        first_job = await queue_job_store.create(
+            kind=JobKind.dashboard_sync,
+            org_id=org_id,
+            backend_job_id="arq-etag-1",
+        )
+        second_job = await queue_job_store.create(
+            kind=JobKind.dashboard_sync,
+            org_id=org_id,
+            backend_job_id="arq-etag-2",
+        )
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "template.toml": _VALID_TEMPLATE_TOML,
+            "dashboard.html.jinja": b"<html>dash</html>",
+        },
+        etag='W/"etag-stable"',
+    )
+
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(
+            arq_queue=arq_queue,
+            http_client=http_client,
+            mock_github=mock_github,
+        )
+        first_result = await dashboard_sync(
+            ctx,
+            {
+                "binding_id": binding_id,
+                "queue_job_id": first_job.id,
+                "queue_job_public_id": serialize_base32_id(
+                    first_job.public_id
+                ),
+            },
+        )
+        enqueues_after_first = sum(
+            1
+            for queue in arq_queue._job_metadata.values()
+            for j in queue.values()
+            if j.name == "dashboard_build"
+        )
+        second_result = await dashboard_sync(
+            ctx,
+            {
+                "binding_id": binding_id,
+                "queue_job_id": second_job.id,
+                "queue_job_public_id": serialize_base32_id(
+                    second_job.public_id
+                ),
+            },
+        )
+
+    assert first_result == "completed"
+    assert second_result == "completed"
+
+    enqueues_after_second = sum(
+        1
+        for queue in arq_queue._job_metadata.values()
+        for j in queue.values()
+        if j.name == "dashboard_build"
+    )
+    assert enqueues_after_second == enqueues_after_first, (
+        "Unchanged re-sync must not enqueue any additional dashboard_build"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dashboard_sync_invalid_template_marks_job_failed(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """An invalid ``template.toml`` fails the job and records the reason."""
+    logger = _logger()
+    async with db_session.begin():
+        org_id, _ = await _setup_org_and_projects(
+            db_session, org_slug="sync-bad", project_slugs=("alpha",)
+        )
+        binding_id = await _create_binding(db_session, org_id=org_id)
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        queue_job = await queue_job_store.create(
+            kind=JobKind.dashboard_sync,
+            org_id=org_id,
+            backend_job_id="arq-bad",
+        )
+
+    mock_github.seed_installation("acme", "templates", installation_id=42)
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"template.toml": b"[dashboard\n= BROKEN"},
+    )
+
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(
+            arq_queue=arq_queue,
+            http_client=http_client,
+            mock_github=mock_github,
+        )
+        payload = {
+            "binding_id": binding_id,
+            "queue_job_id": queue_job.id,
+            "queue_job_public_id": serialize_base32_id(queue_job.public_id),
+        }
+        result = await dashboard_sync(ctx, payload)
+
+    assert result == "failed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            qjs = QueueJobStore(session=session, logger=_logger())
+            job = await qjs.get(queue_job.id)
+            assert job is not None
+            assert job.status == JobStatus.failed
+            assert job.errors is not None
+            assert "template.toml" in job.errors["message"].lower()
+
+            binding_store = DashboardGitHubTemplateBindingStore(
+                session=session, logger=_logger()
+            )
+            binding = await binding_store.get_by_id(binding_id)
+            assert binding is not None
+            assert binding.last_sync_status == "failed"
+
+    enqueued = [
+        j for queue in arq_queue._job_metadata.values() for j in queue.values()
+    ]
+    assert not any(j.name == "dashboard_build" for j in enqueued)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_sync_missing_binding_fails_the_job(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A deleted binding between enqueue and dequeue fails the job cleanly."""
+    logger = _logger()
+    async with db_session.begin():
+        org_id, _ = await _setup_org_and_projects(
+            db_session, org_slug="sync-missing", project_slugs=("alpha",)
+        )
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        queue_job = await queue_job_store.create(
+            kind=JobKind.dashboard_sync,
+            org_id=org_id,
+            backend_job_id="arq-missing",
+        )
+
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(
+            arq_queue=arq_queue,
+            http_client=http_client,
+            mock_github=mock_github,
+        )
+        payload = {
+            "binding_id": 999999,
+            "queue_job_id": queue_job.id,
+            "queue_job_public_id": serialize_base32_id(queue_job.public_id),
+        }
+        result = await dashboard_sync(ctx, payload)
+
+    assert result == "failed"
+    async for session in db_session_dependency():
+        async with session.begin():
+            qjs = QueueJobStore(session=session, logger=_logger())
+            job = await qjs.get(queue_job.id)
+            assert job is not None
+            assert job.status == JobStatus.failed

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -9,7 +9,6 @@ from typing import Any, Self
 import httpx
 import pytest
 import structlog
-from cryptography.fernet import Fernet
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy import select, update
@@ -37,7 +36,6 @@ from docverse.domain.organization import Organization
 from docverse.domain.project import Project
 from docverse.domain.queue import JobKind, JobStatus, QueueJob
 from docverse.factory import Factory
-from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
@@ -53,6 +51,7 @@ from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.publish_edition import publish_edition
 from tests.support.lock_service_spy import install_recording_lock_service
+from tests.worker.conftest import make_worker_ctx
 
 _HASH = "sha256:" + "a" * 64
 
@@ -243,12 +242,10 @@ async def test_publish_edition_success_lifecycle(
         _mock_create_edition_publisher(mock_publisher),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-publish-arq-1",
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-publish-arq-1",
+    )
     payload = _make_payload(
         org=org,
         project=project,
@@ -337,12 +334,10 @@ async def test_publish_edition_failure_lifecycle(
         _mock_create_edition_publisher(failing_publisher),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-publish-arq-fail",
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-publish-arq-fail",
+    )
     payload = _make_payload(
         org=org,
         project=project,
@@ -421,12 +416,10 @@ async def test_publish_edition_no_cdn_shortcut(
             backend_job_id="test-publish-arq-nocdn",
         )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-publish-arq-nocdn",
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-publish-arq-nocdn",
+    )
     payload = _make_payload(
         org=org,
         project=project,
@@ -495,14 +488,12 @@ async def test_publish_edition_success_enqueues_dashboard_build(
         _mock_create_edition_publisher(mock_publisher),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
     mock_arq = MockArqQueue(default_queue_name=_config.arq_queue_name)
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-publish-arq-dash",
-        "arq_queue": mock_arq,
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        arq_queue=mock_arq,
+        job_id="test-publish-arq-dash",
+    )
     payload = _make_payload(
         org=org,
         project=project,
@@ -569,14 +560,12 @@ async def test_publish_edition_failure_does_not_enqueue_dashboard(
         _mock_create_edition_publisher(failing_publisher),
     )
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
     mock_arq = MockArqQueue(default_queue_name=_config.arq_queue_name)
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-publish-arq-dash-fail",
-        "arq_queue": mock_arq,
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        arq_queue=mock_arq,
+        job_id="test-publish-arq-dash-fail",
+    )
     payload = _make_payload(
         org=org,
         project=project,
@@ -671,12 +660,10 @@ async def test_publish_edition_acquires_edition_update_lock(
     )
     events = install_recording_lock_service(monkeypatch)
 
-    encryptor = CredentialEncryptor(current_key=Fernet.generate_key().decode())
-    ctx: dict[str, Any] = {
-        "encryptor": encryptor,
-        "http_client": httpx.AsyncClient(),
-        "job_id": "test-publish-arq-lock",
-    }
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-publish-arq-lock",
+    )
     payload = _make_payload(
         org=org,
         project=project,


### PR DESCRIPTION
## Summary

- Closes the end-to-end loop for GitHub-backed dashboard templates: a new `dashboard_sync` arq worker fetches a template tree, upserts content + files atomically on ETag change, fans out `dashboard_build` jobs to every project whose resolved template points at the synced content, plus `LockClass.DASHBOARD_TEMPLATE` + a super-admin `POST /admin/dashboard-templates/{id}/sync` force-resync endpoint.
- Wires binding PUT (#245) to enqueue an initial `dashboard_sync` automatically and flips the binding to `last_sync_status="failed"` if that enqueue itself raises, so a stuck row is observable rather than sitting in `pending` forever.
- Routes every direct `Store(session=..., logger=...)` construction in arq worker functions and the dashboard-template enqueue-failure recovery path through `Factory.create_*`; promotes three private creators to public and adds `create_build_store` / `create_edition_store`.
- Captures the worker's process-lifetime deps in a `WorkerFactoryBuilder` callable stored at `ctx["factory_builder"]`, so each worker function reduces to `factory = ctx["factory_builder"](session=session, logger=logger)`; drops `encryptor`, `discovery`, and the three `github_app_*` keys from ctx.

## Validation steps

- [ ] Configure the GitHub App secrets on a dev instance (`DOCVERSE_GITHUB_APP_ID`, `DOCVERSE_GITHUB_APP_PRIVATE_KEY`, `DOCVERSE_GITHUB_WEBHOOK_SECRET`), PUT an org-default binding, and confirm a `dashboard_sync` job appears in `/queue` and completes.
- [ ] After a successful sync, open any project dashboard in that org and confirm it rendered from the synced GitHub template (custom HTML/CSS instead of the built-in).
- [ ] PUT the same binding again with identical body — confirm response is 200, no new `dashboard_sync` job enqueued, and `date_updated` is unchanged.
- [ ] Point the binding at a branch whose `template.toml` is malformed; confirm the job fails, the binding shows `last_sync_status="failed"` with a readable `last_sync_error`, and dashboards keep rendering from the last-good bytes.
- [ ] Force-sync via `POST /admin/dashboard-templates/{id}/sync` as a super-admin; confirm the queue job id in the 202 body matches the one visible on `/queue`. Confirm non-superadmin callers receive 403 and unauthenticated callers receive 401/403.

## References

- Closes #237
- Closes #262
- Closes #263
- PRD: #232
- Jira: https://rubinobs.atlassian.net/browse/DM-54689