### PR TITLE
DM-54689: GitHub rename + installation webhook event handlers

### DIFF
--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import httpx
 import structlog
 from pydantic import SecretStr
@@ -21,7 +23,9 @@ from .services.dashboard_templates import (
     DashboardSyncEnqueuer,
     DashboardTemplateBindingService,
     DashboardTemplateSyncer,
+    InstallationEventProcessor,
     PushEventProcessor,
+    RenameEventProcessor,
     TemplateResolver,
 )
 from .services.edition import EditionService
@@ -59,6 +63,23 @@ from .storage.queue_backend import (
 )
 from .storage.queue_job_store import QueueJobStore
 from .storage.user_info_store import UserInfoStore
+
+
+@dataclass(frozen=True)
+class WebhookDispatch:
+    """Bundle of objects the GitHub webhook handler needs per delivery.
+
+    The HMAC secret verifies ``x-hub-signature-256``; the three
+    processors handle the event types the dashboard-template feature
+    subscribes to. Created fresh per request inside
+    :meth:`Factory.create_webhook_dispatch` so each delivery binds to
+    the request's own DB session and logger.
+    """
+
+    webhook_secret: str
+    push: PushEventProcessor
+    rename: RenameEventProcessor
+    installation: InstallationEventProcessor
 
 
 class Factory:
@@ -449,14 +470,16 @@ class Factory:
             logger=self._logger,
         )
 
-    def create_webhook_dispatch(self) -> tuple[str, PushEventProcessor]:
-        """Return the GitHub webhook secret and a :class:`PushEventProcessor`.
+    def create_webhook_dispatch(self) -> WebhookDispatch:
+        """Return the webhook secret + every event-type processor.
 
-        The webhook handler needs both the HMAC secret (to verify
-        ``x-hub-signature-256``) and the processor (to fan a push out
-        to ``dashboard_sync`` enqueues). Bundling them into one
-        accessor gives the handler a single ``GitHubAppNotConfiguredError``
-        raise site to translate into its 404 feature-disabled response.
+        The webhook handler needs the HMAC secret (to verify
+        ``x-hub-signature-256``) and one processor per registered
+        event type. Bundling them into one accessor gives the handler
+        a single ``GitHubAppNotConfiguredError`` raise site to
+        translate into its 404 feature-disabled response, and the
+        gidgethub router dispatches the right processor by event +
+        action without per-handler factory plumbing.
 
         Raises
         ------
@@ -469,14 +492,32 @@ class Factory:
         if self._http_client is None:
             msg = "HTTP client is required to build a PushEventProcessor"
             raise RuntimeError(msg)
