### PR TITLE
DM-54689: Wire stable GitHub IDs through sync + push

### DIFF
--- a/client/src/docverse/client/models/dashboard_template.py
+++ b/client/src/docverse/client/models/dashboard_template.py
@@ -151,6 +151,34 @@ class DashboardTemplateBinding(BaseModel):
         ),
     )
 
+    github_owner_id: int | None = Field(
+        default=None,
+        description=(
+            "GitHub's stable numeric ID for the owner. Captured on first "
+            "successful sync; ``None`` for un-synced bindings. Informational "
+            "only — the public API remains keyed on ``github_owner``."
+        ),
+    )
+
+    github_repo_id: int | None = Field(
+        default=None,
+        description=(
+            "GitHub's stable numeric ID for the repository. Captured on "
+            "first successful sync; ``None`` for un-synced bindings. "
+            "Informational only — the public API remains keyed on "
+            "``github_repo``."
+        ),
+    )
+
+    github_installation_id: int | None = Field(
+        default=None,
+        description=(
+            "GitHub App installation ID for the repository. Captured on "
+            "first successful sync; ``None`` for un-synced bindings or when "
+            "the GitHub App is not installed. Informational only."
+        ),
+    )
+
     date_created: datetime = Field(
         description="Timestamp when the binding was created."
     )

--- a/src/docverse/handlers/orgs/models.py
+++ b/src/docverse/handlers/orgs/models.py
@@ -535,6 +535,9 @@ class DashboardTemplateBindingResponse(_DashboardTemplateBindingBase):
             last_sync_status=domain.last_sync_status,
             last_sync_error=domain.last_sync_error,
             last_sync_queue_job_url=last_sync_queue_job_url,
+            github_owner_id=domain.github_owner_id,
+            github_repo_id=domain.github_repo_id,
+            github_installation_id=domain.github_installation_id,
             date_created=domain.date_created,
             date_updated=domain.date_updated,
         )

--- a/src/docverse/services/dashboard_templates/push_processor.py
+++ b/src/docverse/services/dashboard_templates/push_processor.py
@@ -9,6 +9,9 @@ import httpx
 import structlog
 
 from docverse.client.models.dashboard_template import normalize_github_ref
+from docverse.domain.dashboard_github_template import (
+    DashboardGitHubTemplateBinding,
+)
 from docverse.domain.queue import QueueJob
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
@@ -95,10 +98,10 @@ class PushEventProcessor:
             return []
 
         normalized_ref = normalize_github_ref(ref)
-        bindings = await self._binding_store.list_by_repo_ref(
-            github_owner=owner,
-            github_repo=repo_name,
-            github_ref=normalized_ref,
+        repo_id = _coerce_int(repo.get("id"))
+
+        bindings = await self._lookup_bindings(
+            owner=owner, repo=repo_name, ref=normalized_ref, repo_id=repo_id
         )
         if not bindings:
             self._logger.info(
@@ -107,6 +110,7 @@ class PushEventProcessor:
                 github_repo=repo_name,
                 github_ref_raw=ref,
                 github_ref=normalized_ref,
+                github_repo_id=repo_id,
             )
             return []
 
@@ -143,6 +147,51 @@ class PushEventProcessor:
         )
         return jobs
 
+    async def _lookup_bindings(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        ref: str,
+        repo_id: int | None,
+    ) -> list[DashboardGitHubTemplateBinding]:
+        """Find bindings for a push, preferring ``github_repo_id``.
+
+        Two queries, unioned and deduplicated by binding id:
+
+        - ``list_by_repo_id_and_ref`` — when the payload carries a
+          ``repository.id``, this is the rename-robust primary lookup.
+          Bindings that completed at least one successful sync have
+          their ``github_repo_id`` populated and match here even when
+          the GitHub display name has since changed.
+        - ``list_unsynced_by_repo_ref`` — fallback for bindings that
+          have never synced (and therefore lack a stable ID). The
+          ``github_repo_id IS NULL`` filter inside the store keeps
+          synced bindings whose name happens to coincide with this
+          push out of the result, so a different repo now sitting at
+          the old name does not accidentally trigger a sync.
+
+        Dedup defends against any future loosening of either query.
+        """
+        seen: set[int] = set()
+        bindings: list[DashboardGitHubTemplateBinding] = []
+        if repo_id is not None:
+            for binding in await self._binding_store.list_by_repo_id_and_ref(
+                github_repo_id=repo_id, github_ref=ref
+            ):
+                if binding.id in seen:
+                    continue
+                seen.add(binding.id)
+                bindings.append(binding)
+        for binding in await self._binding_store.list_unsynced_by_repo_ref(
+            github_owner=owner, github_repo=repo, github_ref=ref
+        ):
+            if binding.id in seen:
+                continue
+            seen.add(binding.id)
+            bindings.append(binding)
+        return bindings
+
     async def _resolve_changed_paths(
         self, payload: Mapping[str, Any], *, owner: str, repo: str
     ) -> list[str]:
@@ -177,6 +226,21 @@ def _split_full_name_tuple(full_name: object) -> tuple[str, str] | None:
     if isinstance(full_name, str) and "/" in full_name:
         owner, repo = full_name.split("/", 1)
         return owner, repo
