### PR TITLE
DM-54794: Run service + sync queue + run handlers

### DIFF
--- a/alembic/versions/20260507_0000_r6s7t8u9v0w1_add_queue_jobs_subject_label.py
+++ b/alembic/versions/20260507_0000_r6s7t8u9v0w1_add_queue_jobs_subject_label.py
@@ -1,0 +1,40 @@
+"""Add ``subject_label`` text column to ``queue_jobs``.
+
+Operators triaging a stuck keeper-sync run need to know *which* LTD
+target each child job is processing without paging through arq job
+payloads. The fan-out site has the identifier in hand at enqueue time
+(``ltd_slug`` for ``keeper_sync_project`` rows, an org-scoped label for
+the discovery row), so we denormalise it onto the queue-job row as a
+generic ``subject_label`` column. The name is intentionally
+kind-agnostic: future fan-out kinds (tier_main, tier_other, edition or
+build syncs) get the same observability affordance for free without a
+per-kind column.
+
+Permanently nullable — pre-existing rows have no label and there is no
+retroactive backfill to do.
+
+Revision ID: r6s7t8u9v0w1
+Revises: q5r6s7t8u9v0
+Create Date: 2026-05-07 00:00:00.000000+00:00
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "r6s7t8u9v0w1"
+down_revision: str | None = "q5r6s7t8u9v0"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "queue_jobs",
+        sa.Column("subject_label", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("queue_jobs", "subject_label")

--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -37,7 +37,13 @@ from .infrastructure import (
     ServiceCategory,
     ServiceProvider,
 )
-from .keeper_sync import KeeperSyncConfig
+from .keeper_sync import (
+    KeeperSyncConfig,
+    KeeperSyncRun,
+    KeeperSyncRunCreated,
+    KeeperSyncRunKind,
+    KeeperSyncRunStatus,
+)
 from .memberships import (
     OrgMembership,
     OrgMembershipCreate,
@@ -86,6 +92,10 @@ __all__ = [
     "JobKind",
     "JobStatus",
     "KeeperSyncConfig",
+    "KeeperSyncRun",
+    "KeeperSyncRunCreated",
+    "KeeperSyncRunKind",
+    "KeeperSyncRunStatus",
     "OrgDashboardRebuildEntry",
     "OrgMembership",
     "OrgMembershipCreate",

--- a/client/src/docverse/client/models/keeper_sync.py
+++ b/client/src/docverse/client/models/keeper_sync.py
@@ -121,6 +121,16 @@ class KeeperSyncRun(BaseModel):
         description="Timestamp when the run reached a terminal status.",
     )
 
+    date_last_activity: datetime | None = Field(
+        default=None,
+        description=(
+            "Most-recent state-transition timestamp across the run's"
+            " attributed child queue jobs. Operators can poll this to"
+            " detect a stuck run without paginating its children."
+            " ``null`` while the run has no attributed queue jobs yet."
+        ),
+    )
+
 
 class KeeperSyncRunCreated(BaseModel):
     """Response body returned by ``POST /orgs/{org}/keeper-sync/runs``."""

--- a/client/src/docverse/client/models/keeper_sync.py
+++ b/client/src/docverse/client/models/keeper_sync.py
@@ -1,12 +1,20 @@
-"""Pydantic model for the LTD Keeper sync configuration on an org."""
+"""Pydantic models for LTD Keeper sync configuration and runs."""
 
 from __future__ import annotations
 
+from datetime import datetime
+from enum import StrEnum
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
-__all__ = ["KeeperSyncConfig"]
+__all__ = [
+    "KeeperSyncConfig",
+    "KeeperSyncRun",
+    "KeeperSyncRunCreated",
+    "KeeperSyncRunKind",
+    "KeeperSyncRunStatus",
+]
 
 
 _DEFAULT_LTD_BASE_URL = "https://keeper.lsst.codes"
@@ -39,4 +47,95 @@ class KeeperSyncConfig(BaseModel):
             'LTD project slugs to sync, or ``"*"`` for every project'
             " visible on the LTD instance."
         ),
+    )
+
+
+class KeeperSyncRunKind(StrEnum):
+    """Kind of LTD Keeper sync run."""
+
+    backfill = "backfill"
+    resync = "resync"
+    reconcile = "reconcile"
+
+
+class KeeperSyncRunStatus(StrEnum):
+    """Lifecycle status of a keeper sync run.
+
+    ``pending`` — the discovery job has been enqueued but has not yet
+    fanned out any children. ``in_progress`` — discovery has enqueued
+    at least one child sync job. ``succeeded`` / ``partial_failure`` /
+    ``failed`` are terminal states.
+    """
+
+    pending = "pending"
+    in_progress = "in_progress"
+    succeeded = "succeeded"
+    partial_failure = "partial_failure"
+    failed = "failed"
+
+
+class KeeperSyncRun(BaseModel):
+    """Response model for a keeper sync run resource."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    self_url: str = Field(description="URL to this run resource.")
+
+    id: int = Field(description="Numeric identifier for the run.")
+
+    kind: KeeperSyncRunKind = Field(description="Kind of run.")
+
+    status: KeeperSyncRunStatus = Field(description="Lifecycle status.")
+
+    pending_count: int = Field(
+        description=(
+            "Number of fanned-out child queue jobs still in a non-terminal"
+            " state (queued or in_progress)."
+        )
+    )
+
+    succeeded_count: int = Field(
+        description="Number of fanned-out child queue jobs that succeeded."
+    )
+
+    failed_count: int = Field(
+        description=(
+            "Number of fanned-out child queue jobs that ended in a failure"
+            " state (failed or cancelled)."
+        )
+    )
+
+    total_count: int = Field(
+        description=(
+            "Total number of fanned-out child queue jobs attributed to"
+            " this run."
+        )
+    )
+
+    date_started: datetime = Field(
+        description="Timestamp when the run row was created."
+    )
+
+    date_finished: datetime | None = Field(
+        default=None,
+        description="Timestamp when the run reached a terminal status.",
+    )
+
+
+class KeeperSyncRunCreated(BaseModel):
+    """Response body returned by ``POST /orgs/{org}/keeper-sync/runs``."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    run: KeeperSyncRun = Field(description="The newly created run.")
+
+    queue_job_id: str = Field(
+        description=(
+            "Public Base32 identifier for the enqueued"
+            " ``keeper_sync_run_discovery`` queue job."
+        )
+    )
+
+    queue_job_url: str = Field(
+        description="URL of the enqueued discovery queue job resource."
     )

--- a/client/src/docverse/client/models/queue.py
+++ b/client/src/docverse/client/models/queue.py
@@ -25,6 +25,22 @@ class QueueJob(BaseModel):
 
     status: JobStatus = Field(description="Current status of the job.")
 
+    keeper_sync_run_id: int | None = Field(
+        default=None,
+        description=(
+            "Identifier of the keeper-sync run this job is attributed to,"
+            " or ``null`` for jobs not part of a run."
+        ),
+    )
+
+    subject_label: str | None = Field(
+        default=None,
+        description=(
+            "Human-readable identifier for the resource this job targets"
+            " (e.g. an LTD slug for keeper-sync project jobs)."
+        ),
+    )
+
     phase: str | None = Field(
         default=None,
         description=(

--- a/client/src/docverse/client/models/queue_enums.py
+++ b/client/src/docverse/client/models/queue_enums.py
@@ -23,6 +23,8 @@ class JobKind(StrEnum):
     git_ref_audit = "git_ref_audit"
     purgatory_cleanup = "purgatory_cleanup"
     credential_reencrypt = "credential_reencrypt"
+    keeper_sync_run_discovery = "keeper_sync_run_discovery"
+    keeper_sync_project = "keeper_sync_project"
 
 
 class JobStatus(StrEnum):

--- a/src/docverse/config.py
+++ b/src/docverse/config.py
@@ -142,6 +142,28 @@ class Configuration(BaseSettings):
         title="Name of the arq queue",
     )
 
+    keeper_sync_job_timeout_seconds: int = Field(
+        3600,
+        title="Keeper-sync per-job timeout, in seconds",
+        description=(
+            "Wraps the keeper-sync arq functions on"
+            " ``KeeperSyncWorkerSettings``: arq cancels a job that runs"
+            " past this. Lower this in test/staging to surface"
+            " stuck-worker behaviour quickly."
+        ),
+    )
+
+    keeper_sync_reaper_threshold_seconds: int = Field(
+        21600,
+        title="Keeper-sync stuck-run reaper threshold, in seconds",
+        description=(
+            "Cron-driven backstop for arq losing a job (e.g. an"
+            " OOM-killed worker pod). ``keeper_sync_reaper`` fails any"
+            " keeper-sync child ``queue_jobs`` row that has been"
+            " ``in_progress`` longer than this without ``date_completed``."
+        ),
+    )
+
     superadmin_usernames: Annotated[
         list[str], BeforeValidator(_parse_comma_separated)
     ] = Field(

--- a/src/docverse/dbschema/queue_job.py
+++ b/src/docverse/dbschema/queue_job.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Integer, String
+from sqlalchemy import (
+    BigInteger,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
@@ -57,6 +65,8 @@ class SqlQueueJob(Base):
         ForeignKey("keeper_sync_runs.id", ondelete="SET NULL"),
         nullable=True,
     )
+
+    subject_label: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     progress: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB, nullable=True

--- a/src/docverse/domain/keeper_sync_run.py
+++ b/src/docverse/domain/keeper_sync_run.py
@@ -10,10 +10,10 @@ from docverse.client.models import KeeperSyncRunKind, KeeperSyncRunStatus
 
 __all__ = [
     "KeeperSyncRun",
-    "KeeperSyncRunCounters",
+    "KeeperSyncRunActivity",
     "KeeperSyncRunKind",
     "KeeperSyncRunStatus",
-    "KeeperSyncRunWithCounters",
+    "KeeperSyncRunWithActivity",
 ]
 
 
@@ -35,11 +35,14 @@ class KeeperSyncRun(BaseModel):
     )
 
 
-class KeeperSyncRunCounters(BaseModel):
-    """Aggregate child-job counters for a single run.
+class KeeperSyncRunActivity(BaseModel):
+    """Aggregate child-job activity for a single run.
 
     Computed from ``queue_jobs`` rows filtered on ``keeper_sync_run_id``
-    so a row is never out of step with the underlying job state.
+    so a row is never out of step with the underlying job state. Carries
+    the four count buckets plus a ``date_last_activity`` timestamp so
+    operators have a single top-level signal for "is this run actually
+    making progress" without paginating through children.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -66,12 +69,21 @@ class KeeperSyncRunCounters(BaseModel):
     total_count: int = Field(
         description="Total number of attributed queue jobs."
     )
+    date_last_activity: datetime | None = Field(
+        default=None,
+        description=(
+            "Most-recent state-transition timestamp across the run's"
+            " attributed queue jobs, computed as ``MAX(coalesce("
+            "date_completed, date_started, date_created))``. ``None``"
+            " when the run has no attributed queue jobs yet."
+        ),
+    )
 
 
-class KeeperSyncRunWithCounters(BaseModel):
-    """Domain pair of a run plus its derived counters."""
+class KeeperSyncRunWithActivity(BaseModel):
+    """Domain pair of a run plus its derived activity."""
 
     model_config = ConfigDict(frozen=True)
 
     run: KeeperSyncRun
-    counters: KeeperSyncRunCounters
+    activity: KeeperSyncRunActivity

--- a/src/docverse/domain/keeper_sync_run.py
+++ b/src/docverse/domain/keeper_sync_run.py
@@ -1,0 +1,77 @@
+"""Domain models for keeper-sync runs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from docverse.client.models import KeeperSyncRunKind, KeeperSyncRunStatus
+
+__all__ = [
+    "KeeperSyncRun",
+    "KeeperSyncRunCounters",
+    "KeeperSyncRunKind",
+    "KeeperSyncRunStatus",
+    "KeeperSyncRunWithCounters",
+]
+
+
+class KeeperSyncRun(BaseModel):
+    """Domain representation of a single ``keeper_sync_runs`` row."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(description="Primary key for the run.")
+    org_id: int = Field(description="Organization that owns the run.")
+    kind: KeeperSyncRunKind = Field(description="Kind of run.")
+    status: KeeperSyncRunStatus = Field(description="Lifecycle status.")
+    date_started: datetime = Field(
+        description="Timestamp when the run row was created."
+    )
+    date_finished: datetime | None = Field(
+        default=None,
+        description="Timestamp when the run reached a terminal status.",
+    )
+
+
+class KeeperSyncRunCounters(BaseModel):
+    """Aggregate child-job counters for a single run.
+
+    Computed from ``queue_jobs`` rows filtered on ``keeper_sync_run_id``
+    so a row is never out of step with the underlying job state.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    pending_count: int = Field(
+        description=(
+            "Number of attributed queue jobs in ``queued`` or"
+            " ``in_progress`` state (i.e. non-terminal)."
+        )
+    )
+    succeeded_count: int = Field(
+        description=(
+            "Number of attributed queue jobs in ``completed`` state."
+            " ``completed_with_errors`` is excluded so soft-failure"
+            " distinguishes from clean success."
+        )
+    )
+    failed_count: int = Field(
+        description=(
+            "Number of attributed queue jobs in ``failed``,"
+            " ``cancelled`` or ``completed_with_errors`` state."
+        )
+    )
+    total_count: int = Field(
+        description="Total number of attributed queue jobs."
+    )
+
+
+class KeeperSyncRunWithCounters(BaseModel):
+    """Domain pair of a run plus its derived counters."""
+
+    model_config = ConfigDict(frozen=True)
+
+    run: KeeperSyncRun
+    counters: KeeperSyncRunCounters

--- a/src/docverse/domain/queue.py
+++ b/src/docverse/domain/queue.py
@@ -31,6 +31,7 @@ class QueueJob(BaseModel):
     project_id: int | None = None
     build_id: int | None = None
     edition_id: int | None = None
+    keeper_sync_run_id: int | None = None
     progress: dict[str, Any] | None = None
     errors: dict[str, Any] | None = None
     date_created: datetime

--- a/src/docverse/domain/queue.py
+++ b/src/docverse/domain/queue.py
@@ -32,6 +32,7 @@ class QueueJob(BaseModel):
     build_id: int | None = None
     edition_id: int | None = None
     keeper_sync_run_id: int | None = None
+    subject_label: str | None = None
     progress: dict[str, Any] | None = None
     errors: dict[str, Any] | None = None
     date_created: datetime

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -725,9 +725,10 @@ class Factory:
 
         @asynccontextmanager
         async def _open() -> AsyncGenerator[BuildContentCopier]:
-            destination = await self.create_objectstore_for_org(
-                org_id=org_id, service_label=service_label
-            )
+            async with self._session.begin():
+                destination = await self.create_objectstore_for_org(
+                    org_id=org_id, service_label=service_label
+                )
             source = self.create_ltd_s3_source()
             async with source, destination:
                 yield BuildContentCopier(

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -44,6 +44,7 @@ from .services.keeper_sync import (
     KeeperSyncService,
 )
 from .services.keeper_sync_config import KeeperSyncConfigService
+from .services.keeper_sync_run import KeeperSyncRunService
 from .services.lock_service import LockService
 from .services.organization import OrganizationService
 from .services.project import ProjectService
@@ -60,7 +61,8 @@ from .storage.editionpublisher import (
 )
 from .storage.github import GitHubAppClient, GitHubAppNotConfiguredError
 from .storage.keeper_sync import KeeperSyncStateStore
-from .storage.ltd import LtdClient, LtdS3Source
+from .storage.keeper_sync_run_store import KeeperSyncRunStore
+from .storage.ltd import LtdClient, LtdProductsClient, LtdS3Source
 from .storage.membership_store import OrgMembershipStore
 from .storage.objectstore import ObjectStore, create_objectstore
 from .storage.organization_credential_store import OrganizationCredentialStore
@@ -169,6 +171,39 @@ class Factory:
         """Create a KeeperSyncConfigService."""
         return KeeperSyncConfigService(
             org_store=self.create_org_store(),
+            logger=self._logger,
+        )
+
+    def create_keeper_sync_run_store(self) -> KeeperSyncRunStore:
+        """Create a :class:`KeeperSyncRunStore`."""
+        return KeeperSyncRunStore(session=self._session, logger=self._logger)
+
+    def create_keeper_sync_run_service(self) -> KeeperSyncRunService:
+        """Create a :class:`KeeperSyncRunService`."""
+        return KeeperSyncRunService(
+            org_store=self.create_org_store(),
+            run_store=self.create_keeper_sync_run_store(),
+            queue_backend=self.create_queue_backend(),
+            queue_job_store=self.create_queue_job_store(),
+            logger=self._logger,
+        )
+
+    def create_ltd_products_client(
+        self, *, base_url: str
+    ) -> LtdProductsClient:
+        """Create a :class:`LtdProductsClient`.
+
+        Raises
+        ------
+        RuntimeError
+            If the shared HTTP client is not configured.
+        """
+        if self._http_client is None:
+            msg = "HTTP client is required to build an LtdProductsClient"
+            raise RuntimeError(msg)
+        return LtdProductsClient(
+            http_client=self._http_client,
+            base_url=base_url,
             logger=self._logger,
         )
 

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -128,13 +128,11 @@ async def get_org_keeper_sync_runs(  # noqa: PLR0913
             limit=limit,
         )
         run_store = context.factory.create_keeper_sync_run_store()
-        # Aggregate counters once per row via the same store call so
-        # the list and detail endpoints return identical envelopes —
-        # cheaper than re-resolving the org per row.
-        counters_by_id = {
-            run.id: await run_store.aggregate_counters(run_id=run.id)
-            for run in result.entries
-        }
+        # One ``GROUP BY`` query covers every run in the page; avoids
+        # an N+1 round-trip pattern at ``MAX_PAGE_LIMIT``.
+        counters_by_id = await run_store.aggregate_counters_for_runs(
+            run_ids=[run.id for run in result.entries]
+        )
     context.response.headers["Link"] = result.link_header(context.request.url)
     context.response.headers["X-Total-Count"] = str(result.count)
     return [

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -6,14 +6,20 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, Query, status
 
-from docverse.client.models import KeeperSyncConfig, KeeperSyncRunStatus
+from docverse.client.models import (
+    JobStatus,
+    KeeperSyncConfig,
+    KeeperSyncRunStatus,
+)
 from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.handlers.params import OrgSlugParam
+from docverse.handlers.queue.models import QueueJob
 from docverse.storage.pagination import (
     DEFAULT_PAGE_LIMIT,
     KEEPER_SYNC_RUN_CURSOR_TYPE,
     MAX_PAGE_LIMIT,
+    QUEUE_JOB_CURSOR_TYPE,
 )
 
 from .keeper_sync_models import KeeperSyncRun, KeeperSyncRunCreated
@@ -163,3 +169,57 @@ async def get_org_keeper_sync_run(
     return KeeperSyncRun.from_domain(
         result.run, result.counters, context.request, org_slug
     )
+
+
+@router.get(
+    "/orgs/{org}/keeper-sync/runs/{run_id}/jobs",
+    response_model=list[QueueJob],
+    summary="List child queue jobs for an LTD Keeper sync run",
+    name="get_org_keeper_sync_run_jobs",
+)
+async def get_org_keeper_sync_run_jobs(  # noqa: PLR0913
+    org_slug: OrgSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+    run_id: Annotated[
+        int, Path(description="Numeric identifier for the run.")
+    ],
+    cursor: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Opaque pagination cursor from a previous response's"
+                " ``Link`` header."
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=MAX_PAGE_LIMIT,
+            description="Maximum number of results per page.",
+        ),
+    ] = DEFAULT_PAGE_LIMIT,
+    status_filter: Annotated[
+        JobStatus | None,
+        Query(alias="status", description="Filter jobs by status."),
+    ] = None,
+) -> list[QueueJob]:
+    parsed_cursor = (
+        QUEUE_JOB_CURSOR_TYPE.from_str(cursor) if cursor is not None else None
+    )
+    async with context.session.begin():
+        service = context.factory.create_keeper_sync_run_service()
+        result = await service.list_run_jobs(
+            org_slug=org_slug,
+            run_id=run_id,
+            status=status_filter,
+            cursor=parsed_cursor,
+            limit=limit,
+        )
+    context.response.headers["Link"] = result.link_header(context.request.url)
+    context.response.headers["X-Total-Count"] = str(result.count)
+    return [
+        QueueJob.from_domain(job, context.request) for job in result.entries
+    ]

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -1,15 +1,22 @@
-"""LTD Keeper sync configuration endpoints within an organization."""
+"""LTD Keeper sync configuration and run endpoints within an organization."""
 
 from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Path, Query, status
 
-from docverse.client.models import KeeperSyncConfig
+from docverse.client.models import KeeperSyncConfig, KeeperSyncRunStatus
 from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.handlers.params import OrgSlugParam
+from docverse.storage.pagination import (
+    DEFAULT_PAGE_LIMIT,
+    KEEPER_SYNC_RUN_CURSOR_TYPE,
+    MAX_PAGE_LIMIT,
+)
+
+from .keeper_sync_models import KeeperSyncRun, KeeperSyncRunCreated
 
 router = APIRouter()
 
@@ -47,3 +54,114 @@ async def put_org_keeper_sync_config(
         result = await service.put(org_slug=org_slug, config=data)
         await context.session.commit()
     return result
+
+
+@router.post(
+    "/orgs/{org}/keeper-sync/runs",
+    response_model=KeeperSyncRunCreated,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Start a new LTD Keeper backfill run",
+    name="post_org_keeper_sync_run",
+)
+async def post_org_keeper_sync_run(
+    org_slug: OrgSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+) -> KeeperSyncRunCreated:
+    async with context.session.begin():
+        service = context.factory.create_keeper_sync_run_service()
+        run, queue_job = await service.start_run(org_slug=org_slug)
+        # The run was just created and the discovery queue-job is
+        # already attributed to it; derive counters via the same store
+        # call as ``GET`` so the response shape stays uniform.
+        run_store = context.factory.create_keeper_sync_run_store()
+        counters = await run_store.aggregate_counters(run_id=run.id)
+        await context.session.commit()
+    return KeeperSyncRunCreated.from_domain(
+        run, counters, queue_job, context.request, org_slug
+    )
+
+
+@router.get(
+    "/orgs/{org}/keeper-sync/runs",
+    response_model=list[KeeperSyncRun],
+    summary="List LTD Keeper sync runs for an organization",
+    name="get_org_keeper_sync_runs",
+)
+async def get_org_keeper_sync_runs(  # noqa: PLR0913
+    org_slug: OrgSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+    cursor: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Opaque pagination cursor from a previous response's"
+                " ``Link`` header."
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=MAX_PAGE_LIMIT,
+            description="Maximum number of results per page.",
+        ),
+    ] = DEFAULT_PAGE_LIMIT,
+    status_filter: Annotated[
+        KeeperSyncRunStatus | None,
+        Query(alias="status", description="Filter runs by status."),
+    ] = None,
+) -> list[KeeperSyncRun]:
+    parsed_cursor = (
+        KEEPER_SYNC_RUN_CURSOR_TYPE.from_str(cursor)
+        if cursor is not None
+        else None
+    )
+    async with context.session.begin():
+        service = context.factory.create_keeper_sync_run_service()
+        result = await service.list_runs(
+            org_slug=org_slug,
+            status=status_filter,
+            cursor=parsed_cursor,
+            limit=limit,
+        )
+        run_store = context.factory.create_keeper_sync_run_store()
+        # Aggregate counters once per row via the same store call so
+        # the list and detail endpoints return identical envelopes —
+        # cheaper than re-resolving the org per row.
+        counters_by_id = {
+            run.id: await run_store.aggregate_counters(run_id=run.id)
+            for run in result.entries
+        }
+    context.response.headers["Link"] = result.link_header(context.request.url)
+    context.response.headers["X-Total-Count"] = str(result.count)
+    return [
+        KeeperSyncRun.from_domain(
+            run, counters_by_id[run.id], context.request, org_slug
+        )
+        for run in result.entries
+    ]
+
+
+@router.get(
+    "/orgs/{org}/keeper-sync/runs/{run_id}",
+    response_model=KeeperSyncRun,
+    summary="Get an LTD Keeper sync run with aggregate counters",
+    name="get_org_keeper_sync_run",
+)
+async def get_org_keeper_sync_run(
+    org_slug: OrgSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],  # noqa: ARG001
+    run_id: Annotated[
+        int, Path(description="Numeric identifier for the run.")
+    ],
+) -> KeeperSyncRun:
+    async with context.session.begin():
+        service = context.factory.create_keeper_sync_run_service()
+        result = await service.get_run(org_slug=org_slug, run_id=run_id)
+    return KeeperSyncRun.from_domain(
+        result.run, result.counters, context.request, org_slug
+    )

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -78,13 +78,13 @@ async def post_org_keeper_sync_run(
         service = context.factory.create_keeper_sync_run_service()
         run, queue_job = await service.start_run(org_slug=org_slug)
         # The run was just created and the discovery queue-job is
-        # already attributed to it; derive counters via the same store
+        # already attributed to it; derive activity via the same store
         # call as ``GET`` so the response shape stays uniform.
         run_store = context.factory.create_keeper_sync_run_store()
-        counters = await run_store.aggregate_counters(run_id=run.id)
+        activity = await run_store.aggregate_activity(run_id=run.id)
         await context.session.commit()
     return KeeperSyncRunCreated.from_domain(
-        run, counters, queue_job, context.request, org_slug
+        run, activity, queue_job, context.request, org_slug
     )
 
 
@@ -136,14 +136,14 @@ async def get_org_keeper_sync_runs(  # noqa: PLR0913
         run_store = context.factory.create_keeper_sync_run_store()
         # One ``GROUP BY`` query covers every run in the page; avoids
         # an N+1 round-trip pattern at ``MAX_PAGE_LIMIT``.
-        counters_by_id = await run_store.aggregate_counters_for_runs(
+        activity_by_id = await run_store.aggregate_activity_for_runs(
             run_ids=[run.id for run in result.entries]
         )
     context.response.headers["Link"] = result.link_header(context.request.url)
     context.response.headers["X-Total-Count"] = str(result.count)
     return [
         KeeperSyncRun.from_domain(
-            run, counters_by_id[run.id], context.request, org_slug
+            run, activity_by_id[run.id], context.request, org_slug
         )
         for run in result.entries
     ]
@@ -167,7 +167,7 @@ async def get_org_keeper_sync_run(
         service = context.factory.create_keeper_sync_run_service()
         result = await service.get_run(org_slug=org_slug, run_id=run_id)
     return KeeperSyncRun.from_domain(
-        result.run, result.counters, context.request, org_slug
+        result.run, result.activity, context.request, org_slug
     )
 
 

--- a/src/docverse/handlers/orgs/keeper_sync_models.py
+++ b/src/docverse/handlers/orgs/keeper_sync_models.py
@@ -1,0 +1,78 @@
+"""Handler-level response models for keeper-sync run endpoints."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from starlette.requests import Request
+
+from docverse.client.models import KeeperSyncRun as _KeeperSyncRunBase
+from docverse.client.models import (
+    KeeperSyncRunCreated as _KeeperSyncRunCreatedBase,
+)
+from docverse.client.models import KeeperSyncRunKind, KeeperSyncRunStatus
+from docverse.domain.base32id import serialize_base32_id
+from docverse.domain.keeper_sync_run import (
+    KeeperSyncRun as KeeperSyncRunDomain,
+)
+from docverse.domain.keeper_sync_run import (
+    KeeperSyncRunCounters as KeeperSyncRunCountersDomain,
+)
+from docverse.domain.queue import QueueJob as QueueJobDomain
+
+__all__ = ["KeeperSyncRun", "KeeperSyncRunCreated"]
+
+
+class KeeperSyncRun(_KeeperSyncRunBase):
+    """Keeper sync run response model with HATEOAS ``self_url``."""
+
+    @classmethod
+    def from_domain(
+        cls,
+        run: KeeperSyncRunDomain,
+        counters: KeeperSyncRunCountersDomain,
+        request: Request,
+        org_slug: str,
+    ) -> Self:
+        """Compose the response from a run plus its derived counters."""
+        return cls(
+            self_url=str(
+                request.url_for(
+                    "get_org_keeper_sync_run",
+                    org=org_slug,
+                    run_id=run.id,
+                )
+            ),
+            id=run.id,
+            kind=KeeperSyncRunKind(run.kind),
+            status=KeeperSyncRunStatus(run.status),
+            pending_count=counters.pending_count,
+            succeeded_count=counters.succeeded_count,
+            failed_count=counters.failed_count,
+            total_count=counters.total_count,
+            date_started=run.date_started,
+            date_finished=run.date_finished,
+        )
+
+
+class KeeperSyncRunCreated(_KeeperSyncRunCreatedBase):
+    """``POST /runs`` response — new run plus discovery queue-job link."""
+
+    @classmethod
+    def from_domain(
+        cls,
+        run: KeeperSyncRunDomain,
+        counters: KeeperSyncRunCountersDomain,
+        queue_job: QueueJobDomain,
+        request: Request,
+        org_slug: str,
+    ) -> Self:
+        """Build the 202 envelope from the run + enqueued queue-job."""
+        queue_job_id = serialize_base32_id(queue_job.public_id)
+        return cls(
+            run=KeeperSyncRun.from_domain(run, counters, request, org_slug),
+            queue_job_id=queue_job_id,
+            queue_job_url=str(
+                request.url_for("get_queue_job", job=queue_job_id)
+            ),
+        )

--- a/src/docverse/handlers/orgs/keeper_sync_models.py
+++ b/src/docverse/handlers/orgs/keeper_sync_models.py
@@ -16,7 +16,7 @@ from docverse.domain.keeper_sync_run import (
     KeeperSyncRun as KeeperSyncRunDomain,
 )
 from docverse.domain.keeper_sync_run import (
-    KeeperSyncRunCounters as KeeperSyncRunCountersDomain,
+    KeeperSyncRunActivity as KeeperSyncRunActivityDomain,
 )
 from docverse.domain.queue import QueueJob as QueueJobDomain
 
@@ -30,11 +30,11 @@ class KeeperSyncRun(_KeeperSyncRunBase):
     def from_domain(
         cls,
         run: KeeperSyncRunDomain,
-        counters: KeeperSyncRunCountersDomain,
+        activity: KeeperSyncRunActivityDomain,
         request: Request,
         org_slug: str,
     ) -> Self:
-        """Compose the response from a run plus its derived counters."""
+        """Compose the response from a run plus its derived activity."""
         return cls(
             self_url=str(
                 request.url_for(
@@ -46,12 +46,13 @@ class KeeperSyncRun(_KeeperSyncRunBase):
             id=run.id,
             kind=KeeperSyncRunKind(run.kind),
             status=KeeperSyncRunStatus(run.status),
-            pending_count=counters.pending_count,
-            succeeded_count=counters.succeeded_count,
-            failed_count=counters.failed_count,
-            total_count=counters.total_count,
+            pending_count=activity.pending_count,
+            succeeded_count=activity.succeeded_count,
+            failed_count=activity.failed_count,
+            total_count=activity.total_count,
             date_started=run.date_started,
             date_finished=run.date_finished,
+            date_last_activity=activity.date_last_activity,
         )
 
 
@@ -62,7 +63,7 @@ class KeeperSyncRunCreated(_KeeperSyncRunCreatedBase):
     def from_domain(
         cls,
         run: KeeperSyncRunDomain,
-        counters: KeeperSyncRunCountersDomain,
+        activity: KeeperSyncRunActivityDomain,
         queue_job: QueueJobDomain,
         request: Request,
         org_slug: str,
@@ -70,7 +71,7 @@ class KeeperSyncRunCreated(_KeeperSyncRunCreatedBase):
         """Build the 202 envelope from the run + enqueued queue-job."""
         queue_job_id = serialize_base32_id(queue_job.public_id)
         return cls(
-            run=KeeperSyncRun.from_domain(run, counters, request, org_slug),
+            run=KeeperSyncRun.from_domain(run, activity, request, org_slug),
             queue_job_id=queue_job_id,
             queue_job_url=str(
                 request.url_for("get_queue_job", job=queue_job_id)

--- a/src/docverse/handlers/queue/models.py
+++ b/src/docverse/handlers/queue/models.py
@@ -23,6 +23,8 @@ class QueueJob(_QueueJobBase):
             id=job_id_str,
             kind=domain.kind,
             status=domain.status,
+            keeper_sync_run_id=domain.keeper_sync_run_id,
+            subject_label=domain.subject_label,
             phase=domain.phase,
             progress=domain.progress,
             errors=domain.errors,

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -88,9 +88,17 @@ _SYNC_UPLOADER = "keeper-sync"
 
 @dataclass(frozen=True)
 class BuildSyncOutcome:
-    """What ``sync_build`` did with one LTD build."""
+    """What ``sync_build`` did with one LTD build.
+
+    ``docverse_build_public_id`` carries the public Base32 form of the
+    Docverse build's id so the keeper-sync worker can pass it into the
+    publish-enqueue helper without re-loading the build row.
+    """
 
     docverse_build_id: int | None
+    """``None`` when the call short-circuited (state matched LTD)."""
+
+    docverse_build_public_id: str | None
     """``None`` when the call short-circuited (state matched LTD)."""
 
     short_circuited: bool
@@ -375,6 +383,7 @@ class KeeperSyncService:
             )
             return BuildSyncOutcome(
                 docverse_build_id=existing_state.docverse_id,
+                docverse_build_public_id=None,
                 short_circuited=True,
                 content_hash=existing_state.content_hash,
                 object_count=None,
@@ -420,6 +429,7 @@ class KeeperSyncService:
         )
         return BuildSyncOutcome(
             docverse_build_id=new_build.id,
+            docverse_build_public_id=serialize_base32_id(new_build.public_id),
             short_circuited=False,
             content_hash=copy_result.content_hash,
             object_count=copy_result.object_count,

--- a/src/docverse/services/keeper_sync_finalisation.py
+++ b/src/docverse/services/keeper_sync_finalisation.py
@@ -1,0 +1,58 @@
+"""Shared helper for finalising a keeper-sync run.
+
+Both the ``keeper_sync_project`` worker (after a project sync's child
+``QueueJob`` reaches a terminal state) and the ``publish_edition``
+worker (after a publish job that was attributed to a keeper-sync run
+completes) need to roll the parent ``keeper_sync_runs`` row to a
+terminal status once every attributed child has reached terminal. The
+logic is the same in both places, so it lives here.
+"""
+
+from __future__ import annotations
+
+from docverse.client.models import KeeperSyncRunStatus
+from docverse.exceptions import NotFoundError
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+
+__all__ = ["maybe_finalise_run"]
+
+
+async def maybe_finalise_run(
+    *,
+    run_store: KeeperSyncRunStore,
+    run_id: int,
+) -> None:
+    """Transition the run to a terminal status once all children are terminal.
+
+    Idempotent re-entry on the same terminal status is handled by
+    ``transition_status``'s same-status fast path. The explicit terminal
+    pre-check guards a different case: two child finalisers racing each
+    other can compute *different* terminal statuses (e.g. one sees all
+    children completed and picks ``succeeded`` just as another child's
+    failure commits, so the second finaliser picks ``partial_failure``).
+    Without the pre-check, the second caller would hit
+    ``transition_status``'s terminal→terminal guard and raise
+    ``InvalidJobStateError``, which would roll back the surrounding
+    ``session.begin()`` and undo that child's terminal transition. We
+    swallow the conflict here so the loser of the race exits cleanly
+    and lets the winning terminal status stand.
+    """
+    activity = await run_store.aggregate_activity(run_id=run_id)
+    if activity.total_count == 0 or activity.pending_count > 0:
+        return
+    new_status = (
+        KeeperSyncRunStatus.partial_failure
+        if activity.failed_count > 0
+        else KeeperSyncRunStatus.succeeded
+    )
+    run = await run_store.get(run_id)
+    if run is None:
+        msg = f"Keeper sync run {run_id} not found"
+        raise NotFoundError(msg)
+    if run.status in {
+        KeeperSyncRunStatus.succeeded,
+        KeeperSyncRunStatus.partial_failure,
+        KeeperSyncRunStatus.failed,
+    }:
+        return
+    await run_store.transition_status(run_id=run_id, new_status=new_status)

--- a/src/docverse/services/keeper_sync_run.py
+++ b/src/docverse/services/keeper_sync_run.py
@@ -1,0 +1,180 @@
+"""Service that orchestrates the lifecycle of keeper-sync runs.
+
+This service is the operator-facing seam for the ``/orgs/{org}/
+keeper-sync/runs`` endpoints. It owns the ``POST`` handler's
+"create the run row, enqueue discovery, return the queue-job link"
+flow plus the read-side ``GET`` operations. The deeper per-project
+/ per-edition / per-build sync logic lives elsewhere (the
+``KeeperSyncService`` from #287, called by the
+``keeper_sync_project`` worker function).
+"""
+
+from __future__ import annotations
+
+import structlog
+from safir.database import CountedPaginatedList
+from sqlalchemy.exc import IntegrityError
+
+from docverse.client.models import (
+    JobKind,
+    KeeperSyncRunKind,
+    KeeperSyncRunStatus,
+)
+from docverse.domain.keeper_sync_run import (
+    KeeperSyncRun,
+    KeeperSyncRunWithCounters,
+)
+from docverse.domain.organization import Organization
+from docverse.domain.queue import QueueJob
+from docverse.exceptions import ConflictError, NotFoundError
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.pagination import KeeperSyncRunDateStartedCursor
+from docverse.storage.queue_backend import QueueBackend
+from docverse.storage.queue_job_store import QueueJobStore
+
+__all__ = ["KEEPER_SYNC_QUEUE_NAME", "KeeperSyncRunService"]
+
+
+KEEPER_SYNC_QUEUE_NAME = "docverse:sync-queue"
+"""arq queue name dedicated to LTD-sync work.
+
+The queue is isolated from the regular ``docverse:queue`` so a noisy
+backfill cannot starve ``build_processing`` and ``publish_edition``
+jobs.
+"""
+
+
+class KeeperSyncRunService:
+    """Operator-facing service for keeper-sync run lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        org_store: OrganizationStore,
+        run_store: KeeperSyncRunStore,
+        queue_backend: QueueBackend,
+        queue_job_store: QueueJobStore,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._org_store = org_store
+        self._run_store = run_store
+        self._queue_backend = queue_backend
+        self._queue_job_store = queue_job_store
+        self._logger = logger
+
+    async def start_run(
+        self,
+        *,
+        org_slug: str,
+        kind: KeeperSyncRunKind = KeeperSyncRunKind.backfill,
+    ) -> tuple[KeeperSyncRun, QueueJob]:
+        """Create a run row and enqueue ``keeper_sync_run_discovery``.
+
+        Returns the freshly created run plus the ``queue_jobs`` row
+        that backs the discovery enqueue. Raises 409 ``ConflictError``
+        when sync is disabled on the org or when a non-terminal run
+        already exists — both surface to the operator with
+        actionable messages.
+        """
+        org = await self._org_store.get_by_slug(org_slug)
+        if org is None:
+            msg = f"Organization {org_slug!r} not found"
+            raise NotFoundError(msg)
+        config = org.keeper_sync_config
+        if config is None or not config.enabled:
+            msg = (
+                f"LTD Keeper sync is not enabled for organization {org_slug!r}"
+            )
+            raise ConflictError(msg)
+
+        # Pre-check that no non-terminal run exists. The DB partial
+        # unique index is the authoritative backstop, but checking
+        # first lets us return a clean 409 without burning an
+        # auto-incremented ID inside a savepoint.
+        if await self._run_store.has_non_terminal_run(org_id=org.id):
+            msg = (
+                f"A keeper-sync run is already in progress for "
+                f"organization {org_slug!r}"
+            )
+            raise ConflictError(msg)
+
+        try:
+            run = await self._run_store.create(org_id=org.id, kind=kind)
+        except IntegrityError as exc:
+            # Lost the race against another concurrent ``POST /runs``
+            # — the partial unique index fired. Translate into the
+            # same 409 the pre-check would have surfaced.
+            msg = (
+                f"A keeper-sync run is already in progress for "
+                f"organization {org_slug!r}"
+            )
+            raise ConflictError(msg) from exc
+
+        queue_job = await self._queue_job_store.create(
+            kind=JobKind.keeper_sync_run_discovery,
+            org_id=org.id,
+            keeper_sync_run_id=run.id,
+        )
+        backend_job_id = await self._queue_backend.enqueue(
+            "keeper_sync_run_discovery",
+            {
+                "org_id": org.id,
+                "org_slug": org.slug,
+                "run_id": run.id,
+                "queue_job_id": queue_job.id,
+            },
+            queue_name=KEEPER_SYNC_QUEUE_NAME,
+        )
+        queue_job = await self._queue_job_store.set_backend_job_id(
+            queue_job.id, backend_job_id
+        )
+        self._logger.info(
+            "Started keeper-sync run",
+            org=org_slug,
+            run_id=run.id,
+            kind=kind.value,
+        )
+        return run, queue_job
+
+    async def get_run(
+        self,
+        *,
+        org_slug: str,
+        run_id: int,
+    ) -> KeeperSyncRunWithCounters:
+        """Fetch a run by id, with derived ``queue_jobs`` counters."""
+        org = await self._require_org(org_slug)
+        run = await self._run_store.get(run_id)
+        if run is None or run.org_id != org.id:
+            msg = (
+                f"Keeper sync run {run_id} not found for organization "
+                f"{org_slug!r}"
+            )
+            raise NotFoundError(msg)
+        counters = await self._run_store.aggregate_counters(run_id=run.id)
+        return KeeperSyncRunWithCounters(run=run, counters=counters)
+
+    async def list_runs(
+        self,
+        *,
+        org_slug: str,
+        status: KeeperSyncRunStatus | None = None,
+        cursor: KeeperSyncRunDateStartedCursor | None = None,
+        limit: int,
+    ) -> CountedPaginatedList[KeeperSyncRun, KeeperSyncRunDateStartedCursor]:
+        """List runs for an org, newest-first, with optional status filter."""
+        org = await self._require_org(org_slug)
+        return await self._run_store.list_by_org(
+            org_id=org.id,
+            status=status,
+            cursor=cursor,
+            limit=limit,
+        )
+
+    async def _require_org(self, org_slug: str) -> Organization:
+        org = await self._org_store.get_by_slug(org_slug)
+        if org is None:
+            msg = f"Organization {org_slug!r} not found"
+            raise NotFoundError(msg)
+        return org

--- a/src/docverse/services/keeper_sync_run.py
+++ b/src/docverse/services/keeper_sync_run.py
@@ -25,11 +25,14 @@ from docverse.domain.keeper_sync_run import (
     KeeperSyncRunWithCounters,
 )
 from docverse.domain.organization import Organization
-from docverse.domain.queue import QueueJob
+from docverse.domain.queue import JobStatus, QueueJob
 from docverse.exceptions import ConflictError, NotFoundError
 from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
 from docverse.storage.organization_store import OrganizationStore
-from docverse.storage.pagination import KeeperSyncRunDateStartedCursor
+from docverse.storage.pagination import (
+    KeeperSyncRunDateStartedCursor,
+    QueueJobDateCreatedCursor,
+)
 from docverse.storage.queue_backend import QueueBackend
 from docverse.storage.queue_job_store import QueueJobStore
 
@@ -115,6 +118,7 @@ class KeeperSyncRunService:
             kind=JobKind.keeper_sync_run_discovery,
             org_id=org.id,
             keeper_sync_run_id=run.id,
+            subject_label=f"discovery for {org_slug}",
         )
         backend_job_id = await self._queue_backend.enqueue(
             "keeper_sync_run_discovery",
@@ -167,6 +171,37 @@ class KeeperSyncRunService:
         org = await self._require_org(org_slug)
         return await self._run_store.list_by_org(
             org_id=org.id,
+            status=status,
+            cursor=cursor,
+            limit=limit,
+        )
+
+    async def list_run_jobs(
+        self,
+        *,
+        org_slug: str,
+        run_id: int,
+        status: JobStatus | None = None,
+        cursor: QueueJobDateCreatedCursor | None = None,
+        limit: int,
+    ) -> CountedPaginatedList[QueueJob, QueueJobDateCreatedCursor]:
+        """List child queue jobs attributed to a run, newest-first.
+
+        Validates that the run exists and belongs to the requested org
+        before paging — cross-org access surfaces as 404 (the same
+        shape as a missing run id) rather than 403, mirroring the
+        single-run ``GET`` handler.
+        """
+        org = await self._require_org(org_slug)
+        run = await self._run_store.get(run_id)
+        if run is None or run.org_id != org.id:
+            msg = (
+                f"Keeper sync run {run_id} not found for organization "
+                f"{org_slug!r}"
+            )
+            raise NotFoundError(msg)
+        return await self._queue_job_store.list_by_keeper_sync_run(
+            run_id=run.id,
             status=status,
             cursor=cursor,
             limit=limit,

--- a/src/docverse/services/keeper_sync_run.py
+++ b/src/docverse/services/keeper_sync_run.py
@@ -22,7 +22,7 @@ from docverse.client.models import (
 )
 from docverse.domain.keeper_sync_run import (
     KeeperSyncRun,
-    KeeperSyncRunWithCounters,
+    KeeperSyncRunWithActivity,
 )
 from docverse.domain.organization import Organization
 from docverse.domain.queue import JobStatus, QueueJob
@@ -146,8 +146,8 @@ class KeeperSyncRunService:
         *,
         org_slug: str,
         run_id: int,
-    ) -> KeeperSyncRunWithCounters:
-        """Fetch a run by id, with derived ``queue_jobs`` counters."""
+    ) -> KeeperSyncRunWithActivity:
+        """Fetch a run by id, with derived ``queue_jobs`` activity."""
         org = await self._require_org(org_slug)
         run = await self._run_store.get(run_id)
         if run is None or run.org_id != org.id:
@@ -156,8 +156,8 @@ class KeeperSyncRunService:
                 f"{org_slug!r}"
             )
             raise NotFoundError(msg)
-        counters = await self._run_store.aggregate_counters(run_id=run.id)
-        return KeeperSyncRunWithCounters(run=run, counters=counters)
+        activity = await self._run_store.aggregate_activity(run_id=run.id)
+        return KeeperSyncRunWithActivity(run=run, activity=activity)
 
     async def list_runs(
         self,

--- a/src/docverse/services/publish_enqueue.py
+++ b/src/docverse/services/publish_enqueue.py
@@ -1,0 +1,151 @@
+"""Shared publish-edition enqueue helper.
+
+Both the ``build_processing`` worker (after edition tracking) and the
+``keeper_sync_project`` worker (after a synced build is finalized) need
+to drive an edition through the publish path: mark the edition + its
+``EditionBuildHistory`` row ``pending``, create a child ``QueueJob``,
+and enqueue a ``publish_edition`` arq job. Centralizing that pattern
+here keeps both call sites aligned and lets the keeper-sync worker tag
+its publish jobs with ``keeper_sync_run_id`` for run-attributed
+progress aggregation.
+
+The two-phase commit-then-enqueue split lives inside
+:func:`enqueue_publish_for_edition`: Phase A (the DB writes) commits
+in its own ``session.begin()`` block before Phase B (the arq enqueue
+plus ``backend_job_id`` write-back) runs, so a Phase B failure leaves
+recoverable rows behind rather than silently dropping the publish.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models.queue_enums import JobKind, PublishStatus
+from docverse.domain.base32id import serialize_base32_id
+from docverse.storage.edition_build_history_store import (
+    EditionBuildHistoryStore,
+)
+from docverse.storage.edition_store import EditionStore
+from docverse.storage.queue_backend import QueueBackend
+from docverse.storage.queue_job_store import QueueJobStore
+
+__all__ = ["PublishEnqueueResult", "enqueue_publish_for_edition"]
+
+
+class PublishEnqueueResult:
+    """The publish ``QueueJob`` created and arq job enqueued for one pair."""
+
+    __slots__ = (
+        "backend_job_id",
+        "edition_slug",
+        "queue_job_id",
+        "queue_job_public_id",
+    )
+
+    def __init__(
+        self,
+        *,
+        edition_slug: str,
+        queue_job_id: int,
+        queue_job_public_id: str,
+        backend_job_id: str,
+    ) -> None:
+        self.edition_slug = edition_slug
+        self.queue_job_id = queue_job_id
+        self.queue_job_public_id = queue_job_public_id
+        self.backend_job_id = backend_job_id
+
+
+async def enqueue_publish_for_edition(  # noqa: PLR0913
+    *,
+    session: AsyncSession,
+    edition_store: EditionStore,
+    history_store: EditionBuildHistoryStore,
+    queue_job_store: QueueJobStore,
+    queue_backend: QueueBackend,
+    org_id: int,
+    project_id: int,
+    project_slug: str,
+    edition_id: int,
+    edition_slug: str,
+    build_id: int,
+    build_public_id: str,
+    keeper_sync_run_id: int | None = None,
+) -> PublishEnqueueResult:
+    """Drive one ``(edition, build)`` pair through the publish path.
+
+    Phase A (single ``session.begin()`` transaction):
+
+    * Set the edition's ``publish_status`` to ``pending``.
+    * Look up the matching ``EditionBuildHistory`` row; if none exists
+      (the keeper-sync path skips ``EditionTrackingService``, so the
+      history row hasn't been recorded yet) record one. The normal
+      ``build_processing`` flow always pre-records the history row, so
+      this lookup hits an existing row there.
+    * Set the history row's ``publish_status`` to ``pending``.
+    * Insert the child ``publish_edition`` ``QueueJob`` row carrying
+      ``keeper_sync_run_id`` when supplied so run-attributed progress
+      aggregation can roll it up.
+
+    Phase B (after Phase A commits):
+
+    * Enqueue the ``publish_edition`` arq job on
+      :class:`QueueBackend`'s default queue (the regular Docverse queue,
+      not the dedicated keeper-sync queue).
+    * Write the arq backend job ID back onto the ``QueueJob`` row in a
+      short follow-up transaction.
+
+    Phase A's commit-before-enqueue ordering is the same shape as the
+    pre-existing ``build_processing._enqueue_publish_jobs`` two-phase
+    split: a Phase B failure leaves the DB rows in a single recoverable
+    shape (edition + history pending, child ``QueueJob`` queued without
+    a ``backend_job_id``) that a future reconciliation pass can observe
+    and resolve, instead of silently dropping the publish.
+    """
+    async with session.begin():
+        await edition_store.set_publish_status(
+            edition_id=edition_id, status=PublishStatus.pending
+        )
+        history = await history_store.get_by_edition_and_build(
+            edition_id=edition_id, build_id=build_id
+        )
+        if history is None:
+            history = await history_store.record(
+                edition_id=edition_id, build_id=build_id
+            )
+        await history_store.set_publish_status(
+            history_id=history.id, status=PublishStatus.pending
+        )
+        child_job = await queue_job_store.create(
+            kind=JobKind.publish_edition,
+            org_id=org_id,
+            project_id=project_id,
+            build_id=build_id,
+            edition_id=edition_id,
+            keeper_sync_run_id=keeper_sync_run_id,
+        )
+        child_job_id = child_job.id
+        child_public_id = serialize_base32_id(child_job.public_id)
+
+    backend_job_id = await queue_backend.enqueue(
+        "publish_edition",
+        {
+            "org_id": org_id,
+            "project_slug": project_slug,
+            "edition_id": edition_id,
+            "edition_slug": edition_slug,
+            "build_id": build_id,
+            "build_public_id": build_public_id,
+            "queue_job_id": child_job_id,
+            "queue_job_public_id": child_public_id,
+        },
+    )
+    async with session.begin():
+        await queue_job_store.set_backend_job_id(child_job_id, backend_job_id)
+
+    return PublishEnqueueResult(
+        edition_slug=edition_slug,
+        queue_job_id=child_job_id,
+        queue_job_public_id=child_public_id,
+        backend_job_id=backend_job_id,
+    )

--- a/src/docverse/storage/keeper_sync_run_store.py
+++ b/src/docverse/storage/keeper_sync_run_store.py
@@ -1,0 +1,215 @@
+"""Database operations for the ``keeper_sync_runs`` table.
+
+The store is the single read/write path for run rows. Aggregate
+counters are derived from ``queue_jobs`` filtered on
+``keeper_sync_run_id`` rather than denormalised onto the run row, so
+many child jobs finishing in a burst cannot contend on a single
+counter row.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from safir.database import CountedPaginatedList, CountedPaginatedQueryRunner
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import KeeperSyncRunKind, KeeperSyncRunStatus
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.keeper_sync_run import (
+    KeeperSyncRun,
+    KeeperSyncRunCounters,
+)
+from docverse.domain.queue import JobStatus
+from docverse.exceptions import InvalidJobStateError
+from docverse.storage.pagination import KeeperSyncRunDateStartedCursor
+
+__all__ = ["KeeperSyncRunStore"]
+
+
+_NON_TERMINAL_STATUSES: frozenset[KeeperSyncRunStatus] = frozenset(
+    {KeeperSyncRunStatus.pending, KeeperSyncRunStatus.in_progress}
+)
+
+
+class KeeperSyncRunStore:
+    """Direct database operations for keeper-sync runs."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._session = session
+        self._logger = logger
+
+    async def create(
+        self,
+        *,
+        org_id: int,
+        kind: KeeperSyncRunKind = KeeperSyncRunKind.backfill,
+    ) -> KeeperSyncRun:
+        """Insert a new run row in ``pending`` status.
+
+        The DB-side partial unique index on ``(org_id) WHERE status IN
+        ('pending', 'in_progress')`` enforces the
+        one-non-terminal-run-per-org invariant. The caller is expected
+        to translate the resulting ``IntegrityError`` into a 409 — the
+        store itself stays low-level and lets the constraint speak.
+        """
+        row = SqlKeeperSyncRun(
+            org_id=org_id,
+            kind=kind.value,
+            status=KeeperSyncRunStatus.pending.value,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return KeeperSyncRun.model_validate(row)
+
+    async def get(self, run_id: int) -> KeeperSyncRun | None:
+        """Fetch a run by primary key."""
+        result = await self._session.execute(
+            select(SqlKeeperSyncRun).where(SqlKeeperSyncRun.id == run_id)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return KeeperSyncRun.model_validate(row)
+
+    async def list_by_org(
+        self,
+        *,
+        org_id: int,
+        status: KeeperSyncRunStatus | None = None,
+        cursor: KeeperSyncRunDateStartedCursor | None = None,
+        limit: int,
+    ) -> CountedPaginatedList[KeeperSyncRun, KeeperSyncRunDateStartedCursor]:
+        """List runs for an org, newest first, with optional status filter."""
+        stmt = select(SqlKeeperSyncRun).where(
+            SqlKeeperSyncRun.org_id == org_id
+        )
+        if status is not None:
+            stmt = stmt.where(SqlKeeperSyncRun.status == status.value)
+        runner = CountedPaginatedQueryRunner(
+            entry_type=KeeperSyncRun,
+            cursor_type=KeeperSyncRunDateStartedCursor,
+        )
+        return await runner.query_object(
+            self._session, stmt, cursor=cursor, limit=limit
+        )
+
+    async def has_non_terminal_run(self, *, org_id: int) -> bool:
+        """Return True if the org already has a pending/in-progress run."""
+        stmt = select(SqlKeeperSyncRun.id).where(
+            SqlKeeperSyncRun.org_id == org_id,
+            SqlKeeperSyncRun.status.in_(
+                [s.value for s in _NON_TERMINAL_STATUSES]
+            ),
+        )
+        result = await self._session.execute(stmt)
+        return result.first() is not None
+
+    async def transition_status(
+        self, *, run_id: int, new_status: KeeperSyncRunStatus
+    ) -> KeeperSyncRun:
+        """Update the status column, setting ``date_finished`` on terminal.
+
+        Idempotent: re-applying the same status returns the row
+        unchanged. Otherwise the transition is enforced as a forward
+        progression through ``pending → in_progress → terminal``;
+        backwards moves raise ``InvalidJobStateError``.
+        """
+        row = await self._get_row(run_id)
+        current = KeeperSyncRunStatus(row.status)
+        if current is new_status:
+            return KeeperSyncRun.model_validate(row)
+        if not _is_allowed_transition(current, new_status):
+            msg = (
+                f"Cannot transition keeper sync run {run_id} from "
+                f"{current.value!r} to {new_status.value!r}"
+            )
+            raise InvalidJobStateError(msg)
+
+        row.status = new_status.value
+        if new_status not in _NON_TERMINAL_STATUSES:
+            row.date_finished = datetime.now(tz=UTC)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return KeeperSyncRun.model_validate(row)
+
+    async def aggregate_counters(
+        self, *, run_id: int
+    ) -> KeeperSyncRunCounters:
+        """Aggregate ``queue_jobs`` rows attributed to this run.
+
+        Computes counters with one ``GROUP BY status`` query — one DB
+        round-trip even for a thousand-child fan-out. Buckets queued /
+        in_progress as ``pending_count``; ``completed`` as
+        ``succeeded_count``; everything else (failed, cancelled,
+        completed_with_errors) as ``failed_count``.
+        """
+        stmt = (
+            select(SqlQueueJob.status, func.count(SqlQueueJob.id))
+            .where(SqlQueueJob.keeper_sync_run_id == run_id)
+            .group_by(SqlQueueJob.status)
+        )
+        result = await self._session.execute(stmt)
+        pending = succeeded = failed = total = 0
+        for status_value, count in result.all():
+            total += count
+            if status_value in (
+                JobStatus.queued.value,
+                JobStatus.in_progress.value,
+            ):
+                pending += count
+            elif status_value == JobStatus.completed.value:
+                succeeded += count
+            else:
+                failed += count
+        return KeeperSyncRunCounters(
+            pending_count=pending,
+            succeeded_count=succeeded,
+            failed_count=failed,
+            total_count=total,
+        )
+
+    async def _get_row(self, run_id: int) -> SqlKeeperSyncRun:
+        result = await self._session.execute(
+            select(SqlKeeperSyncRun).where(SqlKeeperSyncRun.id == run_id)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            msg = f"Keeper sync run {run_id} not found"
+            raise InvalidJobStateError(msg)
+        return row
+
+
+_ALLOWED_TRANSITIONS: dict[
+    KeeperSyncRunStatus, frozenset[KeeperSyncRunStatus]
+] = {
+    KeeperSyncRunStatus.pending: frozenset(
+        {
+            KeeperSyncRunStatus.in_progress,
+            KeeperSyncRunStatus.succeeded,
+            KeeperSyncRunStatus.partial_failure,
+            KeeperSyncRunStatus.failed,
+        }
+    ),
+    KeeperSyncRunStatus.in_progress: frozenset(
+        {
+            KeeperSyncRunStatus.succeeded,
+            KeeperSyncRunStatus.partial_failure,
+            KeeperSyncRunStatus.failed,
+        }
+    ),
+}
+
+
+def _is_allowed_transition(
+    current: KeeperSyncRunStatus, new: KeeperSyncRunStatus
+) -> bool:
+    return new in _ALLOWED_TRANSITIONS.get(current, frozenset())

--- a/src/docverse/storage/keeper_sync_run_store.py
+++ b/src/docverse/storage/keeper_sync_run_store.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import UTC, datetime
+from typing import Any
 
 import structlog
 from safir.database import CountedPaginatedList, CountedPaginatedQueryRunner
@@ -22,7 +23,7 @@ from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.keeper_sync_run import (
     KeeperSyncRun,
-    KeeperSyncRunCounters,
+    KeeperSyncRunActivity,
 )
 from docverse.domain.queue import JobStatus
 from docverse.exceptions import InvalidJobStateError
@@ -142,25 +143,39 @@ class KeeperSyncRunStore:
         await self._session.refresh(row)
         return KeeperSyncRun.model_validate(row)
 
-    async def aggregate_counters(
+    async def aggregate_activity(
         self, *, run_id: int
-    ) -> KeeperSyncRunCounters:
+    ) -> KeeperSyncRunActivity:
         """Aggregate ``queue_jobs`` rows attributed to this run.
 
-        Computes counters with one ``GROUP BY status`` query — one DB
-        round-trip even for a thousand-child fan-out. Buckets queued /
-        in_progress as ``pending_count``; ``completed`` as
-        ``succeeded_count``; everything else (failed, cancelled,
-        completed_with_errors) as ``failed_count``.
+        Computes counters and ``date_last_activity`` with one
+        ``GROUP BY status`` query — one DB round-trip even for a
+        thousand-child fan-out. Buckets queued / in_progress as
+        ``pending_count``; ``completed`` as ``succeeded_count``;
+        everything else (failed, cancelled, completed_with_errors) as
+        ``failed_count``. ``date_last_activity`` is the MAX over
+        ``coalesce(date_completed, date_started, date_created)`` per
+        row — the latest meaningful event for each child without
+        needing a separate ``date_updated`` column.
         """
+        last_activity = func.coalesce(
+            SqlQueueJob.date_completed,
+            SqlQueueJob.date_started,
+            SqlQueueJob.date_created,
+        )
         stmt = (
-            select(SqlQueueJob.status, func.count(SqlQueueJob.id))
+            select(
+                SqlQueueJob.status,
+                func.count(SqlQueueJob.id),
+                func.max(last_activity),
+            )
             .where(SqlQueueJob.keeper_sync_run_id == run_id)
             .group_by(SqlQueueJob.status)
         )
         result = await self._session.execute(stmt)
         pending = succeeded = failed = total = 0
-        for status_value, count in result.all():
+        date_last_activity: datetime | None = None
+        for status_value, count, max_ts in result.all():
             total += count
             if status_value in (
                 JobStatus.queued.value,
@@ -171,47 +186,66 @@ class KeeperSyncRunStore:
                 succeeded += count
             else:
                 failed += count
-        return KeeperSyncRunCounters(
+            if max_ts is not None and (
+                date_last_activity is None or max_ts > date_last_activity
+            ):
+                date_last_activity = max_ts
+        return KeeperSyncRunActivity(
             pending_count=pending,
             succeeded_count=succeeded,
             failed_count=failed,
             total_count=total,
+            date_last_activity=date_last_activity,
         )
 
-    async def aggregate_counters_for_runs(
+    async def aggregate_activity_for_runs(
         self, *, run_ids: Sequence[int]
-    ) -> dict[int, KeeperSyncRunCounters]:
-        """Aggregate ``queue_jobs`` rows for many runs in a single query.
+    ) -> dict[int, KeeperSyncRunActivity]:
+        """Aggregate ``queue_jobs`` activity for many runs in a single query.
 
         One ``GROUP BY keeper_sync_run_id, status`` instead of N
         per-run queries — keeps ``GET /runs`` at O(1) round-trips
         even at ``MAX_PAGE_LIMIT``. Runs in ``run_ids`` with no
-        attributed jobs come back with zeroed counters so callers
-        never have to handle missing keys.
+        attributed jobs come back with zeroed counters and
+        ``date_last_activity=None`` so callers never have to handle
+        missing keys.
         """
         if not run_ids:
             return {}
-        zero = KeeperSyncRunCounters(
+        zero = KeeperSyncRunActivity(
             pending_count=0,
             succeeded_count=0,
             failed_count=0,
             total_count=0,
+            date_last_activity=None,
         )
-        result: dict[int, dict[str, int]] = {
-            run_id: {"pending": 0, "succeeded": 0, "failed": 0, "total": 0}
+        result: dict[int, dict[str, Any]] = {
+            run_id: {
+                "pending": 0,
+                "succeeded": 0,
+                "failed": 0,
+                "total": 0,
+                "date_last_activity": None,
+            }
             for run_id in run_ids
         }
+        last_activity = func.coalesce(
+            SqlQueueJob.date_completed,
+            SqlQueueJob.date_started,
+            SqlQueueJob.date_created,
+        )
         stmt = (
             select(
                 SqlQueueJob.keeper_sync_run_id,
                 SqlQueueJob.status,
                 func.count(SqlQueueJob.id),
+                func.max(last_activity),
             )
             .where(SqlQueueJob.keeper_sync_run_id.in_(list(run_ids)))
             .group_by(SqlQueueJob.keeper_sync_run_id, SqlQueueJob.status)
         )
         rows = await self._session.execute(stmt)
-        for run_id, status_value, count in rows.all():
+        for run_id, status_value, count, max_ts in rows.all():
             bucket = result[run_id]
             bucket["total"] += count
             if status_value in (
@@ -223,12 +257,16 @@ class KeeperSyncRunStore:
                 bucket["succeeded"] += count
             else:
                 bucket["failed"] += count
+            current = bucket["date_last_activity"]
+            if max_ts is not None and (current is None or max_ts > current):
+                bucket["date_last_activity"] = max_ts
         return {
-            run_id: KeeperSyncRunCounters(
+            run_id: KeeperSyncRunActivity(
                 pending_count=b["pending"],
                 succeeded_count=b["succeeded"],
                 failed_count=b["failed"],
                 total_count=b["total"],
+                date_last_activity=b["date_last_activity"],
             )
             if b["total"]
             else zero

--- a/src/docverse/storage/keeper_sync_run_store.py
+++ b/src/docverse/storage/keeper_sync_run_store.py
@@ -9,6 +9,7 @@ counter row.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import UTC, datetime
 
 import structlog
@@ -176,6 +177,63 @@ class KeeperSyncRunStore:
             failed_count=failed,
             total_count=total,
         )
+
+    async def aggregate_counters_for_runs(
+        self, *, run_ids: Sequence[int]
+    ) -> dict[int, KeeperSyncRunCounters]:
+        """Aggregate ``queue_jobs`` rows for many runs in a single query.
+
+        One ``GROUP BY keeper_sync_run_id, status`` instead of N
+        per-run queries — keeps ``GET /runs`` at O(1) round-trips
+        even at ``MAX_PAGE_LIMIT``. Runs in ``run_ids`` with no
+        attributed jobs come back with zeroed counters so callers
+        never have to handle missing keys.
+        """
+        if not run_ids:
+            return {}
+        zero = KeeperSyncRunCounters(
+            pending_count=0,
+            succeeded_count=0,
+            failed_count=0,
+            total_count=0,
+        )
+        result: dict[int, dict[str, int]] = {
+            run_id: {"pending": 0, "succeeded": 0, "failed": 0, "total": 0}
+            for run_id in run_ids
+        }
+        stmt = (
+            select(
+                SqlQueueJob.keeper_sync_run_id,
+                SqlQueueJob.status,
+                func.count(SqlQueueJob.id),
+            )
+            .where(SqlQueueJob.keeper_sync_run_id.in_(list(run_ids)))
+            .group_by(SqlQueueJob.keeper_sync_run_id, SqlQueueJob.status)
+        )
+        rows = await self._session.execute(stmt)
+        for run_id, status_value, count in rows.all():
+            bucket = result[run_id]
+            bucket["total"] += count
+            if status_value in (
+                JobStatus.queued.value,
+                JobStatus.in_progress.value,
+            ):
+                bucket["pending"] += count
+            elif status_value == JobStatus.completed.value:
+                bucket["succeeded"] += count
+            else:
+                bucket["failed"] += count
+        return {
+            run_id: KeeperSyncRunCounters(
+                pending_count=b["pending"],
+                succeeded_count=b["succeeded"],
+                failed_count=b["failed"],
+                total_count=b["total"],
+            )
+            if b["total"]
+            else zero
+            for run_id, b in result.items()
+        }
 
     async def _get_row(self, run_id: int) -> SqlKeeperSyncRun:
         result = await self._session.execute(

--- a/src/docverse/storage/ltd/__init__.py
+++ b/src/docverse/storage/ltd/__init__.py
@@ -10,6 +10,7 @@ from .models import (
     LtdProduct,
     LtdProductsListing,
 )
+from .products_client import LtdProductsClient
 from .s3_source import LtdS3Source, LtdSourceProtocol
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     "LtdEditionMode",
     "LtdNotFoundError",
     "LtdProduct",
+    "LtdProductsClient",
     "LtdProductsListing",
     "LtdS3Source",
     "LtdSourceProtocol",

--- a/src/docverse/storage/ltd/products_client.py
+++ b/src/docverse/storage/ltd/products_client.py
@@ -1,0 +1,76 @@
+"""Minimal client for the LTD Keeper v1 ``/products/`` endpoint.
+
+The legacy LTD Keeper API has no search, ``since`` filter, ETag, or
+event stream, so backfill discovery just lists every product slug in
+one HTTP call (~73 KB at the time of writing). Only the slug is
+needed at this layer — the per-product/edition/build sync calls go
+through dedicated endpoints which the deeper sync slice will own.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import httpx
+import structlog
+
+__all__ = ["LtdProductsClient"]
+
+
+class LtdProductsClient:
+    """Fetch the flat product slug list from an LTD Keeper instance."""
+
+    def __init__(
+        self,
+        *,
+        http_client: httpx.AsyncClient,
+        base_url: str,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._http_client = http_client
+        # Strip a trailing slash so url joining is deterministic.
+        self._base_url = base_url.rstrip("/")
+        self._logger = logger
+
+    async def list_product_slugs(self) -> list[str]:
+        """Return every product slug visible on the LTD instance.
+
+        The endpoint returns ``{"products": ["<base>/products/<slug>/",
+        ...]}`` — slugs are extracted by parsing the path. Slugs are
+        de-duplicated and returned in input order so callers can
+        intersect them with an allowlist deterministically.
+        """
+        url = f"{self._base_url}/products/"
+        response = await self._http_client.get(url)
+        response.raise_for_status()
+        payload = response.json()
+        products = payload.get("products", [])
+        slugs: list[str] = []
+        seen: set[str] = set()
+        for product_url in products:
+            slug = _slug_from_url(product_url)
+            if slug is None or slug in seen:
+                continue
+            seen.add(slug)
+            slugs.append(slug)
+        self._logger.debug(
+            "Fetched LTD product slugs",
+            base_url=self._base_url,
+            count=len(slugs),
+        )
+        return slugs
+
+
+def _slug_from_url(url: str) -> str | None:
+    """Extract the product slug from a ``.../products/<slug>/`` URL."""
+    if not isinstance(url, str):
+        return None
+    path = urlparse(url).path
+    parts = [p for p in path.split("/") if p]
+    # The LTD API returns ``/products/<slug>/`` — the last segment is
+    # the slug, the one before it is the literal ``products``. Tolerate
+    # trailing slash variations.
+    min_segments = 2
+    if len(parts) < min_segments or parts[-2] != "products":
+        return None
+    return parts[-1]

--- a/src/docverse/storage/pagination.py
+++ b/src/docverse/storage/pagination.py
@@ -20,11 +20,13 @@ from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.edition_build_history import SqlEditionBuildHistory
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.project import SqlProject
+from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
 from docverse.domain.edition_build_history import EditionBuildHistoryWithBuild
 from docverse.domain.keeper_sync_run import KeeperSyncRun
 from docverse.domain.project import Project
+from docverse.domain.queue import QueueJob
 
 __all__ = [
     "BUILD_CURSOR_TYPE",
@@ -34,6 +36,7 @@ __all__ = [
     "KEEPER_SYNC_RUN_CURSOR_TYPE",
     "MAX_PAGE_LIMIT",
     "PROJECT_CURSOR_TYPES",
+    "QUEUE_JOB_CURSOR_TYPE",
     "BuildDateCreatedCursor",
     "EditionBuildHistoryPositionCursor",
     "EditionDateCreatedCursor",
@@ -45,6 +48,7 @@ __all__ = [
     "ProjectSearchCursor",
     "ProjectSlugCursor",
     "ProjectSortOrder",
+    "QueueJobDateCreatedCursor",
 ]
 
 DEFAULT_PAGE_LIMIT = 25
@@ -308,6 +312,26 @@ class KeeperSyncRunDateStartedCursor(_TzAwareDatetimeIdCursor[KeeperSyncRun]):
         return cls(time=entry.date_started, id=entry.id, previous=reverse)
 
 
+@dataclass(slots=True)
+class QueueJobDateCreatedCursor(_TzAwareDatetimeIdCursor[QueueJob]):
+    """Keyset cursor for queue jobs ordered by date_created DESC, id DESC."""
+
+    @staticmethod
+    @override
+    def id_column() -> InstrumentedAttribute[int]:
+        return SqlQueueJob.id
+
+    @staticmethod
+    @override
+    def time_column() -> InstrumentedAttribute[datetime]:
+        return SqlQueueJob.date_created
+
+    @override
+    @classmethod
+    def from_entry(cls, entry: QueueJob, *, reverse: bool = False) -> Self:
+        return cls(time=entry.date_created, id=entry.id, previous=reverse)
+
+
 # ---------------------------------------------------------------------------
 # Search cursor (score+id compound keyset)
 # ---------------------------------------------------------------------------
@@ -394,6 +418,10 @@ BUILD_CURSOR_TYPE: type[BuildDateCreatedCursor] = BuildDateCreatedCursor
 
 KEEPER_SYNC_RUN_CURSOR_TYPE: type[KeeperSyncRunDateStartedCursor] = (
     KeeperSyncRunDateStartedCursor
+)
+
+QUEUE_JOB_CURSOR_TYPE: type[QueueJobDateCreatedCursor] = (
+    QueueJobDateCreatedCursor
 )
 
 

--- a/src/docverse/storage/pagination.py
+++ b/src/docverse/storage/pagination.py
@@ -12,7 +12,7 @@ from safir.database import (
     InvalidCursorError,
     PaginationCursor,
 )
-from sqlalchemy import Select
+from sqlalchemy import Select, and_, or_
 from sqlalchemy.orm import InstrumentedAttribute
 
 from docverse.dbschema.build import SqlBuild
@@ -172,8 +172,42 @@ class EditionSlugCursor(PaginationCursor[Edition]):
 # ---------------------------------------------------------------------------
 
 
+class _TzAwareDatetimeIdCursor[E: Any](DatetimeIdCursor[E]):
+    """``DatetimeIdCursor`` whose filter keeps the cursor time tz-aware.
+
+    Why: safir's ``DatetimeIdCursor.apply_cursor`` calls ``datetime_to_db``
+    to strip ``tzinfo`` before binding the value. When the resulting naive
+    datetime is compared via asyncpg to a ``TIMESTAMP WITH TIME ZONE``
+    column, the implicit cast does not honour the database session's
+    ``TimeZone`` setting — ``<`` then matches every row and ``=`` matches
+    none, so any cursor that should land on a tied timestamp returns the
+    same page again instead of advancing. Keeping the value timezone-aware
+    sidesteps the broken cast.
+    """
+
+    @override
+    def apply_cursor(
+        self, stmt: Select[tuple[Any, ...]]
+    ) -> Select[tuple[Any, ...]]:
+        time_column = self.time_column()
+        id_column = self.id_column()
+        if self.previous:
+            return stmt.where(
+                or_(
+                    time_column > self.time,
+                    and_(time_column == self.time, id_column > self.id),
+                )
+            )
+        return stmt.where(
+            or_(
+                time_column < self.time,
+                and_(time_column == self.time, id_column <= self.id),
+            )
+        )
+
+
 @dataclass(slots=True)
-class ProjectDateCreatedCursor(DatetimeIdCursor[Project]):
+class ProjectDateCreatedCursor(_TzAwareDatetimeIdCursor[Project]):
     """Keyset cursor for projects ordered by date_created DESC, id DESC."""
 
     @staticmethod
@@ -193,7 +227,7 @@ class ProjectDateCreatedCursor(DatetimeIdCursor[Project]):
 
 
 @dataclass(slots=True)
-class EditionDateCreatedCursor(DatetimeIdCursor[Edition]):
+class EditionDateCreatedCursor(_TzAwareDatetimeIdCursor[Edition]):
     """Keyset cursor for editions ordered by date_created DESC, id DESC."""
 
     @staticmethod
@@ -213,7 +247,7 @@ class EditionDateCreatedCursor(DatetimeIdCursor[Edition]):
 
 
 @dataclass(slots=True)
-class EditionDateUpdatedCursor(DatetimeIdCursor[Edition]):
+class EditionDateUpdatedCursor(_TzAwareDatetimeIdCursor[Edition]):
     """Keyset cursor for editions ordered by date_updated DESC, id DESC."""
 
     @staticmethod
@@ -233,7 +267,7 @@ class EditionDateUpdatedCursor(DatetimeIdCursor[Edition]):
 
 
 @dataclass(slots=True)
-class BuildDateCreatedCursor(DatetimeIdCursor[Build]):
+class BuildDateCreatedCursor(_TzAwareDatetimeIdCursor[Build]):
     """Keyset cursor for builds ordered by date_created DESC, id DESC."""
 
     @staticmethod
@@ -253,7 +287,7 @@ class BuildDateCreatedCursor(DatetimeIdCursor[Build]):
 
 
 @dataclass(slots=True)
-class KeeperSyncRunDateStartedCursor(DatetimeIdCursor[KeeperSyncRun]):
+class KeeperSyncRunDateStartedCursor(_TzAwareDatetimeIdCursor[KeeperSyncRun]):
     """Keyset cursor for runs ordered by date_started DESC, id DESC."""
 
     @staticmethod

--- a/src/docverse/storage/pagination.py
+++ b/src/docverse/storage/pagination.py
@@ -18,10 +18,12 @@ from sqlalchemy.orm import InstrumentedAttribute
 from docverse.dbschema.build import SqlBuild
 from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.edition_build_history import SqlEditionBuildHistory
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.project import SqlProject
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
 from docverse.domain.edition_build_history import EditionBuildHistoryWithBuild
+from docverse.domain.keeper_sync_run import KeeperSyncRun
 from docverse.domain.project import Project
 
 __all__ = [
@@ -29,6 +31,7 @@ __all__ = [
     "DEFAULT_PAGE_LIMIT",
     "EDITION_CURSOR_TYPES",
     "EDITION_HISTORY_CURSOR_TYPE",
+    "KEEPER_SYNC_RUN_CURSOR_TYPE",
     "MAX_PAGE_LIMIT",
     "PROJECT_CURSOR_TYPES",
     "BuildDateCreatedCursor",
@@ -37,6 +40,7 @@ __all__ = [
     "EditionDateUpdatedCursor",
     "EditionSlugCursor",
     "EditionSortOrder",
+    "KeeperSyncRunDateStartedCursor",
     "ProjectDateCreatedCursor",
     "ProjectSearchCursor",
     "ProjectSlugCursor",
@@ -248,6 +252,28 @@ class BuildDateCreatedCursor(DatetimeIdCursor[Build]):
         return cls(time=entry.date_created, id=entry.id, previous=reverse)
 
 
+@dataclass(slots=True)
+class KeeperSyncRunDateStartedCursor(DatetimeIdCursor[KeeperSyncRun]):
+    """Keyset cursor for runs ordered by date_started DESC, id DESC."""
+
+    @staticmethod
+    @override
+    def id_column() -> InstrumentedAttribute[int]:
+        return SqlKeeperSyncRun.id
+
+    @staticmethod
+    @override
+    def time_column() -> InstrumentedAttribute[datetime]:
+        return SqlKeeperSyncRun.date_started
+
+    @override
+    @classmethod
+    def from_entry(
+        cls, entry: KeeperSyncRun, *, reverse: bool = False
+    ) -> Self:
+        return cls(time=entry.date_started, id=entry.id, previous=reverse)
+
+
 # ---------------------------------------------------------------------------
 # Search cursor (score+id compound keyset)
 # ---------------------------------------------------------------------------
@@ -331,6 +357,10 @@ EDITION_CURSOR_TYPES: dict[
 }
 
 BUILD_CURSOR_TYPE: type[BuildDateCreatedCursor] = BuildDateCreatedCursor
+
+KEEPER_SYNC_RUN_CURSOR_TYPE: type[KeeperSyncRunDateStartedCursor] = (
+    KeeperSyncRunDateStartedCursor
+)
 
 
 # ---------------------------------------------------------------------------

--- a/src/docverse/storage/queue_job_store.py
+++ b/src/docverse/storage/queue_job_store.py
@@ -37,6 +37,7 @@ class QueueJobStore:
         project_id: int | None = None,
         build_id: int | None = None,
         edition_id: int | None = None,
+        keeper_sync_run_id: int | None = None,
     ) -> QueueJob:
         """Insert a new QueueJob row with status=queued.
 
@@ -52,6 +53,7 @@ class QueueJobStore:
             project_id=project_id,
             build_id=build_id,
             edition_id=edition_id,
+            keeper_sync_run_id=keeper_sync_run_id,
         )
         self._session.add(row)
         await self._session.flush()

--- a/src/docverse/storage/queue_job_store.py
+++ b/src/docverse/storage/queue_job_store.py
@@ -258,6 +258,55 @@ class QueueJobStore:
         await self._session.refresh(row)
         return QueueJob.model_validate(row, from_attributes=True)
 
+    async def fail_silent_run_children(
+        self,
+        *,
+        idle_after: timedelta,
+    ) -> list[QueueJob]:
+        """Fail keeper-sync child rows that have been ``in_progress`` too long.
+
+        Backstop for the case where arq itself loses a job — typically a
+        worker pod OOM-killed mid-job that never gets to surface a
+        timeout. ``keeper_sync_project`` transitions its row to
+        ``in_progress`` *before* the long copy work begins, so a row
+        that has been ``in_progress`` past ``idle_after`` without ever
+        reaching ``date_completed`` indicates the worker died silently.
+
+        Scoped to rows attached to a keeper-sync run
+        (``keeper_sync_run_id IS NOT NULL``); unrelated long-running
+        ``build_processing`` jobs are not the reaper's concern. Queued
+        rows without ``date_started`` are left alone — those are the
+        ``fail_orphaned_run_children`` shape, swept by the next
+        discovery attempt instead.
+        """
+        cutoff = datetime.now(tz=UTC) - idle_after
+        stmt = select(SqlQueueJob).where(
+            SqlQueueJob.keeper_sync_run_id.is_not(None),
+            SqlQueueJob.status == JobStatus.in_progress.value,
+            SqlQueueJob.date_completed.is_(None),
+            SqlQueueJob.date_started.is_not(None),
+            SqlQueueJob.date_started < cutoff,
+        )
+        result = await self._session.execute(stmt)
+        rows = list(result.scalars().all())
+        now = datetime.now(tz=UTC)
+        reaped: list[QueueJob] = []
+        for row in rows:
+            row.status = JobStatus.failed.value
+            row.date_completed = now
+            row.errors = {
+                "message": (
+                    "Reaped by keeper_sync_reaper: worker went silent "
+                    "while job was in_progress (likely OOM-killed or "
+                    "lost by arq)"
+                ),
+                "type": "SilentWorker",
+            }
+            reaped.append(QueueJob.model_validate(row, from_attributes=True))
+        if reaped:
+            await self._session.flush()
+        return reaped
+
     async def fail_orphaned_run_children(
         self,
         *,

--- a/src/docverse/storage/queue_job_store.py
+++ b/src/docverse/storage/queue_job_store.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
+from safir.database import CountedPaginatedList, CountedPaginatedQueryRunner
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,6 +14,7 @@ from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.domain.queue import JobKind, JobStatus, QueueJob
 from docverse.exceptions import InvalidJobStateError, JobNotFoundError
+from docverse.storage.pagination import QueueJobDateCreatedCursor
 
 __all__ = ["QueueJobStore"]
 
@@ -38,6 +40,7 @@ class QueueJobStore:
         build_id: int | None = None,
         edition_id: int | None = None,
         keeper_sync_run_id: int | None = None,
+        subject_label: str | None = None,
     ) -> QueueJob:
         """Insert a new QueueJob row with status=queued.
 
@@ -54,6 +57,7 @@ class QueueJobStore:
             build_id=build_id,
             edition_id=edition_id,
             keeper_sync_run_id=keeper_sync_run_id,
+            subject_label=subject_label,
         )
         self._session.add(row)
         await self._session.flush()
@@ -257,6 +261,33 @@ class QueueJobStore:
         await self._session.flush()
         await self._session.refresh(row)
         return QueueJob.model_validate(row, from_attributes=True)
+
+    async def list_by_keeper_sync_run(
+        self,
+        *,
+        run_id: int,
+        status: JobStatus | None = None,
+        cursor: QueueJobDateCreatedCursor | None = None,
+        limit: int,
+    ) -> CountedPaginatedList[QueueJob, QueueJobDateCreatedCursor]:
+        """List queue jobs attributed to a run, newest first.
+
+        Optional ``status`` narrows to a single :class:`JobStatus`.
+        Pagination uses the standard ``date_created`` DESC keyset cursor
+        so pages are stable across concurrent inserts.
+        """
+        stmt = select(SqlQueueJob).where(
+            SqlQueueJob.keeper_sync_run_id == run_id
+        )
+        if status is not None:
+            stmt = stmt.where(SqlQueueJob.status == status.value)
+        runner = CountedPaginatedQueryRunner(
+            entry_type=QueueJob,
+            cursor_type=QueueJobDateCreatedCursor,
+        )
+        return await runner.query_object(
+            self._session, stmt, cursor=cursor, limit=limit
+        )
 
     async def fail_silent_run_children(
         self,

--- a/src/docverse/storage/queue_job_store.py
+++ b/src/docverse/storage/queue_job_store.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
@@ -257,6 +257,53 @@ class QueueJobStore:
         await self._session.flush()
         await self._session.refresh(row)
         return QueueJob.model_validate(row, from_attributes=True)
+
+    async def fail_orphaned_run_children(
+        self,
+        *,
+        run_id: int,
+        idle_after: timedelta,
+    ) -> list[QueueJob]:
+        """Fail child rows for a keeper-sync run that never got an arq job.
+
+        Reconciles the gap left by ``_enqueue_children`` in
+        ``docverse.worker.functions.keeper_sync``: the child ``queue_jobs``
+        row commits *before* ``arq_queue.enqueue`` is called, so a worker
+        crash in that window leaves an orphan — ``status='queued'``,
+        ``backend_job_id IS NULL``, no arq job ever scheduled — that
+        otherwise blocks run finalisation forever.
+
+        ``idle_after`` keeps in-flight rows safe: only orphans whose
+        ``date_created`` is older than ``now - idle_after`` are failed,
+        so a concurrently-running discovery worker's freshly-committed
+        rows are never reaped before it has a chance to write back the
+        backend job ID.
+        """
+        cutoff = datetime.now(tz=UTC) - idle_after
+        stmt = select(SqlQueueJob).where(
+            SqlQueueJob.keeper_sync_run_id == run_id,
+            SqlQueueJob.status == JobStatus.queued.value,
+            SqlQueueJob.backend_job_id.is_(None),
+            SqlQueueJob.date_created < cutoff,
+        )
+        result = await self._session.execute(stmt)
+        rows = list(result.scalars().all())
+        now = datetime.now(tz=UTC)
+        failed: list[QueueJob] = []
+        for row in rows:
+            row.status = JobStatus.failed.value
+            row.date_completed = now
+            row.errors = {
+                "message": (
+                    "Orphaned: queue_jobs row committed without an arq "
+                    "backend_job_id (worker likely crashed mid-fanout)"
+                ),
+                "type": "OrphanedQueueJob",
+            }
+            failed.append(QueueJob.model_validate(row, from_attributes=True))
+        if failed:
+            await self._session.flush()
+        return failed
 
     async def _get_row(self, job_id: int) -> SqlQueueJob:
         """Fetch a SqlQueueJob row by id, raising if not found."""

--- a/src/docverse/worker/functions/__init__.py
+++ b/src/docverse/worker/functions/__init__.py
@@ -3,7 +3,11 @@
 from .build_processing import build_processing
 from .dashboard_build import dashboard_build
 from .dashboard_sync import dashboard_sync
-from .keeper_sync import keeper_sync_project, keeper_sync_run_discovery
+from .keeper_sync import (
+    keeper_sync_project,
+    keeper_sync_reaper,
+    keeper_sync_run_discovery,
+)
 from .ping import ping
 from .publish_edition import publish_edition
 
@@ -12,6 +16,7 @@ __all__ = [
     "dashboard_build",
     "dashboard_sync",
     "keeper_sync_project",
+    "keeper_sync_reaper",
     "keeper_sync_run_discovery",
     "ping",
     "publish_edition",

--- a/src/docverse/worker/functions/__init__.py
+++ b/src/docverse/worker/functions/__init__.py
@@ -3,6 +3,7 @@
 from .build_processing import build_processing
 from .dashboard_build import dashboard_build
 from .dashboard_sync import dashboard_sync
+from .keeper_sync import keeper_sync_project, keeper_sync_run_discovery
 from .ping import ping
 from .publish_edition import publish_edition
 
@@ -10,6 +11,8 @@ __all__ = [
     "build_processing",
     "dashboard_build",
     "dashboard_sync",
+    "keeper_sync_project",
+    "keeper_sync_run_discovery",
     "ping",
     "publish_edition",
 ]

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -11,7 +11,6 @@ import asyncio
 import io
 import mimetypes
 import tarfile
-from dataclasses import dataclass
 from typing import Any
 
 import structlog
@@ -19,16 +18,12 @@ from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import BuildStatus
-from docverse.client.models.queue_enums import JobKind, PublishStatus
-from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.build import Build
-from docverse.domain.edition_tracking import (
-    EditionTrackingOutcome,
-    EditionTrackingResult,
-)
+from docverse.domain.edition_tracking import EditionTrackingResult
 from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
 from docverse.services.lock_service import LockKey
+from docverse.services.publish_enqueue import enqueue_publish_for_edition
 from docverse.storage.build_store import BuildStore
 from docverse.storage.objectstore import ObjectStore
 from docverse.storage.organization_store import OrganizationStore
@@ -376,15 +371,6 @@ async def _finalize_success(  # noqa: PLR0913
     logger.info("Build processing completed")
 
 
-@dataclass(frozen=True)
-class _PendingEnqueue:
-    """Child-job rows committed in phase A and awaiting arq enqueue."""
-
-    outcome: EditionTrackingOutcome
-    child_queue_job_id: int
-    child_public_id: str
-
-
 async def _enqueue_publish_jobs(  # noqa: PLR0913
     *,
     session: AsyncSession,
@@ -398,17 +384,13 @@ async def _enqueue_publish_jobs(  # noqa: PLR0913
     build_public_id: str,
     logger: structlog.stdlib.BoundLogger,
 ) -> list[dict[str, str]]:
-    """Create a publish_edition child job for each updated edition.
+    """Create a ``publish_edition`` child job for each updated edition.
 
-    Runs in two phases so the DB never holds partial ``pending`` state:
-
-    1. **Phase A** (one transaction): for each outcome, mark the edition
-       and its history entry ``pending`` and insert the child
-       ``QueueJob`` row. A failure here rolls back the whole batch.
-    2. **Phase B** (after commit): enqueue the ``publish_edition`` arq
-       task for each committed child job. A failure here leaves DB rows
-       that a future reconciliation loop can observe in a single
-       consistent shape.
+    Loops over ``tracking_result.updated`` and delegates each
+    ``(edition, build)`` pair to
+    :func:`docverse.services.publish_enqueue.enqueue_publish_for_edition`,
+    which owns the Phase A (DB writes) / Phase B (arq enqueue +
+    backend-job-id write-back) sequencing.
 
     Returns a list of ``{edition_slug, publish_queue_job_public_id}``
     entries suitable for embedding in the parent build job's progress.
@@ -417,73 +399,32 @@ async def _enqueue_publish_jobs(  # noqa: PLR0913
     history_store = factory.create_edition_build_history_store()
     queue_backend = factory.create_queue_backend()
 
-    pending_enqueues: list[_PendingEnqueue] = []
-    async with session.begin():
-        for outcome in tracking_result.updated:
-            await edition_store.set_publish_status(
-                edition_id=outcome.edition_id,
-                status=PublishStatus.pending,
-            )
-            history = await history_store.get_by_edition_and_build(
-                edition_id=outcome.edition_id,
-                build_id=outcome.build_id,
-            )
-            if history is None:
-                msg = (
-                    f"EditionBuildHistory missing for edition "
-                    f"{outcome.edition_id}, build {outcome.build_id}"
-                )
-                raise RuntimeError(msg)
-            await history_store.set_publish_status(
-                history_id=history.id,
-                status=PublishStatus.pending,
-            )
-            child_job = await queue_job_store.create(
-                kind=JobKind.publish_edition,
-                org_id=org_id,
-                project_id=project_id,
-                build_id=build_id,
-                edition_id=outcome.edition_id,
-            )
-            pending_enqueues.append(
-                _PendingEnqueue(
-                    outcome=outcome,
-                    child_queue_job_id=child_job.id,
-                    child_public_id=serialize_base32_id(child_job.public_id),
-                )
-            )
-
     publish_jobs: list[dict[str, str]] = []
-    for pending in pending_enqueues:
-        outcome = pending.outcome
-        backend_job_id = await queue_backend.enqueue(
-            "publish_edition",
-            {
-                "org_id": org_id,
-                "project_slug": project_slug,
-                "edition_id": outcome.edition_id,
-                "edition_slug": outcome.slug,
-                "build_id": build_id,
-                "build_public_id": build_public_id,
-                "queue_job_id": pending.child_queue_job_id,
-                "queue_job_public_id": pending.child_public_id,
-            },
+    for outcome in tracking_result.updated:
+        result = await enqueue_publish_for_edition(
+            session=session,
+            edition_store=edition_store,
+            history_store=history_store,
+            queue_job_store=queue_job_store,
+            queue_backend=queue_backend,
+            org_id=org_id,
+            project_id=project_id,
+            project_slug=project_slug,
+            edition_id=outcome.edition_id,
+            edition_slug=outcome.slug,
+            build_id=outcome.build_id,
+            build_public_id=build_public_id,
         )
-        async with session.begin():
-            await queue_job_store.set_backend_job_id(
-                pending.child_queue_job_id,
-                backend_job_id,
-            )
         publish_jobs.append(
             {
-                "edition_slug": outcome.slug,
-                "publish_queue_job_public_id": pending.child_public_id,
+                "edition_slug": result.edition_slug,
+                "publish_queue_job_public_id": result.queue_job_public_id,
             }
         )
         logger.info(
             "Enqueued publish_edition job",
-            edition_slug=outcome.slug,
-            publish_queue_job_public_id=pending.child_public_id,
+            edition_slug=result.edition_slug,
+            publish_queue_job_public_id=result.queue_job_public_id,
         )
     return publish_jobs
 

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -402,6 +402,7 @@ async def _enqueue_children(  # noqa: PLR0913
                 kind=JobKind.keeper_sync_project,
                 org_id=org_id,
                 keeper_sync_run_id=run_id,
+                subject_label=ltd_slug,
             )
             if index == 0:
                 await run_store.transition_status(

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -33,6 +33,7 @@ from docverse.client.models import (
     KeeperSyncConfig,
     KeeperSyncRunStatus,
 )
+from docverse.config import config
 from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
@@ -45,7 +46,70 @@ from docverse.storage.queue_job_store import QueueJobStore
 # to free a stuck run on the next discovery attempt.
 _ORPHAN_IDLE_WINDOW = timedelta(minutes=5)
 
-__all__ = ["keeper_sync_project", "keeper_sync_run_discovery"]
+__all__ = [
+    "keeper_sync_project",
+    "keeper_sync_reaper",
+    "keeper_sync_run_discovery",
+]
+
+
+async def keeper_sync_reaper(ctx: dict[str, Any]) -> str:
+    """Cron-driven backstop that finalises silently-stuck keeper-sync runs.
+
+    Mechanism #2 of the two-mechanism guarantee that a sync run always
+    reaches a terminal state. arq's per-function ``timeout`` covers the
+    common case (a job actually runs past the timeout and arq cancels
+    it), but a worker pod that's OOM-killed mid-job or a job that arq
+    itself loses leaves a child ``queue_jobs`` row stuck in
+    ``in_progress`` forever — and with it the parent ``keeper_sync_runs``
+    row, which can never finalise while ``pending_count > 0``.
+
+    The reaper:
+
+    1. Reads ``config.keeper_sync_reaper_threshold_seconds`` (default
+       6 h, env-overridable so test/staging environments can drive it
+       down to seconds for fast verification).
+    2. Calls ``QueueJobStore.fail_silent_run_children`` to mark every
+       keeper-sync child whose ``date_started`` is older than that
+       threshold (and which has no ``date_completed``) as ``failed``.
+    3. For each unique ``keeper_sync_run_id`` whose children were just
+       reaped, calls ``_maybe_finalise_run`` so the parent run rolls up
+       to ``partial_failure``.
+
+    Wired as a cron job on ``KeeperSyncWorkerSettings.cron_jobs``
+    (every 30 min). Returns a one-line status string for arq's result
+    log; the structured ``logger.info`` carries the detail.
+    """
+    logger = structlog.get_logger("docverse.worker.keeper_sync_reaper")
+    threshold = timedelta(seconds=config.keeper_sync_reaper_threshold_seconds)
+
+    async for session in db_session_dependency():
+        factory = ctx["factory_builder"](session=session, logger=logger)
+        queue_job_store = factory.create_queue_job_store()
+        run_store = factory.create_keeper_sync_run_store()
+
+        async with session.begin():
+            reaped = await queue_job_store.fail_silent_run_children(
+                idle_after=threshold
+            )
+            run_ids = {qj.keeper_sync_run_id for qj in reaped}
+            for run_id in run_ids:
+                if run_id is None:
+                    continue
+                await _maybe_finalise_run(run_store=run_store, run_id=run_id)
+
+        if reaped:
+            logger.warning(
+                "Reaped silent keeper-sync child queue jobs",
+                reaped_count=len(reaped),
+                run_ids=sorted(r for r in run_ids if r is not None),
+            )
+        else:
+            logger.debug("No silent keeper-sync child queue jobs to reap")
+        return "completed"
+
+    msg = "No database session available"
+    raise RuntimeError(msg)
 
 
 async def keeper_sync_run_discovery(

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -21,6 +21,7 @@ lifecycle in tests without depending on the deeper
 from __future__ import annotations
 
 import traceback
+from datetime import timedelta
 from typing import Any, Literal
 
 import httpx
@@ -38,6 +39,12 @@ from docverse.factory import Factory
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
 from docverse.storage.queue_job_store import QueueJobStore
+
+# Window before a queued child with no ``backend_job_id`` is treated as
+# orphaned by ``_reconcile_orphan_children``. Long enough to never race
+# a healthy concurrent discovery worker that's mid-fanout, short enough
+# to free a stuck run on the next discovery attempt.
+_ORPHAN_IDLE_WINDOW = timedelta(minutes=5)
 
 __all__ = ["keeper_sync_project", "keeper_sync_run_discovery"]
 
@@ -79,6 +86,11 @@ async def keeper_sync_run_discovery(
 
         async with session.begin():
             await queue_job_store.start(queue_job_id)
+            await _reconcile_orphan_children(
+                queue_job_store=queue_job_store,
+                run_id=run_id,
+                logger=logger,
+            )
 
         try:
             config = await _load_config_snapshot(
@@ -267,6 +279,13 @@ async def _enqueue_children(  # noqa: PLR0913
     ``pending → in_progress`` run transition is atomic with the first
     child's queue-job row insert so any concurrent ``GET /runs/{id}``
     can never observe a run with children but still ``pending``.
+
+    The order leaves an orphan tail: if the worker dies between the
+    SQL commit and ``arq_queue.enqueue``, the row sits in ``queued``
+    with ``backend_job_id IS NULL`` and no arq job will ever pick it
+    up — pending forever, blocking finalisation. The next discovery
+    attempt sweeps these rows via ``_reconcile_orphan_children`` once
+    they age past ``_ORPHAN_IDLE_WINDOW``.
     """
     arq_queue = ctx["arq_queue"]
     for index, ltd_slug in enumerate(ltd_slugs):
@@ -282,7 +301,8 @@ async def _enqueue_children(  # noqa: PLR0913
                     new_status=KeeperSyncRunStatus.in_progress,
                 )
         # arq enqueue lives outside the session so the SQL transaction
-        # commits before redis sees a job id pointing at our row.
+        # commits before redis sees a job id pointing at our row. See
+        # the orphan-tail caveat in this function's docstring.
         metadata = await arq_queue.enqueue(
             "keeper_sync_project",
             _queue_name=KEEPER_SYNC_QUEUE_NAME,
@@ -300,6 +320,33 @@ async def _enqueue_children(  # noqa: PLR0913
             "Enqueued keeper_sync_project",
             ltd_slug=ltd_slug,
             queue_job_id=queue_job.id,
+        )
+
+
+async def _reconcile_orphan_children(
+    *,
+    queue_job_store: QueueJobStore,
+    run_id: int,
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    """Fail any orphan child rows left by a previous discovery attempt.
+
+    ``_enqueue_children`` commits each child ``queue_jobs`` row before
+    calling ``arq_queue.enqueue``, so a worker crash in that window
+    leaves an orphan: ``status='queued'``, ``backend_job_id IS NULL``,
+    no arq job ever scheduled. Without reconciliation the orphan
+    counts toward ``pending_count`` forever and the run can never
+    finalise. We sweep them at the top of each discovery attempt so a
+    retried (or operator-replayed) discovery can finish cleanly.
+    """
+    failed = await queue_job_store.fail_orphaned_run_children(
+        run_id=run_id, idle_after=_ORPHAN_IDLE_WINDOW
+    )
+    if failed:
+        logger.warning(
+            "Reconciled orphan keeper-sync child queue jobs",
+            orphan_count=len(failed),
+            orphan_ids=[job.id for job in failed],
         )
 
 

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -8,14 +8,13 @@ This module owns the ``docverse:sync-queue`` callable surface:
   product. It transitions its run from ``pending`` → ``in_progress``
   atomically with the first child enqueue.
 
-* ``keeper_sync_project`` — placeholder for the per-project sync,
-  which is delivered by #287. The slice keeps the function callable
-  end-to-end so child queue-job rows reach a terminal state and
-  ``GET /runs/{id}`` counter aggregation has something to count.
-
-The two together let an operator drive the full ``POST → GET``
-lifecycle in tests without depending on the deeper
-``KeeperSyncService`` from #287.
+* ``keeper_sync_project`` — orchestrates one LTD product into Docverse
+  by delegating to :class:`KeeperSyncService`. The worker bookends the
+  service call with two short transactions that own the
+  ``queue_jobs`` lifecycle (``start`` then ``complete`` / ``fail``) and
+  recompute run finalisation; the service itself manages the
+  state-row + Docverse-row commits inside its own ``session.begin()``
+  blocks.
 """
 
 from __future__ import annotations
@@ -123,6 +122,7 @@ async def keeper_sync_run_discovery(
                 org_id=org_id,
                 org_slug=org_slug,
                 run_id=run_id,
+                ltd_base_url=str(config.ltd_base_url),
                 ltd_slugs=in_scope,
                 logger=logger,
             )
@@ -173,18 +173,27 @@ async def keeper_sync_run_discovery(
 async def keeper_sync_project(
     ctx: dict[str, Any], payload: dict[str, Any]
 ) -> str:
-    """Stub per-project sync.
+    """Sync one LTD product into Docverse via :class:`KeeperSyncService`.
 
-    Marks the queue job complete and recomputes run finalisation.
-    Replaced wholesale by the deeper ``KeeperSyncService`` orchestration
-    from #287; this slice keeps the call site live so an operator can
-    drive ``POST /runs`` end-to-end and watch the aggregate counters
-    move through ``GET /runs/{id}``.
+    The worker brackets the service call with two short transactions:
+
+    1. Mark the ``queue_jobs`` row ``in_progress``.
+    2. Construct ``KeeperSyncService`` from the factory and invoke
+       :meth:`KeeperSyncService.sync_project`. The service runs outside
+       any outer ``session.begin()`` so it can manage its own commits
+       across LTD HTTP, content copy, and Docverse-side row writes.
+    3. On success, mark the queue job ``completed``; on a caught
+       exception, mark it ``failed`` with structured error details and
+       re-raise so arq records the job as failed. Both branches call
+       :func:`_maybe_finalise_run` so a terminal child cannot leave the
+       parent run stuck in ``in_progress``.
     """
+    org_id: int = payload["org_id"]
     org_slug: str = payload["org_slug"]
     run_id: int = payload["run_id"]
     queue_job_id: int = payload["queue_job_id"]
     ltd_slug: str = payload["ltd_slug"]
+    ltd_base_url: str = payload["ltd_base_url"]
     logger = structlog.get_logger("docverse.worker.keeper_sync_project").bind(
         org=org_slug, run_id=run_id, ltd_slug=ltd_slug
     )
@@ -196,12 +205,32 @@ async def keeper_sync_project(
 
         async with session.begin():
             await queue_job_store.start(queue_job_id)
+
+        service = factory.create_keeper_sync_service(
+            org_id=org_id,
+            service_label="keeper-sync",
+            ltd_base_url=ltd_base_url,
+        )
+        try:
+            await service.sync_project(org_id=org_id, ltd_slug=ltd_slug)
+        except Exception as exc:
+            logger.exception("Keeper-sync project failed")
+            async with session.begin():
+                await queue_job_store.fail(
+                    queue_job_id,
+                    errors={
+                        "message": str(exc),
+                        "type": type(exc).__name__,
+                        "traceback": traceback.format_exc(),
+                    },
+                )
+                await _maybe_finalise_run(run_store=run_store, run_id=run_id)
+            raise
+
+        async with session.begin():
             await queue_job_store.complete(queue_job_id)
-            await _maybe_finalise_run(
-                run_store=run_store,
-                run_id=run_id,
-            )
-        logger.info("Keeper-sync project stub completed")
+            await _maybe_finalise_run(run_store=run_store, run_id=run_id)
+        logger.info("Keeper-sync project completed")
         return "completed"
 
     msg = "No database session available"
@@ -267,6 +296,7 @@ async def _enqueue_children(  # noqa: PLR0913
     org_id: int,
     org_slug: str,
     run_id: int,
+    ltd_base_url: str,
     ltd_slugs: list[str],
     logger: structlog.stdlib.BoundLogger,
 ) -> None:
@@ -312,6 +342,7 @@ async def _enqueue_children(  # noqa: PLR0913
                 "run_id": run_id,
                 "queue_job_id": queue_job.id,
                 "ltd_slug": ltd_slug,
+                "ltd_base_url": ltd_base_url,
             },
         )
         async with session.begin():

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -202,16 +202,30 @@ async def keeper_sync_project(
         factory = ctx["factory_builder"](session=session, logger=logger)
         queue_job_store = factory.create_queue_job_store()
         run_store = factory.create_keeper_sync_run_store()
+        org_store = factory.create_org_store()
 
         async with session.begin():
             await queue_job_store.start(queue_job_id)
+            org = await org_store.get_by_id(org_id)
 
-        service = factory.create_keeper_sync_service(
-            org_id=org_id,
-            service_label="keeper-sync",
-            ltd_base_url=ltd_base_url,
-        )
         try:
+            if org is None:
+                msg = f"Organization {org_id} not found"
+                raise RuntimeError(msg)  # noqa: TRY301
+            publishing_store_label = org.publishing_store_label
+            if publishing_store_label is None:
+                msg = (
+                    f"Org {org_id} has no publishing_store_label "
+                    "configured; keeper-sync requires a publishing "
+                    "object store"
+                )
+                raise RuntimeError(msg)  # noqa: TRY301
+
+            service = factory.create_keeper_sync_service(
+                org_id=org_id,
+                service_label=publishing_store_label,
+                ltd_base_url=ltd_base_url,
+            )
             await service.sync_project(org_id=org_id, ltd_slug=ltd_slug)
         except Exception as exc:
             logger.exception("Keeper-sync project failed")

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -1,0 +1,345 @@
+"""arq worker functions for the LTD Keeper sync queue.
+
+This module owns the ``docverse:sync-queue`` callable surface:
+
+* ``keeper_sync_run_discovery`` — top-of-the-fanout job that loads the
+  org's ``keeper_sync_config`` snapshot, intersects it with LTD's flat
+  product list, and enqueues one ``keeper_sync_project`` per in-scope
+  product. It transitions its run from ``pending`` → ``in_progress``
+  atomically with the first child enqueue.
+
+* ``keeper_sync_project`` — placeholder for the per-project sync,
+  which is delivered by #287. The slice keeps the function callable
+  end-to-end so child queue-job rows reach a terminal state and
+  ``GET /runs/{id}`` counter aggregation has something to count.
+
+The two together let an operator drive the full ``POST → GET``
+lifecycle in tests without depending on the deeper
+``KeeperSyncService`` from #287.
+"""
+
+from __future__ import annotations
+
+import traceback
+from typing import Any, Literal
+
+import httpx
+import structlog
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import (
+    JobKind,
+    KeeperSyncConfig,
+    KeeperSyncRunStatus,
+)
+from docverse.exceptions import NotFoundError
+from docverse.factory import Factory
+from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+from docverse.storage.queue_job_store import QueueJobStore
+
+__all__ = ["keeper_sync_project", "keeper_sync_run_discovery"]
+
+
+async def keeper_sync_run_discovery(
+    ctx: dict[str, Any], payload: dict[str, Any]
+) -> str:
+    """Fan out one ``keeper_sync_project`` job per in-scope LTD product.
+
+    Parameters
+    ----------
+    ctx
+        arq worker context (``factory_builder``, ``http_client``,
+        ``arq_queue``).
+    payload
+        Job payload with ``org_id``, ``org_slug``, ``run_id``, and
+        ``queue_job_id`` (the discovery's own ``queue_jobs`` row, so
+        the worker can transition it through queued → in_progress →
+        completed/failed).
+
+    Returns
+    -------
+    str
+        ``"completed"`` on a clean fan-out (including the empty case)
+        or ``"failed"`` if discovery itself errored before fan-out.
+    """
+    org_id: int = payload["org_id"]
+    org_slug: str = payload["org_slug"]
+    run_id: int = payload["run_id"]
+    queue_job_id: int = payload["queue_job_id"]
+    logger = structlog.get_logger(
+        "docverse.worker.keeper_sync_run_discovery"
+    ).bind(org=org_slug, run_id=run_id)
+
+    async for session in db_session_dependency():
+        factory = ctx["factory_builder"](session=session, logger=logger)
+        queue_job_store = factory.create_queue_job_store()
+        run_store = factory.create_keeper_sync_run_store()
+
+        async with session.begin():
+            await queue_job_store.start(queue_job_id)
+
+        try:
+            config = await _load_config_snapshot(
+                session=session,
+                factory=factory,
+                org_slug=org_slug,
+            )
+            if not config.enabled:
+                msg = (
+                    f"Keeper sync is disabled for organization "
+                    f"{org_slug!r}; aborting discovery"
+                )
+                raise RuntimeError(msg)  # noqa: TRY301
+
+            ltd_slugs = await _fetch_ltd_product_slugs(
+                factory=factory, config=config, logger=logger
+            )
+            in_scope = _filter_to_allowlist(ltd_slugs, config.project_slugs)
+            logger.info(
+                "Resolved keeper-sync run scope",
+                ltd_count=len(ltd_slugs),
+                in_scope_count=len(in_scope),
+            )
+
+            await _enqueue_children(
+                ctx=ctx,
+                session=session,
+                queue_job_store=queue_job_store,
+                run_store=run_store,
+                org_id=org_id,
+                org_slug=org_slug,
+                run_id=run_id,
+                ltd_slugs=in_scope,
+                logger=logger,
+            )
+
+            async with session.begin():
+                await queue_job_store.update_phase(
+                    queue_job_id,
+                    "complete",
+                    progress={
+                        "message": "Discovery complete",
+                        "in_scope_count": len(in_scope),
+                    },
+                )
+                await queue_job_store.complete(queue_job_id)
+                # Empty fan-out: nothing for ``keeper_sync_project`` to
+                # finalise on the run, so terminate it here.
+                if not in_scope:
+                    await run_store.transition_status(
+                        run_id=run_id,
+                        new_status=KeeperSyncRunStatus.succeeded,
+                    )
+            logger.info(
+                "Keeper-sync discovery completed",
+                in_scope_count=len(in_scope),
+            )
+        except Exception as exc:
+            logger.exception("Keeper-sync discovery failed")
+            async with session.begin():
+                await queue_job_store.fail(
+                    queue_job_id,
+                    errors={
+                        "message": str(exc),
+                        "type": type(exc).__name__,
+                        "traceback": traceback.format_exc(),
+                    },
+                )
+                await run_store.transition_status(
+                    run_id=run_id,
+                    new_status=KeeperSyncRunStatus.failed,
+                )
+            return "failed"
+        return "completed"
+
+    msg = "No database session available"
+    raise RuntimeError(msg)
+
+
+async def keeper_sync_project(
+    ctx: dict[str, Any], payload: dict[str, Any]
+) -> str:
+    """Stub per-project sync.
+
+    Marks the queue job complete and recomputes run finalisation.
+    Replaced wholesale by the deeper ``KeeperSyncService`` orchestration
+    from #287; this slice keeps the call site live so an operator can
+    drive ``POST /runs`` end-to-end and watch the aggregate counters
+    move through ``GET /runs/{id}``.
+    """
+    org_slug: str = payload["org_slug"]
+    run_id: int = payload["run_id"]
+    queue_job_id: int = payload["queue_job_id"]
+    ltd_slug: str = payload["ltd_slug"]
+    logger = structlog.get_logger("docverse.worker.keeper_sync_project").bind(
+        org=org_slug, run_id=run_id, ltd_slug=ltd_slug
+    )
+
+    async for session in db_session_dependency():
+        factory = ctx["factory_builder"](session=session, logger=logger)
+        queue_job_store = factory.create_queue_job_store()
+        run_store = factory.create_keeper_sync_run_store()
+
+        async with session.begin():
+            await queue_job_store.start(queue_job_id)
+            await queue_job_store.complete(queue_job_id)
+            await _maybe_finalise_run(
+                run_store=run_store,
+                run_id=run_id,
+            )
+        logger.info("Keeper-sync project stub completed")
+        return "completed"
+
+    msg = "No database session available"
+    raise RuntimeError(msg)
+
+
+async def _load_config_snapshot(
+    *,
+    session: AsyncSession,
+    factory: Factory,
+    org_slug: str,
+) -> KeeperSyncConfig:
+    """Snapshot the org's ``keeper_sync_config`` for the run.
+
+    The snapshot is captured at job start so config edits made while a
+    run is in flight (e.g. an expanded allowlist) do not retroactively
+    widen its scope — the operator must POST a new run after the
+    current one terminates.
+    """
+    async with session.begin():
+        config_service = factory.create_keeper_sync_config_service()
+        return await config_service.get(org_slug=org_slug)
+
+
+async def _fetch_ltd_product_slugs(
+    *,
+    factory: Factory,
+    config: KeeperSyncConfig,
+    logger: structlog.stdlib.BoundLogger,
+) -> list[str]:
+    """Fetch every product slug visible on the configured LTD instance."""
+    client = factory.create_ltd_products_client(
+        base_url=str(config.ltd_base_url)
+    )
+    try:
+        return await client.list_product_slugs()
+    except httpx.HTTPError:
+        logger.exception("Failed to fetch LTD product slugs")
+        raise
+
+
+def _filter_to_allowlist(
+    ltd_slugs: list[str], allowlist: list[str] | Literal["*"]
+) -> list[str]:
+    """Intersect an LTD slug list with the org's configured allowlist.
+
+    ``"*"`` is the wildcard — every LTD slug stays in scope. Otherwise
+    ordering follows the LTD listing so successive runs against the
+    same LTD instance fan out their children deterministically.
+    """
+    if allowlist == "*":
+        return list(ltd_slugs)
+    allowed = set(allowlist)
+    return [slug for slug in ltd_slugs if slug in allowed]
+
+
+async def _enqueue_children(  # noqa: PLR0913
+    *,
+    ctx: dict[str, Any],
+    session: AsyncSession,
+    queue_job_store: QueueJobStore,
+    run_store: KeeperSyncRunStore,
+    org_id: int,
+    org_slug: str,
+    run_id: int,
+    ltd_slugs: list[str],
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    """Fan out one child ``keeper_sync_project`` job per slug.
+
+    Each iteration creates the ``queue_jobs`` row tagged with
+    ``keeper_sync_run_id`` *first* — so a crash mid-fan-out leaves
+    queued rows that progress aggregation can still see — then
+    enqueues the arq job and writes the backend job ID back. The
+    ``pending → in_progress`` run transition is atomic with the first
+    child's queue-job row insert so any concurrent ``GET /runs/{id}``
+    can never observe a run with children but still ``pending``.
+    """
+    arq_queue = ctx["arq_queue"]
+    for index, ltd_slug in enumerate(ltd_slugs):
+        async with session.begin():
+            queue_job = await queue_job_store.create(
+                kind=JobKind.keeper_sync_project,
+                org_id=org_id,
+                keeper_sync_run_id=run_id,
+            )
+            if index == 0:
+                await run_store.transition_status(
+                    run_id=run_id,
+                    new_status=KeeperSyncRunStatus.in_progress,
+                )
+        # arq enqueue lives outside the session so the SQL transaction
+        # commits before redis sees a job id pointing at our row.
+        metadata = await arq_queue.enqueue(
+            "keeper_sync_project",
+            _queue_name=KEEPER_SYNC_QUEUE_NAME,
+            payload={
+                "org_id": org_id,
+                "org_slug": org_slug,
+                "run_id": run_id,
+                "queue_job_id": queue_job.id,
+                "ltd_slug": ltd_slug,
+            },
+        )
+        async with session.begin():
+            await queue_job_store.set_backend_job_id(queue_job.id, metadata.id)
+        logger.debug(
+            "Enqueued keeper_sync_project",
+            ltd_slug=ltd_slug,
+            queue_job_id=queue_job.id,
+        )
+
+
+async def _maybe_finalise_run(
+    *,
+    run_store: KeeperSyncRunStore,
+    run_id: int,
+) -> None:
+    """Transition the run to a terminal status once all children are terminal.
+
+    Idempotent re-entry on the same terminal status is handled by
+    ``transition_status``'s same-status fast path. The explicit terminal
+    pre-check guards a different case: two child finalisers racing each
+    other can compute *different* terminal statuses (e.g. one sees all
+    children completed and picks ``succeeded`` just as another child's
+    failure commits, so the second finaliser picks ``partial_failure``).
+    Without the pre-check, the second caller would hit
+    ``transition_status``'s terminal→terminal guard and raise
+    ``InvalidJobStateError``, which would roll back the surrounding
+    ``session.begin()`` in ``keeper_sync_project`` and undo that
+    child's ``complete()``. We swallow the conflict here so the loser
+    of the race exits cleanly and lets the winning terminal status
+    stand.
+    """
+    counters = await run_store.aggregate_counters(run_id=run_id)
+    if counters.total_count == 0 or counters.pending_count > 0:
+        return
+    new_status = (
+        KeeperSyncRunStatus.partial_failure
+        if counters.failed_count > 0
+        else KeeperSyncRunStatus.succeeded
+    )
+    run = await run_store.get(run_id)
+    if run is None:
+        msg = f"Keeper sync run {run_id} not found"
+        raise NotFoundError(msg)
+    if run.status in {
+        KeeperSyncRunStatus.succeeded,
+        KeeperSyncRunStatus.partial_failure,
+        KeeperSyncRunStatus.failed,
+    }:
+        return
+    await run_store.transition_status(run_id=run_id, new_status=new_status)

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -481,12 +481,12 @@ async def _maybe_finalise_run(
     of the race exits cleanly and lets the winning terminal status
     stand.
     """
-    counters = await run_store.aggregate_counters(run_id=run_id)
-    if counters.total_count == 0 or counters.pending_count > 0:
+    activity = await run_store.aggregate_activity(run_id=run_id)
+    if activity.total_count == 0 or activity.pending_count > 0:
         return
     new_status = (
         KeeperSyncRunStatus.partial_failure
-        if counters.failed_count > 0
+        if activity.failed_count > 0
         else KeeperSyncRunStatus.succeeded
     )
     run = await run_store.get(run_id)

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -34,6 +34,7 @@ from docverse.client.models import (
     KeeperSyncRunStatus,
 )
 from docverse.config import config
+from docverse.domain.base32id import serialize_base32_id
 from docverse.factory import Factory
 from docverse.services.keeper_sync.service import ProjectSyncResult
 from docverse.services.keeper_sync_finalisation import maybe_finalise_run
@@ -348,20 +349,33 @@ async def _enqueue_publish_for_finalized_builds(  # noqa: PLR0913
     sync_result: ProjectSyncResult,
     logger: structlog.stdlib.BoundLogger,
 ) -> None:
-    """Run the publish path for every freshly-synced edition build.
+    """Run the publish path for every edition that needs publishing.
 
-    Iterates ``sync_result.edition_outcomes`` and, for each edition
-    whose ``BuildSyncOutcome`` actually finalized a new build (i.e. the
-    sync did not short-circuit on unchanged LTD ``date_rebuilt``),
-    invokes
+    Iterates ``sync_result.edition_outcomes`` and decides per-edition
+    whether to invoke
     :func:`docverse.services.publish_enqueue.enqueue_publish_for_edition`
     so KV publish + dashboard rebuild fire just like they do after a
     normal client upload. Each helper call tags the publish ``QueueJob``
     row with ``keeper_sync_run_id`` so the publish jobs roll into the
     parent run's ``GET /runs/{id}/jobs`` listing and progress counters.
 
-    Short-circuited builds are skipped intentionally: their state is
-    unchanged, so no new publish is needed.
+    Two branches:
+
+    * **Freshly-synced build** (``build_outcome.short_circuited`` is
+      ``False``). The sync just finalized a new build for the edition,
+      so a publish must follow.
+    * **Self-heal on short-circuit**. When sync short-circuits on
+      unchanged LTD ``date_rebuilt`` we'd normally skip, but if the
+      edition is sitting on a ``current_build_id`` with
+      ``publish_status IS NULL`` it never made it through the publish
+      path (e.g. the build pre-dates this enqueue logic landing, or a
+      prior publish enqueue was lost). In that case we enqueue a
+      catch-up publish using the edition's already-pointed-at build.
+      Editions whose ``publish_status`` is already ``pending`` /
+      ``published`` / ``failed`` are left alone — a stuck pending
+      publish is the in-flight publisher's problem to resolve, not
+      ours, and a successful or failed prior publish does not need
+      re-running on every reconciliation tick.
     """
     edition_store = factory.create_edition_store()
     history_store = factory.create_edition_build_history_store()
@@ -371,13 +385,30 @@ async def _enqueue_publish_for_finalized_builds(  # noqa: PLR0913
 
     for outcome in sync_result.edition_outcomes:
         build_outcome = outcome.build_outcome
-        if build_outcome is None or build_outcome.short_circuited:
+        if build_outcome is None:
             continue
-        if (
-            build_outcome.docverse_build_id is None
-            or build_outcome.docverse_build_public_id is None
-        ):
-            continue
+
+        if build_outcome.short_circuited:
+            target = await _resolve_self_heal_target(
+                session=session,
+                edition_store=edition_store,
+                project_id=project_id,
+                edition_slug=outcome.docverse_slug,
+            )
+            if target is None:
+                continue
+            build_id, build_public_id = target
+            log_phase = "self_heal"
+        else:
+            if (
+                build_outcome.docverse_build_id is None
+                or build_outcome.docverse_build_public_id is None
+            ):
+                continue
+            build_id = build_outcome.docverse_build_id
+            build_public_id = build_outcome.docverse_build_public_id
+            log_phase = "synced"
+
         await enqueue_publish_for_edition(
             session=session,
             edition_store=edition_store,
@@ -389,15 +420,49 @@ async def _enqueue_publish_for_finalized_builds(  # noqa: PLR0913
             project_slug=project_slug,
             edition_id=outcome.docverse_edition_id,
             edition_slug=outcome.docverse_slug,
-            build_id=build_outcome.docverse_build_id,
-            build_public_id=build_outcome.docverse_build_public_id,
+            build_id=build_id,
+            build_public_id=build_public_id,
             keeper_sync_run_id=run_id,
         )
         logger.info(
             "Enqueued publish_edition for synced build",
             edition_slug=outcome.docverse_slug,
-            build_id=build_outcome.docverse_build_id,
+            build_id=build_id,
+            phase=log_phase,
         )
+
+
+async def _resolve_self_heal_target(
+    *,
+    session: AsyncSession,
+    edition_store: Any,
+    project_id: int,
+    edition_slug: str,
+) -> tuple[int, str] | None:
+    """Return ``(build_id, build_public_id)`` if the edition needs catch-up.
+
+    Returns ``None`` when the edition has no ``current_build_id``, when
+    its ``publish_status`` is already set (so a publish has run, is in
+    flight, or previously failed), or when the joined build public_id
+    is missing for any reason. The read happens inside its own
+    transaction so it does not interfere with
+    ``enqueue_publish_for_edition``'s phased commits.
+    """
+    async with session.begin():
+        edition = await edition_store.get_by_slug(
+            project_id=project_id, slug=edition_slug
+        )
+    if edition is None:
+        return None
+    if edition.publish_status is not None:
+        return None
+    if edition.current_build_id is None:
+        return None
+    if edition.current_build_public_id is None:
+        return None
+    return edition.current_build_id, serialize_base32_id(
+        edition.current_build_public_id
+    )
 
 
 async def _load_config_snapshot(

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -34,9 +34,11 @@ from docverse.client.models import (
     KeeperSyncRunStatus,
 )
 from docverse.config import config
-from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
+from docverse.services.keeper_sync.service import ProjectSyncResult
+from docverse.services.keeper_sync_finalisation import maybe_finalise_run
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
+from docverse.services.publish_enqueue import enqueue_publish_for_edition
 from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
 from docverse.storage.queue_job_store import QueueJobStore
 
@@ -73,7 +75,7 @@ async def keeper_sync_reaper(ctx: dict[str, Any]) -> str:
        keeper-sync child whose ``date_started`` is older than that
        threshold (and which has no ``date_completed``) as ``failed``.
     3. For each unique ``keeper_sync_run_id`` whose children were just
-       reaped, calls ``_maybe_finalise_run`` so the parent run rolls up
+       reaped, calls ``maybe_finalise_run`` so the parent run rolls up
        to ``partial_failure``.
 
     Wired as a cron job on ``KeeperSyncWorkerSettings.cron_jobs``
@@ -96,7 +98,7 @@ async def keeper_sync_reaper(ctx: dict[str, Any]) -> str:
             for run_id in run_ids:
                 if run_id is None:
                     continue
-                await _maybe_finalise_run(run_store=run_store, run_id=run_id)
+                await maybe_finalise_run(run_store=run_store, run_id=run_id)
 
         if reaped:
             logger.warning(
@@ -246,10 +248,20 @@ async def keeper_sync_project(
        :meth:`KeeperSyncService.sync_project`. The service runs outside
        any outer ``session.begin()`` so it can manage its own commits
        across LTD HTTP, content copy, and Docverse-side row writes.
-    3. On success, mark the queue job ``completed``; on a caught
+    3. For each finalized ``(edition, build)`` pair the service
+       returned, call
+       :func:`docverse.services.publish_enqueue.enqueue_publish_for_edition`
+       so the publish path runs the same way it does after a normal
+       client upload — KV publish via ``EditionPublishingService.publish``
+       and a cascaded ``dashboard_build`` enqueue. The publish
+       ``QueueJob`` rows carry ``keeper_sync_run_id`` so they roll into
+       the parent run's progress counters and ``date_last_activity``.
+       Short-circuited builds (LTD ``date_rebuilt`` unchanged) are
+       skipped — there's no new state to publish.
+    4. On success, mark the queue job ``completed``; on a caught
        exception, mark it ``failed`` with structured error details and
        re-raise so arq records the job as failed. Both branches call
-       :func:`_maybe_finalise_run` so a terminal child cannot leave the
+       :func:`maybe_finalise_run` so a terminal child cannot leave the
        parent run stuck in ``in_progress``.
     """
     org_id: int = payload["org_id"]
@@ -290,7 +302,18 @@ async def keeper_sync_project(
                 service_label=publishing_store_label,
                 ltd_base_url=ltd_base_url,
             )
-            await service.sync_project(org_id=org_id, ltd_slug=ltd_slug)
+            sync_result = await service.sync_project(
+                org_id=org_id, ltd_slug=ltd_slug
+            )
+            await _enqueue_publish_for_finalized_builds(
+                factory=factory,
+                session=session,
+                queue_job_store=queue_job_store,
+                org_id=org_id,
+                run_id=run_id,
+                sync_result=sync_result,
+                logger=logger,
+            )
         except Exception as exc:
             logger.exception("Keeper-sync project failed")
             async with session.begin():
@@ -302,17 +325,79 @@ async def keeper_sync_project(
                         "traceback": traceback.format_exc(),
                     },
                 )
-                await _maybe_finalise_run(run_store=run_store, run_id=run_id)
+                await maybe_finalise_run(run_store=run_store, run_id=run_id)
             raise
 
         async with session.begin():
             await queue_job_store.complete(queue_job_id)
-            await _maybe_finalise_run(run_store=run_store, run_id=run_id)
+            await maybe_finalise_run(run_store=run_store, run_id=run_id)
         logger.info("Keeper-sync project completed")
         return "completed"
 
     msg = "No database session available"
     raise RuntimeError(msg)
+
+
+async def _enqueue_publish_for_finalized_builds(  # noqa: PLR0913
+    *,
+    factory: Factory,
+    session: AsyncSession,
+    queue_job_store: QueueJobStore,
+    org_id: int,
+    run_id: int,
+    sync_result: ProjectSyncResult,
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    """Run the publish path for every freshly-synced edition build.
+
+    Iterates ``sync_result.edition_outcomes`` and, for each edition
+    whose ``BuildSyncOutcome`` actually finalized a new build (i.e. the
+    sync did not short-circuit on unchanged LTD ``date_rebuilt``),
+    invokes
+    :func:`docverse.services.publish_enqueue.enqueue_publish_for_edition`
+    so KV publish + dashboard rebuild fire just like they do after a
+    normal client upload. Each helper call tags the publish ``QueueJob``
+    row with ``keeper_sync_run_id`` so the publish jobs roll into the
+    parent run's ``GET /runs/{id}/jobs`` listing and progress counters.
+
+    Short-circuited builds are skipped intentionally: their state is
+    unchanged, so no new publish is needed.
+    """
+    edition_store = factory.create_edition_store()
+    history_store = factory.create_edition_build_history_store()
+    queue_backend = factory.create_queue_backend()
+    project_slug = sync_result.docverse_project_slug
+    project_id = sync_result.docverse_project_id
+
+    for outcome in sync_result.edition_outcomes:
+        build_outcome = outcome.build_outcome
+        if build_outcome is None or build_outcome.short_circuited:
+            continue
+        if (
+            build_outcome.docverse_build_id is None
+            or build_outcome.docverse_build_public_id is None
+        ):
+            continue
+        await enqueue_publish_for_edition(
+            session=session,
+            edition_store=edition_store,
+            history_store=history_store,
+            queue_job_store=queue_job_store,
+            queue_backend=queue_backend,
+            org_id=org_id,
+            project_id=project_id,
+            project_slug=project_slug,
+            edition_id=outcome.docverse_edition_id,
+            edition_slug=outcome.docverse_slug,
+            build_id=build_outcome.docverse_build_id,
+            build_public_id=build_outcome.docverse_build_public_id,
+            keeper_sync_run_id=run_id,
+        )
+        logger.info(
+            "Enqueued publish_edition for synced build",
+            edition_slug=outcome.docverse_slug,
+            build_id=build_outcome.docverse_build_id,
+        )
 
 
 async def _load_config_snapshot(
@@ -458,45 +543,3 @@ async def _reconcile_orphan_children(
             orphan_count=len(failed),
             orphan_ids=[job.id for job in failed],
         )
-
-
-async def _maybe_finalise_run(
-    *,
-    run_store: KeeperSyncRunStore,
-    run_id: int,
-) -> None:
-    """Transition the run to a terminal status once all children are terminal.
-
-    Idempotent re-entry on the same terminal status is handled by
-    ``transition_status``'s same-status fast path. The explicit terminal
-    pre-check guards a different case: two child finalisers racing each
-    other can compute *different* terminal statuses (e.g. one sees all
-    children completed and picks ``succeeded`` just as another child's
-    failure commits, so the second finaliser picks ``partial_failure``).
-    Without the pre-check, the second caller would hit
-    ``transition_status``'s terminal→terminal guard and raise
-    ``InvalidJobStateError``, which would roll back the surrounding
-    ``session.begin()`` in ``keeper_sync_project`` and undo that
-    child's ``complete()``. We swallow the conflict here so the loser
-    of the race exits cleanly and lets the winning terminal status
-    stand.
-    """
-    activity = await run_store.aggregate_activity(run_id=run_id)
-    if activity.total_count == 0 or activity.pending_count > 0:
-        return
-    new_status = (
-        KeeperSyncRunStatus.partial_failure
-        if activity.failed_count > 0
-        else KeeperSyncRunStatus.succeeded
-    )
-    run = await run_store.get(run_id)
-    if run is None:
-        msg = f"Keeper sync run {run_id} not found"
-        raise NotFoundError(msg)
-    if run.status in {
-        KeeperSyncRunStatus.succeeded,
-        KeeperSyncRunStatus.partial_failure,
-        KeeperSyncRunStatus.failed,
-    }:
-        return
-    await run_store.transition_status(run_id=run_id, new_status=new_status)

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -24,6 +24,7 @@ from docverse.factory import Factory
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_id,
 )
+from docverse.services.keeper_sync_finalisation import maybe_finalise_run
 from docverse.services.lock_service import LockKey
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -129,9 +130,15 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                         queue_job_id=queue_job_id,
                         exc=exc,
                     )
+                    await _maybe_finalise_keeper_sync_run(
+                        factory=factory, queue_job_id=queue_job_id
+                    )
                 return "failed"
             async with session.begin():
                 await queue_job_store.complete(queue_job_id)
+                await _maybe_finalise_keeper_sync_run(
+                    factory=factory, queue_job_id=queue_job_id
+                )
             logger.info("Edition publish completed")
             await try_enqueue_dashboard_build_by_id(
                 factory=factory,
@@ -242,4 +249,36 @@ async def _mark_failed(  # noqa: PLR0913
             "type": type(exc).__name__,
             "traceback": traceback.format_exc(),
         },
+    )
+
+
+async def _maybe_finalise_keeper_sync_run(
+    *,
+    factory: Factory,
+    queue_job_id: int,
+) -> None:
+    """Roll up the parent keeper-sync run if this publish was attributed.
+
+    Publish jobs enqueued by ``keeper_sync_project`` (via the shared
+    ``enqueue_publish_for_edition`` helper) carry ``keeper_sync_run_id``
+    on their ``queue_jobs`` row so they roll into the run's progress
+    counters. Without an explicit hook here, a successfully-completed
+    publish would leave the parent run perpetually ``in_progress`` —
+    the keeper-sync reaper only fails *silent* ``in_progress`` rows,
+    not legitimately-completed ones. Calling
+    :func:`maybe_finalise_run` after each publish terminal transition
+    drives the run to ``succeeded`` / ``partial_failure`` once every
+    attributed child has reached terminal.
+
+    Publishes that were *not* attributed to a keeper-sync run (the
+    normal client-upload path) leave ``keeper_sync_run_id IS NULL``
+    and this helper returns without touching any run row.
+    """
+    queue_job_store = factory.create_queue_job_store()
+    run_store = factory.create_keeper_sync_run_store()
+    queue_job = await queue_job_store.get(queue_job_id)
+    if queue_job is None or queue_job.keeper_sync_run_id is None:
+        return
+    await maybe_finalise_run(
+        run_store=run_store, run_id=queue_job.keeper_sync_run_id
     )

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -22,12 +22,15 @@ from docverse.config import Configuration
 from docverse.database import get_current_revision
 from docverse.factory import Factory
 from docverse.services.credential_encryptor import CredentialEncryptor
+from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.storage.github import validate_github_app
 
 from .functions import (
     build_processing,
     dashboard_build,
     dashboard_sync,
+    keeper_sync_project,
+    keeper_sync_run_discovery,
     ping,
     publish_edition,
 )
@@ -212,7 +215,7 @@ async def shutdown(ctx: dict[str, Any]) -> None:
 
 
 class WorkerSettings:
-    """arq WorkerSettings for Docverse."""
+    """arq WorkerSettings for the default Docverse queue."""
 
     functions = [
         build_processing,
@@ -223,5 +226,27 @@ class WorkerSettings:
     ]
     redis_settings = config.arq_redis_settings
     queue_name = config.arq_queue_name
+    on_startup = startup
+    on_shutdown = shutdown
+
+
+class KeeperSyncWorkerSettings:
+    """arq WorkerSettings for the dedicated LTD-sync queue.
+
+    Bound to ``docverse:sync-queue`` (see :data:`KEEPER_SYNC_QUEUE_NAME`)
+    so a noisy backfill cannot starve ``build_processing`` and
+    ``publish_edition`` jobs on the default queue. Both classes share
+    the same ``startup`` / ``shutdown`` hooks and therefore the same
+    ``WorkerFactoryBuilder``, so all worker code paths see one
+    consistent dependency graph regardless of which queue the job
+    came in on.
+    """
+
+    functions = [
+        keeper_sync_run_discovery,
+        keeper_sync_project,
+    ]
+    redis_settings = config.arq_redis_settings
+    queue_name = KEEPER_SYNC_QUEUE_NAME
     on_startup = startup
     on_shutdown = shutdown

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import httpx
 import structlog
+from arq import cron, func
 from pydantic import SecretStr
 from rubin.repertoire import DiscoveryClient
 from safir.arq import ArqQueue, RedisArqQueue
@@ -30,6 +31,7 @@ from .functions import (
     dashboard_build,
     dashboard_sync,
     keeper_sync_project,
+    keeper_sync_reaper,
     keeper_sync_run_discovery,
     ping,
     publish_edition,
@@ -240,11 +242,37 @@ class KeeperSyncWorkerSettings:
     ``WorkerFactoryBuilder``, so all worker code paths see one
     consistent dependency graph regardless of which queue the job
     came in on.
+
+    The keeper-sync functions are wrapped with :func:`arq.func` so the
+    queue carries a per-job ``timeout`` (sourced from
+    ``Config.keeper_sync_job_timeout_seconds``) and ``max_tries=1``
+    instead of arq's 5-attempt default. A failure must surface
+    promptly so the existing per-function ``except Exception`` block
+    can route to ``queue_job_store.fail()`` and the parent
+    ``keeper_sync_runs`` row finalises via ``_maybe_finalise_run``.
+    The cron-driven :func:`keeper_sync_reaper` is the second backstop
+    — it covers the case where arq itself loses a job (e.g. an
+    OOM-killed worker pod) and no timeout ever fires.
     """
 
     functions = [
-        keeper_sync_run_discovery,
-        keeper_sync_project,
+        func(
+            keeper_sync_run_discovery,
+            timeout=config.keeper_sync_job_timeout_seconds,
+            max_tries=1,
+        ),
+        func(
+            keeper_sync_project,
+            timeout=config.keeper_sync_job_timeout_seconds,
+            max_tries=1,
+        ),
+        keeper_sync_reaper,
+    ]
+    cron_jobs = [
+        cron(
+            keeper_sync_reaper,
+            minute={0, 30},
+        ),
     ]
     redis_settings = config.arq_redis_settings
     queue_name = KEEPER_SYNC_QUEUE_NAME

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,37 @@
+"""Tests for ``docverse.config.Configuration``.
+
+Smoke-tests the keeper-sync timeout knobs that were introduced for
+the run-finalisation guarantees on ``KeeperSyncWorkerSettings``. Both
+defaults and env-var overrides matter: test/staging environments
+need to drive the values way down (e.g. ``KEEPER_SYNC_JOB_TIMEOUT_SECONDS=30``)
+to surface stuck-worker behaviour quickly, while production needs
+the documented 1-hour / 6-hour defaults.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from docverse.config import Configuration
+
+
+def test_keeper_sync_timeout_defaults() -> None:
+    """Documented defaults: 60 min job timeout, 6 h reaper threshold."""
+    config = Configuration()
+    assert config.keeper_sync_job_timeout_seconds == 3600
+    assert config.keeper_sync_reaper_threshold_seconds == 21600
+
+
+def test_keeper_sync_timeout_env_var_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both knobs are env-var overridable under the ``DOCVERSE_`` prefix.
+
+    Test/staging needs to drive these way down (seconds, not hours)
+    to verify stuck-run handling end-to-end.
+    """
+    monkeypatch.setenv("DOCVERSE_KEEPER_SYNC_JOB_TIMEOUT_SECONDS", "30")
+    monkeypatch.setenv("DOCVERSE_KEEPER_SYNC_REAPER_THRESHOLD_SECONDS", "120")
+    config = Configuration()
+    assert config.keeper_sync_job_timeout_seconds == 30
+    assert config.keeper_sync_reaper_threshold_seconds == 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,12 +38,14 @@ from docverse.dbschema import Base
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.domain.base32id import serialize_base32_id
 from docverse.main import app as docverse_app
+from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.storage.build_store import BuildStore
 from docverse.storage.membership_store import OrgMembershipStore
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from docverse.storage.user_info_store import StubUserInfoStore
 
+from .support.arq_testing import register_queue
 from .support.github_mock import GitHubMock, make_rsa_pem
 
 __all__ = [
@@ -120,9 +122,13 @@ async def app() -> AsyncGenerator[FastAPI]:
         context_dependency._superadmin_usernames = ["superadmin"]
         # Replace the MockArqQueue with one that uses the configured
         # queue name so ArqQueueBackend can enqueue to the right queue.
-        arq_dependency._arq_queue = MockArqQueue(
-            default_queue_name=config.arq_queue_name
-        )
+        # Register the dedicated keeper-sync queue too — MockArqQueue
+        # only auto-creates the slot for its ``default_queue_name``,
+        # so the ``POST /orgs/{org}/keeper-sync/runs`` enqueue would
+        # otherwise hit ``KeyError`` on first use.
+        arq_queue = MockArqQueue(default_queue_name=config.arq_queue_name)
+        register_queue(arq_queue, KEEPER_SYNC_QUEUE_NAME)
+        arq_dependency._arq_queue = arq_queue
         yield docverse_app
 
 

--- a/tests/handlers/keeper_sync_runs_test.py
+++ b/tests/handlers/keeper_sync_runs_test.py
@@ -237,6 +237,54 @@ async def test_get_run_404_for_run_in_other_org(
 
 
 @pytest.mark.asyncio
+async def test_list_runs_returns_per_run_counters(
+    client: AsyncClient,
+) -> None:
+    """``GET /runs`` returns correct counters scoped to each run."""
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    # Seed two terminal runs directly — counter aggregation must scope
+    # per-run, not bleed across runs in the same org.
+    async for session in db_session_dependency():
+        async with session.begin():
+            row_a = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="succeeded"
+            )
+            row_b = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="failed"
+            )
+            session.add(row_a)
+            session.add(row_b)
+            await session.flush()
+            run_a_id = row_a.id
+            run_b_id = row_b.id
+            await session.commit()
+
+    await _seed_queue_job(
+        org_id=org_id, run_id=run_a_id, status=JobStatus.completed
+    )
+    await _seed_queue_job(
+        org_id=org_id, run_id=run_a_id, status=JobStatus.completed
+    )
+    await _seed_queue_job(
+        org_id=org_id, run_id=run_b_id, status=JobStatus.failed
+    )
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    runs = {r["id"]: r for r in response.json()}
+    assert runs[run_a_id]["succeeded_count"] == 2
+    assert runs[run_a_id]["failed_count"] == 0
+    assert runs[run_a_id]["total_count"] == 2
+    assert runs[run_b_id]["succeeded_count"] == 0
+    assert runs[run_b_id]["failed_count"] == 1
+    assert runs[run_b_id]["total_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_list_runs_returns_runs_newest_first(
     client: AsyncClient,
 ) -> None:

--- a/tests/handlers/keeper_sync_runs_test.py
+++ b/tests/handlers/keeper_sync_runs_test.py
@@ -9,6 +9,7 @@ import pytest
 import structlog
 from httpx import AsyncClient
 from safir.dependencies.db_session import db_session_dependency
+from safir.http import PaginationLinkData
 
 from docverse.client.models import OrgRole
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
@@ -312,14 +313,10 @@ async def test_list_runs_paginates_with_cursor(client: AsyncClient) -> None:
     assert first.status_code == 200
     page_one = first.json()
     assert len(page_one) == 2
-    link = first.headers.get("Link", "")
-    assert "next" in link
-
-    # Extract the next cursor from the Link header.
-    next_url = _extract_next_url(link)
-    assert next_url is not None
+    links = PaginationLinkData.from_header(first.headers.get("link"))
+    assert links.next_url is not None
     second = await client.get(
-        next_url, headers={"X-Auth-Request-User": _ADMIN}
+        links.next_url, headers={"X-Auth-Request-User": _ADMIN}
     )
     assert second.status_code == 200
     page_two = second.json()
@@ -327,16 +324,6 @@ async def test_list_runs_paginates_with_cursor(client: AsyncClient) -> None:
     page_one_ids = {r["id"] for r in page_one}
     page_two_ids = {r["id"] for r in page_two}
     assert page_one_ids.isdisjoint(page_two_ids)
-
-
-def _extract_next_url(link_header: str) -> str | None:
-    for part in link_header.split(","):
-        section = part.strip()
-        if section.endswith('rel="next"'):
-            url = section.split(";")[0].strip()
-            if url.startswith("<") and url.endswith(">"):
-                return url[1:-1]
-    return None
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/keeper_sync_runs_test.py
+++ b/tests/handlers/keeper_sync_runs_test.py
@@ -49,8 +49,12 @@ async def _seed_queue_job(
     org_id: int,
     run_id: int,
     status: JobStatus,
-) -> None:
-    """Seed a queue_jobs row directly attributed to the run."""
+    subject_label: str | None = None,
+) -> int:
+    """Seed a queue_jobs row directly attributed to the run.
+
+    Returns the row's primary key id.
+    """
     async for session in db_session_dependency():
         async with session.begin():
             row = SqlQueueJob(
@@ -59,6 +63,7 @@ async def _seed_queue_job(
                 status=status.value,
                 org_id=org_id,
                 keeper_sync_run_id=run_id,
+                subject_label=subject_label,
                 date_completed=datetime.now(tz=UTC)
                 if status
                 in {
@@ -70,7 +75,12 @@ async def _seed_queue_job(
                 else None,
             )
             session.add(row)
+            await session.flush()
+            row_id = row.id
             await session.commit()
+            return row_id
+    msg = "no session"
+    raise AssertionError(msg)
 
 
 async def _get_org_id() -> int:
@@ -392,6 +402,205 @@ async def test_get_runs_403_for_non_admin(client: AsyncClient) -> None:
     await seed_member(_ORG, "reader-user", OrgRole.reader)
     response = await client.get(
         f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_run_jobs_returns_subject_label(
+    client: AsyncClient,
+) -> None:
+    """``GET /runs/{id}/jobs`` round-trips ``subject_label`` per child."""
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    async for session in db_session_dependency():
+        async with session.begin():
+            run = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="in_progress"
+            )
+            session.add(run)
+            await session.flush()
+            run_id = run.id
+            await session.commit()
+
+    await _seed_queue_job(
+        org_id=org_id,
+        run_id=run_id,
+        status=JobStatus.completed,
+        subject_label="sqr-001",
+    )
+    await _seed_queue_job(
+        org_id=org_id,
+        run_id=run_id,
+        status=JobStatus.in_progress,
+        subject_label="sqr-002",
+    )
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    jobs = response.json()
+    assert len(jobs) == 2
+    labels = {job["subject_label"] for job in jobs}
+    assert labels == {"sqr-001", "sqr-002"}
+    # Newest first: in_progress was inserted second.
+    assert jobs[0]["subject_label"] == "sqr-002"
+    assert response.headers["X-Total-Count"] == "2"
+    # The keeper_sync_run_id field is exposed on the response.
+    assert all(job["keeper_sync_run_id"] == run_id for job in jobs)
+
+
+@pytest.mark.asyncio
+async def test_get_run_jobs_filters_by_status(client: AsyncClient) -> None:
+    """``?status=failed`` narrows the result set to failed children."""
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    async for session in db_session_dependency():
+        async with session.begin():
+            run = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="in_progress"
+            )
+            session.add(run)
+            await session.flush()
+            run_id = run.id
+            await session.commit()
+
+    await _seed_queue_job(
+        org_id=org_id,
+        run_id=run_id,
+        status=JobStatus.completed,
+        subject_label="ok-1",
+    )
+    await _seed_queue_job(
+        org_id=org_id,
+        run_id=run_id,
+        status=JobStatus.failed,
+        subject_label="bad-1",
+    )
+    await _seed_queue_job(
+        org_id=org_id,
+        run_id=run_id,
+        status=JobStatus.failed,
+        subject_label="bad-2",
+    )
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs?status=failed",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    jobs = response.json()
+    assert len(jobs) == 2
+    assert {job["subject_label"] for job in jobs} == {"bad-1", "bad-2"}
+    assert all(job["status"] == "failed" for job in jobs)
+    assert response.headers["X-Total-Count"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_get_run_jobs_paginates_with_cursor(
+    client: AsyncClient,
+) -> None:
+    """``limit`` + ``cursor`` paginate through child queue jobs."""
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    async for session in db_session_dependency():
+        async with session.begin():
+            run = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="in_progress"
+            )
+            session.add(run)
+            await session.flush()
+            run_id = run.id
+            await session.commit()
+
+    for index in range(3):
+        await _seed_queue_job(
+            org_id=org_id,
+            run_id=run_id,
+            status=JobStatus.completed,
+            subject_label=f"slug-{index}",
+        )
+
+    first = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs?limit=2",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert first.status_code == 200
+    page_one = first.json()
+    assert len(page_one) == 2
+    links = PaginationLinkData.from_header(first.headers.get("link"))
+    assert links.next_url is not None
+
+    second = await client.get(
+        links.next_url, headers={"X-Auth-Request-User": _ADMIN}
+    )
+    assert second.status_code == 200
+    page_two = second.json()
+    assert len(page_two) == 1
+    page_one_ids = {job["id"] for job in page_one}
+    page_two_ids = {job["id"] for job in page_two}
+    assert page_one_ids.isdisjoint(page_two_ids)
+
+
+@pytest.mark.asyncio
+async def test_get_run_jobs_404_for_unknown_run(client: AsyncClient) -> None:
+    await _setup_org(client)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/999/jobs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_run_jobs_404_for_run_in_other_org(
+    client: AsyncClient,
+) -> None:
+    """Cross-org access surfaces as 404, not 403."""
+    await _setup_org(client)
+    other_org = "ks-org-other"
+    await seed_org_with_admin(client, other_org, _ADMIN)
+    logger = structlog.get_logger("test")
+    async for session in db_session_dependency():
+        async with session.begin():
+            store = OrganizationStore(session=session, logger=logger)
+            other = await store.get_by_slug(other_org)
+            assert other is not None
+            row = SqlKeeperSyncRun(
+                org_id=other.id, kind="backfill", status="pending"
+            )
+            session.add(row)
+            await session.flush()
+            run_id = row.id
+            await session.commit()
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_run_jobs_403_for_non_admin(client: AsyncClient) -> None:
+    await _setup_org(client)
+    await seed_member(_ORG, "reader-user", OrgRole.reader)
+    org_id = await _get_org_id()
+    async for session in db_session_dependency():
+        async with session.begin():
+            run = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="pending"
+            )
+            session.add(run)
+            await session.flush()
+            run_id = run.id
+            await session.commit()
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs",
         headers={"X-Auth-Request-User": "reader-user"},
     )
     assert response.status_code == 403

--- a/tests/handlers/keeper_sync_runs_test.py
+++ b/tests/handlers/keeper_sync_runs_test.py
@@ -10,6 +10,7 @@ import structlog
 from httpx import AsyncClient
 from safir.dependencies.db_session import db_session_dependency
 from safir.http import PaginationLinkData
+from sqlalchemy import select
 
 from docverse.client.models import OrgRole
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
@@ -204,6 +205,125 @@ async def test_get_run_returns_aggregate_counters(
     assert body["succeeded_count"] == 2
     assert body["failed_count"] == 2
     assert body["total_count"] == 7
+    # date_last_activity reflects the MAX(coalesce(...)) across the
+    # children and is non-null because the run has attributed jobs.
+    assert body["date_last_activity"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_run_date_last_activity_matches_max_child_event(
+    client: AsyncClient,
+) -> None:
+    """``date_last_activity`` reflects the MAX coalesced child timestamp."""
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    # Seed a run directly so the response shape doesn't depend on the
+    # discovery queue-job's auto-attributed timestamps.
+    async for session in db_session_dependency():
+        async with session.begin():
+            row = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="in_progress"
+            )
+            session.add(row)
+            await session.flush()
+            run_id = row.id
+            await session.commit()
+
+    # Three children, each completing at successively later instants.
+    # The MAX(coalesce(...)) post-condition picks the latest one.
+    completed_ids: list[int] = [
+        await _seed_queue_job(
+            org_id=org_id, run_id=run_id, status=JobStatus.completed
+        )
+        for _ in range(3)
+    ]
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    last_activity = datetime.fromisoformat(body["date_last_activity"])
+    # The third child's date_completed is the latest event the run has
+    # observed; the response surfaces it as the run's date_last_activity.
+    async for session in db_session_dependency():
+        async with session.begin():
+            stmt = select(SqlQueueJob.date_completed).where(
+                SqlQueueJob.id == completed_ids[-1]
+            )
+            latest = (await session.execute(stmt)).scalar_one()
+            assert latest is not None
+            assert last_activity == latest
+
+
+@pytest.mark.asyncio
+async def test_get_run_date_last_activity_null_when_no_children(
+    client: AsyncClient,
+) -> None:
+    """``date_last_activity`` is null on a run with no attributed jobs."""
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    async for session in db_session_dependency():
+        async with session.begin():
+            row = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="pending"
+            )
+            session.add(row)
+            await session.flush()
+            run_id = row.id
+            await session.commit()
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_count"] == 0
+    assert body["date_last_activity"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_runs_surfaces_date_last_activity_per_row(
+    client: AsyncClient,
+) -> None:
+    """``GET /runs`` exposes ``date_last_activity`` per row.
+
+    A run with attributed children carries a non-null timestamp; a run
+    without children carries ``null``. Both must coexist in a single
+    page so the run-list aggregation is verified to keep its
+    one-round-trip per page guarantee even when child rows are sparse.
+    """
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    async for session in db_session_dependency():
+        async with session.begin():
+            with_children = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="succeeded"
+            )
+            without_children = SqlKeeperSyncRun(
+                org_id=org_id, kind="backfill", status="failed"
+            )
+            session.add(with_children)
+            session.add(without_children)
+            await session.flush()
+            with_id = with_children.id
+            without_id = without_children.id
+            await session.commit()
+
+    await _seed_queue_job(
+        org_id=org_id, run_id=with_id, status=JobStatus.completed
+    )
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    runs = {r["id"]: r for r in response.json()}
+    assert runs[with_id]["date_last_activity"] is not None
+    assert runs[without_id]["date_last_activity"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/keeper_sync_runs_test.py
+++ b/tests/handlers/keeper_sync_runs_test.py
@@ -1,0 +1,362 @@
+"""Tests for the org-scoped LTD Keeper sync run endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+import pytest
+import structlog
+from httpx import AsyncClient
+from safir.dependencies.db_session import db_session_dependency
+
+from docverse.client.models import OrgRole
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
+from docverse.domain.queue import JobKind, JobStatus
+from docverse.storage.organization_store import OrganizationStore
+from tests.conftest import seed_member, seed_org_with_admin
+
+_ADMIN = "admin-user"
+_ORG = "ks-org"
+
+
+async def _setup_org(client: AsyncClient) -> None:
+    await seed_org_with_admin(client, _ORG, _ADMIN)
+
+
+async def _enable_sync(
+    client: AsyncClient,
+    *,
+    project_slugs: list[str] | Literal["*"] = "*",
+) -> None:
+    response = await client.put(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={
+            "enabled": True,
+            "ltd_base_url": "https://keeper.lsst.codes/",
+            "project_slugs": project_slugs,
+        },
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+
+
+async def _seed_queue_job(
+    *,
+    org_id: int,
+    run_id: int,
+    status: JobStatus,
+) -> None:
+    """Seed a queue_jobs row directly attributed to the run."""
+    async for session in db_session_dependency():
+        async with session.begin():
+            row = SqlQueueJob(
+                public_id=validate_base32_id(generate_base32_id()),
+                kind=JobKind.keeper_sync_project.value,
+                status=status.value,
+                org_id=org_id,
+                keeper_sync_run_id=run_id,
+                date_completed=datetime.now(tz=UTC)
+                if status
+                in {
+                    JobStatus.completed,
+                    JobStatus.failed,
+                    JobStatus.cancelled,
+                    JobStatus.completed_with_errors,
+                }
+                else None,
+            )
+            session.add(row)
+            await session.commit()
+
+
+async def _get_org_id() -> int:
+    logger = structlog.get_logger("test")
+    async for session in db_session_dependency():
+        store = OrganizationStore(session=session, logger=logger)
+        org = await store.get_by_slug(_ORG)
+        assert org is not None
+        return org.id
+    msg = "no session"
+    raise AssertionError(msg)
+
+
+@pytest.mark.asyncio
+async def test_post_run_returns_202_with_run_and_queue_job_link(
+    client: AsyncClient,
+) -> None:
+    """``POST /runs`` creates a run, enqueues discovery, returns 202."""
+    await _setup_org(client)
+    await _enable_sync(client)
+
+    response = await client.post(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 202
+    body: dict[str, Any] = response.json()
+    assert body["run"]["status"] == "pending"
+    assert body["run"]["kind"] == "backfill"
+    # The discovery queue-job itself is run-attributed and starts queued,
+    # so the freshly-created run already has one pending job on its books.
+    assert body["run"]["pending_count"] == 1
+    assert body["run"]["succeeded_count"] == 0
+    assert body["run"]["failed_count"] == 0
+    assert body["run"]["total_count"] == 1
+    assert "self_url" in body["run"]
+    assert "queue_job_url" in body
+    assert body["queue_job_id"]
+    assert body["queue_job_url"].endswith(
+        f"/queue/jobs/{body['queue_job_id']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_run_returns_409_when_disabled(
+    client: AsyncClient,
+) -> None:
+    """``POST /runs`` against a disabled config returns 409."""
+    await _setup_org(client)
+    # Default config is disabled, no PUT.
+    response = await client.post(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_post_run_409_when_non_terminal_run_exists(
+    client: AsyncClient,
+) -> None:
+    """A second concurrent ``POST /runs`` returns 409."""
+    await _setup_org(client)
+    await _enable_sync(client)
+    first = await client.post(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert first.status_code == 202
+
+    second = await client.post(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert second.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_get_run_returns_aggregate_counters(
+    client: AsyncClient,
+) -> None:
+    """``GET /runs/{id}`` aggregates counters from run-attributed jobs."""
+    await _setup_org(client)
+    await _enable_sync(client)
+    create_response = await client.post(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert create_response.status_code == 202
+    run_id: int = create_response.json()["run"]["id"]
+    org_id = await _get_org_id()
+
+    # Seed mixed-status queue_jobs attributed to this run.
+    await _seed_queue_job(
+        org_id=org_id, run_id=run_id, status=JobStatus.queued
+    )
+    await _seed_queue_job(
+        org_id=org_id, run_id=run_id, status=JobStatus.in_progress
+    )
+    await _seed_queue_job(
+        org_id=org_id, run_id=run_id, status=JobStatus.completed
+    )
+    await _seed_queue_job(
+        org_id=org_id, run_id=run_id, status=JobStatus.completed
+    )
+    await _seed_queue_job(
+        org_id=org_id, run_id=run_id, status=JobStatus.failed
+    )
+    await _seed_queue_job(
+        org_id=org_id, run_id=run_id, status=JobStatus.cancelled
+    )
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    # 1 queued + 1 in_progress + 1 (discovery's own row) = 3 pending.
+    assert body["pending_count"] == 3
+    assert body["succeeded_count"] == 2
+    assert body["failed_count"] == 2
+    assert body["total_count"] == 7
+
+
+@pytest.mark.asyncio
+async def test_get_run_404_for_unknown_run(client: AsyncClient) -> None:
+    await _setup_org(client)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/999",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_run_404_for_run_in_other_org(
+    client: AsyncClient,
+) -> None:
+    """A run belonging to another org cannot be fetched via this org."""
+    await _setup_org(client)
+    other_org = "ks-org-other"
+    await seed_org_with_admin(client, other_org, _ADMIN)
+    # Seed a run directly into the other org.
+    logger = structlog.get_logger("test")
+    async for session in db_session_dependency():
+        async with session.begin():
+            store = OrganizationStore(session=session, logger=logger)
+            other = await store.get_by_slug(other_org)
+            assert other is not None
+            row = SqlKeeperSyncRun(
+                org_id=other.id, kind="backfill", status="pending"
+            )
+            session.add(row)
+            await session.flush()
+            run_id = row.id
+            await session.commit()
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_runs_returns_runs_newest_first(
+    client: AsyncClient,
+) -> None:
+    """``GET /runs`` returns runs in date_started DESC order."""
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    # Seed three runs directly so we can control the order independently of
+    # the partial unique index that disallows two non-terminal at once.
+    async for session in db_session_dependency():
+        async with session.begin():
+            for status in ("succeeded", "failed", "succeeded"):
+                row = SqlKeeperSyncRun(
+                    org_id=org_id, kind="backfill", status=status
+                )
+                session.add(row)
+            await session.commit()
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    runs = response.json()
+    assert len(runs) == 3
+    starts = [r["date_started"] for r in runs]
+    assert starts == sorted(starts, reverse=True)
+    assert response.headers["X-Total-Count"] == "3"
+
+
+@pytest.mark.asyncio
+async def test_list_runs_filters_by_status(client: AsyncClient) -> None:
+    """``GET /runs?status=...`` returns only runs in the given status."""
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    async for session in db_session_dependency():
+        async with session.begin():
+            for status in ("succeeded", "failed", "succeeded"):
+                session.add(
+                    SqlKeeperSyncRun(
+                        org_id=org_id, kind="backfill", status=status
+                    )
+                )
+            await session.commit()
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs?status=succeeded",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    runs = response.json()
+    assert len(runs) == 2
+    assert all(r["status"] == "succeeded" for r in runs)
+
+
+@pytest.mark.asyncio
+async def test_list_runs_paginates_with_cursor(client: AsyncClient) -> None:
+    """``limit`` + ``cursor`` paginate through the run history."""
+    await _setup_org(client)
+    org_id = await _get_org_id()
+    async for session in db_session_dependency():
+        async with session.begin():
+            for _ in range(3):
+                session.add(
+                    SqlKeeperSyncRun(
+                        org_id=org_id, kind="backfill", status="succeeded"
+                    )
+                )
+            await session.commit()
+
+    first = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs?limit=2",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert first.status_code == 200
+    page_one = first.json()
+    assert len(page_one) == 2
+    link = first.headers.get("Link", "")
+    assert "next" in link
+
+    # Extract the next cursor from the Link header.
+    next_url = _extract_next_url(link)
+    assert next_url is not None
+    second = await client.get(
+        next_url, headers={"X-Auth-Request-User": _ADMIN}
+    )
+    assert second.status_code == 200
+    page_two = second.json()
+    assert len(page_two) == 1
+    page_one_ids = {r["id"] for r in page_one}
+    page_two_ids = {r["id"] for r in page_two}
+    assert page_one_ids.isdisjoint(page_two_ids)
+
+
+def _extract_next_url(link_header: str) -> str | None:
+    for part in link_header.split(","):
+        section = part.strip()
+        if section.endswith('rel="next"'):
+            url = section.split(";")[0].strip()
+            if url.startswith("<") and url.endswith(">"):
+                return url[1:-1]
+    return None
+
+
+@pytest.mark.asyncio
+async def test_post_run_403_for_non_admin(client: AsyncClient) -> None:
+    await _setup_org(client)
+    await _enable_sync(client)
+    await seed_member(_ORG, "reader-user", OrgRole.reader)
+    response = await client.post(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_runs_403_for_non_admin(client: AsyncClient) -> None:
+    await _setup_org(client)
+    await seed_member(_ORG, "reader-user", OrgRole.reader)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs",
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403

--- a/tests/handlers/pagination_test.py
+++ b/tests/handlers/pagination_test.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import pytest
+import structlog
 from httpx import AsyncClient
+from safir.dependencies.db_session import db_session_dependency
 from safir.http import PaginationLinkData
 
+from docverse.client.models import BuildCreate
+from docverse.storage.build_store import BuildStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
 from tests.conftest import seed_build, seed_org_with_admin
 
 CONTENT_HASH = (
@@ -247,6 +253,58 @@ async def test_build_pagination_forward(
     assert resp.headers["X-Total-Count"] == "4"
     links = PaginationLinkData.from_header(resp.headers.get("link"))
     assert links.next_url is not None
+
+
+@pytest.mark.asyncio
+async def test_build_pagination_with_tied_date_created(
+    client: AsyncClient,
+) -> None:
+    """Paginate through builds whose ``date_created`` is tied.
+
+    All three builds are inserted in a single transaction so they share
+    ``date_created`` from ``func.now()``. The cursor's tiebreak (id) must
+    advance pagination correctly even when the timestamp is identical
+    for every row — that path was broken in the safir base class because
+    it stripped ``tzinfo`` before comparing against ``timestamptz``.
+    """
+    await _setup(client)
+    await _create_project(client, "bld-tie-proj")
+    logger = structlog.get_logger("test")
+    async for session in db_session_dependency():
+        async with session.begin():
+            org = await OrganizationStore(
+                session=session, logger=logger
+            ).get_by_slug("pag-org")
+            assert org is not None
+            project = await ProjectStore(
+                session=session, logger=logger
+            ).get_by_slug(org_id=org.id, slug="bld-tie-proj")
+            assert project is not None
+            store = BuildStore(session=session, logger=logger)
+            for _ in range(3):
+                await store.create(
+                    project_id=project.id,
+                    project_slug=project.slug,
+                    data=BuildCreate(
+                        git_ref="main", content_hash=CONTENT_HASH
+                    ),
+                    uploader="testuser",
+                )
+            await session.commit()
+
+    collected: list[int] = []
+    url: str | None = (
+        "/docverse/orgs/pag-org/projects/bld-tie-proj/builds?limit=2"
+    )
+    while url:
+        resp = await client.get(url, headers=AUTH)
+        assert resp.status_code == 200
+        collected.extend(b["id"] for b in resp.json())
+        links = PaginationLinkData.from_header(resp.headers.get("link"))
+        url = links.next_url
+
+    assert len(collected) == 3
+    assert len(set(collected)) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/keeper_sync_run_test.py
+++ b/tests/services/keeper_sync_run_test.py
@@ -1,0 +1,180 @@
+"""Integration tests for ``KeeperSyncRunService``."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from safir.arq import MockArqQueue
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import (
+    KeeperSyncConfig,
+    KeeperSyncRunStatus,
+    OrganizationCreate,
+)
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
+from docverse.domain.queue import JobKind
+from docverse.exceptions import ConflictError, NotFoundError
+from docverse.services.keeper_sync_run import (
+    KEEPER_SYNC_QUEUE_NAME,
+    KeeperSyncRunService,
+)
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.queue_backend import ArqQueueBackend
+from docverse.storage.queue_job_store import QueueJobStore
+from tests.support.arq_testing import register_queue
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org(
+    db_session: AsyncSession, *, enabled: bool = True
+) -> tuple[int, str]:
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug="ks-org",
+            title="KS Org",
+            base_domain="ks.example.com",
+        )
+    )
+    await org_store.update_keeper_sync_config(
+        slug=org.slug,
+        config=KeeperSyncConfig(enabled=enabled),
+    )
+    return org.id, org.slug
+
+
+def _make_service(
+    *, db_session: AsyncSession, mock_arq: MockArqQueue
+) -> KeeperSyncRunService:
+    logger = _logger()
+    return KeeperSyncRunService(
+        org_store=OrganizationStore(session=db_session, logger=logger),
+        run_store=KeeperSyncRunStore(session=db_session, logger=logger),
+        queue_backend=ArqQueueBackend(
+            arq_queue=mock_arq, default_queue_name="docverse:queue"
+        ),
+        queue_job_store=QueueJobStore(session=db_session, logger=logger),
+        logger=logger,
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_run_creates_row_and_enqueues_discovery(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """``start_run`` creates a pending run and enqueues discovery."""
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    async with db_session.begin():
+        _, org_slug = await _seed_org(db_session)
+        service = _make_service(db_session=db_session, mock_arq=mock_arq)
+        run, queue_job = await service.start_run(org_slug=org_slug)
+        await db_session.commit()
+
+    assert run.status == KeeperSyncRunStatus.pending
+    assert queue_job.kind == JobKind.keeper_sync_run_discovery
+    assert queue_job.keeper_sync_run_id == run.id
+    assert queue_job.backend_job_id is not None
+
+    # Verify the enqueue went to the dedicated queue.
+    sync_queue = mock_arq._job_metadata[KEEPER_SYNC_QUEUE_NAME]
+    assert len(sync_queue) == 1
+    metadata = next(iter(sync_queue.values()))
+    assert metadata.name == "keeper_sync_run_discovery"
+
+
+@pytest.mark.asyncio
+async def test_start_run_409_when_disabled(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    async with db_session.begin():
+        _, org_slug = await _seed_org(db_session, enabled=False)
+        service = _make_service(db_session=db_session, mock_arq=mock_arq)
+        with pytest.raises(ConflictError):
+            await service.start_run(org_slug=org_slug)
+
+
+@pytest.mark.asyncio
+async def test_start_run_409_when_concurrent(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A second ``start_run`` against an active run hits the partial UQ."""
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    async with db_session.begin():
+        _, org_slug = await _seed_org(db_session)
+        service = _make_service(db_session=db_session, mock_arq=mock_arq)
+        await service.start_run(org_slug=org_slug)
+        await db_session.commit()
+
+    async with db_session.begin():
+        service = _make_service(db_session=db_session, mock_arq=mock_arq)
+        with pytest.raises(ConflictError):
+            await service.start_run(org_slug=org_slug)
+
+
+@pytest.mark.asyncio
+async def test_get_run_returns_aggregate_counters(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """Counters are derived from queue_jobs filtered on run_id."""
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session)
+        service = _make_service(db_session=db_session, mock_arq=mock_arq)
+        run, _ = await service.start_run(org_slug=org_slug)
+        # Seed three more queue_jobs in mixed states.
+        queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+        for _ in range(2):
+            await queue_job_store.create(
+                kind=JobKind.keeper_sync_project,
+                org_id=org_id,
+                keeper_sync_run_id=run.id,
+            )
+        # And one in completed state via direct INSERT.
+        db_session.add(
+            SqlQueueJob(
+                public_id=validate_base32_id(generate_base32_id()),
+                kind=JobKind.keeper_sync_project.value,
+                status="completed",
+                org_id=org_id,
+                keeper_sync_run_id=run.id,
+            )
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        service = _make_service(db_session=db_session, mock_arq=mock_arq)
+        result = await service.get_run(org_slug=org_slug, run_id=run.id)
+    # Discovery (queued) + 2 keeper_sync_project (queued) = 3 pending,
+    # 1 completed, 0 failed, total 4.
+    assert result.counters.pending_count == 3
+    assert result.counters.succeeded_count == 1
+    assert result.counters.failed_count == 0
+    assert result.counters.total_count == 4
+
+
+@pytest.mark.asyncio
+async def test_get_run_404_for_unknown_run(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    async with db_session.begin():
+        _, org_slug = await _seed_org(db_session)
+        service = _make_service(db_session=db_session, mock_arq=mock_arq)
+        with pytest.raises(NotFoundError):
+            await service.get_run(org_slug=org_slug, run_id=9999)

--- a/tests/services/keeper_sync_run_test.py
+++ b/tests/services/keeper_sync_run_test.py
@@ -161,10 +161,10 @@ async def test_get_run_returns_aggregate_counters(
         result = await service.get_run(org_slug=org_slug, run_id=run.id)
     # Discovery (queued) + 2 keeper_sync_project (queued) = 3 pending,
     # 1 completed, 0 failed, total 4.
-    assert result.counters.pending_count == 3
-    assert result.counters.succeeded_count == 1
-    assert result.counters.failed_count == 0
-    assert result.counters.total_count == 4
+    assert result.activity.pending_count == 3
+    assert result.activity.succeeded_count == 1
+    assert result.activity.failed_count == 0
+    assert result.activity.total_count == 4
 
 
 @pytest.mark.asyncio

--- a/tests/services/publish_enqueue_test.py
+++ b/tests/services/publish_enqueue_test.py
@@ -1,0 +1,272 @@
+"""Tests for the shared :func:`enqueue_publish_for_edition` helper.
+
+The helper is exercised end-to-end through worker tests
+(``tests/worker/build_processing_test.py`` and
+``tests/worker/keeper_sync_project_test.py``); the unit tests here
+focus on the two history-row paths the helper has to cover:
+
+* the **normal** path used after edition tracking, where the
+  ``EditionBuildHistory`` row already exists and the helper just sets
+  it ``pending``;
+* the **sync** path used after a keeper-sync build finalize, where no
+  history row has been recorded yet and the helper must record one
+  before flipping it ``pending``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from safir.arq import MockArqQueue
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import (
+    BuildCreate,
+    BuildStatus,
+    EditionCreate,
+    EditionKind,
+    OrganizationCreate,
+    ProjectCreate,
+    TrackingMode,
+)
+from docverse.client.models.queue_enums import JobKind, PublishStatus
+from docverse.config import Configuration
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
+from docverse.domain.base32id import serialize_base32_id
+from docverse.domain.queue import JobStatus
+from docverse.services.publish_enqueue import enqueue_publish_for_edition
+from docverse.storage.build_store import BuildStore
+from docverse.storage.edition_build_history_store import (
+    EditionBuildHistoryStore,
+)
+from docverse.storage.edition_store import EditionStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+from docverse.storage.queue_backend import ArqQueueBackend
+from docverse.storage.queue_job_store import QueueJobStore
+
+_HASH = "sha256:" + "a" * 64
+_config = Configuration()
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org_project_edition_build(
+    db_session: AsyncSession,
+) -> tuple[int, int, str, int, str, int, str]:
+    """Insert an org/project/edition/build matrix the helper needs."""
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    project_store = ProjectStore(session=db_session, logger=logger)
+    edition_store = EditionStore(session=db_session, logger=logger)
+    build_store = BuildStore(session=db_session, logger=logger)
+
+    org = await org_store.create(
+        OrganizationCreate(
+            slug="pe-org",
+            title="PE Org",
+            base_domain="pe-org.example.com",
+        )
+    )
+    project = await project_store.create(
+        org_id=org.id,
+        data=ProjectCreate(
+            slug="pe-proj",
+            title="PE Project",
+            doc_repo="https://github.com/example/pe",
+        ),
+    )
+    edition = await edition_store.create(
+        project_id=project.id,
+        data=EditionCreate(
+            slug="main",
+            title="Main",
+            kind=EditionKind.draft,
+            tracking_mode=TrackingMode.git_ref,
+            tracking_params={"git_ref": "main"},
+        ),
+    )
+    build = await build_store.create(
+        project_id=project.id,
+        project_slug=project.slug,
+        data=BuildCreate(git_ref="main", content_hash=_HASH),
+        uploader="testuser",
+    )
+    await build_store.transition_status(
+        build_id=build.id, new_status=BuildStatus.processing
+    )
+    await build_store.transition_status(
+        build_id=build.id, new_status=BuildStatus.completed
+    )
+    return (
+        org.id,
+        project.id,
+        project.slug,
+        edition.id,
+        edition.slug,
+        build.id,
+        serialize_base32_id(build.public_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_enqueue_publish_for_edition_records_history_when_missing(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """Sync path: helper records ``EditionBuildHistory`` row when absent.
+
+    The keeper-sync flow finalizes the build directly via the build
+    store, skipping ``EditionTrackingService.track_build`` (the path
+    that records the history row in the normal client-upload flow).
+    The helper must therefore detect the missing row and record one
+    before setting it ``pending``.
+    """
+    async with db_session.begin():
+        (
+            org_id,
+            project_id,
+            project_slug,
+            edition_id,
+            edition_slug,
+            build_id,
+            build_public_id,
+        ) = await _seed_org_project_edition_build(db_session)
+        run_row = SqlKeeperSyncRun(
+            org_id=org_id, kind="backfill", status="in_progress"
+        )
+        db_session.add(run_row)
+        await db_session.flush()
+        run_id = run_row.id
+
+    mock_arq = MockArqQueue(default_queue_name=_config.arq_queue_name)
+    queue_backend = ArqQueueBackend(
+        arq_queue=mock_arq,
+        default_queue_name=_config.arq_queue_name,
+    )
+
+    async for session in db_session_dependency():
+        edition_store = EditionStore(session=session, logger=_logger())
+        history_store = EditionBuildHistoryStore(
+            session=session, logger=_logger()
+        )
+        queue_job_store = QueueJobStore(session=session, logger=_logger())
+
+        result = await enqueue_publish_for_edition(
+            session=session,
+            edition_store=edition_store,
+            history_store=history_store,
+            queue_job_store=queue_job_store,
+            queue_backend=queue_backend,
+            org_id=org_id,
+            project_id=project_id,
+            project_slug=project_slug,
+            edition_id=edition_id,
+            edition_slug=edition_slug,
+            build_id=build_id,
+            build_public_id=build_public_id,
+            keeper_sync_run_id=run_id,
+        )
+
+        async with session.begin():
+            edition = await edition_store.get_by_slug(
+                project_id=project_id, slug=edition_slug
+            )
+            assert edition is not None
+            assert edition.publish_status == PublishStatus.pending
+
+            history = await history_store.get_by_edition_and_build(
+                edition_id=edition_id, build_id=build_id
+            )
+            assert history is not None
+            assert history.publish_status == PublishStatus.pending
+
+            child_qj = await queue_job_store.get(result.queue_job_id)
+            assert child_qj is not None
+            assert child_qj.kind == JobKind.publish_edition
+            assert child_qj.status == JobStatus.queued
+            assert child_qj.keeper_sync_run_id == run_id
+            assert child_qj.backend_job_id == result.backend_job_id
+            assert child_qj.edition_id == edition_id
+            assert child_qj.build_id == build_id
+            assert child_qj.org_id == org_id
+            assert child_qj.project_id == project_id
+
+    # The arq job was enqueued on the regular queue (not the sync queue).
+    queues = mock_arq._job_metadata
+    assert len(queues.get(_config.arq_queue_name, {})) == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueue_publish_for_edition_reuses_existing_history(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """Normal path: helper reuses an existing ``EditionBuildHistory`` row.
+
+    The build_processing flow's ``EditionTrackingService.track_build``
+    records the history row before the publish helper runs. The helper
+    must NOT create a duplicate row; it must look up the existing one
+    and flip it ``pending``.
+    """
+    async with db_session.begin():
+        (
+            org_id,
+            project_id,
+            project_slug,
+            edition_id,
+            edition_slug,
+            build_id,
+            build_public_id,
+        ) = await _seed_org_project_edition_build(db_session)
+
+        history_store = EditionBuildHistoryStore(
+            session=db_session, logger=_logger()
+        )
+        pre_existing = await history_store.record(
+            edition_id=edition_id, build_id=build_id
+        )
+        pre_existing_id = pre_existing.id
+
+    mock_arq = MockArqQueue(default_queue_name=_config.arq_queue_name)
+    queue_backend = ArqQueueBackend(
+        arq_queue=mock_arq,
+        default_queue_name=_config.arq_queue_name,
+    )
+
+    async for session in db_session_dependency():
+        edition_store = EditionStore(session=session, logger=_logger())
+        history_store = EditionBuildHistoryStore(
+            session=session, logger=_logger()
+        )
+        queue_job_store = QueueJobStore(session=session, logger=_logger())
+
+        await enqueue_publish_for_edition(
+            session=session,
+            edition_store=edition_store,
+            history_store=history_store,
+            queue_job_store=queue_job_store,
+            queue_backend=queue_backend,
+            org_id=org_id,
+            project_id=project_id,
+            project_slug=project_slug,
+            edition_id=edition_id,
+            edition_slug=edition_slug,
+            build_id=build_id,
+            build_public_id=build_public_id,
+        )
+
+        async with session.begin():
+            history = await history_store.get_by_edition_and_build(
+                edition_id=edition_id, build_id=build_id
+            )
+            assert history is not None
+            # Same row — the helper must not have inserted a duplicate.
+            assert history.id == pre_existing_id
+            assert history.publish_status == PublishStatus.pending
+
+            entries = await history_store.list_by_edition(edition_id)
+            assert len(entries) == 1

--- a/tests/storage/keeper_sync_run_store_test.py
+++ b/tests/storage/keeper_sync_run_store_test.py
@@ -1,0 +1,147 @@
+"""Tests for ``KeeperSyncRunStore``."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import KeeperSyncRunStatus, OrganizationCreate
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
+from docverse.domain.queue import JobKind, JobStatus
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+from docverse.storage.organization_store import OrganizationStore
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org(db_session: AsyncSession) -> int:
+    org_store = OrganizationStore(session=db_session, logger=_logger())
+    org = await org_store.create(
+        OrganizationCreate(
+            slug="ksrs-org",
+            title="KSRS Org",
+            base_domain="ksrs.example.com",
+        )
+    )
+    return org.id
+
+
+def _seed_queue_job(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    run_id: int,
+    status: JobStatus,
+) -> None:
+    db_session.add(
+        SqlQueueJob(
+            public_id=validate_base32_id(generate_base32_id()),
+            kind=JobKind.keeper_sync_project.value,
+            status=status.value,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_aggregate_counters_for_runs_groups_by_run_id(
+    db_session: AsyncSession,
+) -> None:
+    """One ``GROUP BY`` query returns per-run counters for each ``run_id``."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        run_a = await store.create(org_id=org_id)
+        # The partial unique index allows only one non-terminal run per
+        # org, so transition the first to terminal before seeding the
+        # second.
+        await store.transition_status(
+            run_id=run_a.id, new_status=KeeperSyncRunStatus.in_progress
+        )
+        await store.transition_status(
+            run_id=run_a.id, new_status=KeeperSyncRunStatus.succeeded
+        )
+        run_b = await store.create(org_id=org_id)
+
+        # Run A: 2 completed, 1 failed.
+        for _ in range(2):
+            _seed_queue_job(
+                db_session,
+                org_id=org_id,
+                run_id=run_a.id,
+                status=JobStatus.completed,
+            )
+        _seed_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run_a.id,
+            status=JobStatus.failed,
+        )
+        # Run B: 1 queued, 1 in_progress.
+        _seed_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run_b.id,
+            status=JobStatus.queued,
+        )
+        _seed_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run_b.id,
+            status=JobStatus.in_progress,
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        counters = await store.aggregate_counters_for_runs(
+            run_ids=[run_a.id, run_b.id]
+        )
+
+    assert set(counters.keys()) == {run_a.id, run_b.id}
+    assert counters[run_a.id].pending_count == 0
+    assert counters[run_a.id].succeeded_count == 2
+    assert counters[run_a.id].failed_count == 1
+    assert counters[run_a.id].total_count == 3
+    assert counters[run_b.id].pending_count == 2
+    assert counters[run_b.id].succeeded_count == 0
+    assert counters[run_b.id].failed_count == 0
+    assert counters[run_b.id].total_count == 2
+
+
+@pytest.mark.asyncio
+async def test_aggregate_counters_for_runs_zero_for_runs_without_jobs(
+    db_session: AsyncSession,
+) -> None:
+    """Runs with no jobs return zeroed counters, not missing keys."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        run = await store.create(org_id=org_id)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        counters = await store.aggregate_counters_for_runs(run_ids=[run.id])
+
+    assert run.id in counters
+    assert counters[run.id].pending_count == 0
+    assert counters[run.id].succeeded_count == 0
+    assert counters[run.id].failed_count == 0
+    assert counters[run.id].total_count == 0
+
+
+@pytest.mark.asyncio
+async def test_aggregate_counters_for_runs_empty_input(
+    db_session: AsyncSession,
+) -> None:
+    """An empty ``run_ids`` list short-circuits to an empty mapping."""
+    async with db_session.begin():
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        counters = await store.aggregate_counters_for_runs(run_ids=[])
+    assert counters == {}

--- a/tests/storage/keeper_sync_run_store_test.py
+++ b/tests/storage/keeper_sync_run_store_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -36,20 +38,26 @@ def _seed_queue_job(
     org_id: int,
     run_id: int,
     status: JobStatus,
+    date_created: datetime | None = None,
+    date_started: datetime | None = None,
+    date_completed: datetime | None = None,
 ) -> None:
-    db_session.add(
-        SqlQueueJob(
-            public_id=validate_base32_id(generate_base32_id()),
-            kind=JobKind.keeper_sync_project.value,
-            status=status.value,
-            org_id=org_id,
-            keeper_sync_run_id=run_id,
-        )
+    row = SqlQueueJob(
+        public_id=validate_base32_id(generate_base32_id()),
+        kind=JobKind.keeper_sync_project.value,
+        status=status.value,
+        org_id=org_id,
+        keeper_sync_run_id=run_id,
+        date_started=date_started,
+        date_completed=date_completed,
     )
+    if date_created is not None:
+        row.date_created = date_created
+    db_session.add(row)
 
 
 @pytest.mark.asyncio
-async def test_aggregate_counters_for_runs_groups_by_run_id(
+async def test_aggregate_activity_for_runs_groups_by_run_id(
     db_session: AsyncSession,
 ) -> None:
     """One ``GROUP BY`` query returns per-run counters for each ``run_id``."""
@@ -99,23 +107,23 @@ async def test_aggregate_counters_for_runs_groups_by_run_id(
 
     async with db_session.begin():
         store = KeeperSyncRunStore(session=db_session, logger=_logger())
-        counters = await store.aggregate_counters_for_runs(
+        activity = await store.aggregate_activity_for_runs(
             run_ids=[run_a.id, run_b.id]
         )
 
-    assert set(counters.keys()) == {run_a.id, run_b.id}
-    assert counters[run_a.id].pending_count == 0
-    assert counters[run_a.id].succeeded_count == 2
-    assert counters[run_a.id].failed_count == 1
-    assert counters[run_a.id].total_count == 3
-    assert counters[run_b.id].pending_count == 2
-    assert counters[run_b.id].succeeded_count == 0
-    assert counters[run_b.id].failed_count == 0
-    assert counters[run_b.id].total_count == 2
+    assert set(activity.keys()) == {run_a.id, run_b.id}
+    assert activity[run_a.id].pending_count == 0
+    assert activity[run_a.id].succeeded_count == 2
+    assert activity[run_a.id].failed_count == 1
+    assert activity[run_a.id].total_count == 3
+    assert activity[run_b.id].pending_count == 2
+    assert activity[run_b.id].succeeded_count == 0
+    assert activity[run_b.id].failed_count == 0
+    assert activity[run_b.id].total_count == 2
 
 
 @pytest.mark.asyncio
-async def test_aggregate_counters_for_runs_zero_for_runs_without_jobs(
+async def test_aggregate_activity_for_runs_zero_for_runs_without_jobs(
     db_session: AsyncSession,
 ) -> None:
     """Runs with no jobs return zeroed counters, not missing keys."""
@@ -127,21 +135,97 @@ async def test_aggregate_counters_for_runs_zero_for_runs_without_jobs(
 
     async with db_session.begin():
         store = KeeperSyncRunStore(session=db_session, logger=_logger())
-        counters = await store.aggregate_counters_for_runs(run_ids=[run.id])
+        activity = await store.aggregate_activity_for_runs(run_ids=[run.id])
 
-    assert run.id in counters
-    assert counters[run.id].pending_count == 0
-    assert counters[run.id].succeeded_count == 0
-    assert counters[run.id].failed_count == 0
-    assert counters[run.id].total_count == 0
+    assert run.id in activity
+    assert activity[run.id].pending_count == 0
+    assert activity[run.id].succeeded_count == 0
+    assert activity[run.id].failed_count == 0
+    assert activity[run.id].total_count == 0
+    assert activity[run.id].date_last_activity is None
 
 
 @pytest.mark.asyncio
-async def test_aggregate_counters_for_runs_empty_input(
+async def test_aggregate_activity_for_runs_empty_input(
     db_session: AsyncSession,
 ) -> None:
     """An empty ``run_ids`` list short-circuits to an empty mapping."""
     async with db_session.begin():
         store = KeeperSyncRunStore(session=db_session, logger=_logger())
-        counters = await store.aggregate_counters_for_runs(run_ids=[])
-    assert counters == {}
+        activity = await store.aggregate_activity_for_runs(run_ids=[])
+    assert activity == {}
+
+
+@pytest.mark.asyncio
+async def test_aggregate_activity_picks_max_coalesced_timestamp(
+    db_session: AsyncSession,
+) -> None:
+    """``date_last_activity`` is the MAX of coalesce on each child row.
+
+    A mixed-status run exercises every branch of the coalesce: a
+    completed row contributes its ``date_completed``, a started row
+    contributes its ``date_started``, and a queued row contributes its
+    ``date_created``. The aggregate picks whichever of those is most
+    recent.
+    """
+    base = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        run = await store.create(org_id=org_id)
+        # Queued: only date_created. Earliest of the three by design.
+        _seed_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run.id,
+            status=JobStatus.queued,
+            date_created=base,
+        )
+        # In-progress: date_started fires (more recent than created).
+        _seed_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run.id,
+            status=JobStatus.in_progress,
+            date_created=base,
+            date_started=base + timedelta(minutes=10),
+        )
+        # Completed: date_completed fires; this is the latest event.
+        latest = base + timedelta(minutes=30)
+        _seed_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run.id,
+            status=JobStatus.completed,
+            date_created=base,
+            date_started=base + timedelta(minutes=5),
+            date_completed=latest,
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        single = await store.aggregate_activity(run_id=run.id)
+        batched = await store.aggregate_activity_for_runs(run_ids=[run.id])
+
+    assert single.date_last_activity == latest
+    assert batched[run.id].date_last_activity == latest
+
+
+@pytest.mark.asyncio
+async def test_aggregate_activity_null_when_no_jobs(
+    db_session: AsyncSession,
+) -> None:
+    """``date_last_activity`` is None on a run with no attributed jobs."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        run = await store.create(org_id=org_id)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        activity = await store.aggregate_activity(run_id=run.id)
+
+    assert activity.total_count == 0
+    assert activity.date_last_activity is None

--- a/tests/storage/queue_job_store_test.py
+++ b/tests/storage/queue_job_store_test.py
@@ -425,6 +425,190 @@ async def test_fail_orphaned_run_children_skips_started_rows(
 
 
 @pytest.mark.asyncio
+async def test_fail_silent_run_children_fails_old_in_progress(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """An in_progress child past the idle threshold is reaped to failed."""
+    async with db_session.begin():
+        org_id, run_id = await _seed_org_and_run(db_session)
+        stuck = await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+            backend_job_id="arq-job-stuck",
+        )
+        await store.start(stuck.id)
+        # Backdate date_started past the idle threshold.
+        row = await db_session.get(SqlQueueJob, stuck.id)
+        assert row is not None
+        row.date_started = datetime.now(tz=UTC) - timedelta(hours=10)
+        await db_session.flush()
+
+        reaped = await store.fail_silent_run_children(
+            idle_after=timedelta(hours=6)
+        )
+        await db_session.commit()
+
+    assert len(reaped) == 1
+    assert reaped[0].id == stuck.id
+    assert reaped[0].status == JobStatus.failed
+    assert reaped[0].date_completed is not None
+    assert reaped[0].errors is not None
+    msg = reaped[0].errors["message"].lower()
+    assert "stuck" in msg or "reaper" in msg or "silent" in msg
+
+
+@pytest.mark.asyncio
+async def test_fail_silent_run_children_skips_recent_in_progress(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """An in_progress child within the idle window is left alone."""
+    async with db_session.begin():
+        org_id, run_id = await _seed_org_and_run(db_session)
+        recent = await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+            backend_job_id="arq-job-recent",
+        )
+        await store.start(recent.id)
+
+        reaped = await store.fail_silent_run_children(
+            idle_after=timedelta(hours=6)
+        )
+        await db_session.commit()
+
+    assert reaped == []
+
+
+@pytest.mark.asyncio
+async def test_fail_silent_run_children_skips_completed_rows(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """A completed child is not reaped even when ``date_started`` is old."""
+    async with db_session.begin():
+        org_id, run_id = await _seed_org_and_run(db_session)
+        done = await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+            backend_job_id="arq-job-done",
+        )
+        await store.start(done.id)
+        await store.complete(done.id)
+        row = await db_session.get(SqlQueueJob, done.id)
+        assert row is not None
+        row.date_started = datetime.now(tz=UTC) - timedelta(hours=10)
+        await db_session.flush()
+
+        reaped = await store.fail_silent_run_children(
+            idle_after=timedelta(hours=6)
+        )
+        await db_session.commit()
+
+    assert reaped == []
+
+
+@pytest.mark.asyncio
+async def test_fail_silent_run_children_skips_queued_rows(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """A queued (not-yet-started) child is left to ``fail_orphaned_*``.
+
+    The silent-run reaper only targets jobs that the worker actually
+    picked up and then went silent on. Orphans without ``date_started``
+    are reconciled by the discovery-time orphan sweep instead.
+    """
+    async with db_session.begin():
+        org_id, run_id = await _seed_org_and_run(db_session)
+        await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+            backend_job_id="arq-job-queued",
+        )
+
+        reaped = await store.fail_silent_run_children(
+            idle_after=timedelta(hours=6)
+        )
+        await db_session.commit()
+
+    assert reaped == []
+
+
+@pytest.mark.asyncio
+async def test_fail_silent_run_children_skips_non_keeper_sync_rows(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """Reaper only touches rows attached to a keeper-sync run."""
+    async with db_session.begin():
+        unrelated = await store.create(
+            kind=JobKind.build_processing,
+            org_id=1,
+        )
+        await store.start(unrelated.id)
+        row = await db_session.get(SqlQueueJob, unrelated.id)
+        assert row is not None
+        row.date_started = datetime.now(tz=UTC) - timedelta(hours=10)
+        await db_session.flush()
+
+        reaped = await store.fail_silent_run_children(
+            idle_after=timedelta(hours=6)
+        )
+        await db_session.commit()
+
+    assert reaped == []
+
+
+@pytest.mark.asyncio
+async def test_fail_silent_run_children_returns_distinct_run_ids(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """Reaper returns rows from each run so callers can finalise both."""
+    async with db_session.begin():
+        org_a_id, run_a_id = await _seed_org_and_run(db_session, slug="ks-aa")
+        _, run_b_id = await _seed_org_and_run(db_session, slug="ks-bb")
+        # Two stuck children on run A, one on run B.
+        for backend_id in ("arq-a1", "arq-a2"):
+            j = await store.create(
+                kind=JobKind.keeper_sync_project,
+                org_id=org_a_id,
+                keeper_sync_run_id=run_a_id,
+                backend_job_id=backend_id,
+            )
+            await store.start(j.id)
+            r = await db_session.get(SqlQueueJob, j.id)
+            assert r is not None
+            r.date_started = datetime.now(tz=UTC) - timedelta(hours=10)
+        b_job = await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_a_id,
+            keeper_sync_run_id=run_b_id,
+            backend_job_id="arq-b1",
+        )
+        await store.start(b_job.id)
+        r = await db_session.get(SqlQueueJob, b_job.id)
+        assert r is not None
+        r.date_started = datetime.now(tz=UTC) - timedelta(hours=10)
+        await db_session.flush()
+
+        reaped = await store.fail_silent_run_children(
+            idle_after=timedelta(hours=6)
+        )
+        await db_session.commit()
+
+    assert len(reaped) == 3
+    reaped_run_ids = {qj.keeper_sync_run_id for qj in reaped}
+    assert reaped_run_ids == {run_a_id, run_b_id}
+
+
+@pytest.mark.asyncio
 async def test_fail_orphaned_run_children_scoped_to_run(
     db_session: AsyncSession,
     store: QueueJobStore,

--- a/tests/storage/queue_job_store_test.py
+++ b/tests/storage/queue_job_store_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +15,7 @@ from docverse.client.models import (
     ProjectCreate,
     TrackingMode,
 )
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.queue import JobKind, JobStatus
 from docverse.exceptions import InvalidJobStateError
@@ -286,3 +289,169 @@ async def test_get_by_public_id(
     assert fetched is not None
     assert fetched.id == job.id
     assert fetched.public_id == job.public_id
+
+
+async def _seed_org_and_run(
+    db_session: AsyncSession, *, slug: str = "ks-org"
+) -> tuple[int, int]:
+    logger = structlog.get_logger("docverse")
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=slug,
+            title="KS Org",
+            base_domain=f"{slug}.example.com",
+        )
+    )
+    run = SqlKeeperSyncRun(org_id=org.id, kind="backfill", status="pending")
+    db_session.add(run)
+    await db_session.flush()
+    await db_session.refresh(run)
+    return org.id, run.id
+
+
+@pytest.mark.asyncio
+async def test_fail_orphaned_run_children_fails_old_orphan(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """Old queued child with no backend_job_id is reconciled to failed."""
+    async with db_session.begin():
+        org_id, run_id = await _seed_org_and_run(db_session)
+        orphan = await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+        )
+        # Backdate so the orphan is older than the idle window.
+        row = await db_session.get(SqlQueueJob, orphan.id)
+        assert row is not None
+        row.date_created = datetime.now(tz=UTC) - timedelta(minutes=10)
+        await db_session.flush()
+
+        failed = await store.fail_orphaned_run_children(
+            run_id=run_id, idle_after=timedelta(minutes=5)
+        )
+        await db_session.commit()
+
+    assert len(failed) == 1
+    assert failed[0].id == orphan.id
+    assert failed[0].status == JobStatus.failed
+    assert failed[0].date_completed is not None
+    assert failed[0].errors is not None
+    assert "orphan" in failed[0].errors["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_fail_orphaned_run_children_skips_recent_rows(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """Rows newer than the idle window are left alone (in-flight discovery)."""
+    async with db_session.begin():
+        org_id, run_id = await _seed_org_and_run(db_session)
+        # Created "now" — younger than the 5-minute window.
+        await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+        )
+
+        failed = await store.fail_orphaned_run_children(
+            run_id=run_id, idle_after=timedelta(minutes=5)
+        )
+        await db_session.commit()
+
+    assert failed == []
+
+
+@pytest.mark.asyncio
+async def test_fail_orphaned_run_children_skips_rows_with_backend_id(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """Rows that already have a backend_job_id are not orphans."""
+    async with db_session.begin():
+        org_id, run_id = await _seed_org_and_run(db_session)
+        job = await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+            backend_job_id="arq-job-real",
+        )
+        # Backdate so age alone wouldn't protect it.
+        row = await db_session.get(SqlQueueJob, job.id)
+        assert row is not None
+        row.date_created = datetime.now(tz=UTC) - timedelta(minutes=30)
+        await db_session.flush()
+
+        failed = await store.fail_orphaned_run_children(
+            run_id=run_id, idle_after=timedelta(minutes=5)
+        )
+        await db_session.commit()
+
+    assert failed == []
+
+
+@pytest.mark.asyncio
+async def test_fail_orphaned_run_children_skips_started_rows(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """An in_progress row without a backend_job_id is not reaped.
+
+    The row reached the worker, so the orphan-tail diagnosis no longer
+    applies. Reaping it would race the running child.
+    """
+    async with db_session.begin():
+        org_id, run_id = await _seed_org_and_run(db_session)
+        job = await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+        )
+        await store.start(job.id)
+        row = await db_session.get(SqlQueueJob, job.id)
+        assert row is not None
+        row.date_created = datetime.now(tz=UTC) - timedelta(minutes=30)
+        await db_session.flush()
+
+        failed = await store.fail_orphaned_run_children(
+            run_id=run_id, idle_after=timedelta(minutes=5)
+        )
+        await db_session.commit()
+
+    assert failed == []
+
+
+@pytest.mark.asyncio
+async def test_fail_orphaned_run_children_scoped_to_run(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """An orphan attached to a different run is left untouched."""
+    async with db_session.begin():
+        org_a_id, run_a_id = await _seed_org_and_run(db_session, slug="ks-a")
+        _, run_b_id = await _seed_org_and_run(db_session, slug="ks-b")
+        # Orphan on run B (older than window) — should NOT be touched
+        # by a reconciliation scoped to run A.
+        orphan_b = await store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_a_id,
+            keeper_sync_run_id=run_b_id,
+        )
+        row = await db_session.get(SqlQueueJob, orphan_b.id)
+        assert row is not None
+        row.date_created = datetime.now(tz=UTC) - timedelta(minutes=30)
+        await db_session.flush()
+
+        failed = await store.fail_orphaned_run_children(
+            run_id=run_a_id, idle_after=timedelta(minutes=5)
+        )
+        await db_session.commit()
+
+    assert failed == []
+    async with db_session.begin():
+        refetched = await store.get(orphan_b.id)
+    assert refetched is not None
+    assert refetched.status == JobStatus.queued

--- a/tests/worker/build_processing_test.py
+++ b/tests/worker/build_processing_test.py
@@ -637,17 +637,18 @@ async def test_build_processing_publish_enqueue_failure_leaves_db_consistent(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Phase-A DB updates commit atomically even when phase-B arq fails.
+    """Phase-A DB writes commit per-pair before phase B raises.
 
     Two editions track ``main``. The first ``publish_edition`` arq enqueue
-    raises. Because ``_enqueue_publish_jobs`` commits all DB rows in one
-    transaction before enqueueing, both editions and history entries should
-    be ``pending`` and both child ``QueueJob`` rows should exist, even
-    though no arq job was successfully enqueued. This is the single
-    failure shape a future reconciliation loop has to handle — and the
-    red-green distinction from the per-edition-transaction structure,
-    which would leave edition 2 entirely untouched on a first-edition
-    enqueue failure.
+    raises while running Phase B for edition 1, after that pair's Phase A
+    has already committed. Because the publish enqueue helper splits
+    Phase A (DB writes) from Phase B (arq enqueue) per ``(edition, build)``
+    pair and the helper raises Phase B failures up the loop, edition 1
+    has its full Phase-A footprint (``publish_status=pending`` on both
+    edition + history, child ``QueueJob`` row present, ``backend_job_id``
+    still NULL) and edition 2 is entirely untouched until the next
+    reconciliation pass picks it up. This is the failure shape a future
+    reconciliation loop has to handle.
     """
     logger = _logger()
     mock_store = MockObjectStore()
@@ -738,8 +739,10 @@ async def test_build_processing_publish_enqueue_failure_leaves_db_consistent(
         == 0
     )
 
-    # Phase A committed atomically: both editions and both histories are
-    # pending, and both child QueueJob rows exist.
+    # The first iteration's Phase A commits before its Phase B raises, so
+    # exactly one of the two editions has its publish-pending footprint
+    # (and exactly one child QueueJob row) committed. The second edition
+    # was never reached by the loop.
     async for session in db_session_dependency():
         async with session.begin():
             edition_store = EditionStore(session=session, logger=_logger())
@@ -747,18 +750,30 @@ async def test_build_processing_publish_enqueue_failure_leaves_db_consistent(
                 session=session, logger=_logger()
             )
 
+            statuses: list[PublishStatus | None] = []
+            history_statuses: list[PublishStatus | None] = []
             for slug in ("main", "latest"):
                 edition = await edition_store.get_by_slug(
                     project_id=project.id, slug=slug
                 )
                 assert edition is not None
-                assert edition.publish_status == PublishStatus.pending
+                statuses.append(edition.publish_status)
 
                 history = await history_store.get_by_edition_and_build(
                     edition_id=edition.id, build_id=build.id
                 )
-                assert history is not None
-                assert history.publish_status == PublishStatus.pending
+                history_statuses.append(
+                    history.publish_status if history is not None else None
+                )
+
+            pending_editions = [
+                s for s in statuses if s == PublishStatus.pending
+            ]
+            assert len(pending_editions) == 1
+            pending_histories = [
+                s for s in history_statuses if s == PublishStatus.pending
+            ]
+            assert len(pending_histories) == 1
 
             child_rows = (
                 (
@@ -772,7 +787,8 @@ async def test_build_processing_publish_enqueue_failure_leaves_db_consistent(
                 .scalars()
                 .all()
             )
-            assert len(child_rows) == 2
+            assert len(child_rows) == 1
+            assert child_rows[0].backend_job_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -32,12 +32,16 @@ from docverse.client.models import (
     KeeperSyncRunStatus,
     OrganizationCreate,
 )
+from docverse.client.models.queue_enums import PublishStatus
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.organization import SqlOrganization
 from docverse.domain.queue import JobStatus
 from docverse.factory import Factory
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.storage.build_store import BuildStore
+from docverse.storage.edition_build_history_store import (
+    EditionBuildHistoryStore,
+)
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
 from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
@@ -47,7 +51,7 @@ from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.keeper_sync import keeper_sync_project
-from tests.support.arq_testing import register_queue
+from tests.support.arq_testing import get_jobs_by_name, register_queue
 from tests.worker.conftest import make_worker_ctx
 
 LTD_BASE = "https://keeper.lsst.codes"
@@ -152,14 +156,18 @@ async def _seed_run(db_session: AsyncSession, *, org_id: int) -> int:
 
 
 async def _seed_project_queue_job(
-    db_session: AsyncSession, *, org_id: int, run_id: int
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    run_id: int,
+    backend_job_id: str = "test-arq-project-1",
 ) -> int:
     queue_job_store = QueueJobStore(session=db_session, logger=_logger())
     queue_job = await queue_job_store.create(
         kind=JobKind.keeper_sync_project,
         org_id=org_id,
         keeper_sync_run_id=run_id,
-        backend_job_id="test-arq-project-1",
+        backend_job_id=backend_job_id,
     )
     return queue_job.id
 
@@ -185,13 +193,31 @@ def _seed_ltd(mock_discovery: respx.Router) -> None:
 
 
 @pytest.mark.asyncio
-async def test_keeper_sync_project_runs_service_and_finalises_run(
+async def test_keeper_sync_project_runs_service_and_enqueues_publish(  # noqa: PLR0915
     app: None,
     db_session: AsyncSession,
     mock_discovery: respx.Router,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Happy path: project + edition + build + state rows, run -> succeeded."""
+    """Happy path: project + edition + build, publish_edition enqueued.
+
+    The keeper_sync_project worker must drive the synced edition's
+    finalized build through the same publish path as a normal client
+    upload. Asserts:
+
+    * Project / edition / build / state rows landed (the v1 sync
+      contract).
+    * The edition's ``publish_status`` is ``pending`` and a matching
+      ``EditionBuildHistory`` row exists with ``publish_status=pending``.
+    * A ``publish_edition`` ``QueueJob`` row was created carrying
+      ``keeper_sync_run_id`` so it rolls into the parent run's progress.
+    * A ``publish_edition`` arq job was enqueued on the *regular* queue
+      (``docverse:queue``), not the dedicated ``docverse:sync-queue``,
+      so the existing publish-edition worker pool picks it up.
+    * The parent run remains ``in_progress`` because the publish child
+      is still queued — finalisation cascades through the publish_edition
+      worker once it completes.
+    """
     async with db_session.begin():
         org_id, org_slug = await _seed_org(db_session)
         run_id = await _seed_run(db_session, org_id=org_id)
@@ -231,6 +257,15 @@ async def test_keeper_sync_project_runs_service_and_finalises_run(
     await ctx["http_client"].aclose()
     assert result == "completed"
 
+    publish_jobs = get_jobs_by_name(
+        mock_arq, "publish_edition", queue_name="docverse:queue"
+    )
+    assert len(publish_jobs) == 1
+    publish_payload = publish_jobs[0].kwargs["payload"]
+    assert publish_payload["edition_slug"] == "__main"
+    assert publish_payload["project_slug"] == "pipelines"
+    assert publish_payload["org_id"] == org_id
+
     async for session in db_session_dependency():
         async with session.begin():
             project_store = ProjectStore(session=session, logger=_logger())
@@ -245,12 +280,22 @@ async def test_keeper_sync_project_runs_service_and_finalises_run(
             )
             assert main_edition is not None
             assert main_edition.current_build_id is not None
+            assert main_edition.publish_status == PublishStatus.pending
 
             build_store = BuildStore(session=session, logger=_logger())
             build = await build_store.get_by_id(main_edition.current_build_id)
             assert build is not None
             assert build.status == BuildStatus.completed
             assert build.uploader == "keeper-sync"
+
+            history_store = EditionBuildHistoryStore(
+                session=session, logger=_logger()
+            )
+            history = await history_store.get_by_edition_and_build(
+                edition_id=main_edition.id, build_id=build.id
+            )
+            assert history is not None
+            assert history.publish_status == PublishStatus.pending
 
             state_store = KeeperSyncStateStore(
                 session=session, logger=_logger()
@@ -275,14 +320,104 @@ async def test_keeper_sync_project_runs_service_and_finalises_run(
             assert qj is not None
             assert qj.status == JobStatus.completed
 
+            publish_qj = await queue_job_store.get_by_backend_job_id(
+                publish_jobs[0].id
+            )
+            assert publish_qj is not None
+            assert publish_qj.kind == JobKind.publish_edition
+            assert publish_qj.keeper_sync_run_id == run_id
+            assert publish_qj.edition_id == main_edition.id
+            assert publish_qj.build_id == build.id
+            assert publish_qj.org_id == org_id
+            assert publish_qj.project_id == project.id
+
             run_store = KeeperSyncRunStore(session=session, logger=_logger())
             run = await run_store.get(run_id)
             assert run is not None
-            assert run.status == KeeperSyncRunStatus.succeeded
+            # Publish child is still queued, so the run waits for it.
+            assert run.status == KeeperSyncRunStatus.in_progress
 
     # Build content actually landed in the destination object store.
     assert any(k.endswith("/index.html") for k in object_store.objects)
     assert any(k.endswith("/app.js") for k in object_store.objects)
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_project_short_circuit_skips_publish_enqueue(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A short-circuited sync (LTD ``date_rebuilt`` unchanged) skips publish.
+
+    Runs ``keeper_sync_project`` twice for the same product. The first
+    pass populates everything (project / edition / build / state rows
+    and a ``publish_edition`` arq job). The second pass observes the
+    ``keeper_sync_state`` row's ``date_rebuilt_seen`` matches LTD's
+    ``date_rebuilt`` and short-circuits inside ``KeeperSyncService.
+    sync_build``. It must NOT enqueue a redundant ``publish_edition``
+    arq job — re-publishing on every reconciliation tick would burn
+    KV writes without any state change.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session)
+        run_id = await _seed_run(db_session, org_id=org_id)
+        first_qj = await _seed_project_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    _seed_ltd(mock_discovery)
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v1</html>",
+    }
+    _patch_factory_io(
+        monkeypatch,
+        object_store=object_store,
+        source_objects=source_objects,
+    )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    payload: dict[str, Any] = {
+        "org_id": org_id,
+        "org_slug": org_slug,
+        "run_id": run_id,
+        "queue_job_id": first_qj,
+        "ltd_slug": "pipelines",
+        "ltd_base_url": LTD_BASE,
+    }
+
+    first_result = await keeper_sync_project(ctx, payload)
+    assert first_result == "completed"
+    publish_after_first = get_jobs_by_name(
+        mock_arq, "publish_edition", queue_name="docverse:queue"
+    )
+    assert len(publish_after_first) == 1
+
+    # Second pass on the same LTD state — must short-circuit.
+    async with db_session.begin():
+        second_qj = await _seed_project_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run_id,
+            backend_job_id="test-arq-project-2",
+        )
+    payload["queue_job_id"] = second_qj
+    second_result = await keeper_sync_project(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert second_result == "completed"
+
+    publish_after_second = get_jobs_by_name(
+        mock_arq, "publish_edition", queue_name="docverse:queue"
+    )
+    # Still exactly one publish job — the second pass short-circuited.
+    assert len(publish_after_second) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -22,6 +22,7 @@ import respx
 import structlog
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import (
@@ -32,6 +33,7 @@ from docverse.client.models import (
     OrganizationCreate,
 )
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
+from docverse.dbschema.organization import SqlOrganization
 from docverse.domain.queue import JobStatus
 from docverse.factory import Factory
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
@@ -108,7 +110,11 @@ def _patch_factory_io(
     monkeypatch.setattr(Factory, "create_ltd_s3_source", _create_ltd_s3_source)
 
 
-async def _seed_org(db_session: AsyncSession) -> tuple[int, str]:
+async def _seed_org(
+    db_session: AsyncSession,
+    *,
+    publishing_store_label: str | None = "mock-store",
+) -> tuple[int, str]:
     logger = _logger()
     org_store = OrganizationStore(session=db_session, logger=logger)
     org = await org_store.create(
@@ -125,6 +131,13 @@ async def _seed_org(db_session: AsyncSession) -> tuple[int, str]:
             project_slugs=["pipelines"],
         ),
     )
+    if publishing_store_label is not None:
+        await db_session.execute(
+            update(SqlOrganization)
+            .where(SqlOrganization.id == org.id)
+            .values(publishing_store_label=publishing_store_label)
+        )
+        await db_session.flush()
     return org.id, org.slug
 
 
@@ -334,4 +347,140 @@ async def test_keeper_sync_project_failure_marks_queue_job_and_finalises_run(
             assert run.status == KeeperSyncRunStatus.partial_failure
 
     # Nothing was copied to the destination on the failure path.
+    assert object_store.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_project_objectstore_failure_marks_queue_job_failed(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Objectstore resolution raising → queue job ``failed``, no leaked txn.
+
+    Drives the failure deeper than the LTD-404 path: the service has
+    started copying and invokes the factory's copier closure, which calls
+    ``create_objectstore_for_org``. We make that raise, exercising the
+    worker's except branch after the factory has entered the autobegun
+    transaction region. Without the fix this reproduces
+    ``InvalidRequestError: A transaction is already begun on this Session``.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session)
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_project_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    _seed_ltd(mock_discovery)
+
+    async def _create_objectstore_for_org_raises(
+        self: Factory, *, org_id: int, service_label: str
+    ) -> MockObjectStore:
+        msg = f"Service {service_label!r} not found"
+        raise RuntimeError(msg)
+
+    def _create_ltd_s3_source(
+        self: Factory, *, bucket: str = "lsst-the-docs"
+    ) -> _FakeLtdSource:
+        return _FakeLtdSource({})
+
+    monkeypatch.setattr(
+        Factory,
+        "create_objectstore_for_org",
+        _create_objectstore_for_org_raises,
+    )
+    monkeypatch.setattr(Factory, "create_ltd_s3_source", _create_ltd_s3_source)
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    with pytest.raises(RuntimeError, match="Service 'mock-store' not found"):
+        await keeper_sync_project(
+            ctx,
+            {
+                "org_id": org_id,
+                "org_slug": org_slug,
+                "run_id": run_id,
+                "queue_job_id": queue_job_id,
+                "ltd_slug": "pipelines",
+                "ltd_base_url": LTD_BASE,
+            },
+        )
+    await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            qj = await queue_job_store.get(queue_job_id)
+            assert qj is not None
+            assert qj.status == JobStatus.failed
+            assert qj.errors is not None
+            assert "Service 'mock-store' not found" in qj.errors["message"]
+
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status == KeeperSyncRunStatus.partial_failure
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_project_missing_publishing_store_label(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``publishing_store_label`` → worker fails fast with clear error."""
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, publishing_store_label=None
+        )
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_project_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    object_store = MockObjectStore()
+    _patch_factory_io(
+        monkeypatch, object_store=object_store, source_objects={}
+    )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    with pytest.raises(RuntimeError, match="publishing_store_label"):
+        await keeper_sync_project(
+            ctx,
+            {
+                "org_id": org_id,
+                "org_slug": org_slug,
+                "run_id": run_id,
+                "queue_job_id": queue_job_id,
+                "ltd_slug": "pipelines",
+                "ltd_base_url": LTD_BASE,
+            },
+        )
+    await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            qj = await queue_job_store.get(queue_job_id)
+            assert qj is not None
+            assert qj.status == JobStatus.failed
+            assert qj.errors is not None
+            assert "publishing_store_label" in qj.errors["message"]
+
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status == KeeperSyncRunStatus.partial_failure
+
+    # Nothing copied since the worker bailed before constructing the service.
     assert object_store.objects == {}

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -33,6 +33,7 @@ from docverse.client.models import (
     OrganizationCreate,
 )
 from docverse.client.models.queue_enums import PublishStatus
+from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.organization import SqlOrganization
 from docverse.domain.queue import JobStatus
@@ -418,6 +419,132 @@ async def test_keeper_sync_project_short_circuit_skips_publish_enqueue(
     )
     # Still exactly one publish job — the second pass short-circuited.
     assert len(publish_after_second) == 1
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_project_self_heals_unpublished_short_circuit(  # noqa: PLR0915
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Short-circuited sync re-publishes an edition that was never published.
+
+    Simulates the staging shape from the first sync runs that landed
+    before the publish-enqueue path existed: an edition has its
+    ``current_build_id`` set, the build is ``completed``, and a
+    ``keeper_sync_state`` row matches LTD's ``date_rebuilt`` — but
+    ``publish_status`` is ``NULL`` because no publish was ever enqueued
+    against this build. On the next sync run the build sync still
+    short-circuits (no LTD-side change), but the worker must observe
+    the unpublished edition and enqueue a catch-up
+    ``publish_edition`` job so KV + dashboard come into sync.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session)
+        run_id = await _seed_run(db_session, org_id=org_id)
+        first_qj = await _seed_project_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    _seed_ltd(mock_discovery)
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v1</html>",
+    }
+    _patch_factory_io(
+        monkeypatch,
+        object_store=object_store,
+        source_objects=source_objects,
+    )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    payload: dict[str, Any] = {
+        "org_id": org_id,
+        "org_slug": org_slug,
+        "run_id": run_id,
+        "queue_job_id": first_qj,
+        "ltd_slug": "pipelines",
+        "ltd_base_url": LTD_BASE,
+    }
+
+    first_result = await keeper_sync_project(ctx, payload)
+    assert first_result == "completed"
+    publish_after_first = get_jobs_by_name(
+        mock_arq, "publish_edition", queue_name="docverse:queue"
+    )
+    assert len(publish_after_first) == 1
+
+    # Reset the edition's publish_status to NULL to mimic data that
+    # landed before the publish-enqueue path existed.
+    async for session in db_session_dependency():
+        async with session.begin():
+            project_store = ProjectStore(session=session, logger=_logger())
+            project = await project_store.get_by_slug(
+                org_id=org_id, slug="pipelines"
+            )
+            assert project is not None
+            edition_store = EditionStore(session=session, logger=_logger())
+            main_edition = await edition_store.get_by_slug(
+                project_id=project.id, slug="__main"
+            )
+            assert main_edition is not None
+            await session.execute(
+                update(SqlEdition)
+                .where(SqlEdition.id == main_edition.id)
+                .values(publish_status=None)
+            )
+
+    async with db_session.begin():
+        second_qj = await _seed_project_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run_id,
+            backend_job_id="test-arq-project-2",
+        )
+    payload["queue_job_id"] = second_qj
+    second_result = await keeper_sync_project(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert second_result == "completed"
+
+    publish_after_second = get_jobs_by_name(
+        mock_arq, "publish_edition", queue_name="docverse:queue"
+    )
+    # The second pass short-circuited but observed the unpublished edition,
+    # so a catch-up publish was enqueued.
+    assert len(publish_after_second) == 2
+
+    second_payload = publish_after_second[1].kwargs["payload"]
+    assert second_payload["edition_slug"] == "__main"
+    assert second_payload["project_slug"] == "pipelines"
+    assert second_payload["org_id"] == org_id
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            edition_store = EditionStore(session=session, logger=_logger())
+            project_store = ProjectStore(session=session, logger=_logger())
+            project = await project_store.get_by_slug(
+                org_id=org_id, slug="pipelines"
+            )
+            assert project is not None
+            edition = await edition_store.get_by_slug(
+                project_id=project.id, slug="__main"
+            )
+            assert edition is not None
+            assert edition.publish_status == PublishStatus.pending
+
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            self_heal_qj = await queue_job_store.get_by_backend_job_id(
+                publish_after_second[1].id
+            )
+            assert self_heal_qj is not None
+            assert self_heal_qj.kind == JobKind.publish_edition
+            assert self_heal_qj.keeper_sync_run_id == run_id
 
 
 @pytest.mark.asyncio

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -1,0 +1,347 @@
+"""Tests for the ``keeper_sync_project`` worker function.
+
+Wires the real ``KeeperSyncService`` against the alembic-managed test DB,
+stubs LTD HTTP via ``respx``, and patches ``Factory.create_ltd_s3_source``
++ ``Factory.create_objectstore_for_org`` so the source/destination side
+of :class:`BuildContentCopier` runs against in-memory doubles. This
+covers the worker's contract — service is invoked, queue job tracks
+its lifecycle, and ``_maybe_finalise_run`` runs in both the happy and
+failing paths — without depending on real S3 or R2.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Self
+
+import httpx
+import pytest
+import respx
+import structlog
+from safir.arq import MockArqQueue
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import (
+    BuildStatus,
+    JobKind,
+    KeeperSyncConfig,
+    KeeperSyncRunStatus,
+    OrganizationCreate,
+)
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
+from docverse.domain.queue import JobStatus
+from docverse.factory import Factory
+from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
+from docverse.storage.build_store import BuildStore
+from docverse.storage.edition_store import EditionStore
+from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+from docverse.storage.ltd import LtdNotFoundError
+from docverse.storage.objectstore import MockObjectStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+from docverse.storage.queue_job_store import QueueJobStore
+from docverse.worker.functions.keeper_sync import keeper_sync_project
+from tests.support.arq_testing import register_queue
+from tests.worker.conftest import make_worker_ctx
+
+LTD_BASE = "https://keeper.lsst.codes"
+FIXTURES_DIR = (
+    Path(__file__).parent.parent / "storage" / "ltd" / "fixtures"
+)
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+def _load(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES_DIR / name).read_text())  # type: ignore[no-any-return]
+
+
+class _FakeLtdSource:
+    """In-memory ``LtdSourceProtocol`` backing for worker integration tests."""
+
+    def __init__(self, objects: dict[str, bytes]) -> None:
+        self._objects = objects
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    async def list_keys(self, *, prefix: str) -> list[str]:
+        return [k for k in self._objects if k.startswith(prefix)]
+
+    async def download_object(self, *, key: str) -> bytes:
+        return self._objects[key]
+
+
+def _patch_factory_io(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    object_store: MockObjectStore,
+    source_objects: dict[str, bytes],
+) -> None:
+    """Route the factory's S3/objectstore wiring through in-memory doubles."""
+
+    async def _create_objectstore_for_org(
+        self: Factory, *, org_id: int, service_label: str
+    ) -> MockObjectStore:
+        return object_store
+
+    def _create_ltd_s3_source(
+        self: Factory, *, bucket: str = "lsst-the-docs"
+    ) -> _FakeLtdSource:
+        return _FakeLtdSource(source_objects)
+
+    monkeypatch.setattr(
+        Factory, "create_objectstore_for_org", _create_objectstore_for_org
+    )
+    monkeypatch.setattr(
+        Factory, "create_ltd_s3_source", _create_ltd_s3_source
+    )
+
+
+async def _seed_org(db_session: AsyncSession) -> tuple[int, str]:
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug="ks-worker",
+            title="KS Worker",
+            base_domain="ks-worker.example.com",
+        )
+    )
+    await org_store.update_keeper_sync_config(
+        slug=org.slug,
+        config=KeeperSyncConfig(
+            enabled=True,
+            project_slugs=["pipelines"],
+        ),
+    )
+    return org.id, org.slug
+
+
+async def _seed_run(db_session: AsyncSession, *, org_id: int) -> int:
+    row = SqlKeeperSyncRun(
+        org_id=org_id, kind="backfill", status="in_progress"
+    )
+    db_session.add(row)
+    await db_session.flush()
+    await db_session.refresh(row)
+    return row.id
+
+
+async def _seed_project_queue_job(
+    db_session: AsyncSession, *, org_id: int, run_id: int
+) -> int:
+    queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+    queue_job = await queue_job_store.create(
+        kind=JobKind.keeper_sync_project,
+        org_id=org_id,
+        keeper_sync_run_id=run_id,
+        backend_job_id="test-arq-project-1",
+    )
+    return queue_job.id
+
+
+def _seed_ltd(mock_discovery: respx.Router) -> None:
+    """Stub the canonical LTD endpoints for the ``pipelines`` product."""
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(
+            200, json=_load("product_pipelines.json")
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
+        return_value=httpx.Response(
+            200, json={"editions": [f"{LTD_BASE}/editions/1"]}
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/editions/1").mock(
+        return_value=httpx.Response(
+            200, json=_load("edition_main_git_refs.json")
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/builds/42").mock(
+        return_value=httpx.Response(200, json=_load("build.json"))
+    )
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_project_runs_service_and_finalises_run(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: project + edition + build + state rows, run -> succeeded."""
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session)
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_project_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    _seed_ltd(mock_discovery)
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v1</html>",
+        "pipelines/builds/42/assets/app.js": b"console.log(1)",
+    }
+    _patch_factory_io(
+        monkeypatch,
+        object_store=object_store,
+        source_objects=source_objects,
+    )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await keeper_sync_project(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "run_id": run_id,
+            "queue_job_id": queue_job_id,
+            "ltd_slug": "pipelines",
+            "ltd_base_url": LTD_BASE,
+        },
+    )
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            project_store = ProjectStore(session=session, logger=_logger())
+            project = await project_store.get_by_slug(
+                org_id=org_id, slug="pipelines"
+            )
+            assert project is not None
+
+            edition_store = EditionStore(session=session, logger=_logger())
+            main_edition = await edition_store.get_by_slug(
+                project_id=project.id, slug="__main"
+            )
+            assert main_edition is not None
+            assert main_edition.current_build_id is not None
+
+            build_store = BuildStore(session=session, logger=_logger())
+            build = await build_store.get_by_id(main_edition.current_build_id)
+            assert build is not None
+            assert build.status == BuildStatus.completed
+            assert build.uploader == "keeper-sync"
+
+            state_store = KeeperSyncStateStore(
+                session=session, logger=_logger()
+            )
+            project_state = await state_store.get(
+                org_id=org_id,
+                resource_type=ResourceType.project,
+                ltd_slug="pipelines",
+            )
+            assert project_state is not None
+            assert project_state.docverse_id == project.id
+            build_state = await state_store.get(
+                org_id=org_id,
+                resource_type=ResourceType.build,
+                ltd_id=42,
+            )
+            assert build_state is not None
+            assert build_state.docverse_id == build.id
+
+            queue_job_store = QueueJobStore(
+                session=session, logger=_logger()
+            )
+            qj = await queue_job_store.get(queue_job_id)
+            assert qj is not None
+            assert qj.status == JobStatus.completed
+
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status == KeeperSyncRunStatus.succeeded
+
+    # Build content actually landed in the destination object store.
+    assert any(k.endswith("/index.html") for k in object_store.objects)
+    assert any(k.endswith("/app.js") for k in object_store.objects)
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_project_failure_marks_queue_job_and_finalises_run(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LTD 404 → exception bubbles, queue job ``failed``, run finalised."""
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session)
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_project_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    # Product endpoint returns 404 — the LTD client will raise after
+    # exhausting its bounded retry, and the worker must surface the
+    # exception while still flipping the queue-job + run status rows.
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(404)
+    )
+
+    object_store = MockObjectStore()
+    _patch_factory_io(
+        monkeypatch, object_store=object_store, source_objects={}
+    )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    with pytest.raises(LtdNotFoundError):
+        await keeper_sync_project(
+            ctx,
+            {
+                "org_id": org_id,
+                "org_slug": org_slug,
+                "run_id": run_id,
+                "queue_job_id": queue_job_id,
+                "ltd_slug": "pipelines",
+                "ltd_base_url": LTD_BASE,
+            },
+        )
+    await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            queue_job_store = QueueJobStore(
+                session=session, logger=_logger()
+            )
+            qj = await queue_job_store.get(queue_job_id)
+            assert qj is not None
+            assert qj.status == JobStatus.failed
+            assert qj.errors is not None
+            assert qj.errors.get("message")
+
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            # Single child failed → run finalises as partial_failure.
+            assert run.status == KeeperSyncRunStatus.partial_failure
+
+    # Nothing was copied to the destination on the failure path.
+    assert object_store.objects == {}

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -49,9 +49,7 @@ from tests.support.arq_testing import register_queue
 from tests.worker.conftest import make_worker_ctx
 
 LTD_BASE = "https://keeper.lsst.codes"
-FIXTURES_DIR = (
-    Path(__file__).parent.parent / "storage" / "ltd" / "fixtures"
-)
+FIXTURES_DIR = Path(__file__).parent.parent / "storage" / "ltd" / "fixtures"
 
 
 def _logger() -> structlog.stdlib.BoundLogger:
@@ -107,9 +105,7 @@ def _patch_factory_io(
     monkeypatch.setattr(
         Factory, "create_objectstore_for_org", _create_objectstore_for_org
     )
-    monkeypatch.setattr(
-        Factory, "create_ltd_s3_source", _create_ltd_s3_source
-    )
+    monkeypatch.setattr(Factory, "create_ltd_s3_source", _create_ltd_s3_source)
 
 
 async def _seed_org(db_session: AsyncSession) -> tuple[int, str]:
@@ -158,9 +154,7 @@ async def _seed_project_queue_job(
 def _seed_ltd(mock_discovery: respx.Router) -> None:
     """Stub the canonical LTD endpoints for the ``pipelines`` product."""
     mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
-        return_value=httpx.Response(
-            200, json=_load("product_pipelines.json")
-        )
+        return_value=httpx.Response(200, json=_load("product_pipelines.json"))
     )
     mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
         return_value=httpx.Response(
@@ -263,9 +257,7 @@ async def test_keeper_sync_project_runs_service_and_finalises_run(
             assert build_state is not None
             assert build_state.docverse_id == build.id
 
-            queue_job_store = QueueJobStore(
-                session=session, logger=_logger()
-            )
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
             qj = await queue_job_store.get(queue_job_id)
             assert qj is not None
             assert qj.status == JobStatus.completed
@@ -328,9 +320,7 @@ async def test_keeper_sync_project_failure_marks_queue_job_and_finalises_run(
 
     async for session in db_session_dependency():
         async with session.begin():
-            queue_job_store = QueueJobStore(
-                session=session, logger=_logger()
-            )
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
             qj = await queue_job_store.get(queue_job_id)
             assert qj is not None
             assert qj.status == JobStatus.failed

--- a/tests/worker/keeper_sync_reaper_test.py
+++ b/tests/worker/keeper_sync_reaper_test.py
@@ -98,7 +98,7 @@ async def test_reaper_fails_stuck_child_and_finalises_run(
     app: None,
     db_session: AsyncSession,
 ) -> None:
-    """A child past the threshold is failed and the parent reaches partial_failure."""
+    """Child past the threshold is failed; parent reaches partial_failure."""
     async with db_session.begin():
         org_id = await _seed_org(db_session, slug="ks-reaper-1")
         run_id = await _seed_run(db_session, org_id=org_id)

--- a/tests/worker/keeper_sync_reaper_test.py
+++ b/tests/worker/keeper_sync_reaper_test.py
@@ -1,0 +1,213 @@
+"""Tests for the ``keeper_sync_reaper`` cron worker function.
+
+The reaper is the cron-driven backstop for the case where arq itself
+loses a keeper-sync child job (typically a worker pod OOM-killed
+mid-job that never gets to surface a timeout). It marks any silent
+child as ``failed`` and finalises the parent run so an operator never
+sees a sync stuck in ``in_progress`` forever.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+import structlog
+from safir.arq import MockArqQueue
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import (
+    JobKind,
+    KeeperSyncRunStatus,
+    OrganizationCreate,
+)
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.queue import JobStatus
+from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.queue_job_store import QueueJobStore
+from docverse.worker.functions.keeper_sync import keeper_sync_reaper
+from tests.support.arq_testing import register_queue
+from tests.worker.conftest import make_worker_ctx
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org(db_session: AsyncSession, *, slug: str) -> int:
+    org_store = OrganizationStore(session=db_session, logger=_logger())
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=slug,
+            title=f"KS Org {slug}",
+            base_domain=f"{slug}.example.com",
+        )
+    )
+    return org.id
+
+
+async def _seed_run(
+    db_session: AsyncSession, *, org_id: int, status: str = "in_progress"
+) -> int:
+    row = SqlKeeperSyncRun(org_id=org_id, kind="backfill", status=status)
+    db_session.add(row)
+    await db_session.flush()
+    await db_session.refresh(row)
+    return row.id
+
+
+async def _seed_stuck_child(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    run_id: int,
+    backend_job_id: str,
+    started_minutes_ago: int,
+) -> int:
+    queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+    job = await queue_job_store.create(
+        kind=JobKind.keeper_sync_project,
+        org_id=org_id,
+        keeper_sync_run_id=run_id,
+        backend_job_id=backend_job_id,
+    )
+    await queue_job_store.start(job.id)
+    row = await db_session.get(SqlQueueJob, job.id)
+    assert row is not None
+    row.date_started = datetime.now(tz=UTC) - timedelta(
+        minutes=started_minutes_ago
+    )
+    await db_session.flush()
+    return job.id
+
+
+def _make_ctx(http_client: httpx.AsyncClient) -> dict[str, Any]:
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    return make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+
+@pytest.mark.asyncio
+async def test_reaper_fails_stuck_child_and_finalises_run(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A child past the threshold is failed and the parent reaches partial_failure."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-reaper-1")
+        run_id = await _seed_run(db_session, org_id=org_id)
+        stuck_id = await _seed_stuck_child(
+            db_session,
+            org_id=org_id,
+            run_id=run_id,
+            backend_job_id="arq-stuck-1",
+            started_minutes_ago=600,
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        await keeper_sync_reaper(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            qj_store = QueueJobStore(session=session, logger=_logger())
+            qj = await qj_store.get(stuck_id)
+            assert qj is not None
+            assert qj.status == JobStatus.failed
+            assert qj.errors is not None
+            assert qj.date_completed is not None
+
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status == KeeperSyncRunStatus.partial_failure
+            assert run.date_finished is not None
+
+
+@pytest.mark.asyncio
+async def test_reaper_skips_runs_with_recent_activity(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A child within the idle window leaves its parent run alone."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-reaper-2")
+        run_id = await _seed_run(db_session, org_id=org_id)
+        # Started just now — well within any sane idle window.
+        await _seed_stuck_child(
+            db_session,
+            org_id=org_id,
+            run_id=run_id,
+            backend_job_id="arq-fresh",
+            started_minutes_ago=0,
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        await keeper_sync_reaper(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            # Untouched: still in_progress.
+            assert run.status == KeeperSyncRunStatus.in_progress
+
+
+@pytest.mark.asyncio
+async def test_reaper_finalises_each_distinct_parent_run(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """Stuck children on multiple runs each trigger their own finalisation."""
+    async with db_session.begin():
+        # Two orgs because the partial unique index forbids more than
+        # one non-terminal run per org.
+        org_a_id = await _seed_org(db_session, slug="ks-reaper-3a")
+        org_b_id = await _seed_org(db_session, slug="ks-reaper-3b")
+        run_a_id = await _seed_run(db_session, org_id=org_a_id)
+        run_b_id = await _seed_run(db_session, org_id=org_b_id)
+        await _seed_stuck_child(
+            db_session,
+            org_id=org_a_id,
+            run_id=run_a_id,
+            backend_job_id="arq-stuck-a",
+            started_minutes_ago=600,
+        )
+        await _seed_stuck_child(
+            db_session,
+            org_id=org_b_id,
+            run_id=run_b_id,
+            backend_job_id="arq-stuck-b",
+            started_minutes_ago=600,
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        await keeper_sync_reaper(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run_a = await run_store.get(run_a_id)
+            run_b = await run_store.get(run_b_id)
+            assert run_a is not None
+            assert run_b is not None
+            assert run_a.status == KeeperSyncRunStatus.partial_failure
+            assert run_b.status == KeeperSyncRunStatus.partial_failure

--- a/tests/worker/keeper_sync_run_discovery_test.py
+++ b/tests/worker/keeper_sync_run_discovery_test.py
@@ -1,0 +1,303 @@
+"""Tests for the ``keeper_sync_run_discovery`` worker function."""
+
+from __future__ import annotations
+
+import json
+from typing import Literal
+
+import httpx
+import pytest
+import respx
+import structlog
+from safir.arq import MockArqQueue
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import (
+    JobKind,
+    KeeperSyncConfig,
+    KeeperSyncRunStatus,
+    OrganizationCreate,
+)
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.queue import JobStatus
+from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.queue_job_store import QueueJobStore
+from docverse.worker.functions.keeper_sync import keeper_sync_run_discovery
+from tests.support.arq_testing import get_jobs_by_name, register_queue
+from tests.worker.conftest import make_worker_ctx
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org(
+    db_session: AsyncSession,
+    *,
+    project_slugs: list[str] | Literal["*"] = "*",
+) -> tuple[int, str]:
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug="ks-org",
+            title="KS Org",
+            base_domain="ks.example.com",
+        )
+    )
+    await org_store.update_keeper_sync_config(
+        slug=org.slug,
+        config=KeeperSyncConfig(
+            enabled=True,
+            project_slugs=project_slugs,
+        ),
+    )
+    return org.id, org.slug
+
+
+async def _seed_run(db_session: AsyncSession, *, org_id: int) -> int:
+    row = SqlKeeperSyncRun(org_id=org_id, kind="backfill", status="pending")
+    db_session.add(row)
+    await db_session.flush()
+    await db_session.refresh(row)
+    return row.id
+
+
+async def _seed_discovery_queue_job(
+    db_session: AsyncSession, *, org_id: int, run_id: int
+) -> int:
+    queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+    queue_job = await queue_job_store.create(
+        kind=JobKind.keeper_sync_run_discovery,
+        org_id=org_id,
+        keeper_sync_run_id=run_id,
+        backend_job_id="test-arq-discovery",
+    )
+    return queue_job.id
+
+
+def _mock_ltd_products(mock_discovery: respx.Router, slugs: list[str]) -> None:
+    products = [f"https://keeper.lsst.codes/products/{s}/" for s in slugs]
+    mock_discovery.get("https://keeper.lsst.codes/products/").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            content=json.dumps({"products": products}).encode(),
+            headers={"content-type": "application/json"},
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_discovery_fans_out_intersected_slugs(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """Discovery enqueues one ``keeper_sync_project`` per allowlisted slug."""
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, project_slugs=["dmtn-001", "sqr-112"]
+        )
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_discovery_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    _mock_ltd_products(mock_discovery, ["dmtn-001", "dmtn-002", "sqr-112"])
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await keeper_sync_run_discovery(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    # Two child enqueues — one per intersected slug — landing on the
+    # dedicated sync queue and not the default queue.
+    project_jobs = get_jobs_by_name(
+        mock_arq, "keeper_sync_project", queue_name=KEEPER_SYNC_QUEUE_NAME
+    )
+    assert len(project_jobs) == 2
+    default_jobs = get_jobs_by_name(
+        mock_arq, "keeper_sync_project", queue_name="docverse:queue"
+    )
+    assert default_jobs == []
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            stmt = select(SqlQueueJob).where(
+                SqlQueueJob.keeper_sync_run_id == run_id,
+                SqlQueueJob.kind == JobKind.keeper_sync_project.value,
+            )
+            child_rows = (await session.execute(stmt)).scalars().all()
+            assert len(child_rows) == 2
+            assert all(row.org_id == org_id for row in child_rows)
+            assert all(row.backend_job_id is not None for row in child_rows)
+
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status == KeeperSyncRunStatus.in_progress
+
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            disc = await queue_job_store.get(queue_job_id)
+            assert disc is not None
+            assert disc.status == JobStatus.completed
+            assert disc.progress is not None
+            assert disc.progress["in_scope_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_discovery_with_wildcard_uses_all_ltd_slugs(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """``project_slugs="*"`` keeps every LTD slug in scope."""
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, project_slugs="*")
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_discovery_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    _mock_ltd_products(mock_discovery, ["dmtn-001", "dmtn-002", "sqr-112"])
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await keeper_sync_run_discovery(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            stmt = select(SqlQueueJob).where(
+                SqlQueueJob.keeper_sync_run_id == run_id,
+                SqlQueueJob.kind == JobKind.keeper_sync_project.value,
+            )
+            child_rows = (await session.execute(stmt)).scalars().all()
+            assert len(child_rows) == 3
+
+
+@pytest.mark.asyncio
+async def test_discovery_with_empty_intersection_finalises_run(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """An empty fan-out terminates the run as ``succeeded`` immediately."""
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, project_slugs=["nonexistent"]
+        )
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_discovery_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    _mock_ltd_products(mock_discovery, ["dmtn-001"])
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await keeper_sync_run_discovery(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status == KeeperSyncRunStatus.succeeded
+
+
+@pytest.mark.asyncio
+async def test_discovery_marks_run_failed_when_disabled(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A disabled config aborts discovery and marks the run failed."""
+    logger = _logger()
+    async with db_session.begin():
+        org_store = OrganizationStore(session=db_session, logger=logger)
+        org = await org_store.create(
+            OrganizationCreate(
+                slug="ks-org",
+                title="KS Org",
+                base_domain="ks.example.com",
+            )
+        )
+        # Persist a disabled config, then re-fetch the org id.
+        await org_store.update_keeper_sync_config(
+            slug=org.slug,
+            config=KeeperSyncConfig(enabled=False),
+        )
+        run_id = await _seed_run(db_session, org_id=org.id)
+        queue_job_id = await _seed_discovery_queue_job(
+            db_session, org_id=org.id, run_id=run_id
+        )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await keeper_sync_run_discovery(
+        ctx,
+        {
+            "org_id": org.id,
+            "org_slug": org.slug,
+            "run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await ctx["http_client"].aclose()
+    assert result == "failed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status == KeeperSyncRunStatus.failed
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            disc = await queue_job_store.get(queue_job_id)
+            assert disc is not None
+            assert disc.status == JobStatus.failed

--- a/tests/worker/keeper_sync_run_discovery_test.py
+++ b/tests/worker/keeper_sync_run_discovery_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from typing import Literal
 
 import httpx
@@ -301,3 +302,120 @@ async def test_discovery_marks_run_failed_when_disabled(
             disc = await queue_job_store.get(queue_job_id)
             assert disc is not None
             assert disc.status == JobStatus.failed
+
+
+@pytest.mark.asyncio
+async def test_discovery_reconciles_orphan_children_from_prior_attempt(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """An orphan child from a crashed prior discovery is failed at start.
+
+    Reproduces the race window where ``_enqueue_children`` committed a
+    child ``queue_jobs`` row but died before ``arq_queue.enqueue``: the
+    row is queued, has no ``backend_job_id``, and would block run
+    finalisation forever. The next discovery attempt should sweep it.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, project_slugs=["dmtn-001"]
+        )
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_discovery_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+        # Pre-seed an orphan child older than the 5-minute idle window.
+        queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+        orphan = await queue_job_store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+        )
+        orphan_row = await db_session.get(SqlQueueJob, orphan.id)
+        assert orphan_row is not None
+        orphan_row.date_created = datetime.now(tz=UTC) - timedelta(minutes=10)
+        await db_session.flush()
+
+    _mock_ltd_products(mock_discovery, ["dmtn-001"])
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await keeper_sync_run_discovery(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            reaped = await queue_job_store.get(orphan.id)
+            assert reaped is not None
+            assert reaped.status == JobStatus.failed
+            assert reaped.errors is not None
+            assert "orphan" in reaped.errors["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_discovery_leaves_recent_unenqueued_children_alone(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """A queued child younger than the idle window is not reaped.
+
+    Guards against a discovery worker reaping rows that a concurrent
+    healthy discovery worker just committed but hasn't yet had a chance
+    to write a ``backend_job_id`` back onto.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, project_slugs=["dmtn-001"]
+        )
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_discovery_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+        # Fresh child with no backend_job_id — within the idle window.
+        queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+        recent = await queue_job_store.create(
+            kind=JobKind.keeper_sync_project,
+            org_id=org_id,
+            keeper_sync_run_id=run_id,
+        )
+
+    _mock_ltd_products(mock_discovery, ["dmtn-001"])
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await keeper_sync_run_discovery(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            untouched = await queue_job_store.get(recent.id)
+            assert untouched is not None
+            assert untouched.status == JobStatus.queued

--- a/tests/worker/keeper_sync_run_discovery_test.py
+++ b/tests/worker/keeper_sync_run_discovery_test.py
@@ -139,6 +139,14 @@ async def test_discovery_fans_out_intersected_slugs(
     )
     assert default_jobs == []
 
+    # Each child payload carries the snapshot ``ltd_base_url`` so the
+    # per-project worker can construct its KeeperSyncService without
+    # re-reading the org config (which may have changed mid-run).
+    payloads = [job.kwargs["payload"] for job in project_jobs]
+    assert {p["ltd_slug"] for p in payloads} == {"dmtn-001", "sqr-112"}
+    for payload in payloads:
+        assert payload["ltd_base_url"] == "https://keeper.lsst.codes/"
+
     async for session in db_session_dependency():
         async with session.begin():
             stmt = select(SqlQueueJob).where(

--- a/tests/worker/keeper_sync_worker_settings_test.py
+++ b/tests/worker/keeper_sync_worker_settings_test.py
@@ -1,0 +1,41 @@
+"""Tests for the dual-queue ``WorkerSettings`` shape in ``worker.main``."""
+
+from __future__ import annotations
+
+from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
+from docverse.worker.functions import (
+    keeper_sync_project,
+    keeper_sync_run_discovery,
+)
+from docverse.worker.main import (
+    KeeperSyncWorkerSettings,
+    WorkerSettings,
+    shutdown,
+    startup,
+)
+
+
+def test_keeper_sync_worker_settings_uses_dedicated_queue() -> None:
+    """The sync queue is isolated from the default arq queue."""
+    assert KeeperSyncWorkerSettings.queue_name == KEEPER_SYNC_QUEUE_NAME
+    assert KeeperSyncWorkerSettings.queue_name != WorkerSettings.queue_name
+
+
+def test_keeper_sync_worker_settings_registers_keeper_sync_functions() -> None:
+    """Both keeper_sync functions are registered on the dedicated queue."""
+    assert keeper_sync_run_discovery in KeeperSyncWorkerSettings.functions
+    assert keeper_sync_project in KeeperSyncWorkerSettings.functions
+
+
+def test_default_worker_does_not_register_keeper_sync_functions() -> None:
+    """The default queue stays free of keeper-sync work."""
+    assert keeper_sync_run_discovery not in WorkerSettings.functions
+    assert keeper_sync_project not in WorkerSettings.functions
+
+
+def test_keeper_sync_worker_settings_share_lifecycle_hooks() -> None:
+    """Both classes share startup/shutdown for one factory builder."""
+    assert KeeperSyncWorkerSettings.on_startup is startup
+    assert KeeperSyncWorkerSettings.on_shutdown is shutdown
+    assert KeeperSyncWorkerSettings.on_startup is WorkerSettings.on_startup
+    assert KeeperSyncWorkerSettings.on_shutdown is WorkerSettings.on_shutdown

--- a/tests/worker/keeper_sync_worker_settings_test.py
+++ b/tests/worker/keeper_sync_worker_settings_test.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from arq.cron import CronJob
+from arq.worker import Function
+
+from docverse.config import Configuration
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.worker.functions import (
     keeper_sync_project,
+    keeper_sync_reaper,
     keeper_sync_run_discovery,
 )
 from docverse.worker.main import (
@@ -14,6 +19,16 @@ from docverse.worker.main import (
     startup,
 )
 
+_config = Configuration()
+
+
+def _function_by_coroutine(coro: object) -> Function:
+    for entry in KeeperSyncWorkerSettings.functions:
+        if isinstance(entry, Function) and entry.coroutine is coro:
+            return entry
+    msg = f"No registered Function wraps {coro!r}"
+    raise AssertionError(msg)
+
 
 def test_keeper_sync_worker_settings_uses_dedicated_queue() -> None:
     """The sync queue is isolated from the default arq queue."""
@@ -22,15 +37,36 @@ def test_keeper_sync_worker_settings_uses_dedicated_queue() -> None:
 
 
 def test_keeper_sync_worker_settings_registers_keeper_sync_functions() -> None:
-    """Both keeper_sync functions are registered on the dedicated queue."""
-    assert keeper_sync_run_discovery in KeeperSyncWorkerSettings.functions
-    assert keeper_sync_project in KeeperSyncWorkerSettings.functions
+    """Both keeper_sync functions are registered on the dedicated queue.
+
+    They are wrapped with :func:`arq.func` so the dedicated queue can
+    enforce a per-job timeout and disable arq's default 5-attempt
+    retry behaviour — failure must surface promptly so the existing
+    per-function ``except Exception`` blocks can route to
+    ``queue_job_store.fail()`` and the parent run still finalises.
+    """
+    discovery = _function_by_coroutine(keeper_sync_run_discovery)
+    project = _function_by_coroutine(keeper_sync_project)
+    expected_timeout = float(_config.keeper_sync_job_timeout_seconds)
+    assert discovery.timeout_s == expected_timeout
+    assert project.timeout_s == expected_timeout
+    assert discovery.max_tries == 1
+    assert project.max_tries == 1
 
 
 def test_default_worker_does_not_register_keeper_sync_functions() -> None:
     """The default queue stays free of keeper-sync work."""
     assert keeper_sync_run_discovery not in WorkerSettings.functions
     assert keeper_sync_project not in WorkerSettings.functions
+    assert keeper_sync_reaper not in WorkerSettings.functions
+    # And no ``arq.Function`` wrapper sneaks the same coroutines in either.
+    default_coros: set[object] = set()
+    for entry in WorkerSettings.functions:
+        if isinstance(entry, Function):
+            default_coros.add(entry.coroutine)
+    assert keeper_sync_run_discovery not in default_coros
+    assert keeper_sync_project not in default_coros
+    assert keeper_sync_reaper not in default_coros
 
 
 def test_keeper_sync_worker_settings_share_lifecycle_hooks() -> None:
@@ -39,3 +75,30 @@ def test_keeper_sync_worker_settings_share_lifecycle_hooks() -> None:
     assert KeeperSyncWorkerSettings.on_shutdown is shutdown
     assert KeeperSyncWorkerSettings.on_startup is WorkerSettings.on_startup
     assert KeeperSyncWorkerSettings.on_shutdown is WorkerSettings.on_shutdown
+
+
+def test_keeper_sync_worker_registers_reaper_cron() -> None:
+    """The reaper runs on a 30-minute cron on the dedicated queue.
+
+    Frequent enough that test/staging environments running with low
+    thresholds still see prompt finalisation, infrequent enough that
+    production with the 6 h threshold rarely sees no-work-to-do log
+    spam.
+    """
+    cron_jobs = list(getattr(KeeperSyncWorkerSettings, "cron_jobs", []))
+    reaper_crons = [
+        job
+        for job in cron_jobs
+        if isinstance(job, CronJob) and job.coroutine is keeper_sync_reaper
+    ]
+    assert len(reaper_crons) == 1
+    assert reaper_crons[0].minute == {0, 30}
+
+
+def test_default_worker_has_no_keeper_sync_cron() -> None:
+    """The default queue does not run the reaper."""
+    cron_jobs = list(getattr(WorkerSettings, "cron_jobs", []) or [])
+    coroutines = {
+        job.coroutine for job in cron_jobs if isinstance(job, CronJob)
+    }
+    assert keeper_sync_reaper not in coroutines


### PR DESCRIPTION
## Summary

- Adds `KeeperSyncRunService` and the operator-facing `POST/GET /orgs/{org}/keeper-sync/runs[/{id}]` endpoints, with run-aggregate counters derived from `queue_jobs` filtered on `keeper_sync_run_id` (no denormalised counter row).
- Adds a dedicated `docverse:sync-queue` arq queue and a second `KeeperSyncWorkerSettings` class sharing startup/shutdown + `WorkerFactoryBuilder` with the default `WorkerSettings`, so a noisy backfill cannot starve `build_processing` and `publish_edition`.
- Wires `keeper_sync_run_discovery` end-to-end: snapshots the org's `keeper_sync_config`, fetches LTD's flat `/products/`, intersects with the allowlist, fans out one `keeper_sync_project` per in-scope slug (with a snapshot `ltd_base_url` in the child payload), and transitions the run `pending → in_progress` atomically with the first child enqueue.
- Replaces the `keeper_sync_project` stub with a real call to `KeeperSyncService.sync_project`. The worker brackets the service call with two short transactions (`start` then `complete`/`fail` + run finalisation); the service manages its own state-row + Docverse-row commits. An LTD or copy failure marks the queue-job `failed`, finalises the parent run, and re-raises so arq records the job as failed.
- Guarantees a sync run always reaches a terminal state. Wraps `keeper_sync_run_discovery` and `keeper_sync_project` with `arq.func(timeout=..., max_tries=1)` on `KeeperSyncWorkerSettings` so the dedicated queue carries a per-job timeout from `Config` (default 60 min) instead of arq's 5-attempt default. Adds a cron-driven `keeper_sync_reaper` (every 30 min) that fails any keeper-sync child stuck `in_progress` past `Config.keeper_sync_reaper_threshold_seconds` (default 6 h) and finalises the parent via `maybe_finalise_run`.
- Adds `GET /orgs/{org}/keeper-sync/runs/{run_id}/jobs`, a paginated child-jobs sub-resource that mirrors the run-list endpoint shape (`Link` + `X-Total-Count`, opaque cursor, `?status=` filter, `require_admin`). Adds a generic nullable `subject_label` column to `queue_jobs` so each child carries the LTD slug (or a discovery label) without operators having to page through arq payloads. The existing `GET /queue/jobs/{id}` response also now exposes `keeper_sync_run_id` and `subject_label`.
- Surfaces a top-level `date_last_activity` timestamp on the `KeeperSyncRun` response, derived as `MAX(coalesce(date_completed, date_started, date_created))` over the run's attributed `queue_jobs` rows. Operators can poll the run-detail (or scan the run-list) and flag any non-terminal run whose `date_last_activity` is older than their tolerance, without paginating children. Internally renames `KeeperSyncRunCounters` → `KeeperSyncRunActivity` since it now carries a timestamp alongside the four counts; the response model flattens those fields, so the rename is internal-only.
- Runs the full publish path on every keeper-sync finalized edition build. After `KeeperSyncService.sync_project` returns, the worker loops over each non-short-circuited `BuildSyncOutcome` and calls a new shared `enqueue_publish_for_edition` helper (`services/publish_enqueue.py`) — same Phase A / Phase B split the regular upload flow uses — so Cloudflare Workers KV writes and a cascaded `dashboard_build` enqueue land for every synced edition (including `__main`). The publish `QueueJob` rows carry `keeper_sync_run_id` so they roll into the parent run's progress counters and `date_last_activity`, and `publish_edition` calls a shared `maybe_finalise_run` helper post-terminal so a successful publish drives the run to `succeeded`/`partial_failure`. Refactors `_enqueue_publish_jobs` in `build_processing` onto the same shared helper.

## Validation steps

- [ ] `POST /orgs/{org}/keeper-sync/runs` against an enabled org returns 202 with the run + a working `queue_job_url` link.
- [ ] `POST` while a non-terminal run exists for the same org returns 409 with a clear conflict message.
- [ ] `POST` against an `enabled: false` config returns 409.
- [ ] `GET /runs/{run_id}` aggregates counters across mixed-status `queue_jobs` filtered on `run_id` (verified against seeded queued/in_progress/completed/failed/cancelled rows).
- [ ] `GET /runs/{run_id}` returns a `date_last_activity` timestamp matching the most recent of `coalesce(date_completed, date_started, date_created)` across the run's children; runs with zero attributed children return `date_last_activity: null`.
- [ ] `GET /runs?status=...&cursor=...&limit=...` returns runs newest-first with a `Link: rel=next` header that round-trips through pagination, and each row carries its own `date_last_activity` populated for runs with children and null for runs without.
- [ ] `GET /runs/{run_id}/jobs` returns paginated child queue-jobs newest-first with working `Link` + `X-Total-Count` headers; `?status=failed` narrows to failed children; each row carries `subject_label` (LTD slug for project rows) and `keeper_sync_run_id`.
- [ ] `GET /runs/{run_id}/jobs` for a run owned by another org returns 404, not 403.
- [ ] All non-admin role checks return 403 (POST and GET, including the new `/jobs` endpoint).
- [ ] On staging, `POST /orgs/{org}/keeper-sync/runs` against an org configured for `["sqr-112"]` produces a Docverse project, edition, and build serving the copied LTD content.
- [ ] On staging with `DOCVERSE_KEEPER_SYNC_REAPER_THRESHOLD_SECONDS=120`, a `keeper_sync_project` queue-job manually transitioned to `in_progress` and left for 3 min is reaped by the next 30-min cron tick (or `arq --run-cron`); the row reaches `failed` with a `SilentWorker` error and the parent run reaches `partial_failure` with `date_finished` set.
- [ ] On a real sync run end-to-end, the `__main` edition and every newly-tracked draft edition show up as KV entries (`{project}/{edition_slug}` keys) in Cloudflare Workers KV with values pointing at the synced build, and a `dashboard_build` job runs once per project.
- [ ] After `keeper_sync_project` finalizes a synced build for an edition, the corresponding edition has `publish_status=pending`, an `EditionBuildHistory` row exists (also `pending`) for the new build, and a `publish_edition` `QueueJob` is created with `keeper_sync_run_id` populated and the matching arq job enqueued on the regular queue (`docverse:queue`, not `docverse:sync-queue`).
- [ ] A short-circuited `sync_build` (LTD `date_rebuilt` unchanged) enqueues no `publish_edition` job.
- [ ] Sync-enqueued publish jobs appear under `GET /keeper-sync/runs/{id}/jobs`, are counted in the run's `pending`/`succeeded`/`failed_count`, and update its `date_last_activity` as they progress; the parent run reaches `succeeded`/`partial_failure` once every attributed publish child terminates.

## Operational notes

Deploying the second worker pool in production requires a Phalanx chart change to spin up a worker deployment pointing at `docverse.worker.main:KeeperSyncWorkerSettings` (queue `docverse:sync-queue`); that config lives outside this repo and is not blocking for this PR. The `DOCVERSE_KEEPER_SYNC_JOB_TIMEOUT_SECONDS` (default 3600) and `DOCVERSE_KEEPER_SYNC_REAPER_THRESHOLD_SECONDS` (default 21600) env vars are available on `KeeperSyncWorkerSettings` to override the in-code defaults; no deploy is required if the defaults are acceptable. Migration `r6s7t8u9v0w1` adds the nullable `subject_label` column to `queue_jobs`; pre-existing rows have NULL labels and there is no retroactive backfill — runs from this PR forward populate the field. The `date_last_activity` timestamp on `KeeperSyncRun` is derived at read time from `queue_jobs` and requires no migration.

## References

- Closes #288
- Closes #301
- Closes #302
- Closes #303
- Closes #304
- Closes #307
- PRD: #275
- Jira: https://rubinobs.atlassian.net/browse/DM-54794