-        processor = PushEventProcessor(
-            binding_store=self.create_dashboard_github_template_binding_store(),
+        binding_store = self.create_dashboard_github_template_binding_store()
+        template_store = DashboardGitHubTemplateStore(
+            session=self._session, logger=self._logger
+        )
+        push = PushEventProcessor(
+            binding_store=binding_store,
             enqueuer=self.create_dashboard_sync_enqueuer(),
             app_client=self.create_github_app_client(),
             http_client=self._http_client,
             logger=self._logger,
         )
-        return webhook_secret.get_secret_value(), processor
+        rename = RenameEventProcessor(
+            binding_store=binding_store,
+            template_store=template_store,
+            logger=self._logger,
+        )
+        installation = InstallationEventProcessor(
+            binding_store=binding_store,
+            logger=self._logger,
+        )
+        return WebhookDispatch(
+            webhook_secret=webhook_secret.get_secret_value(),
+            push=push,
+            rename=rename,
+            installation=installation,
+        )
 
     def create_dashboard_publisher(self) -> DashboardPublisher:
         """Create a DashboardPublisher for one render.

--- a/src/docverse/handlers/webhooks/github.py
+++ b/src/docverse/handlers/webhooks/github.py
@@ -1,9 +1,9 @@
-"""GitHub webhook endpoint dispatching push events to the sync queue."""
+"""GitHub webhook endpoint dispatching events to per-event processors."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated
+from typing import Annotated, Any
 
 import gidgethub
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -11,7 +11,12 @@ from gidgethub import sansio
 from gidgethub.routing import Router as GidgethubRouter
 
 from docverse.dependencies.context import RequestContext, context_dependency
-from docverse.services.dashboard_templates import PushEventProcessor
+from docverse.factory import WebhookDispatch
+from docverse.services.dashboard_templates import (
+    InstallationEventProcessor,
+    PushEventProcessor,
+    RenameEventProcessor,
+)
 from docverse.storage.github import GitHubAppNotConfiguredError
 
 __all__ = ["router"]
@@ -41,20 +46,82 @@ once, dispatch many.
 async def _handle_push(
     event: sansio.Event,
     *,
-    processor: PushEventProcessor,
+    push: PushEventProcessor,
     context: RequestContext,
+    **_unused: Any,
 ) -> None:
     """Translate a push event into ``dashboard_sync`` enqueues.
 
     The processor owns transaction-free DB writes through the
     enqueuer; the handler wraps both the binding lookup and the
     enqueue in a single ``session.begin()`` so a failure aborts the
-    whole webhook delivery cleanly.
+    whole webhook delivery cleanly. ``**_unused`` absorbs the
+    rename/installation processors that gidgethub's dispatcher passes
+    to every callback uniformly.
     """
     async with context.session.begin():
-        jobs = await processor.process(event.data)
+        jobs = await push.process(event.data)
         await context.session.commit()
     context.logger.info("Processed push webhook", enqueued=len(jobs))
+
+
+@_event_router.register("repository", action="renamed")
+async def _handle_repository_renamed(
+    event: sansio.Event,
+    *,
+    rename: RenameEventProcessor,
+    context: RequestContext,
+    **_unused: Any,
+) -> None:
+    """Rewrite display names on bindings + content rows for a renamed repo."""
+    async with context.session.begin():
+        await rename.process_repository_renamed(event.data)
+        await context.session.commit()
+
+
+@_event_router.register("repository", action="transferred")
+async def _handle_repository_transferred(
+    event: sansio.Event,
+    *,
+    rename: RenameEventProcessor,
+    context: RequestContext,
+    **_unused: Any,
+) -> None:
+    """Rewrite owner identity on rows for a transferred repo."""
+    async with context.session.begin():
+        await rename.process_repository_transferred(event.data)
+        await context.session.commit()
+
+
+@_event_router.register("organization", action="renamed")
+async def _handle_organization_renamed(
+    event: sansio.Event,
+    *,
+    rename: RenameEventProcessor,
+    context: RequestContext,
+    **_unused: Any,
+) -> None:
+    """Rewrite owner login on bindings + content rows for a renamed org."""
+    async with context.session.begin():
+        await rename.process_organization_renamed(event.data)
+        await context.session.commit()
+
+
+@_event_router.register("installation", action="created")
+@_event_router.register("installation", action="deleted")
+@_event_router.register("installation", action="suspend")
+@_event_router.register("installation", action="unsuspend")
+async def _handle_installation(
+    event: sansio.Event,
+    *,
+    installation: InstallationEventProcessor,
+    context: RequestContext,
+    **_unused: Any,
+) -> None:
+    """Update binding reachability for installation lifecycle events."""
+    async with context.session.begin():
+        await installation.process(event.data)
+        await context.session.commit()
 
 
 @router.post(
@@ -85,7 +152,7 @@ async def post_github_webhook(
     chosen not to act on.
     """
     try:
-        secret, processor = context.factory.create_webhook_dispatch()
+        dispatch: WebhookDispatch = context.factory.create_webhook_dispatch()
     except GitHubAppNotConfiguredError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -95,7 +162,9 @@ async def post_github_webhook(
     body = await request.body()
     try:
         event = sansio.Event.from_http(
-            _lowercase_headers(request.headers), body, secret=secret
+            _lowercase_headers(request.headers),
+            body,
+            secret=dispatch.webhook_secret,
         )
     except gidgethub.ValidationFailure as exc:
         raise HTTPException(
@@ -107,7 +176,13 @@ async def post_github_webhook(
         github_event=event.event, github_delivery_id=event.delivery_id
     )
 
-    await _event_router.dispatch(event, processor=processor, context=context)
+    await _event_router.dispatch(
+        event,
+        push=dispatch.push,
+        rename=dispatch.rename,
+        installation=dispatch.installation,
+        context=context,
+    )
 
     return {"status": "ok"}
 

--- a/src/docverse/services/dashboard_templates/__init__.py
+++ b/src/docverse/services/dashboard_templates/__init__.py
@@ -8,7 +8,9 @@ from .binding import (
 )
 from .enqueue import DashboardSyncEnqueuer
 from .fanout import DashboardRebuildFanout
+from .installation_processor import InstallationEventProcessor
 from .push_processor import PushEventProcessor
+from .rename_processor import RenameEventProcessor
 from .resolver import (
     ResolvedTemplate,
     ResolvedTemplateOrigin,
@@ -23,7 +25,9 @@ __all__ = [
     "DashboardTemplateBindingService",
     "DashboardTemplateSyncError",
     "DashboardTemplateSyncer",
+    "InstallationEventProcessor",
     "PushEventProcessor",
+    "RenameEventProcessor",
     "ResolvedTemplate",
     "ResolvedTemplateOrigin",
     "TemplateResolver",

--- a/src/docverse/services/dashboard_templates/installation_processor.py
+++ b/src/docverse/services/dashboard_templates/installation_processor.py
@@ -1,0 +1,145 @@
+"""Service that records installation reachability on bindings."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import structlog
+
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+)
+
+__all__ = [
+    "INSTALLATION_DELETED_REASON",
+    "INSTALLATION_SUSPENDED_REASON",
+    "InstallationEventProcessor",
+]
+
+
+# Machine-readable tags written to ``dashboard_github_template_bindings
+# .last_sync_error``. ``installation.unsuspend`` clears only rows whose
+# error matches ``INSTALLATION_SUSPENDED_REASON``, so the suspend and
+# delete tags are distinct strings rather than a shared "installation".
+INSTALLATION_SUSPENDED_REASON = "installation_suspended"
+INSTALLATION_DELETED_REASON = "installation_deleted"
+
+
+class InstallationEventProcessor:
+    """Translate ``installation.*`` webhooks into reachability flips.
+
+    GitHub fires an installation event whenever the Docverse GitHub
+    App's install state on a tenant changes:
+
+    - ``installation.created`` — log only. The binding side cannot
+      know about the install before it is registered through the
+      binding PUT, so created is a no-op until that PUT runs and the
+      next sync captures the installation id.
+    - ``installation.suspend`` — mark every binding keyed by the
+      installation id as ``last_sync_status='failed'`` with
+      :data:`INSTALLATION_SUSPENDED_REASON`. Next render falls back to
+      the previously-cached content; the operator sees the failure on
+      the binding response.
+    - ``installation.deleted`` — same as suspend but with
+      :data:`INSTALLATION_DELETED_REASON`. Distinct from suspend so
+      a future ``installation.unsuspend`` cannot accidentally revive
+      a binding whose installation is actually gone.
+    - ``installation.unsuspend`` — clear the suspend flag on rows
+      whose ``last_sync_error`` matches
+      :data:`INSTALLATION_SUSPENDED_REASON`. Non-suspend failures
+      (real syncer errors) are preserved so an unsuspend that races
+      with a separate failure does not paper over the second one.
+
+    The caller (the webhook handler) owns the surrounding transaction;
+    the processor only flushes through store-level updates and never
+    opens its own ``session.begin()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        binding_store: DashboardGitHubTemplateBindingStore,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._binding_store = binding_store
+        self._logger = logger
+
+    async def process(self, payload: Mapping[str, Any]) -> None:
+        """Dispatch on the installation action."""
+        action = payload.get("action")
+        installation = payload.get("installation", {})
+        installation_id = _coerce_int(installation.get("id"))
+
+        if installation_id is None or not isinstance(action, str):
+            self._logger.warning(
+                "installation payload missing id or action",
+                installation_id=installation_id,
+                action=action,
+            )
+            return
+
+        if action == "created":
+            # No DB write — the binding cannot know about the install
+            # before the operator registers it through the API. Log so
+            # the delivery is visible in audit trails.
+            self._logger.info(
+                "Processed installation.created (no-op)",
+                github_installation_id=installation_id,
+            )
+            return
+
+        if action == "suspend":
+            ids = (
+                await self._binding_store.mark_unreachable_by_installation_id(
+                    github_installation_id=installation_id,
+                    reason=INSTALLATION_SUSPENDED_REASON,
+                )
+            )
+            self._logger.info(
+                "Processed installation.suspend",
+                github_installation_id=installation_id,
+                bindings_updated=len(ids),
+            )
+            return
+
+        if action == "deleted":
+            ids = (
+                await self._binding_store.mark_unreachable_by_installation_id(
+                    github_installation_id=installation_id,
+                    reason=INSTALLATION_DELETED_REASON,
+                )
+            )
+            self._logger.info(
+                "Processed installation.deleted",
+                github_installation_id=installation_id,
+                bindings_updated=len(ids),
+            )
+            return
+
+        if action == "unsuspend":
+            store = self._binding_store
+            ids = await store.clear_failure_by_installation_id_and_reason(
+                github_installation_id=installation_id,
+                reason=INSTALLATION_SUSPENDED_REASON,
+            )
+            self._logger.info(
+                "Processed installation.unsuspend",
+                github_installation_id=installation_id,
+                bindings_updated=len(ids),
+            )
+            return
+
+        self._logger.info(
+            "Ignoring unknown installation action",
+            github_installation_id=installation_id,
+            action=action,
+        )
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None

--- a/src/docverse/services/dashboard_templates/rename_processor.py
+++ b/src/docverse/services/dashboard_templates/rename_processor.py
@@ -1,0 +1,228 @@
+"""Service that rewrites display names on rename / transfer webhooks."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import structlog
+
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
+)
+
+__all__ = ["RenameEventProcessor"]
+
+
+class RenameEventProcessor:
+    """Translate rename / transfer webhooks into display-name rewrites.
+
+    GitHub rename and transfer events carry stable numeric IDs in the
+    payload alongside the new display strings. The processor rewrites
+    name columns on every binding and content row matching the stable
+    ID, with a name-keyed fallback for rows whose first sync did not
+    capture the ID (un-synced bindings).
+
+    No syncs are enqueued — the synced bytes are unchanged by a name
+    flip, only the strings that operators read and that the dedup-key
+    on the content row uses for the next ETag short-circuit. The
+    caller (the webhook handler) owns the surrounding transaction; the
+    processor only flushes through store-level updates and never opens
+    its own ``session.begin()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        binding_store: DashboardGitHubTemplateBindingStore,
+        template_store: DashboardGitHubTemplateStore,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._binding_store = binding_store
+        self._template_store = template_store
+        self._logger = logger
+
+    async def process_repository_renamed(
+        self, payload: Mapping[str, Any]
+    ) -> None:
+        """Rewrite ``github_repo`` on rows for a renamed repository.
+
+        Primary path: every binding and content row whose stable
+        ``github_repo_id`` matches ``repository.id``. Fallback path:
+        un-synced bindings matching ``(github_owner, old_name)`` —
+        their numeric ID was never captured so the primary lookup
+        cannot reach them.
+        """
+        repo = payload.get("repository", {})
+        repo_id = _coerce_int(repo.get("id"))
+        new_repo = repo.get("name")
+        owner_block = repo.get("owner", {})
+        owner = owner_block.get("login") or owner_block.get("name")
+        old_repo = (
+            payload.get("changes", {})
+            .get("repository", {})
+            .get("name", {})
+            .get("from")
+        )
+
+        if not (isinstance(new_repo, str) and isinstance(old_repo, str)):
+            self._logger.warning(
+                "repository.renamed payload missing names",
+                old_repo=old_repo,
+                new_repo=new_repo,
+            )
+            return
+
+        binding_ids: list[int] = []
+        template_ids: list[int] = []
+        unsynced_ids: list[int] = []
+
+        if repo_id is not None:
+            binding_ids = await self._binding_store.rename_repo_by_repo_id(
+                github_repo_id=repo_id, new_repo=new_repo
+            )
+            template_ids = await self._template_store.rename_repo_by_repo_id(
+                github_repo_id=repo_id, new_repo=new_repo
+            )
+
+        if isinstance(owner, str) and old_repo != new_repo:
+            unsynced_ids = (
+                await self._binding_store.rename_repo_for_unsynced_by_old_name(
+                    github_owner=owner,
+                    old_repo=old_repo,
+                    new_repo=new_repo,
+                )
+            )
+
+        self._logger.info(
+            "Processed repository.renamed",
+            github_repo_id=repo_id,
+            github_owner=owner,
+            old_repo=old_repo,
+            new_repo=new_repo,
+            bindings_updated=len(binding_ids),
+            templates_updated=len(template_ids),
+            bindings_updated_unsynced=len(unsynced_ids),
+        )
+
+    async def process_repository_transferred(
+        self, payload: Mapping[str, Any]
+    ) -> None:
+        """Rewrite owner + repo strings + ``github_owner_id`` on transfer.
+
+        Only the ID-keyed primary path is used: a transfer changes the
+        owner namespace, so a name-only fallback could collide with a
+        same-name binding under either the old or the new owner. The
+        binding has to have been synced (``github_repo_id`` populated)
+        for the transfer to land on it.
+        """
+        repo = payload.get("repository", {})
+        repo_id = _coerce_int(repo.get("id"))
+        new_repo = repo.get("name")
+        owner_block = repo.get("owner", {})
+        new_owner = owner_block.get("login") or owner_block.get("name")
+        new_owner_id = _coerce_int(owner_block.get("id"))
+
+        if repo_id is None or not isinstance(new_owner, str):
+            self._logger.warning(
+                "repository.transferred payload missing repo_id or owner",
+                repo_id=repo_id,
+                new_owner=new_owner,
+            )
+            return
+        if new_owner_id is None or not isinstance(new_repo, str):
+            self._logger.warning(
+                "repository.transferred payload missing owner_id or new_repo",
+                new_owner_id=new_owner_id,
+                new_repo=new_repo,
+            )
+            return
+
+        binding_ids = await self._binding_store.transfer_repo_by_repo_id(
+            github_repo_id=repo_id,
+            new_owner=new_owner,
+            new_owner_id=new_owner_id,
+            new_repo=new_repo,
+        )
+        template_ids = await self._template_store.transfer_repo_by_repo_id(
+            github_repo_id=repo_id,
+            new_owner=new_owner,
+            new_owner_id=new_owner_id,
+            new_repo=new_repo,
+        )
+
+        self._logger.info(
+            "Processed repository.transferred",
+            github_repo_id=repo_id,
+            new_owner=new_owner,
+            new_owner_id=new_owner_id,
+            new_repo=new_repo,
+            bindings_updated=len(binding_ids),
+            templates_updated=len(template_ids),
+        )
+
+    async def process_organization_renamed(
+        self, payload: Mapping[str, Any]
+    ) -> None:
+        """Rewrite ``github_owner`` on rows for a renamed organization.
+
+        Primary path: every binding and content row whose
+        ``github_owner_id`` matches ``organization.id``. Fallback:
+        un-synced bindings matching the old login.
+        """
+        org_block = payload.get("organization", {})
+        org_id = _coerce_int(org_block.get("id"))
+        new_login = org_block.get("login")
+        old_login = payload.get("changes", {}).get("login", {}).get("from")
+
+        if not (isinstance(new_login, str) and isinstance(old_login, str)):
+            self._logger.warning(
+                "organization.renamed payload missing login fields",
+                old_login=old_login,
+                new_login=new_login,
+            )
+            return
+
+        binding_ids: list[int] = []
+        template_ids: list[int] = []
+        unsynced_ids: list[int] = []
+
+        if org_id is not None:
+            binding_ids = await self._binding_store.rename_owner_by_owner_id(
+                github_owner_id=org_id, new_owner=new_login
+            )
+            template_ids = await self._template_store.rename_owner_by_owner_id(
+                github_owner_id=org_id, new_owner=new_login
+            )
+
+        if old_login != new_login:
+            store = self._binding_store
+            unsynced_ids = await store.rename_owner_for_unsynced_by_old_login(
+                old_login=old_login, new_owner=new_login
+            )
+
+        self._logger.info(
+            "Processed organization.renamed",
+            github_owner_id=org_id,
+            old_login=old_login,
+            new_login=new_login,
+            bindings_updated=len(binding_ids),
+            templates_updated=len(template_ids),
+            bindings_updated_unsynced=len(unsynced_ids),
+        )
+
+
+def _coerce_int(value: object) -> int | None:
+    """Return ``value`` as ``int`` when it is a non-bool int, else ``None``.
+
+    Mirrors the strict guard in :class:`PushEventProcessor`: GitHub
+    sends numeric IDs as JSON ints, but a malformed payload that sent
+    ``"id": true`` would otherwise leak ``1`` through as a real id
+    because ``isinstance(True, int)`` is ``True`` in Python.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None

--- a/src/docverse/storage/dashboard_templates/github/binding_store.py
+++ b/src/docverse/storage/dashboard_templates/github/binding_store.py
@@ -389,6 +389,227 @@ class DashboardGitHubTemplateBindingStore:
         await self._session.flush()
         return True
 
+    async def rename_repo_by_repo_id(
+        self,
+        *,
+        github_repo_id: int,
+        new_repo: str,
+    ) -> list[int]:
+        """Rewrite ``github_repo`` on all bindings keyed by stable repo ID.
+
+        Used by the ``repository.renamed`` webhook handler: any binding
+        whose first sync captured ``github_repo_id`` matches here, even
+        when its display name is now stale. ``date_updated`` is
+        preserved because operator-visible source-coordinate writes
+        come through PUT, not through GitHub-side metadata sync.
+        """
+        stmt = (
+            update(SqlDashboardGitHubTemplateBinding)
+            .where(
+                SqlDashboardGitHubTemplateBinding.github_repo_id
+                == github_repo_id,
+            )
+            .values(
+                github_repo=new_repo,
+                date_updated=SqlDashboardGitHubTemplateBinding.date_updated,
+            )
+            .returning(SqlDashboardGitHubTemplateBinding.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
+    async def rename_repo_for_unsynced_by_old_name(
+        self,
+        *,
+        github_owner: str,
+        old_repo: str,
+        new_repo: str,
+    ) -> list[int]:
+        """Rewrite ``github_repo`` on un-synced bindings matching old name.
+
+        Fallback for bindings registered via PUT but never synced —
+        ``github_repo_id IS NULL``, so ID-keyed matching cannot reach
+        them. The owner-side filter pins the update to the namespace
+        where the rename actually happened so a same-name binding in
+        another GitHub owner is not collateral damage.
+        """
+        stmt = (
+            update(SqlDashboardGitHubTemplateBinding)
+            .where(
+                SqlDashboardGitHubTemplateBinding.github_owner == github_owner,
+                SqlDashboardGitHubTemplateBinding.github_repo == old_repo,
+                SqlDashboardGitHubTemplateBinding.github_repo_id.is_(None),
+            )
+            .values(
+                github_repo=new_repo,
+                date_updated=SqlDashboardGitHubTemplateBinding.date_updated,
+            )
+            .returning(SqlDashboardGitHubTemplateBinding.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
+    async def transfer_repo_by_repo_id(
+        self,
+        *,
+        github_repo_id: int,
+        new_owner: str,
+        new_owner_id: int,
+        new_repo: str,
+    ) -> list[int]:
+        """Rewrite owner + repo strings + ``github_owner_id`` on transfer.
+
+        ``repository.transferred`` payloads carry the same ``repository
+        .id`` but a new ``repository.owner`` (login + id) and may
+        carry a new ``repository.name`` if the transfer was followed by
+        a rename. All four columns flip together so a subsequent push
+        from the new namespace matches the binding by stable repo ID
+        and the display name does not lag.
+        """
+        stmt = (
+            update(SqlDashboardGitHubTemplateBinding)
+            .where(
+                SqlDashboardGitHubTemplateBinding.github_repo_id
+                == github_repo_id,
+            )
+            .values(
+                github_owner=new_owner,
+                github_owner_id=new_owner_id,
+                github_repo=new_repo,
+                date_updated=SqlDashboardGitHubTemplateBinding.date_updated,
+            )
+            .returning(SqlDashboardGitHubTemplateBinding.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
+    async def rename_owner_by_owner_id(
+        self,
+        *,
+        github_owner_id: int,
+        new_owner: str,
+    ) -> list[int]:
+        """Rewrite ``github_owner`` on all bindings keyed by owner ID.
+
+        The ``organization.renamed`` webhook handler uses this for
+        synced bindings. ``github_owner_id`` is the stable handle —
+        the org's display login is the only field that flips on a
+        rename.
+        """
+        stmt = (
+            update(SqlDashboardGitHubTemplateBinding)
+            .where(
+                SqlDashboardGitHubTemplateBinding.github_owner_id
+                == github_owner_id,
+            )
+            .values(
+                github_owner=new_owner,
+                date_updated=SqlDashboardGitHubTemplateBinding.date_updated,
+            )
+            .returning(SqlDashboardGitHubTemplateBinding.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
+    async def rename_owner_for_unsynced_by_old_login(
+        self,
+        *,
+        old_login: str,
+        new_owner: str,
+    ) -> list[int]:
+        """Rewrite ``github_owner`` on un-synced bindings matching old login.
+
+        Fallback for bindings whose ``github_owner_id`` was never
+        captured. Restricted to ``github_owner_id IS NULL`` so a
+        coincidentally-named org (different numeric id, same login at
+        some past point) cannot be moved by a rename event aimed at
+        a different namespace.
+        """
+        stmt = (
+            update(SqlDashboardGitHubTemplateBinding)
+            .where(
+                SqlDashboardGitHubTemplateBinding.github_owner == old_login,
+                SqlDashboardGitHubTemplateBinding.github_owner_id.is_(None),
+            )
+            .values(
+                github_owner=new_owner,
+                date_updated=SqlDashboardGitHubTemplateBinding.date_updated,
+            )
+            .returning(SqlDashboardGitHubTemplateBinding.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
+    async def mark_unreachable_by_installation_id(
+        self,
+        *,
+        github_installation_id: int,
+        reason: str,
+    ) -> list[int]:
+        """Mark all bindings under an installation as ``failed``.
+
+        Used for ``installation.deleted`` and ``installation.suspend``.
+        ``reason`` lands in ``last_sync_error`` as a machine-readable
+        tag (e.g. ``installation_suspended``) so the
+        ``installation.unsuspend`` clearer can target the same set of
+        rows. ``date_updated`` is preserved — installation-state flips
+        are not source-coordinate edits.
+        """
+        stmt = (
+            update(SqlDashboardGitHubTemplateBinding)
+            .where(
+                SqlDashboardGitHubTemplateBinding.github_installation_id
+                == github_installation_id,
+            )
+            .values(
+                last_sync_status="failed",
+                last_sync_error=reason,
+                date_updated=SqlDashboardGitHubTemplateBinding.date_updated,
+            )
+            .returning(SqlDashboardGitHubTemplateBinding.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
+    async def clear_failure_by_installation_id_and_reason(
+        self,
+        *,
+        github_installation_id: int,
+        reason: str,
+    ) -> list[int]:
+        """Clear a previously-recorded installation-failure flag.
+
+        ``installation.unsuspend`` uses this to reverse the
+        ``installation_suspended`` mark left by ``installation.suspend``.
+        The ``reason`` filter prevents the unsuspend from clobbering
+        a different failure (e.g. a real GitHub 5xx from the syncer)
+        that happened to land between the suspend and the unsuspend.
+        """
+        stmt = (
+            update(SqlDashboardGitHubTemplateBinding)
+            .where(
+                SqlDashboardGitHubTemplateBinding.github_installation_id
+                == github_installation_id,
+                SqlDashboardGitHubTemplateBinding.last_sync_status == "failed",
+                SqlDashboardGitHubTemplateBinding.last_sync_error == reason,
+            )
+            .values(
+                last_sync_status="pending",
+                last_sync_error=None,
+                date_updated=SqlDashboardGitHubTemplateBinding.date_updated,
+            )
+            .returning(SqlDashboardGitHubTemplateBinding.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
     async def _get_row(
         self, binding_id: int
     ) -> SqlDashboardGitHubTemplateBinding | None:

--- a/src/docverse/storage/dashboard_templates/github/template_store.py
+++ b/src/docverse/storage/dashboard_templates/github/template_store.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import structlog
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.dbschema.dashboard_github_template import (
@@ -236,6 +236,80 @@ class DashboardGitHubTemplateStore:
         if row is None:
             return None
         return DashboardGitHubTemplateFile.model_validate(row)
+
+    async def rename_repo_by_repo_id(
+        self,
+        *,
+        github_repo_id: int,
+        new_repo: str,
+    ) -> list[int]:
+        """Rewrite ``github_repo`` on all content rows keyed by stable repo ID.
+
+        The synced bytes themselves don't change — only the dedup-key
+        component that carries the GitHub display name. Keeps the
+        binding's ETag short-circuit on the next sync from re-fetching
+        a tree it already has.
+        """
+        stmt = (
+            update(SqlDashboardGitHubTemplate)
+            .where(
+                SqlDashboardGitHubTemplate.github_repo_id == github_repo_id,
+            )
+            .values(github_repo=new_repo)
+            .returning(SqlDashboardGitHubTemplate.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
+    async def transfer_repo_by_repo_id(
+        self,
+        *,
+        github_repo_id: int,
+        new_owner: str,
+        new_owner_id: int,
+        new_repo: str,
+    ) -> list[int]:
+        """Rewrite owner + repo strings + ``github_owner_id`` on transfer.
+
+        Mirror of :meth:`DashboardGitHubTemplateBindingStore
+        .transfer_repo_by_repo_id` for the synced content row whose
+        dedup key includes the owner login.
+        """
+        stmt = (
+            update(SqlDashboardGitHubTemplate)
+            .where(
+                SqlDashboardGitHubTemplate.github_repo_id == github_repo_id,
+            )
+            .values(
+                github_owner=new_owner,
+                github_owner_id=new_owner_id,
+                github_repo=new_repo,
+            )
+            .returning(SqlDashboardGitHubTemplate.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
+    async def rename_owner_by_owner_id(
+        self,
+        *,
+        github_owner_id: int,
+        new_owner: str,
+    ) -> list[int]:
+        """Rewrite ``github_owner`` on content rows keyed by owner ID."""
+        stmt = (
+            update(SqlDashboardGitHubTemplate)
+            .where(
+                SqlDashboardGitHubTemplate.github_owner_id == github_owner_id,
+            )
+            .values(github_owner=new_owner)
+            .returning(SqlDashboardGitHubTemplate.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
 
     async def _get_row_by_id(
         self, template_id: int

--- a/tests/handlers/webhooks_github_rename_test.py
+++ b/tests/handlers/webhooks_github_rename_test.py
@@ -1,0 +1,517 @@
+"""Handler-level tests for the rename / transfer / installation events."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+import structlog
+from fastapi import FastAPI
+from httpx import AsyncClient
+from pydantic import SecretStr
+from safir.arq import MockArqQueue
+from safir.dependencies.arq import arq_dependency
+from safir.dependencies.db_session import db_session_dependency
+
+from docverse.client.models import OrganizationCreate
+from docverse.dependencies.context import context_dependency
+from docverse.services.dashboard_templates.installation_processor import (
+    INSTALLATION_DELETED_REASON,
+    INSTALLATION_SUSPENDED_REASON,
+)
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.organization_store import OrganizationStore
+from tests.support.arq_testing import count_jobs_by_name
+from tests.support.github_mock import GitHubMock
+
+_WEBHOOK_PATH = "/docverse/webhooks/github"
+_WEBHOOK_SECRET = "test-webhook-secret"  # noqa: S105
+
+
+def _sign(secret: str, body: bytes) -> str:
+    digest = hmac.new(
+        secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256
+    ).hexdigest()
+    return f"sha256={digest}"
+
+
+@pytest_asyncio.fixture
+async def github_app_enabled(
+    app: FastAPI,
+    mock_github: GitHubMock,
+) -> AsyncIterator[None]:
+    saved = (
+        context_dependency._github_app_id,
+        context_dependency._github_app_private_key,
+        context_dependency._github_webhook_secret,
+    )
+    context_dependency.set_github_secrets(
+        app_id=mock_github.app_id,
+        private_key=SecretStr(mock_github.private_key_pem),
+        webhook_secret=SecretStr(_WEBHOOK_SECRET),
+    )
+    try:
+        yield
+    finally:
+        context_dependency.set_github_secrets(
+            app_id=saved[0],
+            private_key=saved[1],
+            webhook_secret=saved[2],
+        )
+
+
+async def _seed_binding(
+    *,
+    org_slug: str,
+    github_owner: str = "acme",
+    github_repo: str = "templates",
+    github_ref: str = "main",
+    github_owner_id: int | None = None,
+    github_repo_id: int | None = None,
+    github_installation_id: int | None = None,
+) -> int:
+    logger = structlog.get_logger("test")
+    binding_id = 0
+    async for session in db_session_dependency():
+        async with session.begin():
+            org_store = OrganizationStore(session=session, logger=logger)
+            org = await org_store.create(
+                OrganizationCreate(
+                    slug=org_slug,
+                    title=f"Org {org_slug}",
+                    base_domain=f"{org_slug}.example.com",
+                )
+            )
+            store = DashboardGitHubTemplateBindingStore(
+                session=session, logger=logger
+            )
+            binding = await store.create(
+                DashboardGitHubTemplateBindingCreate(
+                    org_id=org.id,
+                    project_id=None,
+                    github_owner=github_owner,
+                    github_repo=github_repo,
+                    github_ref=github_ref,
+                    root_path="/",
+                    github_owner_id=github_owner_id,
+                    github_repo_id=github_repo_id,
+                    github_installation_id=github_installation_id,
+                )
+            )
+            binding_id = binding.id
+            await session.commit()
+        return binding_id
+    msg = "db_session_dependency yielded nothing"
+    raise AssertionError(msg)
+
+
+async def _read_binding(binding_id: int) -> Any:
+    logger = structlog.get_logger("test")
+    async for session in db_session_dependency():
+        async with session.begin():
+            store = DashboardGitHubTemplateBindingStore(
+                session=session, logger=logger
+            )
+            return await store.get_by_id(binding_id)
+    msg = "db_session_dependency yielded nothing"
+    raise AssertionError(msg)
+
+
+def _post_signed_event(
+    *,
+    event: str,
+    payload: dict[str, Any],
+    delivery_id: str = "00000000-0000-0000-0000-000000000010",
+) -> tuple[bytes, dict[str, str]]:
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "X-GitHub-Event": event,
+        "X-GitHub-Delivery": delivery_id,
+        "X-Hub-Signature-256": _sign(_WEBHOOK_SECRET, body),
+    }
+    return body, headers
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_signed_post_updates_binding(
+    client: AsyncClient,
+    github_app_enabled: None,
+) -> None:
+    """A signed ``repository.renamed`` rewrites the binding's display name."""
+    arq_queue = arq_dependency._arq_queue
+    assert isinstance(arq_queue, MockArqQueue)
+    sync_jobs_before = count_jobs_by_name(arq_queue, "dashboard_sync")
+
+    binding_id = await _seed_binding(
+        org_slug="rename-handler",
+        github_owner="acme",
+        github_repo="old-name",
+        github_repo_id=12345,
+        github_owner_id=999,
+    )
+    payload = {
+        "action": "renamed",
+        "changes": {"repository": {"name": {"from": "old-name"}}},
+        "repository": {
+            "id": 12345,
+            "name": "new-name",
+            "full_name": "acme/new-name",
+            "owner": {"login": "acme", "id": 999},
+        },
+        "installation": {"id": 99},
+    }
+    body, headers = _post_signed_event(event="repository", payload=payload)
+
+    response = await client.post(_WEBHOOK_PATH, content=body, headers=headers)
+
+    assert response.status_code == 200
+    binding = await _read_binding(binding_id)
+    assert binding is not None
+    assert binding.github_repo == "new-name"
+    # No syncs are enqueued for a rename — only display strings change.
+    assert count_jobs_by_name(arq_queue, "dashboard_sync") == sync_jobs_before
+
+
+@pytest.mark.asyncio
+async def test_repository_transferred_signed_post_updates_owner(
+    client: AsyncClient,
+    github_app_enabled: None,
+) -> None:
+    """A signed ``repository.transferred`` rewrites owner + owner id."""
+    arq_queue = arq_dependency._arq_queue
+    assert isinstance(arq_queue, MockArqQueue)
+    sync_jobs_before = count_jobs_by_name(arq_queue, "dashboard_sync")
+
+    binding_id = await _seed_binding(
+        org_slug="transfer-handler",
+        github_owner="old-owner",
+        github_repo="templates",
+        github_repo_id=12345,
+        github_owner_id=111,
+    )
+    payload = {
+        "action": "transferred",
+        "changes": {
+            "owner": {
+                "from": {
+                    "user": {"login": "old-owner", "id": 111},
+                }
+            }
+        },
+        "repository": {
+            "id": 12345,
+            "name": "templates",
+            "full_name": "new-owner/templates",
+            "owner": {"login": "new-owner", "id": 222},
+        },
+        "installation": {"id": 99},
+    }
+    body, headers = _post_signed_event(event="repository", payload=payload)
+
+    response = await client.post(_WEBHOOK_PATH, content=body, headers=headers)
+
+    assert response.status_code == 200
+    binding = await _read_binding(binding_id)
+    assert binding is not None
+    assert binding.github_owner == "new-owner"
+    assert binding.github_owner_id == 222
+    assert count_jobs_by_name(arq_queue, "dashboard_sync") == sync_jobs_before
+
+
+@pytest.mark.asyncio
+async def test_organization_renamed_signed_post_updates_owner(
+    client: AsyncClient,
+    github_app_enabled: None,
+) -> None:
+    """A signed ``organization.renamed`` rewrites the binding's owner login."""
+    arq_queue = arq_dependency._arq_queue
+    assert isinstance(arq_queue, MockArqQueue)
+    sync_jobs_before = count_jobs_by_name(arq_queue, "dashboard_sync")
+
+    binding_id = await _seed_binding(
+        org_slug="org-rename-handler",
+        github_owner="old-org",
+        github_owner_id=999,
+        github_repo_id=12345,
+    )
+    payload = {
+        "action": "renamed",
+        "changes": {"login": {"from": "old-org"}},
+        "organization": {"id": 999, "login": "new-org"},
+        "installation": {"id": 99},
+    }
+    body, headers = _post_signed_event(event="organization", payload=payload)
+
+    response = await client.post(_WEBHOOK_PATH, content=body, headers=headers)
+
+    assert response.status_code == 200
+    binding = await _read_binding(binding_id)
+    assert binding is not None
+    assert binding.github_owner == "new-org"
+    assert count_jobs_by_name(arq_queue, "dashboard_sync") == sync_jobs_before
+
+
+@pytest.mark.asyncio
+async def test_installation_suspend_signed_post_marks_binding_failed(
+    client: AsyncClient,
+    github_app_enabled: None,
+) -> None:
+    """A signed ``installation.suspend`` flips matching bindings to failed."""
+    binding_id = await _seed_binding(
+        org_slug="install-suspend-handler", github_installation_id=99
+    )
+    payload = {
+        "action": "suspend",
+        "installation": {"id": 99, "account": {"login": "acme", "id": 999}},
+        "repositories": [],
+    }
+    body, headers = _post_signed_event(event="installation", payload=payload)
+
+    response = await client.post(_WEBHOOK_PATH, content=body, headers=headers)
+
+    assert response.status_code == 200
+    binding = await _read_binding(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "failed"
+    assert binding.last_sync_error == INSTALLATION_SUSPENDED_REASON
+
+
+@pytest.mark.asyncio
+async def test_installation_unsuspend_signed_post_clears_failure(
+    client: AsyncClient,
+    github_app_enabled: None,
+) -> None:
+    """A signed ``installation.unsuspend`` clears a prior suspend flag."""
+    binding_id = await _seed_binding(
+        org_slug="install-unsuspend-handler", github_installation_id=99
+    )
+    suspend_payload = {
+        "action": "suspend",
+        "installation": {"id": 99, "account": {"login": "acme", "id": 999}},
+        "repositories": [],
+    }
+    body, headers = _post_signed_event(
+        event="installation",
+        payload=suspend_payload,
+        delivery_id="00000000-0000-0000-0000-000000000020",
+    )
+    suspend_response = await client.post(
+        _WEBHOOK_PATH, content=body, headers=headers
+    )
+    assert suspend_response.status_code == 200
+
+    unsuspend_payload = {
+        "action": "unsuspend",
+        "installation": {"id": 99, "account": {"login": "acme", "id": 999}},
+        "repositories": [],
+    }
+    body, headers = _post_signed_event(
+        event="installation",
+        payload=unsuspend_payload,
+        delivery_id="00000000-0000-0000-0000-000000000021",
+    )
+    response = await client.post(_WEBHOOK_PATH, content=body, headers=headers)
+
+    assert response.status_code == 200
+    binding = await _read_binding(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "pending"
+    assert binding.last_sync_error is None
+
+
+@pytest.mark.asyncio
+async def test_installation_deleted_signed_post_marks_binding_failed(
+    client: AsyncClient,
+    github_app_enabled: None,
+) -> None:
+    """``installation.deleted`` lands the distinct ``deleted`` tag."""
+    binding_id = await _seed_binding(
+        org_slug="install-delete-handler", github_installation_id=99
+    )
+    payload = {
+        "action": "deleted",
+        "installation": {"id": 99, "account": {"login": "acme", "id": 999}},
+        "repositories": [],
+    }
+    body, headers = _post_signed_event(event="installation", payload=payload)
+
+    response = await client.post(_WEBHOOK_PATH, content=body, headers=headers)
+
+    assert response.status_code == 200
+    binding = await _read_binding(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "failed"
+    assert binding.last_sync_error == INSTALLATION_DELETED_REASON
+
+
+@pytest.mark.asyncio
+async def test_unsigned_rename_event_returns_401_no_writes(
+    client: AsyncClient,
+    github_app_enabled: None,
+) -> None:
+    """An unsigned rename event returns 401 and writes nothing."""
+    binding_id = await _seed_binding(
+        org_slug="unsigned-rename",
+        github_owner="acme",
+        github_repo="old-name",
+        github_repo_id=12345,
+        github_owner_id=999,
+    )
+    payload = {
+        "action": "renamed",
+        "changes": {"repository": {"name": {"from": "old-name"}}},
+        "repository": {
+            "id": 12345,
+            "name": "new-name",
+            "full_name": "acme/new-name",
+            "owner": {"login": "acme", "id": 999},
+        },
+        "installation": {"id": 99},
+    }
+    body = json.dumps(payload).encode("utf-8")
+
+    response = await client.post(
+        _WEBHOOK_PATH,
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-GitHub-Event": "repository",
+            "X-GitHub-Delivery": "00000000-0000-0000-0000-000000000030",
+        },
+    )
+
+    assert response.status_code == 401
+    binding = await _read_binding(binding_id)
+    assert binding is not None
+    assert binding.github_repo == "old-name"
+
+
+@pytest.mark.asyncio
+async def test_unrelated_repository_action_signed_no_writes(
+    client: AsyncClient,
+    github_app_enabled: None,
+) -> None:
+    """A signed ``repository.created`` is a no-op (unsubscribed action)."""
+    binding_id = await _seed_binding(
+        org_slug="unrelated-action",
+        github_owner="acme",
+        github_repo="templates",
+        github_repo_id=12345,
+        github_owner_id=999,
+    )
+    payload = {
+        "action": "created",
+        "repository": {
+            "id": 12345,
+            "name": "templates",
+            "owner": {"login": "acme", "id": 999},
+        },
+        "installation": {"id": 99},
+    }
+    body, headers = _post_signed_event(event="repository", payload=payload)
+
+    response = await client.post(_WEBHOOK_PATH, content=body, headers=headers)
+
+    assert response.status_code == 200
+    binding = await _read_binding(binding_id)
+    assert binding is not None
+    assert binding.github_repo == "templates"
+
+
+@pytest.mark.asyncio
+async def test_rename_event_does_not_enqueue_dashboard_sync(
+    client: AsyncClient,
+    github_app_enabled: None,
+) -> None:
+    """All four event handlers respect "no syncs enqueued" — pin the contract.
+
+    A regression where a rename or installation event accidentally
+    enqueued a sync would cost real GitHub API calls; this test checks
+    the queue counter across all four signed events.
+    """
+    arq_queue = arq_dependency._arq_queue
+    assert isinstance(arq_queue, MockArqQueue)
+    sync_jobs_before = count_jobs_by_name(arq_queue, "dashboard_sync")
+
+    await _seed_binding(
+        org_slug="no-sync-enqueue",
+        github_owner="acme",
+        github_repo="templates",
+        github_repo_id=12345,
+        github_owner_id=999,
+        github_installation_id=99,
+    )
+
+    events: list[tuple[str, dict[str, Any], str]] = [
+        (
+            "repository",
+            {
+                "action": "renamed",
+                "changes": {"repository": {"name": {"from": "templates"}}},
+                "repository": {
+                    "id": 12345,
+                    "name": "new-templates",
+                    "owner": {"login": "acme", "id": 999},
+                },
+                "installation": {"id": 99},
+            },
+            "00000000-0000-0000-0000-000000000040",
+        ),
+        (
+            "repository",
+            {
+                "action": "transferred",
+                "changes": {
+                    "owner": {"from": {"user": {"login": "acme", "id": 999}}}
+                },
+                "repository": {
+                    "id": 12345,
+                    "name": "new-templates",
+                    "owner": {"login": "other-org", "id": 1000},
+                },
+                "installation": {"id": 99},
+            },
+            "00000000-0000-0000-0000-000000000041",
+        ),
+        (
+            "organization",
+            {
+                "action": "renamed",
+                "changes": {"login": {"from": "other-org"}},
+                "organization": {"id": 1000, "login": "renamed-org"},
+                "installation": {"id": 99},
+            },
+            "00000000-0000-0000-0000-000000000042",
+        ),
+        (
+            "installation",
+            {
+                "action": "suspend",
+                "installation": {
+                    "id": 99,
+                    "account": {"login": "renamed-org", "id": 1000},
+                },
+                "repositories": [],
+            },
+            "00000000-0000-0000-0000-000000000043",
+        ),
+    ]
+    for event, payload, delivery_id in events:
+        body, headers = _post_signed_event(
+            event=event, payload=payload, delivery_id=delivery_id
+        )
+        response = await client.post(
+            _WEBHOOK_PATH, content=body, headers=headers
+        )
+        assert response.status_code == 200
+
+    assert count_jobs_by_name(arq_queue, "dashboard_sync") == sync_jobs_before

--- a/tests/services/dashboard_templates/installation_processor_test.py
+++ b/tests/services/dashboard_templates/installation_processor_test.py
@@ -1,0 +1,285 @@
+"""Tests for the InstallationEventProcessor service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import OrganizationCreate
+from docverse.services.dashboard_templates.installation_processor import (
+    INSTALLATION_DELETED_REASON,
+    INSTALLATION_SUSPENDED_REASON,
+    InstallationEventProcessor,
+)
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.organization_store import OrganizationStore
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("test")  # type: ignore[no-any-return]
+
+
+def _make_processor(session: AsyncSession) -> InstallationEventProcessor:
+    return InstallationEventProcessor(
+        binding_store=DashboardGitHubTemplateBindingStore(
+            session=session, logger=_logger()
+        ),
+        logger=_logger(),
+    )
+
+
+async def _seed_org(session: AsyncSession, slug: str) -> int:
+    store = OrganizationStore(session=session, logger=_logger())
+    org = await store.create(
+        OrganizationCreate(
+            slug=slug,
+            title=f"Org {slug}",
+            base_domain=f"{slug}.example.com",
+        )
+    )
+    return org.id
+
+
+async def _seed_binding(
+    session: AsyncSession,
+    *,
+    org_id: int,
+    github_installation_id: int | None,
+    github_owner: str = "acme",
+    github_repo: str = "templates",
+    github_ref: str = "main",
+) -> int:
+    store = DashboardGitHubTemplateBindingStore(
+        session=session, logger=_logger()
+    )
+    binding = await store.create(
+        DashboardGitHubTemplateBindingCreate(
+            org_id=org_id,
+            project_id=None,
+            github_owner=github_owner,
+            github_repo=github_repo,
+            github_ref=github_ref,
+            root_path="/",
+            github_installation_id=github_installation_id,
+        )
+    )
+    return binding.id
+
+
+def _installation_payload(
+    *, action: str, installation_id: int = 99
+) -> dict[str, Any]:
+    return {
+        "action": action,
+        "installation": {
+            "id": installation_id,
+            "account": {"login": "acme", "id": 999},
+        },
+        "repositories": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_installation_suspend_marks_bindings_failed(
+    db_session: AsyncSession,
+) -> None:
+    """``installation.suspend`` flips matching bindings to ``failed``.
+
+    The ``last_sync_error`` carries a machine-readable tag so the
+    matching ``installation.unsuspend`` can target the same set of
+    rows without sweeping up unrelated failures.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-suspend")
+        binding_id = await _seed_binding(
+            db_session, org_id=org_id, github_installation_id=99
+        )
+        await db_session.commit()
+
+    payload = _installation_payload(action="suspend", installation_id=99)
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "failed"
+    assert binding.last_sync_error == INSTALLATION_SUSPENDED_REASON
+
+
+@pytest.mark.asyncio
+async def test_installation_deleted_marks_bindings_failed(
+    db_session: AsyncSession,
+) -> None:
+    """``installation.deleted`` flips matching bindings with a distinct tag."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-delete")
+        binding_id = await _seed_binding(
+            db_session, org_id=org_id, github_installation_id=99
+        )
+        await db_session.commit()
+
+    payload = _installation_payload(action="deleted", installation_id=99)
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "failed"
+    assert binding.last_sync_error == INSTALLATION_DELETED_REASON
+
+
+@pytest.mark.asyncio
+async def test_installation_unsuspend_clears_suspend_flag(
+    db_session: AsyncSession,
+) -> None:
+    """``installation.unsuspend`` clears the suspend tag on matching bindings.
+
+    The clear only fires for rows whose ``last_sync_error`` matches the
+    suspend tag — a non-installation failure (e.g. a real syncer 5xx)
+    that landed between suspend and unsuspend stays put.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-unsuspend")
+        binding_id = await _seed_binding(
+            db_session, org_id=org_id, github_installation_id=99
+        )
+        # Suspend first to set up the failed state.
+        processor = _make_processor(db_session)
+        await processor.process(
+            _installation_payload(action="suspend", installation_id=99)
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        await _make_processor(db_session).process(
+            _installation_payload(action="unsuspend", installation_id=99)
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "pending"
+    assert binding.last_sync_error is None
+
+
+@pytest.mark.asyncio
+async def test_installation_unsuspend_does_not_clear_unrelated_failure(
+    db_session: AsyncSession,
+) -> None:
+    """A non-suspend failure on the same installation is preserved."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-unsuspend-keep")
+        binding_id = await _seed_binding(
+            db_session, org_id=org_id, github_installation_id=99
+        )
+        # Set a failure that did not come from a suspend — e.g. a
+        # syncer 5xx that ended up tagging the binding as failed.
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        await store.update_sync_state(
+            binding_id=binding_id,
+            last_sync_status="failed",
+            last_sync_error="Sync failed: GitHub 503",
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        await _make_processor(db_session).process(
+            _installation_payload(action="unsuspend", installation_id=99)
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "failed"
+    assert binding.last_sync_error == "Sync failed: GitHub 503"
+
+
+@pytest.mark.asyncio
+async def test_installation_created_is_a_no_op(
+    db_session: AsyncSession,
+) -> None:
+    """``installation.created`` does not mutate any row.
+
+    Per the issue, only deleted/suspend/unsuspend change DB state;
+    created is registered so unrelated installation actions return
+    200 cleanly through the gidgethub router.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-create")
+        binding_id = await _seed_binding(
+            db_session, org_id=org_id, github_installation_id=99
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        await _make_processor(db_session).process(
+            _installation_payload(action="created", installation_id=99)
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "pending"
+    assert binding.last_sync_error is None
+
+
+@pytest.mark.asyncio
+async def test_installation_event_does_not_touch_other_installations(
+    db_session: AsyncSession,
+) -> None:
+    """A binding under a different installation id is left untouched."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-isolation")
+        keep_id = await _seed_binding(
+            db_session, org_id=org_id, github_installation_id=42
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        await _make_processor(db_session).process(
+            _installation_payload(action="suspend", installation_id=99)
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(keep_id)
+    assert binding is not None
+    assert binding.last_sync_status == "pending"
+    assert binding.last_sync_error is None

--- a/tests/services/dashboard_templates/rename_processor_test.py
+++ b/tests/services/dashboard_templates/rename_processor_test.py
@@ -1,0 +1,626 @@
+"""Tests for the RenameEventProcessor service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import OrganizationCreate
+from docverse.services.dashboard_templates.rename_processor import (
+    RenameEventProcessor,
+)
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
+    DashboardGitHubTemplateBindingStore,
+    DashboardGitHubTemplateStore,
+    GitHubTemplateFileInput,
+    GitHubTemplateKey,
+)
+from docverse.storage.organization_store import OrganizationStore
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("test")  # type: ignore[no-any-return]
+
+
+def _make_processor(session: AsyncSession) -> RenameEventProcessor:
+    logger = _logger()
+    return RenameEventProcessor(
+        binding_store=DashboardGitHubTemplateBindingStore(
+            session=session, logger=logger
+        ),
+        template_store=DashboardGitHubTemplateStore(
+            session=session, logger=logger
+        ),
+        logger=logger,
+    )
+
+
+async def _seed_org(session: AsyncSession, slug: str) -> int:
+    store = OrganizationStore(session=session, logger=_logger())
+    org = await store.create(
+        OrganizationCreate(
+            slug=slug,
+            title=f"Org {slug}",
+            base_domain=f"{slug}.example.com",
+        )
+    )
+    return org.id
+
+
+async def _seed_binding(
+    session: AsyncSession,
+    *,
+    org_id: int,
+    github_owner: str = "acme",
+    github_repo: str = "templates",
+    github_ref: str = "main",
+    root_path: str = "/",
+    github_owner_id: int | None = None,
+    github_repo_id: int | None = None,
+    github_installation_id: int | None = None,
+) -> int:
+    store = DashboardGitHubTemplateBindingStore(
+        session=session, logger=_logger()
+    )
+    binding = await store.create(
+        DashboardGitHubTemplateBindingCreate(
+            org_id=org_id,
+            project_id=None,
+            github_owner=github_owner,
+            github_repo=github_repo,
+            github_ref=github_ref,
+            root_path=root_path,
+            github_owner_id=github_owner_id,
+            github_repo_id=github_repo_id,
+            github_installation_id=github_installation_id,
+        )
+    )
+    return binding.id
+
+
+async def _seed_template(
+    session: AsyncSession,
+    *,
+    github_owner: str = "acme",
+    github_repo: str = "templates",
+    github_ref: str = "main",
+    root_path: str = "/",
+    github_owner_id: int | None = None,
+    github_repo_id: int | None = None,
+) -> int:
+    store = DashboardGitHubTemplateStore(session=session, logger=_logger())
+    result = await store.upsert(
+        key=GitHubTemplateKey(
+            github_owner=github_owner,
+            github_repo=github_repo,
+            github_ref=github_ref,
+            root_path=root_path,
+        ),
+        commit_sha="cafebabe",
+        etag=f"etag-{github_owner}-{github_repo}-{github_ref}",
+        template_toml=b"[dashboard]\n",
+        files=[
+            GitHubTemplateFileInput(
+                relative_path="dashboard.html.jinja",
+                is_text=True,
+                data=b"<html></html>",
+            )
+        ],
+        github_owner_id=github_owner_id,
+        github_repo_id=github_repo_id,
+    )
+    return result.template.id
+
+
+def _repository_renamed_payload(
+    *,
+    repo_id: int,
+    owner: str,
+    owner_id: int,
+    new_name: str,
+    old_name: str,
+) -> dict[str, Any]:
+    return {
+        "action": "renamed",
+        "changes": {"repository": {"name": {"from": old_name}}},
+        "repository": {
+            "id": repo_id,
+            "name": new_name,
+            "full_name": f"{owner}/{new_name}",
+            "owner": {"login": owner, "id": owner_id},
+        },
+        "installation": {"id": 99},
+    }
+
+
+def _repository_transferred_payload(
+    *,
+    repo_id: int,
+    new_owner: str,
+    new_owner_id: int,
+    new_name: str,
+    old_owner: str,
+    old_owner_id: int,
+) -> dict[str, Any]:
+    return {
+        "action": "transferred",
+        "changes": {
+            "owner": {
+                "from": {
+                    "user": {"login": old_owner, "id": old_owner_id},
+                }
+            }
+        },
+        "repository": {
+            "id": repo_id,
+            "name": new_name,
+            "full_name": f"{new_owner}/{new_name}",
+            "owner": {"login": new_owner, "id": new_owner_id},
+        },
+        "installation": {"id": 99},
+    }
+
+
+def _organization_renamed_payload(
+    *,
+    org_id: int,
+    new_login: str,
+    old_login: str,
+) -> dict[str, Any]:
+    return {
+        "action": "renamed",
+        "changes": {"login": {"from": old_login}},
+        "organization": {"id": org_id, "login": new_login},
+        "installation": {"id": 99},
+    }
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_updates_binding_keyed_by_repo_id(
+    db_session: AsyncSession,
+) -> None:
+    """A synced binding gets its ``github_repo`` rewritten on rename.
+
+    Reproduces the post-rename steady state: the binding's stable
+    ``github_repo_id`` was captured on first sync, GitHub now sends a
+    ``repository.renamed`` event with the new display name, and we
+    expect the binding row to land on the new name without churn.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "rename-by-id")
+        binding_id = await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="acme",
+            github_repo="old-name",
+            github_repo_id=12345,
+            github_owner_id=999,
+        )
+        await db_session.commit()
+
+    payload = _repository_renamed_payload(
+        repo_id=12345,
+        owner="acme",
+        owner_id=999,
+        new_name="new-name",
+        old_name="old-name",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.github_repo == "new-name"
+    assert binding.github_repo_id == 12345
+    assert binding.github_owner == "acme"
+    assert binding.github_owner_id == 999
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_updates_template_content_row(
+    db_session: AsyncSession,
+) -> None:
+    """The synced ``dashboard_github_templates`` row also gets renamed.
+
+    Content rows are deduplicated by ``(owner, repo, ref, root_path)``
+    so renaming the binding without renaming the content would break
+    the next ETag short-circuit lookup. Both rows must move together.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "rename-content-by-id")
+        await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="acme",
+            github_repo="old-name",
+            github_repo_id=12345,
+            github_owner_id=999,
+        )
+        template_id = await _seed_template(
+            db_session,
+            github_owner="acme",
+            github_repo="old-name",
+            github_repo_id=12345,
+            github_owner_id=999,
+        )
+        await db_session.commit()
+
+    payload = _repository_renamed_payload(
+        repo_id=12345,
+        owner="acme",
+        owner_id=999,
+        new_name="new-name",
+        old_name="old-name",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateStore(
+            session=db_session, logger=_logger()
+        )
+        template = await store.get_by_id(template_id)
+    assert template is not None
+    assert template.github_repo == "new-name"
+    assert template.github_repo_id == 12345
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_falls_back_to_old_name_for_unsynced(
+    db_session: AsyncSession,
+) -> None:
+    """Un-synced bindings (no repo id) match by ``(owner, old_name)``.
+
+    A binding registered via the API but never synced has
+    ``github_repo_id IS NULL``; the rename event must still update its
+    display name so the next manual sync attempt resolves to the new
+    upstream.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "rename-unsynced")
+        binding_id = await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="acme",
+            github_repo="old-name",
+            github_repo_id=None,
+            github_owner_id=None,
+        )
+        await db_session.commit()
+
+    payload = _repository_renamed_payload(
+        repo_id=12345,
+        owner="acme",
+        owner_id=999,
+        new_name="new-name",
+        old_name="old-name",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.github_repo == "new-name"
+    # The fallback path does not back-fill the ID — that remains the
+    # syncer's job on the next successful sync.
+    assert binding.github_repo_id is None
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_does_not_touch_unrelated_bindings(
+    db_session: AsyncSession,
+) -> None:
+    """A binding for a different repo with the same name is not modified."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "rename-isolation")
+        keep_id = await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="acme",
+            github_repo="old-name",
+            github_repo_id=99999,
+            github_owner_id=999,
+        )
+        await db_session.commit()
+
+    payload = _repository_renamed_payload(
+        repo_id=12345,
+        owner="acme",
+        owner_id=999,
+        new_name="new-name",
+        old_name="old-name",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(keep_id)
+    assert binding is not None
+    assert binding.github_repo == "old-name"
+
+
+@pytest.mark.asyncio
+async def test_repository_transferred_updates_owner_keyed_by_repo_id(
+    db_session: AsyncSession,
+) -> None:
+    """A repo transfer rewrites ``github_owner`` and ``github_owner_id``.
+
+    The transfer leaves ``repository.id`` stable but moves the repo to
+    a new owner; the binding has to switch its owner-side identity to
+    keep matching push events from the new namespace.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "transfer-by-id")
+        binding_id = await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="old-owner",
+            github_repo="templates",
+            github_repo_id=12345,
+            github_owner_id=111,
+        )
+        await db_session.commit()
+
+    payload = _repository_transferred_payload(
+        repo_id=12345,
+        new_owner="new-owner",
+        new_owner_id=222,
+        new_name="templates",
+        old_owner="old-owner",
+        old_owner_id=111,
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_transferred(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.github_owner == "new-owner"
+    assert binding.github_owner_id == 222
+    assert binding.github_repo == "templates"
+    assert binding.github_repo_id == 12345
+
+
+@pytest.mark.asyncio
+async def test_repository_transferred_updates_template_content_row(
+    db_session: AsyncSession,
+) -> None:
+    """The dedup-key on the content row also gets the new owner login."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "transfer-content")
+        await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="old-owner",
+            github_repo="templates",
+            github_repo_id=12345,
+            github_owner_id=111,
+        )
+        template_id = await _seed_template(
+            db_session,
+            github_owner="old-owner",
+            github_repo="templates",
+            github_repo_id=12345,
+            github_owner_id=111,
+        )
+        await db_session.commit()
+
+    payload = _repository_transferred_payload(
+        repo_id=12345,
+        new_owner="new-owner",
+        new_owner_id=222,
+        new_name="templates",
+        old_owner="old-owner",
+        old_owner_id=111,
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_transferred(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateStore(
+            session=db_session, logger=_logger()
+        )
+        template = await store.get_by_id(template_id)
+    assert template is not None
+    assert template.github_owner == "new-owner"
+    assert template.github_owner_id == 222
+
+
+@pytest.mark.asyncio
+async def test_organization_renamed_updates_binding_keyed_by_owner_id(
+    db_session: AsyncSession,
+) -> None:
+    """An org rename rewrites ``github_owner`` on every matching binding."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "org-rename-by-id")
+        binding_id = await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="old-org",
+            github_repo="templates",
+            github_repo_id=12345,
+            github_owner_id=999,
+        )
+        await db_session.commit()
+
+    payload = _organization_renamed_payload(
+        org_id=999,
+        new_login="new-org",
+        old_login="old-org",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_organization_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.github_owner == "new-org"
+    assert binding.github_owner_id == 999
+
+
+@pytest.mark.asyncio
+async def test_organization_renamed_updates_template_content_row(
+    db_session: AsyncSession,
+) -> None:
+    """An org rename also rewrites the synced content row's owner string."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "org-rename-content")
+        await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="old-org",
+            github_repo="templates",
+            github_repo_id=12345,
+            github_owner_id=999,
+        )
+        template_id = await _seed_template(
+            db_session,
+            github_owner="old-org",
+            github_repo="templates",
+            github_repo_id=12345,
+            github_owner_id=999,
+        )
+        await db_session.commit()
+
+    payload = _organization_renamed_payload(
+        org_id=999,
+        new_login="new-org",
+        old_login="old-org",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_organization_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateStore(
+            session=db_session, logger=_logger()
+        )
+        template = await store.get_by_id(template_id)
+    assert template is not None
+    assert template.github_owner == "new-org"
+    assert template.github_owner_id == 999
+
+
+@pytest.mark.asyncio
+async def test_organization_renamed_falls_back_to_old_login_for_unsynced(
+    db_session: AsyncSession,
+) -> None:
+    """Un-synced bindings match by old login when owner ID is null."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "org-rename-unsynced")
+        binding_id = await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="old-org",
+            github_repo="templates",
+            github_repo_id=None,
+            github_owner_id=None,
+        )
+        await db_session.commit()
+
+    payload = _organization_renamed_payload(
+        org_id=999,
+        new_login="new-org",
+        old_login="old-org",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_organization_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.github_owner == "new-org"
+    assert binding.github_owner_id is None
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_no_id_match_no_writes(
+    db_session: AsyncSession,
+) -> None:
+    """A rename event for a repo with no matching binding is a no-op.
+
+    The processor still returns cleanly — it does not raise — so a
+    GitHub redelivery attempt does not loop on a transient error.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "rename-no-match")
+        keep_id = await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="other",
+            github_repo="other",
+            github_repo_id=42,
+            github_owner_id=42,
+        )
+        await db_session.commit()
+
+    payload = _repository_renamed_payload(
+        repo_id=12345,
+        owner="acme",
+        owner_id=999,
+        new_name="new-name",
+        old_name="old-name",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        )
+        binding = await store.get_by_id(keep_id)
+    assert binding is not None
+    assert binding.github_repo == "other"


### PR DESCRIPTION
## Summary

- Register four non-push GitHub webhook events (`repository.renamed`, `repository.transferred`, `organization.renamed`, `installation.{created,deleted,suspend,unsuspend}`) on the existing `GitHubWebhookRouter`, with new `RenameEventProcessor` and `InstallationEventProcessor` services that rewrite display names or flip a reachability posture on matching bindings + content rows keyed by stable GitHub numeric IDs (with a name-keyed fallback for un-synced bindings).
- Bulk-update helpers on `DashboardGitHubTemplateBindingStore` and `DashboardGitHubTemplateStore` use Core `UPDATE ... RETURNING id` so per-event affected-row counts land in structured logs without a follow-up SELECT; `date_updated` is preserved on the binding side because operator-visible source-coordinate writes come through PUT, not GitHub-side metadata sync.
- `installation.suspend` and `installation.deleted` write distinct machine-readable `last_sync_error` tags so `installation.unsuspend` only clears its own suspend mark and never silently revives a binding whose installation is actually deleted, nor papers over a real syncer 5xx that races between the suspend and the unsuspend.

## Validation steps

- [ ] POST a signed `repository.renamed` payload at `/docverse/webhooks/github` and confirm the matching binding's `github_repo` flips to the new name without enqueueing a `dashboard_sync` job; confirm the synced content row in `dashboard_github_templates` flips too.
- [ ] POST a signed `repository.transferred` payload and confirm `github_owner` + `github_owner_id` flip to the new namespace on rows keyed by the stable `github_repo_id`.
- [ ] POST a signed `organization.renamed` payload and confirm `github_owner` flips on every binding and content row keyed by the stable `github_owner_id`.
- [ ] POST a signed `installation.suspend` payload and confirm bindings under that installation flip to `last_sync_status='failed'` with `last_sync_error='installation_suspended'`; POST a signed `installation.unsuspend` and confirm the flag clears (status back to `pending`, error to NULL).
- [ ] POST an unsigned rename event and confirm a `401` response with no DB writes; POST a signed unrelated event (e.g. `repository.created`) and confirm a `200` response with no DB writes.
- [ ] Confirm no `dashboard_sync` jobs land on the queue as a side effect of any of the above events (the rename / installation paths are name-flip only).

## References

- Closes #242
- PRD: #232
- Jira: https://rubinobs.atlassian.net/browse/DM-54689