+    return None
+
+
+def _coerce_int(value: object) -> int | None:
+    """Return ``value`` as ``int`` when it is a non-bool int, else ``None``.
+
+    GitHub webhooks send numeric IDs as JSON ints, but defensive
+    payload parsing prefers a strict guard: the ``not isinstance(bool)``
+    clause keeps the ``isinstance(True, int)`` quirk from leaking a
+    truth value through as the repo id.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
     return None
 
 

--- a/src/docverse/services/dashboard_templates/sync.py
+++ b/src/docverse/services/dashboard_templates/sync.py
@@ -219,6 +219,8 @@ class DashboardTemplateSyncer:
             etag=etag,
             template_toml=template_toml,
             files=other_files,
+            github_owner_id=fetched.owner_id,
+            github_repo_id=fetched.repo_id,
         )
 
         updated = await self._binding_store.update_sync_state(
@@ -226,6 +228,9 @@ class DashboardTemplateSyncer:
             last_sync_status="succeeded",
             last_sync_error=None,
             github_template_id=upsert.template.id,
+            github_owner_id=fetched.owner_id,
+            github_repo_id=fetched.repo_id,
+            github_installation_id=auth.installation_id,
         )
         if updated is None:
             msg = (

--- a/src/docverse/storage/dashboard_templates/github/binding_store.py
+++ b/src/docverse/storage/dashboard_templates/github/binding_store.py
@@ -221,6 +221,62 @@ class DashboardGitHubTemplateBindingStore:
             for binding_row, public_id, commit_sha in result
         ]
 
+    async def list_by_repo_id_and_ref(
+        self,
+        *,
+        github_repo_id: int,
+        github_ref: str,
+    ) -> list[DashboardGitHubTemplateBinding]:
+        """List every binding pinned to a stable GitHub repo ID + ref.
+
+        Backed by the
+        ``idx_dashboard_github_template_bindings_repo_id_ref`` composite
+        index. Used by the push event processor as the primary
+        rename-robust lookup: bindings keep matching their upstream
+        repository even after a GitHub rename or transfer because the
+        numeric ID is invariant.
+        """
+        result = await self._session.execute(
+            select(SqlDashboardGitHubTemplateBinding).where(
+                SqlDashboardGitHubTemplateBinding.github_repo_id
+                == github_repo_id,
+                SqlDashboardGitHubTemplateBinding.github_ref == github_ref,
+            )
+        )
+        return [
+            DashboardGitHubTemplateBinding.model_validate(row)
+            for row in result.scalars().all()
+        ]
+
+    async def list_unsynced_by_repo_ref(
+        self,
+        *,
+        github_owner: str,
+        github_repo: str,
+        github_ref: str,
+    ) -> list[DashboardGitHubTemplateBinding]:
+        """List ``(owner, repo, ref)`` matches that have no captured repo ID.
+
+        The push event processor unions this with
+        :meth:`list_by_repo_id_and_ref` to cover bindings that have
+        never completed a successful sync (and therefore lack a
+        ``github_repo_id``). Already-synced bindings whose name
+        coincidentally matches a different repo are excluded — the
+        ID lookup is the authoritative match for those.
+        """
+        result = await self._session.execute(
+            select(SqlDashboardGitHubTemplateBinding).where(
+                SqlDashboardGitHubTemplateBinding.github_owner == github_owner,
+                SqlDashboardGitHubTemplateBinding.github_repo == github_repo,
+                SqlDashboardGitHubTemplateBinding.github_ref == github_ref,
+                SqlDashboardGitHubTemplateBinding.github_repo_id.is_(None),
+            )
+        )
+        return [
+            DashboardGitHubTemplateBinding.model_validate(row)
+            for row in result.scalars().all()
+        ]
+
     async def list_project_overrides_for_org(
         self, org_id: int
     ) -> list[DashboardGitHubTemplateBinding]:

--- a/src/docverse/storage/github/app_client.py
+++ b/src/docverse/storage/github/app_client.py
@@ -29,9 +29,16 @@ class InstallationAuth:
     ``base_url`` and attach ``Authorization: Bearer {token}`` on each
     request so the process-wide ``httpx.AsyncClient`` defaults stay
     untouched.
+
+    ``installation_id`` is GitHub's stable identifier for the
+    repository's app installation. The syncer captures it onto the
+    binding so future push events can reference the installation
+    directly without an extra ``/repos/{owner}/{repo}/installation``
+    round-trip.
     """
 
     token: str
+    installation_id: int
     base_url: str = GITHUB_API_BASE_URL
 
 
@@ -147,4 +154,4 @@ class GitHubAppClient:
         """
         installation_id = await self.get_installation_id(owner, repo)
         token = await self.exchange_installation_token(installation_id)
-        return InstallationAuth(token=token)
+        return InstallationAuth(token=token, installation_id=installation_id)

--- a/src/docverse/storage/github/tree_fetcher.py
+++ b/src/docverse/storage/github/tree_fetcher.py
@@ -55,6 +55,12 @@ class FetchedTree:
     ``commit_sha`` is the resolved commit the ref pointed at when the
     tree was read, independent of whether ``ref`` was a branch, tag, or
     raw SHA.
+
+    ``repo_id`` and ``owner_id`` are GitHub's stable numeric IDs for
+    the repository and its owner. The syncer writes them to the
+    binding + content rows so the push event processor can match
+    incoming events by ID rather than by display name, which keeps
+    matching robust across GitHub repo / org renames.
     """
 
     owner: str
