### PR TITLE
DM-54916: Wire Sentry init into api, worker, and CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 ]
 
 [project.scripts]
-docverse-admin = "docverse.cli:main"
+docverse-admin = "docverse.cli:main_with_sentry"
 
 [build-system]
 requires = [

--- a/src/docverse/cli.py
+++ b/src/docverse/cli.py
@@ -21,8 +21,9 @@ from safir.logging import configure_logging
 
 from .config import config
 from .database import check_database_state, get_current_revision, init_database
+from .sentry import initialize_sentry
 
-__all__ = ["help", "main"]
+__all__ = ["help", "main", "main_with_sentry"]
 
 # Add -h as a help shortcut option
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -40,6 +41,18 @@ def main() -> None:
         log_level=config.log_level,
         name="docverse",
     )
+
+
+def main_with_sentry() -> None:
+    """Console-script entry point that initializes Sentry before Click.
+
+    The ``docverse-admin`` script in ``pyproject.toml`` points here so a
+    failed admin invocation (e.g. ``update-db-schema``) reports to the
+    same Sentry project as runtime errors. No-op when ``SENTRY_DSN`` is
+    unset.
+    """
+    initialize_sentry(component="cli")
+    main()
 
 
 @main.command()

--- a/src/docverse/handlers/admin/endpoints.py
+++ b/src/docverse/handlers/admin/endpoints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
 
 from docverse.client.models import OrganizationCreate
 from docverse.dependencies.auth import require_superadmin
@@ -15,6 +16,23 @@ from docverse.handlers.params import OrgSlugParam
 from .models import Organization
 
 router = APIRouter(tags=["admin"], dependencies=[Depends(require_superadmin)])
