### PR TITLE
DM-54794: Dual-upload convergence skips copy on matching hash

### DIFF
--- a/alembic/versions/20260507_0001_s7t8u9v0w1x2_add_builds_project_id_content_hash_index.py
+++ b/alembic/versions/20260507_0001_s7t8u9v0w1x2_add_builds_project_id_content_hash_index.py
@@ -1,0 +1,38 @@
+"""Add composite ``(project_id, content_hash)`` index on ``builds``.
+
+The keeper-sync engine's dual-upload convergence lookup
+(``BuildStore.get_completed_by_content_hash``) runs on every inbound LTD
+``sync_build`` call, filtering ``builds`` on
+``(project_id, content_hash, status, date_deleted)``. The convergence
+query has to execute even when no match exists — that is how the sync
+decides whether to copy. Without a leading ``(project_id, content_hash)``
+index, this is a project-scoped scan whose cost grows with both project
+size and sync frequency. A composite index on the leading filter columns
+serves the lookup directly; the trailing ``status`` and ``date_deleted``
+predicates are cheap to apply against the small candidate set the index
+returns.
+
+Revision ID: s7t8u9v0w1x2
+Revises: r6s7t8u9v0w1
+Create Date: 2026-05-07 00:01:00.000000+00:00
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "s7t8u9v0w1x2"
+down_revision: str | None = "r6s7t8u9v0w1"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_builds_project_id_content_hash",
+        "builds",
+        ["project_id", "content_hash"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_builds_project_id_content_hash", table_name="builds")

--- a/src/docverse/dbschema/build.py
+++ b/src/docverse/dbschema/build.py
@@ -80,6 +80,11 @@ class SqlBuild(Base):
 
     __table_args__ = (
         Index("idx_builds_project_id_git_ref", "project_id", "git_ref"),
+        Index(
+            "idx_builds_project_id_content_hash",
+            "project_id",
+            "content_hash",
+        ),
         Index("idx_builds_status", "status"),
         Index("idx_builds_git_ref", "git_ref"),
     )

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -764,6 +764,14 @@ class Factory:
                     source_prefix=source_prefix, dest_prefix=dest_prefix
                 )
 
+        async def manifest_callable(source_prefix: str) -> str:
+            async with self.create_build_content_copier_for_org(
+                org_id=org_id, service_label=service_label
+            ) as copier:
+                return await copier.compute_manifest_hash(
+                    source_prefix=source_prefix
+                )
+
         context = KeeperSyncContext(
             org_store=self.create_org_store(),
             project_store=self.create_project_store(),
@@ -777,6 +785,7 @@ class Factory:
             context=context,
             ltd_client=ltd_client,
             copy_callable=copy_callable,
+            manifest_callable=manifest_callable,
             logger=self._logger,
         )
 

--- a/src/docverse/services/keeper_sync/copier.py
+++ b/src/docverse/services/keeper_sync/copier.py
@@ -53,6 +53,45 @@ class BuildContentCopier:
         self._logger = logger
         self._max_concurrent = max_concurrent
 
+    async def compute_manifest_hash(self, *, source_prefix: str) -> str:
+        """Compute the manifest hash for ``source_prefix`` without copying.
+
+        Performs the download-and-hash phase of :meth:`copy_build`
+        without writing anything to the destination, so the keeper-sync
+        engine can decide whether an existing Docverse build already
+        matches the inbound LTD content (dual-upload convergence) before
+        committing to an upload that would just duplicate it. Returns
+        the same ``sha256:<hex>`` shape :meth:`copy_build` produces.
+        """
+        normalized_source_prefix = _ensure_trailing_slash(source_prefix)
+        keys = sorted(
+            await self._source.list_keys(prefix=normalized_source_prefix)
+        )
+        if not keys:
+            return _empty_manifest_hash()
+
+        semaphore = asyncio.Semaphore(self._max_concurrent)
+        manifest_entries: list[tuple[str, str]] = []
+        manifest_lock = asyncio.Lock()
+
+        async def _hash_one(source_key: str) -> None:
+            relative = source_key.removeprefix(normalized_source_prefix)
+            if ".." in relative.split("/"):
+                msg = (
+                    f"Refusing to hash source key {source_key!r}:"
+                    " relative path contains '..' segment"
+                )
+                raise RuntimeError(msg)
+            async with semaphore:
+                data = await self._source.download_object(key=source_key)
+            digest = hashlib.sha256(data).hexdigest()
+            async with manifest_lock:
+                manifest_entries.append((relative, digest))
+
+        await asyncio.gather(*(_hash_one(k) for k in keys))
+        manifest_entries.sort(key=lambda e: e[0])
+        return _hash_manifest_pairs(manifest_entries)
+
     async def copy_build(
         self, *, source_prefix: str, dest_prefix: str
     ) -> CopyResult:
@@ -161,8 +200,15 @@ def _hash_manifest(entries: list[tuple[str, str, int]]) -> str:
     derivable from the data; including it would couple the hash to a
     second representation of the same fact and risk drift.
     """