@@ -65,6 +71,8 @@ class FetchedTree:
     tree_sha: str
     etag: str | None
     files: tuple[FetchedTreeFile, ...]
+    repo_id: int
+    owner_id: int
 
 
 def _normalize_root(root_path: str) -> str:
@@ -101,10 +109,13 @@ class GitHubTreeFetcher:
     ) -> FetchedTree:
         """Fetch the tree under ``root_path`` at ``ref`` for ``owner/repo``.
 
-        Steps: resolve the ref to a commit (giving us ``commit_sha`` +
-        the top-level tree SHA), list the recursive tree, keep only
-        blobs inside ``root_path``, then fetch each blob's bytes.
+        Steps: fetch the repository metadata (for the stable
+        ``repo_id`` / ``owner_id``), resolve the ref to a commit
+        (giving us ``commit_sha`` + the top-level tree SHA), list the
+        recursive tree, keep only blobs inside ``root_path``, then
+        fetch each blob's bytes.
         """
+        repo_id, owner_id = await self._fetch_repo(owner, repo)
         commit_sha, tree_sha = await self._resolve_ref(owner, repo, ref)
         tree_entries, etag = await self._list_tree(owner, repo, tree_sha)
 
@@ -153,6 +164,8 @@ class GitHubTreeFetcher:
             tree_sha=tree_sha,
             etag=etag,
             files=tuple(cast("list[FetchedTreeFile]", files)),
+            repo_id=repo_id,
+            owner_id=owner_id,
         )
 
     def _auth_headers(self, accept: str) -> dict[str, str]:
@@ -160,6 +173,22 @@ class GitHubTreeFetcher:
             "Accept": accept,
             "Authorization": f"Bearer {self._auth.token}",
         }