+
+
+class SentryTestRequest(BaseModel):
+    """Body for the Sentry validation endpoint.
+
+    The optional ``message`` is carried verbatim into the deliberately-raised
+    ``RuntimeError`` so an operator running the post-deploy validation can
+    grep for their marker in the Sentry UI.
+    """
+
+    message: str | None = Field(
+        default=None,
+        description=(
+            "Optional marker string echoed into the deliberate exception so "
+            "the resulting Sentry event is easy to identify."
+        ),
+    )
 
 
 @router.post(
@@ -90,6 +108,31 @@ async def get_organization(
         service_store = context.factory.create_service_store()
         services = await service_store.list_by_org(org.id)
     return Organization.from_domain(org, context.request, services=services)
+
+
+@router.post(
+    "/admin/sentry/test",
+    summary="Trigger a test Sentry alert (diagnostic / validation tool)",
+    name="admin_post_sentry_test",
+    responses={
+        500: {
+            "description": (
+                "Always returned. This endpoint deliberately raises a "
+                "server-side exception so an operator can verify the "
+                "Sentry pipeline end-to-end after a deploy. Not part of "
+                "the application's normal API surface."
+            ),
+        },
+    },
+)
+async def post_sentry_test(
+    data: SentryTestRequest,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> None:
+    if data.message:
+        context.rebind_logger(sentry_test_marker=data.message)
+    msg = f"Sentry validation alert: {data.message or 'no marker'}"
+    raise RuntimeError(msg)
 
 
 @router.delete(

--- a/src/docverse/main.py
+++ b/src/docverse/main.py
@@ -27,6 +27,7 @@ from .handlers.internal import internal_router
 from .handlers.orgs import orgs_router
 from .handlers.queue import queue_router
 from .handlers.webhooks import webhook_router
+from .sentry import initialize_sentry
 from .services.credential_encryptor import CredentialEncryptor
 from .storage.github import validate_github_app
 from .storage.user_info_store import GafaelfawrUserInfoStore
@@ -39,6 +40,9 @@ configure_logging(
     name="docverse",
 )
 configure_uvicorn_logging(config.log_level)
+# Initialize at module import time, outside ``lifespan``, so app-construction
+# errors are captured too (matches gafaelfawr's pattern).
+initialize_sentry(component="api")
 
 
 @asynccontextmanager

--- a/src/docverse/sentry.py
+++ b/src/docverse/sentry.py
@@ -1,0 +1,40 @@
+"""Docverse-specific Sentry initialization."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+from typing import Literal
+
+import sentry_sdk
+from safir.sentry import initialize_sentry as _safir_initialize_sentry
+from safir.sentry import should_enable_sentry
+
+__all__ = ["DocverseSentryComponent", "initialize_sentry"]
+
+
+DocverseSentryComponent = Literal[
+    "api", "worker", "worker-keeper-sync", "worker-lifecycle-eval", "cli"
+]
+"""Tag values for the ``component`` Sentry global tag.
+
+One label per Docverse entry point so events from the FastAPI app, the two
+arq worker pools, and ``docverse-admin`` can be filtered apart on Sentry.
+"""
+
+
+def initialize_sentry(component: DocverseSentryComponent) -> None:
+    """Initialize Sentry for one Docverse process.
+
+    A no-op when ``SENTRY_DSN`` is unset, so local development, CI, and
+    ``nox -s test`` runs never report. When the env var is set, delegates
+    to :func:`safir.sentry.initialize_sentry` with the
+    ``setuptools_scm``-derived ``docverse`` package version as the Sentry
+    ``release``, then attaches ``service`` and ``component`` global tags so
+    every event from this process carries them.
+    """
+    if not should_enable_sentry():
+        return
+    _safir_initialize_sentry(release=version("docverse"))
+    scope = sentry_sdk.get_global_scope()
+    scope.set_tag("service", "docverse")
+    scope.set_tag("component", component)

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.config import Configuration
 from docverse.database import get_current_revision
 from docverse.factory import Factory
+from docverse.sentry import DocverseSentryComponent, initialize_sentry
 from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.keeper_sync.scheduler import (
     TIER_DISCOVERY_CRON_INTERVAL,
@@ -162,8 +163,16 @@ class WorkerFactoryBuilder:
         )
 
 
-async def startup(ctx: dict[str, Any]) -> None:
-    """Initialize resources for the arq worker process."""
+async def _startup(
+    ctx: dict[str, Any], *, component: DocverseSentryComponent
+) -> None:
+    """Initialize resources for the arq worker process.
+
+    ``component`` distinguishes the three queues on Sentry: all worker
+    settings share this body, so the per-startup wrappers below pick the
+    right tag.
+    """
+    initialize_sentry(component=component)
     configure_logging(
         profile=config.log_profile,
         log_level=config.log_level,
@@ -245,6 +254,21 @@ async def startup(ctx: dict[str, Any]) -> None:
     logger.info("Worker startup complete")
 
 
+async def startup_default(ctx: dict[str, Any]) -> None:
+    """on_startup for the default Docverse arq queue."""
+    await _startup(ctx, component="worker")
+
+
+async def startup_keeper_sync(ctx: dict[str, Any]) -> None:
+    """on_startup for the dedicated keeper-sync arq queue."""
+    await _startup(ctx, component="worker-keeper-sync")
+
+
+async def startup_lifecycle_eval(ctx: dict[str, Any]) -> None:
+    """on_startup for the dedicated lifecycle-eval arq queue."""
+    await _startup(ctx, component="worker-lifecycle-eval")
+
+
 async def shutdown(ctx: dict[str, Any]) -> None:
     """Clean up resources for the arq worker process."""
     arq_queue = ctx.get("arq_queue")
@@ -270,7 +294,7 @@ class WorkerSettings:
     ]
     redis_settings = config.arq_redis_settings
     queue_name = config.arq_queue_name
-    on_startup = startup
+    on_startup = startup_default
     on_shutdown = shutdown
 
 
@@ -345,7 +369,7 @@ class KeeperSyncWorkerSettings:
     ]
     redis_settings = config.arq_redis_settings
     queue_name = KEEPER_SYNC_QUEUE_NAME
-    on_startup = startup
+    on_startup = startup_keeper_sync
     on_shutdown = shutdown
 
 
@@ -400,5 +424,5 @@ class LifecycleEvalWorkerSettings:
     ]
     redis_settings = config.arq_redis_settings
     queue_name = LIFECYCLE_EVAL_QUEUE_NAME
-    on_startup = startup
+    on_startup = startup_lifecycle_eval
     on_shutdown = shutdown

--- a/tests/handlers/admin_test.py
+++ b/tests/handlers/admin_test.py
@@ -281,3 +281,24 @@ async def test_admin_requires_superadmin(client: AsyncClient) -> None:
         headers={"X-Auth-Request-User": "regular-user"},
     )
     assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_sentry_test_requires_superadmin(client: AsyncClient) -> None:
+    """``/admin/sentry/test`` inherits the router's superadmin gate.
+
+    The deliberate-error endpoint must short-circuit on auth before reaching
+    the handler so that an unauthenticated or non-superadmin caller cannot
+    pollute the Sentry tenant with bogus validation events.
+    """
+    # No auth header — rejected before the RuntimeError fires
+    response = await client.post("/docverse/admin/sentry/test", json={})
+    assert response.status_code == 403
+
+    # Authenticated as a non-superadmin user — same rejection path
+    response = await client.post(
+        "/docverse/admin/sentry/test",
+        json={},
+        headers={"X-Auth-Request-User": "regular-user"},
+    )
+    assert response.status_code == 403

--- a/tests/sentry_test.py
+++ b/tests/sentry_test.py
@@ -1,0 +1,129 @@
+"""End-to-end Sentry wiring tests.
+
+Exercises :func:`docverse.sentry.initialize_sentry` against a minimal
+fixture-only FastAPI app so the per-process wiring (DSN gating, release,
+``service``/``component`` global tags) is locked down without depending
+on the real Docverse app's lifespan, DB, or GitHub validator.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from importlib.metadata import version
+from typing import Any
+
+import pytest
+import sentry_sdk
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from safir.testing.sentry import (
+    TestTransport,
+    capture_events_fixture,
+    sentry_init_fixture,
+)
+
+from docverse.sentry import initialize_sentry
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sentry_global_scope() -> Iterator[None]:
+    """Strip ``initialize_sentry``'s global-scope tags around each test.
+
+    ``sentry_init_fixture`` saves and restores the *client* on the
+    global scope, but ``initialize_sentry`` also writes ``service`` and
+    ``component`` tags directly to that scope, which would otherwise
+    persist across tests in the session. Running on both sides isolates
+    this file from prior Sentry state and prevents tag bleed into any
+    later test that asserts tag absence.
+    """
+    scope = sentry_sdk.get_global_scope()
+    scope.remove_tag("service")
+    scope.remove_tag("component")
+    yield
+    scope = sentry_sdk.get_global_scope()
+    scope.remove_tag("service")
+    scope.remove_tag("component")
+
+
+def _patch_sentry_init_with_test_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Force every ``sentry_sdk.init`` to use ``TestTransport``.
+
+    :func:`docverse.sentry.initialize_sentry` delegates to
+    :func:`safir.sentry.initialize_sentry` → ``sentry_sdk.init`` and does
+    not accept a transport argument, so the test redirects via
+    monkey-patch rather than asking the production wrapper to expose a
+    testing-only knob.
+    """
+    real_init = sentry_sdk.init
+
+    def init_with_test_transport(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("transport", TestTransport())
+        return real_init(*args, **kwargs)
+
+    monkeypatch.setattr(sentry_sdk, "init", init_with_test_transport)
+
+
+@pytest.mark.asyncio
+async def test_api_initialize_sentry_captures_event_with_release_and_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An uncaught FastAPI error reaches Sentry with the right metadata.
+
+    Locks the contract:
+
+    * ``release`` matches ``importlib.metadata.version("docverse")``.
+    * ``tags.component == "api"`` distinguishes API events from worker /
+      CLI ones once the same wrapper runs from those entry points.
+    * ``tags.service == "docverse"`` separates Docverse from sibling
+      SQuaRE services on the shared Sentry tenant.
+    """
+    monkeypatch.setenv("SENTRY_DSN", "https://test@example.com/1")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "test")
+    _patch_sentry_init_with_test_transport(monkeypatch)
+
+    boom_message = "intentional test failure"
+
+    with sentry_init_fixture():
+        initialize_sentry(component="api")
+        captured = capture_events_fixture(monkeypatch)()
+
+        app = FastAPI()
+
+        @app.get("/boom")
+        async def boom() -> None:
+            raise RuntimeError(boom_message)
+
+        async with AsyncClient(
+            base_url="https://example.com",
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+        ) as client:
+            await client.get("/boom")
+
+    assert len(captured.errors) == 1
+    event = captured.errors[0]
+    assert event["release"] == version("docverse")
+    assert event["tags"]["component"] == "api"
+    assert event["tags"]["service"] == "docverse"
+
+
+def test_initialize_sentry_is_noop_when_dsn_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``SENTRY_DSN`` env var → wrapper does not configure a client.
+
+    Pins the local-dev / CI contract that ``nox -s test`` never reports.
+    """
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    with sentry_init_fixture():
+        initialize_sentry(component="api")
+        # ``sentry_init_fixture`` clears any prior client on entry; the
+        # wrapper's early return leaves Sentry uninitialized.
+        assert sentry_sdk.is_initialized() is False
+        # The early return must also skip the global-scope tag writes
+        # so a DSN-less run leaves no fingerprint for the next test.
+        scope_tags = getattr(sentry_sdk.get_global_scope(), "_tags", {})
+        assert "service" not in scope_tags
+        assert "component" not in scope_tags

--- a/tests/sentry_test.py
+++ b/tests/sentry_test.py
@@ -22,7 +22,31 @@ from safir.testing.sentry import (
     sentry_init_fixture,
 )
 
+from docverse.dependencies.auth import require_superadmin
+from docverse.dependencies.context import context_dependency
+from docverse.handlers.admin import admin_router
 from docverse.sentry import initialize_sentry
+
+
+class _StubContext:
+    """Duck-typed :class:`RequestContext` for endpoint-level Sentry tests.
+
+    The ``/admin/sentry/test`` handler only touches ``rebind_logger`` before
+    raising, so the test substitutes a no-op stub via
+    :pyattr:`FastAPI.dependency_overrides` rather than wiring the full DB /
+    factory / arq machinery just to reach a deliberate ``RuntimeError``.
+    """
+
+    def rebind_logger(self, **_values: Any) -> None:
+        return None
+
+
+async def _stub_context_dependency() -> _StubContext:
+    return _StubContext()
+
+
+async def _stub_require_superadmin() -> None:
+    return None
 
 
 @pytest.fixture(autouse=True)
@@ -106,6 +130,57 @@ async def test_api_initialize_sentry_captures_event_with_release_and_tags(
     assert event["release"] == version("docverse")
     assert event["tags"]["component"] == "api"
     assert event["tags"]["service"] == "docverse"
+
+
+@pytest.mark.asyncio
+async def test_admin_sentry_test_endpoint_captures_event_with_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``POST /admin/sentry/test`` produces one Sentry event carrying marker.
+
+    Locks the validation-tooling contract for the SRE-facing
+    ``/admin/sentry/test`` route from PRD #338: hitting the endpoint must
+    produce exactly one captured event tagged ``service=docverse`` /
+    ``component=api`` / ``release=<docverse version>``, and the request-body
+    ``message`` must land in the exception ``value`` so an operator can grep
+    for their marker after a deploy.
+
+    The router-level ``require_superadmin`` and ``context_dependency`` are
+    overridden because the contract under test is the Sentry envelope, not
+    the auth gate (covered in ``tests/handlers/admin_test.py``).
+    """
+    monkeypatch.setenv("SENTRY_DSN", "https://test@example.com/1")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "test")
+    _patch_sentry_init_with_test_transport(monkeypatch)
+
+    marker = "validation-marker-42"
+
+    with sentry_init_fixture():
+        initialize_sentry(component="api")
+        captured = capture_events_fixture(monkeypatch)()
+
+        app = FastAPI()
+        app.include_router(admin_router)
+        app.dependency_overrides[context_dependency] = _stub_context_dependency
+        app.dependency_overrides[require_superadmin] = _stub_require_superadmin
+
+        async with AsyncClient(
+            base_url="https://example.com",
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+        ) as client:
+            response = await client.post(
+                "/admin/sentry/test",
+                json={"message": marker},
+            )
+        assert response.status_code == 500
+
+    assert len(captured.errors) == 1
+    event = captured.errors[0]
+    assert event["release"] == version("docverse")
+    assert event["tags"]["service"] == "docverse"
+    assert event["tags"]["component"] == "api"
+    exc_values = event["exception"]["values"]
+    assert any(marker in exc["value"] for exc in exc_values)
 
 
 def test_initialize_sentry_is_noop_when_dsn_unset(

--- a/tests/worker/keeper_sync_worker_settings_test.py
+++ b/tests/worker/keeper_sync_worker_settings_test.py
@@ -16,7 +16,8 @@ from docverse.worker.main import (
     KeeperSyncWorkerSettings,
     WorkerSettings,
     shutdown,
-    startup,
+    startup_default,
+    startup_keeper_sync,
 )
 
 _config = Configuration()
@@ -70,10 +71,17 @@ def test_default_worker_does_not_register_keeper_sync_functions() -> None:
 
 
 def test_keeper_sync_worker_settings_share_lifecycle_hooks() -> None:
-    """Both classes share startup/shutdown for one factory builder."""
-    assert KeeperSyncWorkerSettings.on_startup is startup
+    """Each queue has its own ``on_startup`` (per-component Sentry tag).
+
+    Both wrappers funnel through the same ``_startup`` body so the
+    factory-builder shape stays uniform across the two queues; the only
+    intentional divergence is the Sentry ``component`` tag (``worker``
+    vs. ``worker-keeper-sync``). ``on_shutdown`` is fully shared.
+    """
+    assert WorkerSettings.on_startup is startup_default
+    assert KeeperSyncWorkerSettings.on_startup is startup_keeper_sync
+    assert KeeperSyncWorkerSettings.on_startup is not WorkerSettings.on_startup
     assert KeeperSyncWorkerSettings.on_shutdown is shutdown
-    assert KeeperSyncWorkerSettings.on_startup is WorkerSettings.on_startup
     assert KeeperSyncWorkerSettings.on_shutdown is WorkerSettings.on_shutdown
 
 

--- a/tests/worker/lifecycle_eval_worker_settings_test.py
+++ b/tests/worker/lifecycle_eval_worker_settings_test.py
@@ -25,7 +25,7 @@ from docverse.worker.main import (
     LifecycleEvalWorkerSettings,
     WorkerSettings,
     shutdown,
-    startup,
+    startup_lifecycle_eval,
 )
 
 _config = Configuration()
@@ -68,8 +68,17 @@ def test_lifecycle_eval_worker_settings_registers_functions() -> None:
 
 
 def test_lifecycle_eval_worker_settings_share_lifecycle_hooks() -> None:
-    """All three WorkerSettings classes share startup/shutdown."""
-    assert LifecycleEvalWorkerSettings.on_startup is startup
+    """Lifecycle queue has its own ``on_startup`` (per-component Sentry tag).
+
+    The lifecycle wrapper funnels through the same ``_startup`` body as
+    the default and keeper-sync queues so the factory-builder shape stays
+    uniform; the only intentional divergence is the Sentry ``component``
+    tag (``worker-lifecycle-eval``). ``on_shutdown`` is fully shared.
+    """
+    assert LifecycleEvalWorkerSettings.on_startup is startup_lifecycle_eval
+    assert (
+        LifecycleEvalWorkerSettings.on_startup is not WorkerSettings.on_startup
+    )
     assert LifecycleEvalWorkerSettings.on_shutdown is shutdown
 
 


### PR DESCRIPTION
## Summary

- Wire `docverse.sentry.initialize_sentry(component=...)` into the FastAPI app, both arq `WorkerSettings` classes, and the new `main_with_sentry` `docverse-admin` console-script entry point so every Docverse process emits Sentry events with the right `release` (from `setuptools_scm`), a `service=docverse` global tag, and a per-entry-point `component` tag (`api`, `worker`, `worker-keeper-sync`, `cli`). Sentry config (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_TRACES_SAMPLE_RATE`) is read straight from the environment by safir, so no Python-side `SentryConfig` model is needed and a DSN-less run is a no-op.
- Add `POST /admin/sentry/test` (gated by the existing router-level `require_superadmin`) so an operator can deliberately fire a Sentry event after a deploy and verify the pipeline end-to-end without having to invent a malformed-payload route; the request body's optional `message` lands in the exception value for grep-ability in the Sentry UI.
- Tests pin the contract end-to-end: an uncaught FastAPI error reaches a captured envelope with the expected `release` / `tags.service` / `tags.component`; a no-DSN run leaves Sentry uninitialized and writes no tags; an autouse fixture strips `service`/`component` from the global Sentry scope around each test so tag bleed cannot mask bugs; and a sentry-pipeline test hits `POST /admin/sentry/test` directly to assert the marker survives into the captured exception.

## Validation steps

- [ ] Run `docverse-admin --help` locally with `SENTRY_DSN` unset — the help text renders and no Sentry initialization side effects occur (no traffic, no module errors).
- [ ] Set `SENTRY_DSN` / `SENTRY_ENVIRONMENT` to a test-tenant project in `idfdev`, deploy, and `POST /admin/sentry/test` with a `message` marker as a configured superadmin; confirm the event lands in the Sentry project with `release=<docverse version>`, `tags.service=docverse`, `tags.component=api`, `environment=idfdev`, and the marker visible in the exception value.
- [ ] In the same `idfdev` deployment, force a worker failure (e.g. a `keeper_sync_project` run against an unreachable LTD); confirm a Sentry event lands with `tags.component=worker-keeper-sync` and the `setuptools_scm` release.
- [ ] Run `docverse-admin update-db-schema` with a deliberately-broken Alembic config in the production container; confirm the failure surfaces in Sentry with `tags.component=cli`.
- [ ] Confirm `POST /admin/sentry/test` is rejected with 403 for unauthenticated and non-superadmin callers (i.e. the diagnostic endpoint cannot be triggered by a regular user to pollute the Sentry tenant).

## References

- Closes #339
- Closes #369
- PRD: #338
- Jira: https://rubinobs.atlassian.net/browse/DM-54916