+    return _hash_manifest_pairs(
+        [(relative, digest) for relative, digest, _ in entries]
+    )
+
+
+def _hash_manifest_pairs(entries: list[tuple[str, str]]) -> str:
+    r"""Compute ``sha256:`` over sorted ``relative\tdigest\n`` lines."""
     hasher = hashlib.sha256()
-    for relative, digest, _ in entries:
+    for relative, digest in entries:
         hasher.update(f"{relative}\t{digest}\n".encode())
     return f"sha256:{hasher.hexdigest()}"
 

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -67,6 +67,7 @@ __all__ = [
     "EditionSyncOutcome",
     "KeeperSyncContext",
     "KeeperSyncService",
+    "ManifestCallable",
     "ProjectSyncResult",
 ]
 
@@ -82,6 +83,12 @@ DEFAULT_ORPHAN_RECLAIM_MAX_AGE = timedelta(hours=1)
 #: callable the service consumes. Tests inject a fake; the production
 #: factory wires it onto a real :class:`BuildContentCopier`.
 CopyCallable = Callable[[str, str], Awaitable[CopyResult]]
+
+#: Type alias for the ``(source_prefix) -> manifest_hash`` callable
+#: used for dual-upload convergence: the service computes the inbound
+#: LTD manifest hash via this callable, then short-circuits the upload
+#: when an existing Docverse build for the project already carries it.
+ManifestCallable = Callable[[str], Awaitable[str]]
 
 #: Placeholder hash on a freshly-created synced build row. Overwritten
 #: with the real manifest hash once the copier has run. The regex on
@@ -158,6 +165,7 @@ class KeeperSyncService:
         context: KeeperSyncContext,
         ltd_client: LtdClient,
         copy_callable: CopyCallable,
+        manifest_callable: ManifestCallable,
         logger: structlog.stdlib.BoundLogger,
         orphan_reclaim_max_age: timedelta = DEFAULT_ORPHAN_RECLAIM_MAX_AGE,
     ) -> None:
@@ -170,6 +178,7 @@ class KeeperSyncService:
         self._state_store = context.state_store
         self._ltd_client = ltd_client
         self._copy_callable = copy_callable
+        self._manifest_callable = manifest_callable
         self._logger = logger
         self._orphan_reclaim_max_age = orphan_reclaim_max_age
 
@@ -415,6 +424,59 @@ class KeeperSyncService:
                 docverse_build_public_id=None,
                 short_circuited=True,
                 content_hash=existing_state.content_hash,