+
+    async def _fetch_repo(self, owner: str, repo: str) -> tuple[int, int]:
+        """Fetch repository metadata, returning ``(repo_id, owner_id)``.
+
+        Reads ``GET /repos/{owner}/{repo}`` to capture GitHub's stable
+        numeric IDs for the repository and its owner. The syncer
+        writes these to the binding + content rows so push events
+        match by ID even after a GitHub repo or org rename.
+        """
+        response = await self._http_client.get(
+            f"{self._auth.base_url}/repos/{owner}/{repo}",
+            headers=self._auth_headers("application/vnd.github+json"),
+        )
+        response.raise_for_status()
+        data = response.json()
+        return int(data["id"]), int(data["owner"]["id"])
 
     async def _resolve_ref(
         self, owner: str, repo: str, ref: str

--- a/tests/handlers/dashboard_template_test.py
+++ b/tests/handlers/dashboard_template_test.py
@@ -204,6 +204,61 @@ async def test_org_get_returns_existing_binding(client: AsyncClient) -> None:
     assert body["github_owner"] == "lsst-sqre"
     assert body["github_ref"] == "main"
     assert body["last_sync_status"] == "pending"
+    # Pre-sync the GitHub numeric IDs are unset; the response surfaces
+    # them as ``null`` so operators can see the binding has not yet
+    # captured them.
+    assert body["github_owner_id"] is None
+    assert body["github_repo_id"] is None
+    assert body["github_installation_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_org_get_surfaces_captured_github_numeric_ids(
+    client: AsyncClient,
+) -> None:
+    """A populated binding's GitHub numeric IDs are visible to operators.
+
+    The public API stays name-keyed; the IDs are informational only,
+    surfaced for debugging the rename-robust internal lookup path.
+    """
+    await _setup_org(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        json=_VALID_BODY,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            org_store = OrganizationStore(
+                session=session, logger=structlog.get_logger("test")
+            )
+            org = await org_store.get_by_slug(_ORG)
+            assert org is not None
+            binding_store = DashboardGitHubTemplateBindingStore(
+                session=session, logger=structlog.get_logger("test")
+            )
+            existing = await binding_store.get_org_default(org.id)
+            assert existing is not None
+            await binding_store.update_sync_state(
+                binding_id=existing.id,
+                last_sync_status="succeeded",
+                github_owner_id=111,
+                github_repo_id=222,
+                github_installation_id=333,
+            )
+            await session.commit()
+        break
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/dashboard-template",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["github_owner_id"] == 111
+    assert body["github_repo_id"] == 222
+    assert body["github_installation_id"] == 333
 
 
 @pytest.mark.asyncio

--- a/tests/services/dashboard_templates/push_processor_test.py
+++ b/tests/services/dashboard_templates/push_processor_test.py
@@ -64,6 +64,9 @@ async def _seed_org_with_bindings(
             github_repo=raw.github_repo,
             github_ref=raw.github_ref,
             root_path=raw.root_path,
+            github_owner_id=raw.github_owner_id,
+            github_repo_id=raw.github_repo_id,
+            github_installation_id=raw.github_installation_id,
         )
         created = await binding_store.create(new)
         binding_ids.append(created.id)
@@ -119,17 +122,31 @@ def _make_push_payload(
     commits: list[dict[str, Any]] | None = None,
     size: int | None = None,
     installation_id: int = 99,
+    repo_id: int | None = None,
+    owner_id: int | None = None,
 ) -> dict[str, Any]:
-    """Build a minimal push-event payload."""
+    """Build a minimal push-event payload.
+
+    ``repo_id`` and ``owner_id`` mirror GitHub's real ``repository.id``
+    and ``repository.owner.id`` fields. They are optional so legacy
+    tests that only need name-based matching keep their current
+    payload shape; tests that exercise the rename-robust ID-keyed
+    lookup path pass them explicitly.
+    """
+    repository: dict[str, Any] = {
+        "name": repo,
+        "full_name": f"{owner}/{repo}",
+        "owner": {"login": owner, "name": owner},
+    }
+    if repo_id is not None:
+        repository["id"] = repo_id
+    if owner_id is not None:
+        repository["owner"]["id"] = owner_id
     payload: dict[str, Any] = {
         "ref": ref,
         "before": before,
         "after": after,
-        "repository": {
-            "name": repo,
-            "full_name": f"{owner}/{repo}",
-            "owner": {"login": owner, "name": owner},
-        },
+        "repository": repository,
         "installation": {"id": installation_id},
     }
     if commits is not None:
@@ -583,6 +600,256 @@ async def test_process_compare_fallback_filters_correctly(
         before="before-sha",
         after="after-sha",
         changed_paths=["templates/blue/dashboard.html.jinja"],
+    )
+
+    async with httpx.AsyncClient() as http_client, db_session.begin():
+        processor = _make_processor(
+            db_session,
+            arq_queue=arq_queue,
+            http_client=http_client,
+            mock_github=mock_github,
+        )
+        jobs = await processor.process(payload)
+        await db_session.commit()
+
+    assert jobs == []
+
+
+@pytest.mark.asyncio
+async def test_process_matches_synced_binding_by_repo_id(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A push with ``repository.id`` finds bindings keyed by stable ID.
+
+    The binding's ``github_owner`` / ``github_repo`` deliberately do
+    NOT match the payload — this is the rename / transfer case where
+    the display name has changed but the numeric ID is invariant.
+    Without ID-keyed lookup the binding would be lost.
+    """
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+
+    async with db_session.begin():
+        _, _ = await _seed_org_with_bindings(
+            db_session,
+            org_slug="push-by-id-rename",
+            bindings=[
+                DashboardGitHubTemplateBindingCreate(
+                    org_id=0,
+                    project_id=None,
+                    github_owner="acme",
+                    github_repo="old-name",
+                    github_ref="main",
+                    root_path="/",
+                    github_repo_id=12345,
+                    github_owner_id=999,
+                ),
+            ],
+        )
+        await db_session.commit()
+
+    payload = _make_push_payload(
+        owner="acme",
+        repo="renamed-repo",
+        ref="refs/heads/main",
+        commits=[
+            {
+                "id": "after-sha",
+                "modified": ["dashboard.html.jinja"],
+                "added": [],
+                "removed": [],
+            }
+        ],
+        size=1,
+        repo_id=12345,
+        owner_id=999,
+    )
+
+    async with httpx.AsyncClient() as http_client, db_session.begin():
+        processor = _make_processor(
+            db_session,
+            arq_queue=arq_queue,
+            http_client=http_client,
+            mock_github=mock_github,
+        )
+        jobs = await processor.process(payload)
+        await db_session.commit()
+
+    assert len(jobs) == 1
+
+
+@pytest.mark.asyncio
+async def test_process_falls_back_to_name_for_unsynced_bindings(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A push for an un-synced binding still matches by ``(owner, repo)``.
+
+    Bindings created via the binding PUT but not yet synced have
+    ``github_repo_id IS NULL``. Until their first successful sync
+    populates the stable ID, name-based matching is the only way the
+    push processor can route a push event to them.
+    """
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+
+    async with db_session.begin():
+        _, _ = await _seed_org_with_bindings(
+            db_session,
+            org_slug="push-name-fallback",
+            bindings=[
+                DashboardGitHubTemplateBindingCreate(
+                    org_id=0,
+                    project_id=None,
+                    github_owner="acme",
+                    github_repo="templates",
+                    github_ref="main",
+                    root_path="/",
+                ),
+            ],
+        )
+        await db_session.commit()
+
+    payload = _make_push_payload(
+        owner="acme",
+        repo="templates",
+        ref="refs/heads/main",
+        commits=[
+            {
+                "id": "after-sha",
+                "modified": ["dashboard.html.jinja"],
+                "added": [],
+                "removed": [],
+            }
+        ],
+        size=1,
+        repo_id=12345,
+        owner_id=999,
+    )
+
+    async with httpx.AsyncClient() as http_client, db_session.begin():
+        processor = _make_processor(
+            db_session,
+            arq_queue=arq_queue,
+            http_client=http_client,
+            mock_github=mock_github,
+        )
+        jobs = await processor.process(payload)
+        await db_session.commit()
+
+    assert len(jobs) == 1
+
+
+@pytest.mark.asyncio
+async def test_process_dedupes_id_and_name_matches(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A binding that matches by both ID and name is enqueued once.
+
+    The two store lookups are disjoint by construction
+    (``list_unsynced_by_repo_ref`` filters out populated IDs), but
+    pin the dedup-by-binding-id step at the processor seam so a
+    refactor that loosens that filter cannot regress to double-
+    enqueueing the same sync job.
+    """
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+
+    async with db_session.begin():
+        _, _ = await _seed_org_with_bindings(
+            db_session,
+            org_slug="push-dedup",
+            bindings=[
+                DashboardGitHubTemplateBindingCreate(
+                    org_id=0,
+                    project_id=None,
+                    github_owner="acme",
+                    github_repo="templates",
+                    github_ref="main",
+                    root_path="/",
+                    github_repo_id=12345,
+                ),
+            ],
+        )
+        await db_session.commit()
+
+    payload = _make_push_payload(
+        owner="acme",
+        repo="templates",
+        ref="refs/heads/main",
+        commits=[
+            {
+                "id": "after-sha",
+                "modified": ["dashboard.html.jinja"],
+                "added": [],
+                "removed": [],
+            }
+        ],
+        size=1,
+        repo_id=12345,
+        owner_id=999,
+    )
+
+    async with httpx.AsyncClient() as http_client, db_session.begin():
+        processor = _make_processor(
+            db_session,
+            arq_queue=arq_queue,
+            http_client=http_client,
+            mock_github=mock_github,
+        )
+        jobs = await processor.process(payload)
+        await db_session.commit()
+
+    assert len(jobs) == 1
+
+
+@pytest.mark.asyncio
+async def test_process_synced_binding_with_different_repo_id_no_match(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """Once synced, a binding only matches its captured repo ID.
+
+    A push that shares the binding's ``(owner, repo, ref)`` strings
+    but carries a *different* ``repository.id`` must NOT match the
+    binding — that scenario indicates a different repository now
+    sitting at the old name (e.g. after a rename + new-repo creation
+    cycle), not the original one the binding was anchored to.
+    """
+    arq_queue = MockArqQueue(default_queue_name=_config.arq_queue_name)
+
+    async with db_session.begin():
+        _, _ = await _seed_org_with_bindings(
+            db_session,
+            org_slug="push-stale-name",
+            bindings=[
+                DashboardGitHubTemplateBindingCreate(
+                    org_id=0,
+                    project_id=None,
+                    github_owner="acme",
+                    github_repo="templates",
+                    github_ref="main",
+                    root_path="/",
+                    github_repo_id=12345,
+                ),
+            ],
+        )
+        await db_session.commit()
+
+    payload = _make_push_payload(
+        owner="acme",
+        repo="templates",
+        ref="refs/heads/main",
+        commits=[
+            {
+                "id": "after-sha",
+                "modified": ["dashboard.html.jinja"],
+                "added": [],
+                "removed": [],
+            }
+        ],
+        size=1,
+        repo_id=99999,
+        owner_id=999,
     )
 
     async with httpx.AsyncClient() as http_client, db_session.begin():

--- a/tests/services/dashboard_templates/sync_test.py
+++ b/tests/services/dashboard_templates/sync_test.py
@@ -153,6 +153,105 @@ async def test_sync_writes_content_and_files_on_first_sync(
 
 
 @pytest.mark.asyncio
+async def test_sync_captures_github_numeric_ids_on_first_sync(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """First sync writes repo/owner/installation IDs to binding + content."""
+    async with db_session.begin():
+        binding_id = await _seed_binding(db_session, org_slug="sync-ids")
+        await db_session.commit()
+
+    mock_github.seed_installation(
+        "acme", "templates", installation_id=4242, owner_id=111
+    )
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={
+            "template.toml": _VALID_TEMPLATE_TOML,
+            "dashboard.html.jinja": b"<html>ids</html>",
+        },
+        repo_id=999,
+        owner_id=111,
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        async with db_session.begin():
+            result = await syncer.sync(binding_id)
+            await db_session.commit()
+
+    assert result.binding.github_owner_id == 111
+    assert result.binding.github_repo_id == 999
+    assert result.binding.github_installation_id == 4242
+    assert result.github_template_id is not None
+
+    async with db_session.begin():
+        template_store = DashboardGitHubTemplateStore(
+            session=db_session, logger=_logger()
+        )
+        template = await template_store.get_by_id(result.github_template_id)
+    assert template is not None
+    assert template.github_owner_id == 111
+    assert template.github_repo_id == 999
+
+
+@pytest.mark.asyncio
+async def test_sync_does_not_overwrite_populated_ids_on_resync(
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """Re-sync of an already-populated binding leaves IDs intact.
+
+    The store-layer guard (``update_sync_state`` / ``upsert`` only
+    assigning IDs when the kwarg is non-``None``) is the load-bearing
+    invariant, but pin it at the syncer seam so the contract holds
+    end-to-end. Passing the same IDs twice is a no-op overwrite, but
+    the test asserts that the second sync does not zero them — which
+    is the realistic regression to guard against.
+    """
+    async with db_session.begin():
+        binding_id = await _seed_binding(
+            db_session, org_slug="sync-ids-resync"
+        )
+        await db_session.commit()
+
+    mock_github.seed_installation(
+        "acme", "templates", installation_id=42, owner_id=11
+    )
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"template.toml": _VALID_TEMPLATE_TOML},
+        commit_sha="sha-1",
+        tree_sha="tree-1",
+        etag='W/"tree-etag-1"',
+        repo_id=900,
+        owner_id=11,
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        syncer = _make_syncer(
+            db_session, http_client=http_client, mock_github=mock_github
+        )
+        async with db_session.begin():
+            await syncer.sync(binding_id)
+            await db_session.commit()
+        async with db_session.begin():
+            second = await syncer.sync(binding_id)
+            await db_session.commit()
+
+    assert second.binding.github_owner_id == 11
+    assert second.binding.github_repo_id == 900
+    assert second.binding.github_installation_id == 42
+
+
+@pytest.mark.asyncio
 async def test_sync_etag_unchanged_does_not_rewrite_content(
     db_session: AsyncSession,
     mock_github: GitHubMock,
@@ -340,11 +439,13 @@ async def test_sync_github_error_records_failure_without_clearing_content(
         )
         await db_session.commit()
 
-    # Seed the installation lookup so auth succeeds, then wire an
-    # explicit 404 on the tree's commit lookup so the fetcher raises
+    # Seed the installation lookup + repo metadata so auth and the
+    # initial repo fetch succeed, then wire an explicit 404 on the
+    # tree's commit lookup so the fetcher raises
     # ``httpx.HTTPStatusError`` (a subclass of ``httpx.HTTPError``) and
     # the syncer records the failure via its narrow catch.
     mock_github.seed_installation("acme", "broken", installation_id=77)
+    mock_github.seed_repo("acme", "broken")
     mock_github.router.get(
         "https://api.github.com/repos/acme/broken/commits/main"
     ).mock(return_value=httpx.Response(404, json={"message": "Not Found"}))

--- a/tests/storage/dashboard_templates/github/binding_store_test.py
+++ b/tests/storage/dashboard_templates/github/binding_store_test.py
@@ -621,3 +621,127 @@ async def test_list_by_repo_ref_returns_empty_when_no_matches(
         )
         await db_session.rollback()
     assert matches == []
+
+
+@pytest.mark.asyncio
+async def test_list_by_repo_id_and_ref_matches_synced_bindings(
+    db_session: AsyncSession,
+) -> None:
+    """ID-keyed lookup returns synced bindings; ignores name + null IDs."""
+    async with db_session.begin():
+        org_id, project_id = await _seed_org_and_project(
+            db_session, org_slug="repo-id-org"
+        )
+        store = _store(db_session)
+        synced_default = await store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org_id,
+                project_id=None,
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/",
+                github_repo_id=42,
+            )
+        )
+        synced_override = await store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org_id,
+                project_id=project_id,
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/themes/blue",
+                github_repo_id=42,
+            )
+        )
+        # Different repo id — should not match.
+        other_org_id, _ = await _seed_org_and_project(
+            db_session,
+            org_slug="repo-id-other-org",
+            project_slug="other-id-proj",
+        )
+        await store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=other_org_id,
+                project_id=None,
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/",
+                github_repo_id=99,
+            )
+        )
+        # Unsynced binding (NULL repo_id) — should not match by ID.
+        third_org_id, _ = await _seed_org_and_project(
+            db_session,
+            org_slug="repo-id-unsynced-org",
+            project_slug="unsynced-proj",
+        )
+        await store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=third_org_id,
+                project_id=None,
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/",
+            )
+        )
+        await db_session.commit()
+    async with db_session.begin():
+        store = _store(db_session)
+        matches = await store.list_by_repo_id_and_ref(
+            github_repo_id=42, github_ref="main"
+        )
+        await db_session.rollback()
+    matched_ids = {m.id for m in matches}
+    assert matched_ids == {synced_default.id, synced_override.id}
+
+
+@pytest.mark.asyncio
+async def test_list_unsynced_by_repo_ref_excludes_synced_bindings(
+    db_session: AsyncSession,
+) -> None:
+    """Name lookup for the rename-fallback path skips populated IDs.
+
+    Only bindings with ``github_repo_id IS NULL`` count as un-synced;
+    populated rows belong to the ID-keyed lookup so the push processor
+    does not double-count them across the union.
+    """
+    async with db_session.begin():
+        org_id, project_id = await _seed_org_and_project(
+            db_session, org_slug="unsynced-name-org"
+        )
+        store = _store(db_session)
+        unsynced = await store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org_id,
+                project_id=None,
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/",
+            )
+        )
+        await store.create(
+            DashboardGitHubTemplateBindingCreate(
+                org_id=org_id,
+                project_id=project_id,
+                github_owner="acme",
+                github_repo="templates",
+                github_ref="main",
+                root_path="/themes/blue",
+                github_repo_id=42,
+            )
+        )
+        await db_session.commit()
+    async with db_session.begin():
+        store = _store(db_session)
+        matches = await store.list_unsynced_by_repo_ref(
+            github_owner="acme",
+            github_repo="templates",
+            github_ref="main",
+        )
+        await db_session.rollback()
+    assert [m.id for m in matches] == [unsynced.id]

--- a/tests/storage/github/app_client_test.py
+++ b/tests/storage/github/app_client_test.py
@@ -101,6 +101,7 @@ async def test_get_installation_auth_returns_token_record(
     assert isinstance(auth, InstallationAuth)
     assert auth.token == "ghs_installtok"  # noqa: S105
     assert auth.base_url == GITHUB_API_BASE_URL
+    assert auth.installation_id == 42
 
 
 @pytest.mark.asyncio

--- a/tests/storage/github/changed_paths_test.py
+++ b/tests/storage/github/changed_paths_test.py
@@ -144,7 +144,7 @@ async def test_fetch_changed_paths_from_compare_with_null_files(
     mock_github.router.get(
         "https://api.github.com/repos/acme/repo/compare/aaaa...bbbb"
     ).mock(return_value=httpx.Response(200, json={"files": None}))
-    auth = InstallationAuth(token="ghs_test")
+    auth = InstallationAuth(token="ghs_test", installation_id=99)
 
     async with httpx.AsyncClient() as http_client:
         paths = await fetch_changed_paths_from_compare(
@@ -177,7 +177,7 @@ async def test_fetch_changed_paths_from_compare_attaches_authorization(
         after="bbbb",
         changed_paths=["templates/a.html"],
     )
-    auth = InstallationAuth(token="ghs_compare_attach")
+    auth = InstallationAuth(token="ghs_compare_attach", installation_id=99)
 
     async with httpx.AsyncClient() as http_client:
         assert "authorization" not in http_client.headers
@@ -215,7 +215,7 @@ async def test_fetch_changed_paths_from_compare_raises_on_non_2xx(
     mock_github.router.get(
         "https://api.github.com/repos/acme/repo/compare/aaaa...bbbb"
     ).mock(return_value=httpx.Response(status))
-    auth = InstallationAuth(token="ghs_test")
+    auth = InstallationAuth(token="ghs_test", installation_id=99)
 
     async with httpx.AsyncClient() as http_client:
         with pytest.raises(httpx.HTTPStatusError):

--- a/tests/storage/github/tree_fetcher_test.py
+++ b/tests/storage/github/tree_fetcher_test.py
@@ -57,6 +57,39 @@ async def test_tree_fetcher_scoped_to_root_path(
 
 
 @pytest.mark.asyncio
+async def test_tree_fetcher_captures_repo_and_owner_ids(
+    mock_github: GitHubMock,
+) -> None:
+    """``FetchedTree`` carries the GitHub numeric repo + owner IDs.
+
+    Pins the rename-robust capture path: the syncer reads these IDs
+    off ``FetchedTree`` and writes them onto the binding + content
+    rows so future push events can match by stable ID even after a
+    GitHub rename / transfer.
+    """
+    mock_github.seed_tree(
+        "acme",
+        "templates",
+        "main",
+        files={"template.toml": b"[dashboard]\n"},
+        repo_id=987654321,
+        owner_id=123456789,
+    )
+    auth = mock_github.installation_auth("acme", "templates")
+
+    async with httpx.AsyncClient() as http_client:
+        fetcher = GitHubTreeFetcher(
+            http_client=http_client, auth=auth, logger=_logger()
+        )
+        tree = await fetcher.fetch(
+            owner="acme", repo="templates", ref="main", root_path="/"
+        )
+
+    assert tree.repo_id == 987654321
+    assert tree.owner_id == 123456789
+
+
+@pytest.mark.asyncio
 async def test_tree_fetcher_captures_etag_and_commit_sha(
     mock_github: GitHubMock,
 ) -> None:
@@ -190,7 +223,7 @@ async def test_tree_fetcher_attaches_authorization_header(
         "main",
         files={"template.toml": b"[dashboard]\n"},
     )
-    auth = InstallationAuth(token="ghs_attach_test")
+    auth = InstallationAuth(token="ghs_attach_test", installation_id=99)
 
     async with httpx.AsyncClient() as http_client:
         # The shared client must not be configured with a base_url or an
@@ -230,10 +263,11 @@ async def test_tree_fetcher_raises_on_non_2xx_ref_resolution(
     The sync worker (#237) will layer typed exceptions on top; this
     test fences against an accidental swallow at the storage layer.
     """
+    mock_github.seed_repo("acme", "templates")
     mock_github.router.get(
         "https://api.github.com/repos/acme/templates/commits/main"
     ).mock(return_value=httpx.Response(status))
-    auth = InstallationAuth(token="ghs_test")
+    auth = InstallationAuth(token="ghs_test", installation_id=99)
 
     async with httpx.AsyncClient() as http_client:
         fetcher = GitHubTreeFetcher(

--- a/tests/support/github_mock.py
+++ b/tests/support/github_mock.py
@@ -117,6 +117,7 @@ class GitHubMock:
         *,
         installation_id: int | None = None,
         token: str | None = None,
+        owner_id: int = 1,
     ) -> int:
         """Wire (repo → installation id) lookup and (id → token) exchange.
 
@@ -127,6 +128,10 @@ class GitHubMock:
         :meth:`installation_auth` when the test needs the
         ``InstallationAuth`` record without round-tripping the app
         client.
+
+        ``owner_id`` populates ``account.id`` on the installation
+        lookup response, mirroring real GitHub. Tests that exercise
+        the rename-robust ID capture path override the default.
         """
         iid = installation_id or self.default_installation_id
         bearer_token = token or self.default_token
@@ -137,7 +142,11 @@ class GitHubMock:
             f"{_GITHUB_API}/repos/{owner}/{repo}/installation"
         ).mock(
             return_value=httpx.Response(
-                200, json={"id": iid, "account": {"login": owner}}
+                200,
+                json={
+                    "id": iid,
+                    "account": {"login": owner, "id": owner_id},
+                },
             )
         )
         self.router.post(
@@ -153,6 +162,35 @@ class GitHubMock:
         )
         return iid
 
+    def seed_repo(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        repo_id: int = 1,
+        owner_id: int = 1,
+    ) -> None:
+        """Register ``GET /repos/{owner}/{repo}`` returning numeric IDs.
+
+        The tree fetcher calls this endpoint on every fetch so the
+        rename-robust ID capture path (#241) sees stable
+        ``repository.id`` / ``repository.owner.id`` values. Tests that
+        only exercise tree/blob fetches without asserting on captured
+        IDs may accept the (1, 1) defaults; tests that round-trip
+        captured IDs into the database should pass values that match
+        the rest of the assertion.
+        """
+        self.router.get(f"{_GITHUB_API}/repos/{owner}/{repo}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": repo_id,
+                    "name": repo,
+                    "owner": {"login": owner, "id": owner_id},
+                },
+            )
+        )
+
     def installation_auth(
         self,
         owner: str,
@@ -165,14 +203,22 @@ class GitHubMock:
         Tests that exercise the tree fetcher / compare helper directly
         — without going through ``GitHubAppClient.get_installation_auth``
         — call this to grab the same token they seeded on the router.
-        Falls back to ``default_token`` when ``seed_installation`` was
-        not called for ``(owner, repo)``, which mirrors what the live
+        Falls back to ``default_token`` /
+        ``default_installation_id`` when ``seed_installation`` was not
+        called for ``(owner, repo)``, which mirrors what the live
         client would have minted from a default installation.
         """
         token = self._installation_tokens.get(
             (owner, repo), self.default_token
         )
-        return InstallationAuth(token=token, base_url=base_url)
+        installation_id = self._installation_ids.get(
+            (owner, repo), self.default_installation_id
+        )
+        return InstallationAuth(
+            token=token,
+            installation_id=installation_id,
+            base_url=base_url,
+        )
 
     def seed_tree(
         self,
@@ -185,6 +231,8 @@ class GitHubMock:
         tree_sha: str | None = None,
         etag: str = 'W/"test-etag"',
         extra_tree_entries: list[dict[str, object]] | None = None,
+        repo_id: int = 1,
+        owner_id: int = 1,
     ) -> tuple[str, str]:
         """Register the commit, tree, and blob endpoints for a fetch.
 
@@ -201,6 +249,8 @@ class GitHubMock:
         """
         csha = commit_sha or f"commit-{owner}-{repo}-{ref}"
         tsha = tree_sha or f"tree-{owner}-{repo}-{ref}"
+
+        self.seed_repo(owner, repo, repo_id=repo_id, owner_id=owner_id)
 
         self.router.get(
             f"{_GITHUB_API}/repos/{owner}/{repo}/commits/{ref}"


### PR DESCRIPTION
## Summary

- Capture GitHub's stable repo / owner / installation IDs on first successful sync and write them onto the binding row + content row, so internal matching survives a GitHub repo or org rename without operator intervention.
- Rework `PushEventProcessor` to look up bindings primarily by `(github_repo_id, github_ref)` (using the `idx_dashboard_github_template_bindings_repo_id_ref` index from #240) and union with a name-based fallback restricted to un-synced bindings (`github_repo_id IS NULL`); dedup by binding id before the root-path filter.
- Surface the captured `github_owner_id` / `github_repo_id` / `github_installation_id` on the dashboard-template binding `GET` response for operator debugging — public API stays name-keyed.

## Validation steps

- [ ] Create an org-default binding via `PUT /docverse/orgs/{org}/dashboard-template`; confirm the returned body has `github_owner_id`, `github_repo_id`, and `github_installation_id` set to `null`, and `last_sync_status="pending"`.
- [ ] Trigger a sync (force-sync endpoint or initial enqueue from PUT) and confirm the binding GET response now shows the three numeric IDs populated, and the `dashboard_github_templates` content row carries `github_owner_id` / `github_repo_id`.
- [ ] Re-sync the same binding (force-sync) and confirm none of the three numeric IDs revert to `null`.
- [ ] Send a signed push webhook whose `repository.id` matches a synced binding but whose `repository.name` is different (rename simulation); confirm a `dashboard_sync` job is enqueued.
- [ ] Send a signed push webhook for an un-synced binding (matching by `(owner, repo, ref)` strings only); confirm a `dashboard_sync` job is enqueued.
- [ ] Send a signed push webhook whose `(owner, repo, ref)` matches a synced binding but whose `repository.id` differs; confirm no `dashboard_sync` job is enqueued (stale-name guard).

## References

- Closes #241
- PRD: #232
- Jira: https://rubinobs.atlassian.net/browse/DM-54689