### PR TITLE
DM-54794: Relax edition slug regex to permit uppercase ticket IDs

### DIFF
--- a/alembic/versions/20260505_0000_p4q5r6s7t8u9_editions_case_insensitive_slug_unique.py
+++ b/alembic/versions/20260505_0000_p4q5r6s7t8u9_editions_case_insensitive_slug_unique.py
@@ -1,0 +1,45 @@
+"""Replace editions UNIQUE(project_id, slug) with case-insensitive index.
+
+Drops the case-sensitive ``uq_editions_project_slug`` UNIQUE constraint
+and replaces it with a functional unique index on
+``(project_id, lower(slug))`` so a project cannot hold two editions
+whose slugs differ only by case (e.g. ``DM-54112`` and ``dm-54112``).
+
+PR #295 widened ``EditionCreate.slug`` to permit uppercase ticket-style
+slugs without adjusting the table-level uniqueness rule, which would
+otherwise let case-only duplicates land as siblings — confusing or
+shadowing each other under the per-project ``/v/{slug}/`` URL segment.
+
+Revision ID: p4q5r6s7t8u9
+Revises: o3p4q5r6s7t8
+Create Date: 2026-05-05 00:00:00.000000+00:00
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "p4q5r6s7t8u9"
+down_revision: str | None = "o3p4q5r6s7t8"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "uq_editions_project_slug",
+        "editions",
+        type_="unique",
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX uq_editions_project_lower_slug "
+        "ON editions (project_id, lower(slug))"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_editions_project_lower_slug", table_name="editions")
+    op.create_unique_constraint(
+        "uq_editions_project_slug",
+        "editions",
+        ["project_id", "slug"],
+    )

--- a/client/src/docverse/client/models/editions.py
+++ b/client/src/docverse/client/models/editions.py
@@ -96,11 +96,11 @@ class EditionCreate(BaseModel):
     slug: Annotated[
         str,
         Field(
-            pattern=r"^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$",
+            pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9]$",
             min_length=2,
             max_length=128,
             description="URL-safe identifier for the edition.",
-            examples=["main", "v1", "DM-54112"],
+            examples=["main", "v1", "DM-54112", "v2.3.0", "foo_bar"],
         ),
     ]
 

--- a/client/src/docverse/client/models/editions.py
+++ b/client/src/docverse/client/models/editions.py
@@ -96,11 +96,11 @@ class EditionCreate(BaseModel):
     slug: Annotated[
         str,
         Field(
-            pattern=r"^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+            pattern=r"^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$",
             min_length=2,
             max_length=128,
             description="URL-safe identifier for the edition.",
-            examples=["main", "v1"],
+            examples=["main", "v1", "DM-54112"],
         ),
     ]
 

--- a/client/tests/edition_model_test.py
+++ b/client/tests/edition_model_test.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from docverse.client.models import Edition, EditionKind, TrackingMode
+import pytest
+from pydantic import ValidationError
+
+from docverse.client.models import (
+    Edition,
+    EditionCreate,
+    EditionKind,
+    OrganizationCreate,
+    ProjectCreate,
+    TrackingMode,
+)
 from docverse.client.models.queue_enums import PublishStatus
 
 
@@ -34,3 +44,61 @@ def test_edition_publish_status_default_is_none() -> None:
 def test_edition_with_publish_status() -> None:
     edition = _base_edition(publish_status=PublishStatus.published)
     assert edition.publish_status == PublishStatus.published
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["main", "v1", "release-1", "dm-54112"],
+)
+def test_edition_create_accepts_lowercase_slug(slug: str) -> None:
+    edition = EditionCreate(
+        slug=slug,
+        title="T",
+        kind=EditionKind.draft,
+        tracking_mode=TrackingMode.git_ref,
+    )
+    assert edition.slug == slug
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["DM-54112", "DM-54794-relax-edition-slug", "Mixed-Case-1"],
+)
+def test_edition_create_accepts_uppercase_ticket_slug(slug: str) -> None:
+    edition = EditionCreate(
+        slug=slug,
+        title="T",
+        kind=EditionKind.draft,
+        tracking_mode=TrackingMode.git_ref,
+    )
+    assert edition.slug == slug
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["-leading", "trailing-", "with space", "with_underscore", "a"],
+)
+def test_edition_create_rejects_invalid_slug(slug: str) -> None:
+    with pytest.raises(ValidationError):
+        EditionCreate(
+            slug=slug,
+            title="T",
+            kind=EditionKind.draft,
+            tracking_mode=TrackingMode.git_ref,
+        )
+
+
+def test_uppercase_slug_is_edition_only() -> None:
+    """Edition slug relaxation must not leak into project/org slugs."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(
+            slug="DM-54112",
+            title="T",
+            doc_repo="https://github.com/example/repo",
+        )
+    with pytest.raises(ValidationError):
+        OrganizationCreate(
+            slug="LSST",
+            title="T",
+            base_domain="lsst.io",
+        )

