### PR TITLE
DM-54794: Map every LTD edition tracking mode

### DIFF
--- a/src/docverse/services/keeper_sync/mappers.py
+++ b/src/docverse/services/keeper_sync/mappers.py
@@ -3,9 +3,11 @@
 These are intentionally side-effect-free helpers so the
 :class:`docverse.services.keeper_sync.service.KeeperSyncService`
 orchestration can remain a thin wrapper over the existing
-:class:`docverse.services.edition.EditionService` and friends. Only
-``git_refs`` is fully mapped here; the remaining LTD modes raise
-:class:`NotImplementedError` and are filled in by issue #289.
+:class:`docverse.services.edition.EditionService` and friends. Every
+:class:`LtdEditionMode` value has a documented Docverse counterpart;
+``manual`` is special-cased because Docverse has no semantic ``manual``
+mode (PRD #275 "Out of scope") and is collapsed onto a pinned
+``git_ref`` instead.
 """
 
 from __future__ import annotations
@@ -13,7 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 from docverse.client.models import EditionKind, TrackingMode
-from docverse.storage.ltd import LtdEdition, LtdEditionMode
+from docverse.storage.ltd import LtdBuild, LtdEdition, LtdEditionMode
 
 __all__ = [
     "LTD_MAIN_SLUG",
@@ -52,34 +54,88 @@ def derive_edition_slug(ltd_slug: str) -> str:
     return ltd_slug
 
 
+_VERSION_MODE_TABLE: dict[LtdEditionMode, TrackingMode] = {
+    LtdEditionMode.lsst_doc: TrackingMode.lsst_doc,
+    LtdEditionMode.eups_major_release: TrackingMode.eups_major_release,
+    LtdEditionMode.eups_weekly_release: TrackingMode.eups_weekly_release,
+    LtdEditionMode.eups_daily_release: TrackingMode.eups_daily_release,
+}
+
+
 def map_edition_tracking(
     edition: LtdEdition,
+    *,
+    build: LtdBuild | None = None,
 ) -> tuple[TrackingMode, dict[str, Any]]:
     """Map an LTD edition's tracking mode onto Docverse's tracking pair.
 
     Returns a ``(tracking_mode, tracking_params)`` tuple matching the
-    columns on Docverse's ``editions`` row. Only ``git_refs`` is
-    implemented in this slice; other modes raise
-    :class:`NotImplementedError`.
+    columns on Docverse's ``editions`` row.
+
+    ``manual`` is the only mode that needs the currently-published
+    build: LTD's ``manual`` editions do not auto-track at all, so the
+    importer pins them to whichever ref the published build was built
+    from (``LtdBuild.git_refs[0]``). The original LTD ``manual`` mode
+    is preserved by the caller in ``keeper_sync_state.annotations`` for
+    reversibility — this mapper just emits the tracking pair.
 
     Raises
     ------
-    NotImplementedError
-        For any non-``git_refs`` LTD mode. Filled in by #289.
     ValueError
-        If ``mode == "git_refs"`` but ``tracked_refs`` is empty/None.
+        If ``mode == "git_refs"`` but ``tracked_refs`` is empty/None,
+        if ``mode == "manual"`` but ``build`` is None or its
+        ``git_refs`` is empty/None, or if ``mode`` is an unknown LTD
+        string (schema drift).
     """
-    if edition.mode == LtdEditionMode.git_refs:
-        if not edition.tracked_refs:
-            msg = (
-                f"LTD edition {edition.slug!r} declares mode=git_refs but"
-                " supplies no tracked_refs"
-            )
-            raise ValueError(msg)
-        return TrackingMode.git_ref, {"git_ref": edition.tracked_refs[0]}
+    try:
+        ltd_mode = LtdEditionMode(edition.mode)
+    except ValueError as exc:
+        msg = (
+            f"LTD edition {edition.slug!r} reports unknown mode"
+            f" {edition.mode!r}; LTD schema drift not handled here"
+        )
+        raise ValueError(msg) from exc
+
+    if ltd_mode is LtdEditionMode.git_refs:
+        return _map_git_refs(edition)
+    mapped = _VERSION_MODE_TABLE.get(ltd_mode)
+    if mapped is not None:
+        return mapped, {}
+    if ltd_mode is LtdEditionMode.manual:
+        return _map_manual(edition, build)
 
     msg = (
-        f"LTD edition mode {edition.mode!r} is not yet supported by the"
-        " sync engine; tracked in #289"
+        f"LTD edition {edition.slug!r} declares mode {edition.mode!r} but no"
+        " mapper rule is defined; this is a programming error in mappers.py"
     )
-    raise NotImplementedError(msg)
+    raise ValueError(msg)
+
+
+def _map_git_refs(edition: LtdEdition) -> tuple[TrackingMode, dict[str, Any]]:
+    if not edition.tracked_refs:
+        msg = (
+            f"LTD edition {edition.slug!r} declares mode=git_refs but"
+            " supplies no tracked_refs"
+        )
+        raise ValueError(msg)
+    return TrackingMode.git_ref, {"git_ref": edition.tracked_refs[0]}
+
+
+def _map_manual(
+    edition: LtdEdition, build: LtdBuild | None
+) -> tuple[TrackingMode, dict[str, Any]]:
+    if build is None:
+        msg = (
+            f"LTD edition {edition.slug!r} declares mode=manual but no"
+            " build was supplied; the published build's git_refs is"
+            " required to pin a Docverse git_ref tracking pair"
+        )
+        raise ValueError(msg)
+    if not build.git_refs:
+        msg = (
+            f"LTD edition {edition.slug!r} declares mode=manual and the"
+            f" published build (id={build.ltd_id}) reports no git_refs;"
+            " cannot derive a Docverse git_ref tracking pair"
+        )
+        raise ValueError(msg)
+    return TrackingMode.git_ref, {"git_ref": build.git_refs[0]}

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -43,7 +43,13 @@ from docverse.services.project import DEFAULT_EDITION_SLUG, ProjectService
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
-from docverse.storage.ltd import LtdClient, LtdEdition, LtdProduct
+from docverse.storage.ltd import (
+    LtdBuild,
+    LtdClient,
+    LtdEdition,
+    LtdEditionMode,
+    LtdProduct,
+)
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 
@@ -236,7 +242,22 @@ class KeeperSyncService:
         ltd_edition: LtdEdition,
     ) -> EditionSyncOutcome:
         """Sync one LTD edition (and its current build) into Docverse."""
-        tracking_mode, tracking_params = map_edition_tracking(ltd_edition)
+        # ``manual`` editions need the published build's git_refs to
+        # synthesize a Docverse ``git_ref`` tracking pair. Other modes
+        # ignore the build for mapping; we skip the extra fetch when we
+        # can.
+        ltd_build_for_mapping: LtdBuild | None = None
+        if (
+            ltd_edition.mode == LtdEditionMode.manual
+            and ltd_edition.build_url is not None
+        ):
+            ltd_build_for_mapping = await self._ltd_client.get_build_by_url(
+                str(ltd_edition.build_url)
+            )
+
+        tracking_mode, tracking_params = map_edition_tracking(
+            ltd_edition, build=ltd_build_for_mapping
+        )
         kind = derive_edition_kind(ltd_edition.slug)
         docverse_slug = derive_edition_slug(ltd_edition.slug)
 
@@ -270,6 +291,7 @@ class KeeperSyncService:
                 project=project,
                 edition=edition,
                 ltd_edition=ltd_edition,
+                ltd_build=ltd_build_for_mapping,
             )
 
         return EditionSyncOutcome(
@@ -337,18 +359,25 @@ class KeeperSyncService:
         project: Project,
         edition: Edition,
         ltd_edition: LtdEdition,
+        ltd_build: LtdBuild | None = None,
     ) -> BuildSyncOutcome:
         """Sync the LTD edition's current build into Docverse.
 
         Short-circuits when ``keeper_sync_state`` already records a
         Docverse build whose ``date_rebuilt_seen`` matches LTD's.
+
+        ``ltd_build`` may be passed in by callers that already fetched
+        the build (e.g. ``sync_edition`` does so for ``manual`` editions
+        to derive the tracking pair). Skipping the refetch saves a round
+        trip to LTD.
         """
         if ltd_edition.build_url is None:
             msg = "sync_build requires an edition with build_url set"
             raise ValueError(msg)
-        ltd_build = await self._ltd_client.get_build_by_url(
-            str(ltd_edition.build_url)
-        )
+        if ltd_build is None:
+            ltd_build = await self._ltd_client.get_build_by_url(
+                str(ltd_edition.build_url)
+            )
         if not ltd_build.uploaded:
             msg = (
                 f"LTD build id={ltd_build.ltd_id} for edition"

--- a/tests/services/keeper_sync/mappers_test.py
+++ b/tests/services/keeper_sync/mappers_test.py
@@ -8,6 +8,7 @@ rules") so a future change has to update both the rule and the test.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 from pydantic import HttpUrl
@@ -18,7 +19,7 @@ from docverse.services.keeper_sync.mappers import (
     derive_edition_slug,
     map_edition_tracking,
 )
-from docverse.storage.ltd import LtdEdition
+from docverse.storage.ltd import LtdBuild, LtdEdition
 
 
 def _edition(
@@ -36,6 +37,20 @@ def _edition(
         date_created=datetime(2026, 4, 1, tzinfo=UTC),
         mode=mode,
         tracked_refs=tracked_refs,
+    )
+
+
+def _build(*, git_refs: list[str] | None = None) -> LtdBuild:
+    return LtdBuild(
+        self_url=HttpUrl("https://keeper.lsst.codes/builds/42"),
+        product_url=HttpUrl("https://keeper.lsst.codes/products/p"),
+        slug="42",
+        date_created=datetime(2026, 4, 1, tzinfo=UTC),
+        uploaded=True,
+        bucket_name="lsst-the-docs",
+        bucket_root_dir="p/builds/42",
+        git_refs=git_refs,
+        published_url=HttpUrl("https://example.com/"),
     )
 
 
@@ -62,6 +77,30 @@ def test_derive_edition_kind(ltd_slug: str, expected: EditionKind) -> None:
 )
 def test_derive_edition_slug(ltd_slug: str, expected: str) -> None:
     assert derive_edition_slug(ltd_slug) == expected
+
+
+@pytest.mark.parametrize(
+    ("ltd_mode", "expected_mode"),
+    [
+        ("lsst_doc", TrackingMode.lsst_doc),
+        ("eups_major_release", TrackingMode.eups_major_release),
+        ("eups_weekly_release", TrackingMode.eups_weekly_release),
+        ("eups_daily_release", TrackingMode.eups_daily_release),
+    ],
+)
+def test_map_edition_tracking_version_modes_pass_through(
+    ltd_mode: str, expected_mode: TrackingMode
+) -> None:
+    """``lsst_doc`` and ``eups_*`` map onto same-named Docverse modes.
+
+    These are version-based modes whose match logic uses the build's
+    git_ref directly (not ``tracking_params``), so the mapper emits an
+    empty params dict — the columns are NOT NULL JSONB.
+    """
+    edition = _edition(mode=ltd_mode, tracked_refs=["main"])
+    mode, params = map_edition_tracking(edition)
+    assert mode == expected_mode
+    assert params == {}
 
 
 def test_map_edition_tracking_git_refs_picks_first_tracked_ref() -> None:
@@ -102,18 +141,100 @@ def test_map_edition_tracking_git_refs_empty_tracked_refs_raises() -> None:
         map_edition_tracking(edition)
 
 
+def test_map_edition_tracking_manual_uses_build_git_refs() -> None:
+    """``manual`` collapses to ``git_ref`` pinned to the build's first ref.
+
+    LTD's `manual` mode has no Docverse equivalent yet (PRD #275 "Out
+    of scope"), so the importer pins the edition to whichever ref the
+    currently-published build was built from. State preservation of the
+    original ``manual`` mode is the service's responsibility; this
+    mapper just emits the tracking pair.
+    """
+    edition = _edition(mode="manual", tracked_refs=["main"])
+    build = _build(git_refs=["v1.2.3"])
+    mode, params = map_edition_tracking(edition, build=build)
+    assert mode == TrackingMode.git_ref
+    assert params == {"git_ref": "v1.2.3"}
+
+
+def test_map_edition_tracking_manual_picks_first_when_multi() -> None:
+    edition = _edition(mode="manual", tracked_refs=None)
+    build = _build(git_refs=["main", "feature/x"])
+    _, params = map_edition_tracking(edition, build=build)
+    assert params == {"git_ref": "main"}
+
+
+def test_map_edition_tracking_manual_without_build_raises() -> None:
+    """``manual`` cannot be mapped without the build's git_refs."""
+    edition = _edition(mode="manual", tracked_refs=["main"])
+    with pytest.raises(ValueError, match="manual"):
+        map_edition_tracking(edition)
+
+
+def test_map_edition_tracking_manual_missing_build_git_refs_raises() -> None:
+    edition = _edition(mode="manual", tracked_refs=None)
+    build = _build(git_refs=None)
+    with pytest.raises(ValueError, match="git_refs"):
+        map_edition_tracking(edition, build=build)
+
+
+def test_map_edition_tracking_manual_empty_build_git_refs_raises() -> None:
+    edition = _edition(mode="manual", tracked_refs=None)
+    build = _build(git_refs=[])
+    with pytest.raises(ValueError, match="git_refs"):
+        map_edition_tracking(edition, build=build)
+
+
+def test_map_edition_tracking_unknown_mode_raises() -> None:
+    """Unknown LTD modes (schema drift) surface as ValueError, not silent."""
+    edition = _edition(mode="some_future_mode", tracked_refs=["main"])
+    with pytest.raises(ValueError, match="some_future_mode"):
+        map_edition_tracking(edition)
+
+
 @pytest.mark.parametrize(
-    "mode",
+    ("ltd_mode", "tracked_refs", "build_git_refs", "expected"),
     [
-        "lsst_doc",
-        "eups_major_release",
-        "eups_weekly_release",
-        "eups_daily_release",
-        "manual",
+        (
+            "git_refs",
+            ["main"],
+            None,
+            (TrackingMode.git_ref, {"git_ref": "main"}),
+        ),
+        ("lsst_doc", ["main"], None, (TrackingMode.lsst_doc, {})),
+        (
+            "eups_major_release",
+            ["main"],
+            None,
+            (TrackingMode.eups_major_release, {}),
+        ),
+        (
+            "eups_weekly_release",
+            ["main"],
+            None,
+            (TrackingMode.eups_weekly_release, {}),
+        ),
+        (
+            "eups_daily_release",
+            ["main"],
+            None,
+            (TrackingMode.eups_daily_release, {}),
+        ),
+        (
+            "manual",
+            None,
+            ["v22_0_0"],
+            (TrackingMode.git_ref, {"git_ref": "v22_0_0"}),
+        ),
     ],
 )
-def test_map_edition_tracking_other_modes_not_implemented(mode: str) -> None:
-    """Non-``git_refs`` modes must raise NotImplementedError until #289."""
-    edition = _edition(mode=mode, tracked_refs=["main"])
-    with pytest.raises(NotImplementedError, match="#289"):
-        map_edition_tracking(edition)
+def test_map_edition_tracking_table(
+    ltd_mode: str,
+    tracked_refs: list[str] | None,
+    build_git_refs: list[str] | None,
+    expected: tuple[TrackingMode, dict[str, Any]],
+) -> None:
+    """Single table test covering every ``LtdEditionMode`` value."""
+    edition = _edition(mode=ltd_mode, tracked_refs=tracked_refs)
+    build = _build(git_refs=build_git_refs) if build_git_refs else None
+    assert map_edition_tracking(edition, build=build) == expected

--- a/tests/services/keeper_sync/service_test.py
+++ b/tests/services/keeper_sync/service_test.py
@@ -541,32 +541,216 @@ async def test_sync_build_refuses_half_uploaded_build(
 
 
 @pytest.mark.asyncio
-async def test_unsupported_ltd_mode_raises_not_implemented(
+@pytest.mark.parametrize(
+    ("ltd_mode", "expected_tracking_mode"),
+    [
+        ("lsst_doc", TrackingMode.lsst_doc),
+        ("eups_major_release", TrackingMode.eups_major_release),
+        ("eups_weekly_release", TrackingMode.eups_weekly_release),
+        ("eups_daily_release", TrackingMode.eups_daily_release),
+    ],
+)
+async def test_sync_edition_round_trips_version_modes(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+    ltd_mode: str,
+    expected_tracking_mode: TrackingMode,
+) -> None:
+    """Same-named LTD/Docverse version modes round-trip with no params.
+
+    ``lsst_doc`` and the three ``eups_*_release`` modes use Docverse
+    version parsers (no ``tracking_params`` needed), so the imported
+    edition row carries an empty params dict and the recorded LTD mode
+    survives in the state row's ``annotations``.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+
+    edition_payload = _load("edition_main_git_refs.json")
+    edition_payload["mode"] = ltd_mode
+    _seed_ltd(mock_discovery, edition_main=edition_payload)
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v1</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+    await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    edition_store = EditionStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    project_store = ProjectStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    async with db_session.begin():
+        project = await project_store.get_by_slug(
+            org_id=org_id, slug="pipelines"
+        )
+        assert project is not None
+        edition = await edition_store.get_by_slug(
+            project_id=project.id, slug="__main"
+        )
+        assert edition is not None
+        assert edition.tracking_mode == expected_tracking_mode
+        assert edition.tracking_params == {}
+
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+        )
+        assert state is not None
+        assert state.annotations is not None
+        assert state.annotations["ltd_mode"] == ltd_mode
+
+
+@pytest.mark.asyncio
+async def test_sync_edition_imports_lsst_doc_branch_edition(
     db_session: AsyncSession,
     http_client: httpx.AsyncClient,
     mock_discovery: respx.Router,
 ) -> None:
-    """LTD modes other than ``git_refs`` cleanly raise NotImplementedError."""
+    """A non-main ``lsst_doc`` edition imports as a Docverse draft."""
     async with db_session.begin():
         org_id = await _seed_org(db_session)
 
-    edition = _load("edition_main_git_refs.json")
-    edition["mode"] = "lsst_doc"
+    branch_edition = _load("edition_branch_git_refs.json")
+    branch_edition["mode"] = "lsst_doc"
+    branch_build = _load("build.json")
+    branch_build["self_url"] = f"{LTD_BASE}/builds/43"
+    branch_build["bucket_root_dir"] = "pipelines/builds/43"
+    branch_edition["build_url"] = f"{LTD_BASE}/builds/43"
+
     mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
         return_value=httpx.Response(200, json=_load("product_pipelines.json"))
     )
     mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
         return_value=httpx.Response(
-            200, json={"editions": [f"{LTD_BASE}/editions/1"]}
+            200, json={"editions": [f"{LTD_BASE}/editions/2"]}
         )
     )
-    mock_discovery.get(f"{LTD_BASE}/editions/1").mock(
-        return_value=httpx.Response(200, json=edition)
+    mock_discovery.get(f"{LTD_BASE}/editions/2").mock(
+        return_value=httpx.Response(200, json=branch_edition)
+    )
+    mock_discovery.get(f"{LTD_BASE}/builds/43").mock(
+        return_value=httpx.Response(200, json=branch_build)
     )
 
-    service = _build_service(db_session, http_client, MockObjectStore(), {})
-    with pytest.raises(NotImplementedError, match="#289"):
-        await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/43/index.html": b"<html>branch</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    edition_store = EditionStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    project_store = ProjectStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    async with db_session.begin():
+        project = await project_store.get_by_slug(
+            org_id=org_id, slug="pipelines"
+        )
+        assert project is not None
+        draft = await edition_store.get_by_slug(
+            project_id=project.id, slug="u-jsick-feature"
+        )
+        assert draft is not None
+        assert draft.kind == EditionKind.draft
+        assert draft.tracking_mode == TrackingMode.lsst_doc
+        assert draft.tracking_params == {}
+
+    outcome = result.edition_outcomes[0]
+    assert outcome.docverse_slug == "u-jsick-feature"
+
+
+@pytest.mark.asyncio
+async def test_sync_edition_imports_manual_as_pinned_git_ref(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+) -> None:
+    """``manual`` LTD editions become ``git_ref`` pinned to the build's ref.
+
+    Docverse has no ``manual`` tracking mode (PRD #275 "Out of scope"),
+    so the importer collapses ``manual`` onto a pinned ``git_ref`` while
+    preserving the original LTD ``manual`` label in
+    ``keeper_sync_state.annotations`` for later reversibility.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+
+    edition_payload = _load("edition_main_git_refs.json")
+    edition_payload["mode"] = "manual"
+    # Keep ``tracked_refs`` set so the existing ``_create_synced_build``
+    # path remains happy; the assertion on tracking_params below proves
+    # the mapper still pins to the BUILD's git_refs[0] rather than the
+    # edition's tracked_refs[0]. Hardening
+    # ``_create_synced_build`` to derive the Docverse build's git_ref
+    # from ``LtdBuild.git_refs[0]`` (so manual editions with
+    # ``tracked_refs is None`` round-trip cleanly) is tracked as
+    # follow-up — out of scope for this mapper-only slice.
+    edition_payload["tracked_refs"] = ["main"]
+    build_payload = _load("build.json")
+    build_payload["git_refs"] = ["v22_0_0", "main"]
+    _seed_ltd(
+        mock_discovery,
+        edition_main=edition_payload,
+        build_payload=build_payload,
+    )
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v22</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+    await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    edition_store = EditionStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    project_store = ProjectStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    async with db_session.begin():
+        project = await project_store.get_by_slug(
+            org_id=org_id, slug="pipelines"
+        )
+        assert project is not None
+        edition = await edition_store.get_by_slug(
+            project_id=project.id, slug="__main"
+        )
+        assert edition is not None
+        assert edition.tracking_mode == TrackingMode.git_ref
+        # The build's first git_ref is pinned, NOT the edition's
+        # tracked_refs (which manual editions need not maintain).
+        assert edition.tracking_params == {"git_ref": "v22_0_0"}
+
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+        )
+        assert state is not None
+        assert state.annotations is not None
+        # Original LTD mode preserved for reversibility.
+        assert state.annotations["ltd_mode"] == "manual"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Extend `keeper_sync/mappers.py` so every `LtdEditionMode` value maps onto a Docverse tracking pair: `lsst_doc` and the three `eups_*_release` modes pass through to the same-named Docverse modes with empty params; `manual` collapses onto `git_ref` pinned to the published build's `git_refs[0]`, with the original `manual` label preserved in `keeper_sync_state.annotations` for reversibility.
- Wire `KeeperSyncService.sync_edition` to fetch the published build before mapping when (and only when) the LTD edition's mode is `manual`, so non-manual paths pay no extra HTTP.
- Replace the `NotImplementedError` placeholder paths from #287 — the sync engine can now faithfully import any edition LTD exposes.

## Validation steps

- [ ] Spot-check that a synced `manual` LTD edition lands in Docverse with `tracking_mode == git_ref` and `tracking_params.git_ref` matching the build's first git ref (not the edition's `tracked_refs`).
- [ ] Confirm `keeper_sync_state.annotations` retains `ltd_mode == "manual"` for that same imported edition, so a future reverse-mode tool has the data it needs.
- [ ] Confirm a synced `lsst_doc` or `eups_*_release` LTD edition imports with the same-named Docverse `tracking_mode` and an empty `tracking_params` dict.

## References

- Closes #289
- PRD: #275
- Jira: https://rubinobs.atlassian.net/browse/DM-54794