+                object_count=None,
+                total_size_bytes=None,
+            )
+
+        manifest_hash = await self._manifest_callable(
+            _ensure_trailing_slash(ltd_build.bucket_root_dir)
+        )
+        async with self._session.begin():
+            existing_build = (
+                await self._build_store.get_completed_by_content_hash(
+                    project_id=project.id, content_hash=manifest_hash
+                )
+            )
+            if existing_build is not None:
+                if edition.current_build_id != existing_build.id:
+                    # Convergence intentionally targets the oldest
+                    # completed build with this content hash so the
+                    # canonical row is stable; bypass the date guard
+                    # because re-pointing the edition backwards to that
+                    # row is the de-duplicating choice when the user-
+                    # visible content is identical.
+                    await self._edition_store.set_current_build(
+                        edition_id=edition.id,
+                        build_id=existing_build.id,
+                        skip_date_guard=True,
+                    )
+                await self._state_store.upsert(
+                    org_id=org_id,
+                    resource_type=ResourceType.build,
+                    ltd_id=ltd_build.ltd_id,
+                    ltd_slug=ltd_build.slug,
+                    docverse_id=existing_build.id,
+                    date_last_synced=_now(),
+                    date_rebuilt_seen=ltd_edition.date_rebuilt,
+                    content_hash=manifest_hash,
+                )
+        if existing_build is not None:
+            self._logger.info(
+                "Sync converged on existing Docverse build",
+                ltd_build_id=ltd_build.ltd_id,
+                docverse_build_public_id=serialize_base32_id(
+                    existing_build.public_id
+                ),
+                edition_slug=edition.slug,
+                content_hash=manifest_hash,
+            )
+            return BuildSyncOutcome(
+                docverse_build_id=existing_build.id,
+                docverse_build_public_id=serialize_base32_id(
+                    existing_build.public_id
+                ),
+                short_circuited=True,
+                content_hash=manifest_hash,
                 object_count=None,
                 total_size_bytes=None,
             )

--- a/src/docverse/storage/build_store.py
+++ b/src/docverse/storage/build_store.py
@@ -129,6 +129,35 @@ class BuildStore:
         )
         return [Build.model_validate(row) for row in result.scalars().all()]
 