--- a/client/tests/edition_model_test.py
+++ b/client/tests/edition_model_test.py
@@ -48,7 +48,7 @@ def test_edition_with_publish_status() -> None:
 
 @pytest.mark.parametrize(
     "slug",
-    ["main", "v1", "release-1", "dm-54112"],
+    ["main", "v1", "release-1", "dm-54112", "v2.3.0", "foo_bar"],
 )
 def test_edition_create_accepts_lowercase_slug(slug: str) -> None:
     edition = EditionCreate(
@@ -62,7 +62,12 @@ def test_edition_create_accepts_lowercase_slug(slug: str) -> None:
 
 @pytest.mark.parametrize(
     "slug",
-    ["DM-54112", "DM-54794-relax-edition-slug", "Mixed-Case-1"],
+    [
+        "DM-54112",
+        "DM-54794-relax-edition-slug",
+        "Mixed-Case-1",
+        "My.Branch_v1",
+    ],
 )
 def test_edition_create_accepts_uppercase_ticket_slug(slug: str) -> None:
     edition = EditionCreate(
@@ -76,7 +81,16 @@ def test_edition_create_accepts_uppercase_ticket_slug(slug: str) -> None:
 
 @pytest.mark.parametrize(
     "slug",
-    ["-leading", "trailing-", "with space", "with_underscore", "a"],
+    [
+        "-leading",
+        "trailing-",
+        "_foo",
+        "foo_",
+        ".foo",
+        "foo.",
+        "with space",
+        "a",
+    ],
 )
 def test_edition_create_rejects_invalid_slug(slug: str) -> None:
     with pytest.raises(ValidationError):
@@ -88,17 +102,25 @@ def test_edition_create_rejects_invalid_slug(slug: str) -> None:
         )
 
 
-def test_uppercase_slug_is_edition_only() -> None:
-    """Edition slug relaxation must not leak into project/org slugs."""
+@pytest.mark.parametrize(
+    "slug",
+    ["DM-54112", "v2.3.0", "foo_bar", "My.Branch_v1"],
+)
+def test_relaxed_edition_slug_chars_stay_edition_only(slug: str) -> None:
+    """Relaxed edition slug chars must not leak into project/org slugs.
+
+    Edition relaxation (uppercase, dots, underscores) is scoped to editions;
+    project and org slugs continue to reject these characters.
+    """
     with pytest.raises(ValidationError):
         ProjectCreate(
-            slug="DM-54112",
+            slug=slug,
             title="T",
             doc_repo="https://github.com/example/repo",
         )
     with pytest.raises(ValidationError):
         OrganizationCreate(
-            slug="LSST",
+            slug=slug,
             title="T",
             base_domain="lsst.io",
         )

--- a/src/docverse/dbschema/edition.py
+++ b/src/docverse/dbschema/edition.py
@@ -13,7 +13,7 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
-    UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
@@ -87,8 +87,11 @@ class SqlEdition(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint(
-            "project_id", "slug", name="uq_editions_project_slug"
+        Index(
+            "uq_editions_project_lower_slug",
+            "project_id",
+            text("lower(slug)"),
+            unique=True,
         ),
         CheckConstraint(
             "(kind = 'main') = (slug = '__main')",

--- a/src/docverse/domain/published_url.py
+++ b/src/docverse/domain/published_url.py
@@ -32,7 +32,13 @@ def project_published_url(org: Organization, project: Project) -> str:
 
 
 def edition_published_url(project_url: str, edition: Edition) -> str:
-    """Public URL for one edition under its project's URL space."""
+    """Public URL for one edition under its project's URL space.
+
+    Callers must pass the canonical ``Edition`` row loaded from the
+    database, never an edition synthesized from a request-supplied
+    slug. The URL is built from ``edition.slug``, which is the
+    creation-time casing the store is case-preserving about.
+    """
     if edition.slug == MAIN_SLUG:
         return project_url
     return f"{project_url}v/{edition.slug}/"

--- a/src/docverse/handlers/orgs/editions.py
+++ b/src/docverse/handlers/orgs/editions.py
@@ -295,7 +295,7 @@ async def patch_edition(  # noqa: PLR0913
     context: Annotated[RequestContext, Depends(context_dependency)],
     user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
 ) -> Edition:
-    if edition_slug == "__main" and data.kind is not None:
+    if edition_slug.lower() == "__main" and data.kind is not None:
         msg = "Cannot change the kind of the default '__main' edition"
         raise PermissionDeniedError(msg)
     async with context.session.begin():
@@ -337,7 +337,7 @@ async def delete_edition(
     context: Annotated[RequestContext, Depends(context_dependency)],
     user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
 ) -> None:
-    if edition_slug == "__main":
+    if edition_slug.lower() == "__main":
         msg = "The default edition '__main' cannot be deleted"
         raise PermissionDeniedError(msg)
     async with context.session.begin():

--- a/src/docverse/services/edition.py
+++ b/src/docverse/services/edition.py
@@ -80,10 +80,9 @@ class EditionService:
             If an edition with the same slug already exists.
         """
         org, project = await self._resolve_org_project(org_slug, project_slug)
-        existing = await self._store.get_by_slug(
+        if await self._store.slug_exists_case_insensitive(
             project_id=project.id, slug=data.slug
-        )
-        if existing is not None:
+        ):
             msg = f"Edition with slug {data.slug!r} already exists"
             raise ConflictError(msg)
         edition = await self._store.create(project_id=project.id, data=data)

--- a/src/docverse/services/edition.py
+++ b/src/docverse/services/edition.py
@@ -80,9 +80,10 @@ class EditionService:
             If an edition with the same slug already exists.
         """
         org, project = await self._resolve_org_project(org_slug, project_slug)
-        if await self._store.slug_exists_case_insensitive(
+        existing = await self._store.get_by_slug(
             project_id=project.id, slug=data.slug
-        ):
+        )
+        if existing is not None:
             msg = f"Edition with slug {data.slug!r} already exists"
             raise ConflictError(msg)
         edition = await self._store.create(project_id=project.id, data=data)

--- a/src/docverse/storage/edition_store.py
+++ b/src/docverse/storage/edition_store.py
@@ -160,23 +160,6 @@ class EditionStore:
         edition_row, build_public_id, build_git_ref = row_tuple
         return self._validate(edition_row, build_public_id, build_git_ref)
 
-    async def slug_exists_case_insensitive(
-        self, *, project_id: int, slug: str
-    ) -> bool:
-        """Return True iff a non-deleted edition's slug matches by ``lower()``.
-
-        Mirrors the ``(project_id, lower(slug))`` unique index so the
-        ``EditionService.create`` pre-check surfaces case-only duplicates
-        as a friendly ``ConflictError`` rather than a raw DB violation.
-        """
-        stmt = select(SqlEdition.id).where(
-            SqlEdition.project_id == project_id,
-            func.lower(SqlEdition.slug) == slug.lower(),
-            SqlEdition.date_deleted.is_(None),
-        )
-        result = await self._session.execute(stmt)
-        return result.first() is not None
-
     async def list_all_by_project(self, project_id: int) -> list[Edition]:
         """List every non-deleted edition for a project.
 

--- a/src/docverse/storage/edition_store.py
+++ b/src/docverse/storage/edition_store.py
@@ -154,6 +154,23 @@ class EditionStore:
         edition_row, build_public_id, build_git_ref = row_tuple
         return self._validate(edition_row, build_public_id, build_git_ref)
 
+    async def slug_exists_case_insensitive(
+        self, *, project_id: int, slug: str
+    ) -> bool:
+        """Return True iff a non-deleted edition's slug matches by ``lower()``.
+
+        Mirrors the ``(project_id, lower(slug))`` unique index so the
+        ``EditionService.create`` pre-check surfaces case-only duplicates
+        as a friendly ``ConflictError`` rather than a raw DB violation.
+        """
+        stmt = select(SqlEdition.id).where(
+            SqlEdition.project_id == project_id,
+            func.lower(SqlEdition.slug) == slug.lower(),
+            SqlEdition.date_deleted.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        return result.first() is not None
+
     async def list_all_by_project(self, project_id: int) -> list[Edition]:
         """List every non-deleted edition for a project.
 

--- a/src/docverse/storage/edition_store.py
+++ b/src/docverse/storage/edition_store.py
@@ -141,10 +141,16 @@ class EditionStore:
     async def get_by_slug(
         self, *, project_id: int, slug: str
     ) -> Edition | None:
-        """Fetch an edition by project_id and slug."""
+        """Fetch an edition by project_id and slug.
+
+        Slug matching is case-insensitive: the row stores the canonical
+        creation-time casing, but any case from the caller resolves to
+        the same row. The returned ``Edition.slug`` is always the
+        canonical stored value, never the caller's input.
+        """
         stmt = self._base_query().where(
             SqlEdition.project_id == project_id,
-            SqlEdition.slug == slug,
+            func.lower(SqlEdition.slug) == slug.lower(),
             SqlEdition.date_deleted.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -219,11 +225,14 @@ class EditionStore:
     async def update(
         self, *, project_id: int, slug: str, data: EditionUpdate
     ) -> Edition | None:
-        """Update an edition by project_id and slug."""
+        """Update an edition by project_id and slug.
+
+        Slug matching is case-insensitive (see :meth:`get_by_slug`).
+        """
         result = await self._session.execute(
             select(SqlEdition).where(
                 SqlEdition.project_id == project_id,
-                SqlEdition.slug == slug,
+                func.lower(SqlEdition.slug) == slug.lower(),
                 SqlEdition.date_deleted.is_(None),
             )
         )
@@ -236,7 +245,7 @@ class EditionStore:
         await self._session.flush()
         await self._session.refresh(row)
         # Re-query to get current_build_public_id via join
-        return await self.get_by_slug(project_id=project_id, slug=slug)
+        return await self.get_by_slug(project_id=project_id, slug=row.slug)
 
     async def set_current_build(
         self,
@@ -335,6 +344,8 @@ class EditionStore:
     async def soft_delete(self, *, project_id: int, slug: str) -> bool:
         """Soft-delete an edition by setting date_deleted.
 
+        Slug matching is case-insensitive (see :meth:`get_by_slug`).
+
         Returns
         -------
         bool
@@ -343,7 +354,7 @@ class EditionStore:
         result = await self._session.execute(
             select(SqlEdition).where(
                 SqlEdition.project_id == project_id,
-                SqlEdition.slug == slug,
+                func.lower(SqlEdition.slug) == slug.lower(),
                 SqlEdition.date_deleted.is_(None),
             )
         )

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -331,6 +331,41 @@ async def test_create_edition_with_uppercase_ticket_slug(
     assert fetched.json()["slug"] == "DM-54112"
 
 
+@pytest.mark.asyncio
+async def test_create_edition_with_dotted_slug(
+    client: AsyncClient,
+) -> None:
+    """Edition slugs round-trip dots and underscores end-to-end."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "v2.3.0",
+            "title": "v2.3.0",
+            "kind": "release",
+            "tracking_mode": "git_ref",
+            "tracking_params": {"git_ref": "v2.3.0"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["slug"] == "v2.3.0"
+    assert data["self_url"].endswith(
+        "/orgs/ed-org/projects/ed-proj/editions/v2.3.0"
+    )
+    assert data["published_url"] == (
+        "https://ed-proj.ed-org.example.com/v/v2.3.0/"
+    )
+
+    fetched = await client.get(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions/v2.3.0",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert fetched.status_code == 200
+    assert fetched.json()["slug"] == "v2.3.0"
+
+
 async def _record_builds_in_history(
     db_session: AsyncSession,
     org_slug: str,

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -259,6 +259,42 @@ async def test_user_cannot_create_dunder_edition(
     assert response.status_code == 422
 
 
+@pytest.mark.asyncio
+async def test_create_edition_with_uppercase_ticket_slug(
+    client: AsyncClient,
+) -> None:
+    """Edition slugs preserve uppercase ticket-style identifiers end-to-end."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "DM-54112",
+            "title": "Ticket DM-54112",
+            "kind": "draft",
+            "tracking_mode": "git_ref",
+            "tracking_params": {"git_ref": "tickets/DM-54112"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["slug"] == "DM-54112"
+    assert data["self_url"].endswith(
+        "/orgs/ed-org/projects/ed-proj/editions/DM-54112"
+    )
+    assert data["published_url"] == (
+        "https://ed-proj.ed-org.example.com/v/DM-54112/"
+    )
+
+    # Round-trip via GET must preserve the original slug case.
+    fetched = await client.get(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions/DM-54112",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert fetched.status_code == 200
+    assert fetched.json()["slug"] == "DM-54112"
+
+
 async def _record_builds_in_history(
     db_session: AsyncSession,
     org_slug: str,

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -195,24 +195,28 @@ async def test_get_default_edition(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_delete_default_edition_blocked(client: AsyncClient) -> None:
-    """DELETE __main returns 403."""
+@pytest.mark.parametrize("slug", ["__main", "__MAIN", "__Main", "__mAiN"])
+async def test_delete_default_edition_blocked(
+    client: AsyncClient, slug: str
+) -> None:
+    """DELETE __main returns 403 regardless of slug case."""
     await _setup(client)
     response = await client.delete(
-        "/docverse/orgs/ed-org/projects/ed-proj/editions/__main",
+        f"/docverse/orgs/ed-org/projects/ed-proj/editions/{slug}",
         headers={"X-Auth-Request-User": "testuser"},
     )
     assert response.status_code == 403
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("slug", ["__main", "__MAIN", "__Main", "__mAiN"])
 async def test_patch_default_edition_kind_blocked(
-    client: AsyncClient,
+    client: AsyncClient, slug: str
 ) -> None:
-    """PATCH __main with kind returns 403."""
+    """PATCH __main with kind returns 403 regardless of slug case."""
     await _setup(client)
     response = await client.patch(
-        "/docverse/orgs/ed-org/projects/ed-proj/editions/__main",
+        f"/docverse/orgs/ed-org/projects/ed-proj/editions/{slug}",
         json={"kind": "draft"},
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import BuildCreate
 from docverse.client.models.builds import BuildAnnotations
+from docverse.domain.base32id import serialize_base32_id
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -329,6 +330,125 @@ async def test_create_edition_with_uppercase_ticket_slug(
     )
     assert fetched.status_code == 200
     assert fetched.json()["slug"] == "DM-54112"
+
+
+@pytest.mark.asyncio
+async def test_edition_lookup_is_case_insensitive(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Read/write handlers resolve edition slugs case-insensitively.
+
+    Like macOS HFS+: the row stores the creation-time casing, but any
+    case from the client resolves to the same row, and every response
+    echoes the canonical slug.
+    """
+    await _setup(client)
+    create = await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "DM-54112",
+            "title": "Ticket DM-54112",
+            "kind": "draft",
+            "tracking_mode": "git_ref",
+            "tracking_params": {"git_ref": "tickets/DM-54112"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert create.status_code == 201
+
+    canonical_self = "/docverse/orgs/ed-org/projects/ed-proj/editions/DM-54112"
+    canonical_published = "https://ed-proj.ed-org.example.com/v/DM-54112/"
+
+    for cased in ("dm-54112", "Dm-54112"):
+        # GET resolves any case to the same canonical row.
+        fetched = await client.get(
+            f"/docverse/orgs/ed-org/projects/ed-proj/editions/{cased}",
+            headers={"X-Auth-Request-User": "testuser"},
+        )
+        assert fetched.status_code == 200, cased
+        body = fetched.json()
+        assert body["slug"] == "DM-54112"
+        assert body["self_url"].endswith(canonical_self)
+        assert body["history_url"].endswith(f"{canonical_self}/history")
+        assert body["rollback_url"].endswith(f"{canonical_self}/rollback")
+        assert body["published_url"] == canonical_published
+
+        # PATCH echoes the canonical slug regardless of request casing.
+        patched = await client.patch(
+            f"/docverse/orgs/ed-org/projects/ed-proj/editions/{cased}",
+            json={"title": f"Patched via {cased}"},
+            headers={"X-Auth-Request-User": "testuser"},
+        )
+        assert patched.status_code == 200, cased
+        patched_body = patched.json()
+        assert patched_body["slug"] == "DM-54112"
+        assert patched_body["title"] == f"Patched via {cased}"
+        assert patched_body["self_url"].endswith(canonical_self)
+        assert patched_body["published_url"] == canonical_published
+
+        # History endpoint resolves the slug case-insensitively too.
+        history = await client.get(
+            f"/docverse/orgs/ed-org/projects/ed-proj/editions/{cased}/history",
+            headers={"X-Auth-Request-User": "testuser"},
+        )
+        assert history.status_code == 200, cased
+
+    # Rollback resolves the slug case-insensitively and echoes canonical.
+    async with db_session.begin():
+        logger = structlog.get_logger("docverse")
+        org_store = OrganizationStore(session=db_session, logger=logger)
+        proj_store = ProjectStore(session=db_session, logger=logger)
+        edition_store = EditionStore(session=db_session, logger=logger)
+        build_store = BuildStore(session=db_session, logger=logger)
+        history_store = EditionBuildHistoryStore(
+            session=db_session, logger=logger
+        )
+        org = await org_store.get_by_slug("ed-org")
+        assert org is not None
+        project = await proj_store.get_by_slug(org_id=org.id, slug="ed-proj")
+        assert project is not None
+        edition = await edition_store.get_by_slug(
+            project_id=project.id, slug="DM-54112"
+        )
+        assert edition is not None
+        build = await build_store.create(
+            project_id=project.id,
+            data=BuildCreate(
+                git_ref="tickets/DM-54112",
+                content_hash="sha256:" + "f" * 64,
+            ),
+            uploader="testuser",
+            project_slug="ed-proj",
+        )
+        target_public_id = serialize_base32_id(build.public_id)
+        await history_store.record(edition_id=edition.id, build_id=build.id)
+        await db_session.commit()
+
+    rollback = await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions/Dm-54112/rollback",
+        json={"build": target_public_id},
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert rollback.status_code == 200
+    rollback_body = rollback.json()
+    assert rollback_body["slug"] == "DM-54112"
+    assert rollback_body["self_url"].endswith(canonical_self)
+    assert rollback_body["published_url"] == canonical_published
+
+    # DELETE resolves the slug case-insensitively; afterward, the
+    # canonical-cased row is gone too.
+    deleted = await client.delete(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions/dm-54112",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert deleted.status_code == 204
+
+    gone = await client.get(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions/DM-54112",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert gone.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -260,6 +260,42 @@ async def test_user_cannot_create_dunder_edition(
 
 
 @pytest.mark.asyncio
+async def test_create_edition_rejects_case_only_duplicate(
+    client: AsyncClient,
+) -> None:
+    """Case-only duplicate slugs surface as a friendly ConflictError."""
+    await _setup(client)
+    first = await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "DM-54112",
+            "title": "Ticket DM-54112",
+            "kind": "draft",
+            "tracking_mode": "git_ref",
+            "tracking_params": {"git_ref": "tickets/DM-54112"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert first.status_code == 201
+
+    second = await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "dm-54112",
+            "title": "Lowercase duplicate",
+            "kind": "draft",
+            "tracking_mode": "git_ref",
+            "tracking_params": {"git_ref": "tickets/dm-54112"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert second.status_code == 409
+    # The conflict message preserves the request's slug casing so the
+    # caller can identify which input was rejected.
+    assert "'dm-54112'" in second.json()["detail"][0]["msg"]
+
+
+@pytest.mark.asyncio
 async def test_create_edition_with_uppercase_ticket_slug(
     client: AsyncClient,
 ) -> None:

--- a/tests/storage/edition_store_test.py
+++ b/tests/storage/edition_store_test.py
@@ -993,3 +993,77 @@ async def test_second_main_edition_rejected(
                 kind=EditionKind.main,
                 tracking_mode=TrackingMode.git_ref,
             )
+
+
+# ── Case-insensitive slug uniqueness ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_case_only_different_slugs_rejected_by_db(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """Slugs differing only by case in one project violate the unique index."""
+    async with db_session.begin():
+        project_id = await _create_project(db_session)
+        await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="DM-54112",
+                title="Ticket",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+            ),
+        )
+        await db_session.commit()
+    with pytest.raises(IntegrityError):
+        async with db_session.begin():
+            await edition_store.create(
+                project_id=project_id,
+                data=EditionCreate(
+                    slug="dm-54112",
+                    title="Lowercase duplicate",
+                    kind=EditionKind.draft,
+                    tracking_mode=TrackingMode.git_ref,
+                ),
+            )
+
+
+@pytest.mark.asyncio
+async def test_slug_exists_case_insensitive(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """slug_exists_case_insensitive matches across case and skips deletes."""
+    async with db_session.begin():
+        project_id = await _create_project(db_session)
+        await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="DM-54112",
+                title="Ticket",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+            ),
+        )
+        # Same slug, lowercase form: matches.
+        assert await edition_store.slug_exists_case_insensitive(
+            project_id=project_id, slug="dm-54112"
+        )
+        # Same slug, original case: also matches.
+        assert await edition_store.slug_exists_case_insensitive(
+            project_id=project_id, slug="DM-54112"
+        )
+        # Different slug: no match.
+        assert not await edition_store.slug_exists_case_insensitive(
+            project_id=project_id, slug="other-slug"
+        )
+        await db_session.commit()
+
+    # Soft-deleting the row releases the slug for reuse.
+    async with db_session.begin():
+        await edition_store.soft_delete(project_id=project_id, slug="DM-54112")
+        assert not await edition_store.slug_exists_case_insensitive(
+            project_id=project_id, slug="dm-54112"
+        )
+        await db_session.commit()

--- a/tests/storage/edition_store_test.py
+++ b/tests/storage/edition_store_test.py
@@ -1030,11 +1030,11 @@ async def test_case_only_different_slugs_rejected_by_db(
 
 
 @pytest.mark.asyncio
-async def test_slug_exists_case_insensitive(
+async def test_get_by_slug_case_insensitive(
     db_session: AsyncSession,
     edition_store: EditionStore,
 ) -> None:
-    """slug_exists_case_insensitive matches across case and skips deletes."""
+    """get_by_slug matches across case and skips soft-deleted rows."""
     async with db_session.begin():
         project_id = await _create_project(db_session)
         await edition_store.create(
@@ -1046,24 +1046,34 @@ async def test_slug_exists_case_insensitive(
                 tracking_mode=TrackingMode.git_ref,
             ),
         )
-        # Same slug, lowercase form: matches.
-        assert await edition_store.slug_exists_case_insensitive(
+        # Lowercase form resolves; canonical stored casing is returned.
+        edition = await edition_store.get_by_slug(
             project_id=project_id, slug="dm-54112"
         )
-        # Same slug, original case: also matches.
-        assert await edition_store.slug_exists_case_insensitive(
+        assert edition is not None
+        assert edition.slug == "DM-54112"
+        # Original case also resolves.
+        edition = await edition_store.get_by_slug(
             project_id=project_id, slug="DM-54112"
         )
-        # Different slug: no match.
-        assert not await edition_store.slug_exists_case_insensitive(
-            project_id=project_id, slug="other-slug"
+        assert edition is not None
+        assert edition.slug == "DM-54112"
+        # Different slug returns None.
+        assert (
+            await edition_store.get_by_slug(
+                project_id=project_id, slug="other-slug"
+            )
+            is None
         )
         await db_session.commit()
 
     # Soft-deleting the row releases the slug for reuse.
     async with db_session.begin():
         await edition_store.soft_delete(project_id=project_id, slug="DM-54112")
-        assert not await edition_store.slug_exists_case_insensitive(
-            project_id=project_id, slug="dm-54112"
+        assert (
+            await edition_store.get_by_slug(
+                project_id=project_id, slug="dm-54112"
+            )
+            is None
         )
         await db_session.commit()


### PR DESCRIPTION
## Summary

- Widen `EditionCreate.slug` to permit uppercase (#286) and then dots and underscores (#297), so LTD ticket-style slugs (`DM-54112`), semver tags (`v2.3.0`), and underscore-bearing branches (`foo_bar`, `My.Branch_v1`) round-trip through the create-edition API and DB without normalization. The relaxed pattern's character class mirrors `domain.slug.validate_slug` at `src/docverse/domain/slug.py:38` so the API seam matches the auto-edition tracking path.
- Close the case-sensitivity gap the wider regex exposed: replace the `editions` `UNIQUE(project_id, slug)` constraint with a functional unique index on `(project_id, lower(slug))`, and have `EditionService.create` pre-check case-insensitively so case-only duplicates surface as a friendly `ConflictError` instead of a raw DB violation (#296).
- Make every read/write path resolve `{edition}` slugs case-insensitively against the same functional index (#298): `EditionStore.get_by_slug`, `update`, and `soft_delete` now compare `func.lower(SqlEdition.slug) == slug.lower()`, so any case from the client (`DM-54112`, `dm-54112`, `Dm-54112`) hits the row written at create time and every response — `slug`, `self_url`, `history_url`, `rollback_url`, `published_url` — echoes the canonical creation-time casing. Case-preserving but case-insensitive, like macOS HFS+. No new SQL function or extension; the read path consumes the index from #296.
- Project, organization, and service-label slug regexes stay unchanged; a parametrized isolation test pins the relaxation (uppercase, dots, underscores) as edition-only.

## Validation steps

- [ ] `EditionCreate(slug="DM-54112", ...)`, `EditionCreate(slug="v2.3.0", ...)`, and `EditionCreate(slug="foo_bar", ...)` validate without raising.
- [ ] `POST /docverse/orgs/{org}/projects/{project}/editions` with `{"slug": "DM-54112", ...}` returns 201 and the response `slug`, `self_url`, and `published_url` all preserve the original case.
- [ ] `POST /docverse/orgs/{org}/projects/{project}/editions` with `{"slug": "v2.3.0", ...}` returns 201 and the response `slug`, `self_url`, and `published_url` preserve the dots verbatim.
- [ ] `GET` of the just-created editions by their original slug returns 200 with the same casing/punctuation.
- [ ] After creating `DM-54112`, every `GET` / `PATCH` / `DELETE` / `GET /history` / `POST /rollback` against `…/editions/dm-54112` and `…/editions/Dm-54112` resolves to the same row. Each non-204 response echoes `slug == "DM-54112"` and `self_url`, `history_url`, `rollback_url`, and `published_url` all use the canonical `DM-54112` regardless of the case in the request URL.
- [ ] `POST /docverse/orgs/{org}/projects` with an uppercase, dotted, or underscored project slug still returns 422.
- [ ] After creating `DM-54112`, a second `POST` with `{"slug": "dm-54112", ...}` to the same project returns 409 with the request's slug casing in the error message.
- [ ] A direct SQL `INSERT` of two case-only-different slugs into `editions` (same `project_id`) is rejected with `duplicate key value violates unique constraint "uq_editions_project_lower_slug"`.
- [ ] `alembic upgrade head` followed by `alembic downgrade -1` then `alembic upgrade head` round-trips cleanly against a test DB seeded with pre-existing lowercase edition rows; no rows are lost.

## References

- Closes #286
- Closes #296
- Closes #297
- Closes #298
- PRD: #275
- Jira: https://rubinobs.atlassian.net/browse/DM-54794