+    async def get_completed_by_content_hash(
+        self, *, project_id: int, content_hash: str
+    ) -> Build | None:
+        """Return the oldest non-deleted ``completed`` build with this hash.
+
+        Used by the keeper-sync engine for dual-upload convergence:
+        when an inbound LTD build's content hash matches a build that
+        already exists in Docverse for the same project (typically from
+        a direct Docverse upload), the sync links its state row to that
+        build instead of re-copying the same content into a fresh row.
+        Soft-deleted rows and builds that haven't reached ``completed``
+        are excluded so the linked-to row is canonical and stable.
+        """
+        result = await self._session.execute(
+            select(SqlBuild)
+            .where(
+                SqlBuild.project_id == project_id,
+                SqlBuild.content_hash == content_hash,
+                SqlBuild.status == BuildStatus.completed,
+                SqlBuild.date_deleted.is_(None),
+            )
+            .order_by(SqlBuild.date_created.asc(), SqlBuild.id.asc())
+            .limit(1)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return Build.model_validate(row)
+
     async def get_latest_build_id_for_ref(
         self, *, project_id: int, git_ref: str
     ) -> int | None:

--- a/tests/services/keeper_sync/service_test.py
+++ b/tests/services/keeper_sync/service_test.py
@@ -123,6 +123,9 @@ def _build_service(
             source_prefix=source_prefix, dest_prefix=dest_prefix
         )
 
+    async def manifest_callable(source_prefix: str) -> str:
+        return await copier.compute_manifest_hash(source_prefix=source_prefix)
+
     context = KeeperSyncContext(
         org_store=org_store,
         project_store=project_store,
@@ -136,6 +139,7 @@ def _build_service(
         context=context,
         ltd_client=ltd_client,
         copy_callable=copy_callable,  # type: ignore[arg-type]
+        manifest_callable=manifest_callable,
         logger=logger,
     )
 
@@ -946,6 +950,261 @@ async def test_sync_build_does_not_reclaim_recent_pending_placeholders(
         recent = await build_store.get_by_id(recent_orphan.id)
         assert recent is not None
         assert recent.status == BuildStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_dual_upload_convergence_links_existing_build_and_skips_copy(  # noqa: PLR0915
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+) -> None:
+    """Skip the copy and link state when content matches an existing build.
+
+    Models the dual-upload scenario from PRD #275 user story 12: a
+    project has cut over to direct Docverse uploads, so its current
+    Docverse build holds the canonical content; LTD CI is still pushing
+    the same content to LTD as well. Re-copying that content into a new
+    Docverse build row would have the two upload paths fight each other.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+
+    _seed_ltd(mock_discovery)
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v1</html>",
+        "pipelines/builds/42/assets/app.js": b"console.log(1)",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+    first = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+    existing_build_id = first.edition_outcomes[
+        0
+    ].build_outcome.docverse_build_id  # type: ignore[union-attr]
+    assert existing_build_id is not None
+    keys_after_first = set(object_store.objects.keys())
+    assert keys_after_first
+
+    edition_store = EditionStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    project_store = ProjectStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    build_store = BuildStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+
+    async with db_session.begin():
+        project = await project_store.get_by_slug(
+            org_id=org_id, slug="pipelines"
+        )
+        assert project is not None
+        edition_before = await edition_store.get_by_slug(
+            project_id=project.id, slug="__main"
+        )
+        assert edition_before is not None
+        edition_date_updated_before = edition_before.date_updated
+
+    # Now LTD reports a *new* build (id 43) at a new bucket prefix, but
+    # the source content under that prefix is byte-identical to what's
+    # already in Docverse. The keeper-sync state has no row for ltd_id=43,
+    # so the existing date-based short-circuit cannot fire.
+    edition_v2 = _load("edition_main_git_refs.json")
+    edition_v2["date_rebuilt"] = "2026-05-04T12:00:00.000000+00:00"
+    edition_v2["build_url"] = f"{LTD_BASE}/builds/43"
+    build_v2 = _load("build.json")
+    build_v2["self_url"] = f"{LTD_BASE}/builds/43"
+    build_v2["bucket_root_dir"] = "pipelines/builds/43"
+
+    mock_discovery.reset()
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(200, json=_load("product_pipelines.json"))
+    )
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
+        return_value=httpx.Response(
+            200, json={"editions": [f"{LTD_BASE}/editions/1"]}
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/editions/1").mock(
+        return_value=httpx.Response(200, json=edition_v2)
+    )
+    mock_discovery.get(f"{LTD_BASE}/builds/43").mock(
+        return_value=httpx.Response(200, json=build_v2)
+    )
+
+    # Same files under a different LTD bucket prefix → same manifest
+    # hash (the manifest is over relative key + content).
+    source_objects_v2 = {
+        "pipelines/builds/43/index.html": b"<html>v1</html>",
+        "pipelines/builds/43/assets/app.js": b"console.log(1)",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects_v2
+    )
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    main_outcome = result.edition_outcomes[0]
+    assert main_outcome.build_outcome is not None
+    assert main_outcome.build_outcome.short_circuited is True
+    assert main_outcome.build_outcome.docverse_build_id == existing_build_id
+    assert main_outcome.build_outcome.docverse_build_public_id is not None
+    # Object store unchanged: convergence skipped the upload entirely.
+    assert set(object_store.objects.keys()) == keys_after_first
+
+    async with db_session.begin():
+        # No new build row was created — only the original survives.
+        builds = await build_store.list_by_project(project.id, limit=10)
+        assert len(builds.entries) == 1
+        assert builds.entries[0].id == existing_build_id
+
+        # State for the new ltd_id points at the existing Docverse build.
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.build,
+            ltd_id=43,
+        )
+        assert state is not None
+        assert state.docverse_id == existing_build_id
+        assert state.content_hash is not None
+        assert state.content_hash.startswith("sha256:")
+
+        # Edition still points at the existing build and was not touched
+        # (date_updated unchanged).
+        edition_after = await edition_store.get_by_slug(
+            project_id=project.id, slug="__main"
+        )
+        assert edition_after is not None
+        assert edition_after.current_build_id == existing_build_id
+        assert edition_after.date_updated == edition_date_updated_before
+
+
+@pytest.mark.asyncio
+async def test_dual_upload_convergence_repoints_edition_when_pointer_differs(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+) -> None:
+    """Convergence updates the edition pointer when it points elsewhere.
+
+    The edition currently points at a different build (e.g. a stale
+    keeper-sync row from an earlier resync). Discovering the matching-
+    hash build means the sync must atomically re-point the edition to
+    that build inside the same transaction that links the state row.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+
+    _seed_ltd(mock_discovery)
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v1</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+    first = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+    matching_build_id = first.edition_outcomes[
+        0
+    ].build_outcome.docverse_build_id  # type: ignore[union-attr]
+    assert matching_build_id is not None
+
+    edition_store = EditionStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    project_store = ProjectStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    build_store = BuildStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+
+    # Create a second Docverse build with a different content hash, then
+    # point the edition at it. Convergence should detect the matching-
+    # hash build above and re-point back.
+    async with db_session.begin():
+        project = await project_store.get_by_slug(
+            org_id=org_id, slug="pipelines"
+        )
+        assert project is not None
+        other_build = await build_store.create(
+            project_id=project.id,
+            project_slug=project.slug,
+            data=BuildCreate(
+                git_ref="main",
+                content_hash="sha256:" + "1" * 64,
+            ),
+            uploader="direct-upload",
+        )
+        # Walk it through to ``completed`` so set_current_build's stale
+        # guard sees a real ``date_created`` on the row.
+        await build_store.transition_status(
+            build_id=other_build.id, new_status=BuildStatus.processing
+        )
+        await build_store.transition_status(
+            build_id=other_build.id, new_status=BuildStatus.completed
+        )
+        edition = await edition_store.get_by_slug(
+            project_id=project.id, slug="__main"
+        )
+        assert edition is not None
+        await edition_store.set_current_build(
+            edition_id=edition.id,
+            build_id=other_build.id,
+            skip_date_guard=True,
+        )
+
+    # LTD now reports a new build (id 43) whose content matches build_42
+    # (and thus the original Docverse build).
+    edition_v2 = _load("edition_main_git_refs.json")
+    edition_v2["date_rebuilt"] = "2026-05-04T12:00:00.000000+00:00"
+    edition_v2["build_url"] = f"{LTD_BASE}/builds/43"
+    build_v2 = _load("build.json")
+    build_v2["self_url"] = f"{LTD_BASE}/builds/43"
+    build_v2["bucket_root_dir"] = "pipelines/builds/43"
+
+    mock_discovery.reset()
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(200, json=_load("product_pipelines.json"))
+    )
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
+        return_value=httpx.Response(
+            200, json={"editions": [f"{LTD_BASE}/editions/1"]}
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/editions/1").mock(
+        return_value=httpx.Response(200, json=edition_v2)
+    )
+    mock_discovery.get(f"{LTD_BASE}/builds/43").mock(
+        return_value=httpx.Response(200, json=build_v2)
+    )
+
+    keys_before = set(object_store.objects.keys())
+    source_objects_v2 = {
+        "pipelines/builds/43/index.html": b"<html>v1</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects_v2
+    )
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    main_outcome = result.edition_outcomes[0]
+    assert main_outcome.build_outcome is not None
+    assert main_outcome.build_outcome.docverse_build_id == matching_build_id
+    assert main_outcome.build_outcome.docverse_build_public_id is not None
+    # Skipped the copy.
+    assert set(object_store.objects.keys()) == keys_before
+
+    async with db_session.begin():
+        edition_after = await edition_store.get_by_slug(
+            project_id=project.id, slug="__main"
+        )
+        assert edition_after is not None
+        assert edition_after.current_build_id == matching_build_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `KeeperSyncService.sync_build` now hashes the LTD source manifest before any upload and short-circuits to an existing non-deleted `completed` Docverse build that already carries that hash for the same project, instead of copying identical content into a fresh build row.
- `keeper_sync_state` for the inbound LTD build is linked to the existing Docverse build, and the edition's `current_build_id` is left untouched when it already points there or atomically re-pointed inside the same transaction otherwise.
- New `BuildContentCopier.compute_manifest_hash` exposes the manifest computation without performing the upload, and `BuildStore.get_completed_by_content_hash` returns the canonical match.

## Validation steps

- [ ] Trigger a sync of an LTD project whose current build's content already exists in the demo Docverse org under a directly-uploaded build, and confirm no new objects land under the new build's R2 prefix.
- [ ] After that sync, confirm the corresponding `keeper_sync_state` row points at the existing Docverse build's id and that no new `builds` row was inserted.
- [ ] Verify that when an LTD build's content does not match any existing Docverse build's hash, the sync still creates a new build row and copies content as before.
- [ ] Confirm the edition row's `date_updated` is unchanged when convergence finds the edition already pointing at the matching build.

## References

- Closes #292
- PRD: #275
- Jira: https://rubinobs.atlassian.net/browse/DM-54794
