### PR TITLE
DM-54688: Persistence layer for the lifecycle_eval dispatcher

### DIFF
--- a/alembic/versions/20260512_0000_v0w1x2y3z4a5_add_lifecycle_eval_runs_schema.py
+++ b/alembic/versions/20260512_0000_v0w1x2y3z4a5_add_lifecycle_eval_runs_schema.py
@@ -1,0 +1,131 @@
+"""Add ``lifecycle_eval_runs`` table and ``queue_jobs`` per-org mutex index.
+
+The persistence layer for the new ``lifecycle_eval`` periodic job.
+The dispatcher cron writes one ``lifecycle_eval_runs`` aggregate row
+per tick, fans out per-org work to ``queue_jobs`` with
+``kind='lifecycle_eval'`` and ``subject_label=str(org_id)``, and the
+per-org worker calls ``maybe_finalise_lifecycle_run`` to transition
+the parent row when every child is terminal.
+
+Schema deltas:
+
+- ``lifecycle_eval_runs`` aggregate table with five-state status
+  enumeration (``pending`` / ``in_progress`` / ``succeeded`` /
+  ``partial_failure`` / ``failed``) and a JSONB summary column for
+  dispatcher-level tick metadata.
+- ``idx_lifecycle_eval_runs_non_terminal_uq``: a partial unique index
+  on the constant expression ``(true)`` with
+  ``WHERE status IN ('pending', 'in_progress')`` so at most one row
+  globally can hold a non-terminal status. This is the DB-level
+  backstop for the singleton-tick invariant — without it a slow tick
+  could be doubled up by the next cron firing.
+- ``queue_jobs.lifecycle_eval_run_id``: a nullable FK to the new
+  table so per-org child rows can be aggregated into the parent run's
+  activity counters. ``ON DELETE SET NULL`` mirrors
+  ``keeper_sync_run_id`` so a deleted parent row never cascades into
+  losing the queue-job history.
+- ``idx_queue_jobs_lifecycle_eval_active_uq``: a partial unique index
+  on ``(org_id, subject_label) WHERE kind = 'lifecycle_eval' AND
+  status IN ('queued', 'in_progress')`` mirroring the
+  ``keeper_sync_project_active_uq`` precedent. Provides the per-org
+  mutex so a slow per-org evaluation cannot be doubled up by the
+  next tick.
+
+Revision ID: v0w1x2y3z4a5
+Revises: u9v0w1x2y3z4
+Create Date: 2026-05-12 00:00:00.000000+00:00
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "v0w1x2y3z4a5"
+down_revision: str | None = "u9v0w1x2y3z4"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lifecycle_eval_runs",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("status", sa.String(32), nullable=False),
+        sa.Column(
+            "date_started",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("date_finished", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("summary", postgresql.JSONB, nullable=True),
+        sa.CheckConstraint(
+            "status IN ('pending', 'in_progress', 'succeeded', "
+            "'partial_failure', 'failed')",
+            name="ck_lifecycle_eval_runs_status",
+        ),
+    )
+    # Singleton-tick invariant: at most one non-terminal row anywhere.
+    # SQLAlchemy's ``op.create_index`` does not directly accept an
+    # expression column, so emit raw SQL — the index is owned by the
+    # migration, and the ORM declares the same partial-unique index
+    # via ``text("(true)")`` so a future ``Base.metadata.create_all``
+    # path matches.
+    op.execute(
+        "CREATE UNIQUE INDEX idx_lifecycle_eval_runs_non_terminal_uq"
+        " ON lifecycle_eval_runs ((true))"
+        " WHERE status IN ('pending', 'in_progress')"
+    )
+
+    op.add_column(
+        "queue_jobs",
+        sa.Column("lifecycle_eval_run_id", sa.Integer, nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_queue_jobs_lifecycle_eval_run_id",
+        "queue_jobs",
+        "lifecycle_eval_runs",
+        ["lifecycle_eval_run_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "idx_queue_jobs_lifecycle_eval_run_id",
+        "queue_jobs",
+        ["lifecycle_eval_run_id"],
+    )
+
+    op.create_index(
+        "idx_queue_jobs_lifecycle_eval_active_uq",
+        "queue_jobs",
+        ["org_id", "subject_label"],
+        unique=True,
+        postgresql_where=sa.text(
+            "kind = 'lifecycle_eval' AND status IN ('queued', 'in_progress')"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_queue_jobs_lifecycle_eval_active_uq",
+        table_name="queue_jobs",
+    )
+    op.drop_index(
+        "idx_queue_jobs_lifecycle_eval_run_id",
+        table_name="queue_jobs",
+    )
+    op.drop_constraint(
+        "fk_queue_jobs_lifecycle_eval_run_id",
+        "queue_jobs",
+        type_="foreignkey",
+    )
+    op.drop_column("queue_jobs", "lifecycle_eval_run_id")
+
+    op.drop_index(
+        "idx_lifecycle_eval_runs_non_terminal_uq",
+        table_name="lifecycle_eval_runs",
+    )
+    op.drop_table("lifecycle_eval_runs")

--- a/client/changelog.d/20260512_180000_DM_54688.md
+++ b/client/changelog.d/20260512_180000_DM_54688.md
@@ -1,0 +1,3 @@
+### New features
+
+- New `LifecycleEvalRunStatus` enum (`pending`, `in_progress`, `succeeded`, `partial_failure`, `failed`) describes the lifecycle of a `lifecycle_eval_runs` aggregate row. Shared shape with `KeeperSyncRunStatus` so the dispatcher / per-org / reaper pattern transfers between the two subsystems.

--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -55,6 +55,7 @@ from .keeper_sync import (
 from .lifecycle import (
     BuildHistoryOrphanRule,
     DraftInactivityRule,
+    LifecycleEvalRunStatus,
     LifecycleRule,
     LifecycleRuleSet,
     RefDeletedRule,
@@ -121,6 +122,7 @@ __all__ = [
     "KeeperSyncTierCohort",
     "KeeperSyncTierName",
     "KeeperSyncTierStatus",
+    "LifecycleEvalRunStatus",
     "LifecycleRule",
     "LifecycleRuleSet",
     "OrgDashboardRebuildEntry",

--- a/client/src/docverse/client/models/lifecycle.py
+++ b/client/src/docverse/client/models/lifecycle.py
@@ -6,10 +6,18 @@ rule schema is a tagged union discriminated on ``type`` so operators
 get an early 422 with a discriminator-aware error message when a
 PATCH payload names an unknown rule kind or omits a required field
 for a known one.
+
+The dispatcher cron writes one ``lifecycle_eval_runs`` aggregate row per
+tick, fans out per-org work onto ``queue_jobs``, and finalises the run
+when every child job is terminal. ``LifecycleEvalRunStatus`` is the
+lifecycle of that aggregate row; it shares the five-state shape of
+``KeeperSyncRunStatus`` so the dispatcher / per-org / reaper pattern
+transfers between the two subsystems without operator re-training.
 """
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Annotated, Literal, Self
 
 from pydantic import (
@@ -24,6 +32,7 @@ from pydantic import (
 __all__ = [
     "BuildHistoryOrphanRule",
     "DraftInactivityRule",
+    "LifecycleEvalRunStatus",
     "LifecycleRule",
     "LifecycleRuleSet",
     "RefDeletedRule",
@@ -138,3 +147,20 @@ class LifecycleRuleSet(RootModel[list[LifecycleRule]]):
                 raise ValueError(msg)
             seen.add(rule.type)
         return self
+
+
+class LifecycleEvalRunStatus(StrEnum):
+    """Lifecycle status of a ``lifecycle_eval_runs`` aggregate row.
+
+    ``pending`` — the dispatcher has created the run row but has not yet
+    enqueued any per-org child jobs. ``in_progress`` — at least one
+    per-org child has been enqueued. ``succeeded`` /
+    ``partial_failure`` / ``failed`` are terminal states set by
+    ``maybe_finalise_lifecycle_run`` when every child is terminal.
+    """
+
+    pending = "pending"
+    in_progress = "in_progress"
+    succeeded = "succeeded"
+    partial_failure = "partial_failure"
+    failed = "failed"

--- a/server-changelog.d/20260512_180000_DM_54688.md
+++ b/server-changelog.d/20260512_180000_DM_54688.md
@@ -1,0 +1,4 @@
+### New features
+
+- New `lifecycle_eval_runs` aggregate table and `LifecycleEvalRunStore` are the persistence layer for the upcoming `lifecycle_eval` periodic background job. The dispatcher cron will write one aggregate row per tick and a partial unique index on `(true) WHERE status IN ('pending', 'in_progress')` enforces the singleton non-terminal-tick invariant at the DB level. Per-org child work attributes to the parent run via a new nullable `queue_jobs.lifecycle_eval_run_id` FK, mirroring the `keeper_sync_run_id` shape.
+- New partial unique index `idx_queue_jobs_lifecycle_eval_active_uq` on `queue_jobs(org_id, subject_label) WHERE kind = 'lifecycle_eval' AND status IN ('queued', 'in_progress')` is the per-org mutex: a slow per-org evaluation cannot be doubled up by the next dispatcher tick. The dispatcher writes `subject_label = str(org_id)`.

--- a/src/docverse/dbschema/__init__.py
+++ b/src/docverse/dbschema/__init__.py
@@ -11,6 +11,7 @@ from .edition import SqlEdition
 from .edition_build_history import SqlEditionBuildHistory
 from .keeper_sync_run import SqlKeeperSyncRun
 from .keeper_sync_state import SqlKeeperSyncState
+from .lifecycle_eval_run import SqlLifecycleEvalRun
 from .membership import SqlOrgMembership
 from .organization import SqlOrganization
 from .organization_credential import SqlOrganizationCredential
@@ -28,6 +29,7 @@ __all__ = [
     "SqlEditionBuildHistory",
     "SqlKeeperSyncRun",
     "SqlKeeperSyncState",
+    "SqlLifecycleEvalRun",
     "SqlOrgMembership",
     "SqlOrganization",
     "SqlOrganizationCredential",

--- a/src/docverse/dbschema/lifecycle_eval_run.py
+++ b/src/docverse/dbschema/lifecycle_eval_run.py
@@ -1,0 +1,67 @@
+"""SQLAlchemy ORM model for the ``lifecycle_eval_runs`` table."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import CheckConstraint, DateTime, Index, Integer, String, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+class SqlLifecycleEvalRun(Base):
+    """ORM model for the ``lifecycle_eval_runs`` table.
+
+    One row per dispatcher tick of the ``lifecycle_eval`` periodic job.
+    Per-org child work lives on ``queue_jobs`` and is attributed to the
+    parent run via the nullable ``queue_jobs.lifecycle_eval_run_id``
+    FK; aggregate counters are derived from that filter at read time
+    rather than denormalised here.
+
+    The partial unique index
+    ``idx_lifecycle_eval_runs_non_terminal_uq`` indexes a constant
+    expression so at most one row can match the
+    ``status IN ('pending', 'in_progress')`` predicate at any moment.
+    This is the DB-level backstop that prevents the previous tick from
+    being doubled up by the next tick if it has not yet finalised.
+    """
+
+    __tablename__ = "lifecycle_eval_runs"
+
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, autoincrement=True
+    )
+
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+
+    date_started: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    date_finished: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    summary: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('pending', 'in_progress', 'succeeded', "
+            "'partial_failure', 'failed')",
+            name="ck_lifecycle_eval_runs_status",
+        ),
+        Index(
+            "idx_lifecycle_eval_runs_non_terminal_uq",
+            text("(true)"),
+            unique=True,
+            postgresql_where=text("status IN ('pending', 'in_progress')"),
+        ),
+    )

--- a/src/docverse/dbschema/queue_job.py
+++ b/src/docverse/dbschema/queue_job.py
@@ -67,6 +67,12 @@ class SqlQueueJob(Base):
         nullable=True,
     )
 
+    lifecycle_eval_run_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("lifecycle_eval_runs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
     subject_label: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     progress: Mapped[dict[str, Any] | None] = mapped_column(
@@ -94,6 +100,10 @@ class SqlQueueJob(Base):
         Index("idx_queue_jobs_status", "status"),
         Index("idx_queue_jobs_org_id", "org_id"),
         Index("idx_queue_jobs_keeper_sync_run_id", "keeper_sync_run_id"),
+        Index(
+            "idx_queue_jobs_lifecycle_eval_run_id",
+            "lifecycle_eval_run_id",
+        ),
         # Per-project mutex for keeper_sync_project jobs: at most one
         # queued or in_progress row per (org_id, subject_label). The
         # partial WHERE means terminal rows do not participate, so a
@@ -105,6 +115,23 @@ class SqlQueueJob(Base):
             unique=True,
             postgresql_where=text(
                 "kind = 'keeper_sync_project' "
+                "AND status IN ('queued', 'in_progress')"
+            ),
+        ),
+        # Per-org mutex for ``lifecycle_eval`` per-org child jobs: at
+        # most one queued or in_progress row per (org_id,
+        # subject_label). The dispatcher writes
+        # ``subject_label = str(org_id)`` so this is effectively one
+        # row per org while the per-org evaluator is running. The
+        # partial WHERE means terminal rows do not participate, so a
+        # finished tick never blocks the next.
+        Index(
+            "idx_queue_jobs_lifecycle_eval_active_uq",
+            "org_id",
+            "subject_label",
+            unique=True,
+            postgresql_where=text(
+                "kind = 'lifecycle_eval' "
                 "AND status IN ('queued', 'in_progress')"
             ),
         ),

--- a/src/docverse/domain/lifecycle_eval_run.py
+++ b/src/docverse/domain/lifecycle_eval_run.py
@@ -1,0 +1,91 @@
+"""Domain models for ``lifecycle_eval`` runs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from docverse.client.models import LifecycleEvalRunStatus
+
+__all__ = [
+    "LifecycleEvalRun",
+    "LifecycleEvalRunActivity",
+    "LifecycleEvalRunStatus",
+]
+
+
+class LifecycleEvalRun(BaseModel):
+    """Domain representation of a single ``lifecycle_eval_runs`` row.
+
+    The dispatcher cron writes one of these per tick. Unlike
+    ``KeeperSyncRun`` there is no ``org_id``: lifecycle_eval is a
+    system-wide tick that fans out per-org child jobs in one pass, so
+    the aggregate row is global and the partial-unique non-terminal
+    index enforces a singleton in-flight tick at the DB level.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(description="Primary key for the run.")
+    status: LifecycleEvalRunStatus = Field(description="Lifecycle status.")
+    date_started: datetime = Field(
+        description="Timestamp when the dispatcher tick began."
+    )
+    date_finished: datetime | None = Field(
+        default=None,
+        description="Timestamp when the run reached a terminal status.",
+    )
+    summary: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "JSONB summary written by the dispatcher: orgs enqueued,"
+            " orgs skipped, and any other tick-level metadata."
+        ),
+    )
+
+
+class LifecycleEvalRunActivity(BaseModel):
+    """Aggregate child-job activity for a single lifecycle_eval run.
+
+    Computed from ``queue_jobs`` rows filtered on
+    ``lifecycle_eval_run_id`` so a row is never out of step with the
+    underlying job state. Same shape as ``KeeperSyncRunActivity`` so
+    ``maybe_finalise_lifecycle_run`` can mirror ``maybe_finalise_run``
+    without re-typing the counters.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    pending_count: int = Field(
+        description=(
+            "Number of attributed queue jobs in ``queued`` or"
+            " ``in_progress`` state (i.e. non-terminal)."
+        )
+    )
+    succeeded_count: int = Field(
+        description=(
+            "Number of attributed queue jobs in ``completed`` state."
+            " ``completed_with_errors`` is excluded so soft-failure"
+            " distinguishes from clean success."
+        )
+    )
+    failed_count: int = Field(
+        description=(
+            "Number of attributed queue jobs in ``failed``,"
+            " ``cancelled`` or ``completed_with_errors`` state."
+        )
+    )
+    total_count: int = Field(
+        description="Total number of attributed queue jobs."
+    )
+    date_last_activity: datetime | None = Field(
+        default=None,
+        description=(
+            "Most-recent state-transition timestamp across the run's"
+            " attributed queue jobs, computed as ``MAX(coalesce("
+            "date_completed, date_started, date_created))``. ``None``"
+            " when the run has no attributed queue jobs yet."
+        ),
+    )

--- a/src/docverse/domain/queue.py
+++ b/src/docverse/domain/queue.py
@@ -32,6 +32,7 @@ class QueueJob(BaseModel):
     build_id: int | None = None
     edition_id: int | None = None
     keeper_sync_run_id: int | None = None
+    lifecycle_eval_run_id: int | None = None
     subject_label: str | None = None
     progress: dict[str, Any] | None = None
     errors: dict[str, Any] | None = None

--- a/src/docverse/storage/lifecycle_eval_run_store.py
+++ b/src/docverse/storage/lifecycle_eval_run_store.py
@@ -1,0 +1,213 @@
+"""Database operations for the ``lifecycle_eval_runs`` table.
+
+The store is the single read/write path for ``lifecycle_eval`` run
+rows. Aggregate counters are derived from ``queue_jobs`` filtered on
+``lifecycle_eval_run_id`` rather than denormalised onto the run row,
+mirroring ``KeeperSyncRunStore`` so the dispatcher / per-org / reaper
+pattern transfers between subsystems.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import LifecycleEvalRunStatus
+from docverse.dbschema.lifecycle_eval_run import SqlLifecycleEvalRun
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.lifecycle_eval_run import (
+    LifecycleEvalRun,
+    LifecycleEvalRunActivity,
+)
+from docverse.domain.queue import JobStatus
+from docverse.exceptions import InvalidJobStateError
+
+__all__ = ["LifecycleEvalRunStore"]
+
+
+_NON_TERMINAL_STATUSES: frozenset[LifecycleEvalRunStatus] = frozenset(
+    {
+        LifecycleEvalRunStatus.pending,
+        LifecycleEvalRunStatus.in_progress,
+    }
+)
+
+
+class LifecycleEvalRunStore:
+    """Direct database operations for lifecycle_eval runs."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._session = session
+        self._logger = logger
+
+    async def create(self) -> LifecycleEvalRun:
+        """Insert a new run row in ``pending`` status.
+
+        The DB-side partial unique index
+        ``idx_lifecycle_eval_runs_non_terminal_uq`` enforces the
+        singleton-non-terminal-run invariant globally (not per-org).
+        Two dispatcher cron firings racing into ``create`` surface one
+        ``IntegrityError``; the caller is expected to translate that
+        into a "skip this tick" decision so a slow tick is never
+        doubled up.
+        """
+        row = SqlLifecycleEvalRun(
+            status=LifecycleEvalRunStatus.pending.value,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return LifecycleEvalRun.model_validate(row)
+
+    async def get(self, run_id: int) -> LifecycleEvalRun | None:
+        """Fetch a run by primary key."""
+        result = await self._session.execute(
+            select(SqlLifecycleEvalRun).where(SqlLifecycleEvalRun.id == run_id)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return LifecycleEvalRun.model_validate(row)
+
+    async def has_non_terminal_run(self) -> bool:
+        """Return True if a pending or in-progress run exists anywhere.
+
+        Lifecycle_eval is a system-wide tick, so this check is global
+        (not parameterised by org). It backstops the dispatcher's
+        pre-check before ``create`` so two ticks racing through the
+        cron handler surface as a clean skip rather than an
+        ``IntegrityError``.
+        """
+        stmt = select(SqlLifecycleEvalRun.id).where(
+            SqlLifecycleEvalRun.status.in_(
+                [s.value for s in _NON_TERMINAL_STATUSES]
+            ),
+        )
+        result = await self._session.execute(stmt)
+        return result.first() is not None
+
+    async def transition_status(
+        self, *, run_id: int, new_status: LifecycleEvalRunStatus
+    ) -> LifecycleEvalRun:
+        """Update the status column, setting ``date_finished`` on terminal.
+
+        Idempotent: re-applying the same status returns the row
+        unchanged. Otherwise the transition is enforced as a forward
+        progression through ``pending → in_progress → terminal``;
+        backwards moves raise ``InvalidJobStateError``.
+        """
+        row = await self._get_row(run_id)
+        current = LifecycleEvalRunStatus(row.status)
+        if current is new_status:
+            return LifecycleEvalRun.model_validate(row)
+        if not _is_allowed_transition(current, new_status):
+            msg = (
+                f"Cannot transition lifecycle eval run {run_id} from "
+                f"{current.value!r} to {new_status.value!r}"
+            )
+            raise InvalidJobStateError(msg)
+
+        row.status = new_status.value
+        if new_status not in _NON_TERMINAL_STATUSES:
+            row.date_finished = datetime.now(tz=UTC)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return LifecycleEvalRun.model_validate(row)
+
+    async def aggregate_activity(
+        self, *, run_id: int
+    ) -> LifecycleEvalRunActivity:
+        """Aggregate ``queue_jobs`` rows attributed to this run.
+
+        Same shape as ``KeeperSyncRunStore.aggregate_activity``: one
+        ``GROUP BY status`` query returns the four counters plus a
+        ``date_last_activity`` derived from ``MAX(coalesce(
+        date_completed, date_started, date_created))`` per row.
+        Buckets ``queued`` / ``in_progress`` as ``pending_count``,
+        ``completed`` as ``succeeded_count``, and everything else
+        (``failed`` / ``cancelled`` / ``completed_with_errors``) as
+        ``failed_count``.
+        """
+        last_activity = func.coalesce(
+            SqlQueueJob.date_completed,
+            SqlQueueJob.date_started,
+            SqlQueueJob.date_created,
+        )
+        stmt = (
+            select(
+                SqlQueueJob.status,
+                func.count(SqlQueueJob.id),
+                func.max(last_activity),
+            )
+            .where(SqlQueueJob.lifecycle_eval_run_id == run_id)
+            .group_by(SqlQueueJob.status)
+        )
+        result = await self._session.execute(stmt)
+        pending = succeeded = failed = total = 0
+        date_last_activity: datetime | None = None
+        for status_value, count, max_ts in result.all():
+            total += count
+            if status_value in (
+                JobStatus.queued.value,
+                JobStatus.in_progress.value,
+            ):
+                pending += count
+            elif status_value == JobStatus.completed.value:
+                succeeded += count
+            else:
+                failed += count
+            if max_ts is not None and (
+                date_last_activity is None or max_ts > date_last_activity
+            ):
+                date_last_activity = max_ts
+        return LifecycleEvalRunActivity(
+            pending_count=pending,
+            succeeded_count=succeeded,
+            failed_count=failed,
+            total_count=total,
+            date_last_activity=date_last_activity,
+        )
+
+    async def _get_row(self, run_id: int) -> SqlLifecycleEvalRun:
+        result = await self._session.execute(
+            select(SqlLifecycleEvalRun).where(SqlLifecycleEvalRun.id == run_id)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            msg = f"Lifecycle eval run {run_id} not found"
+            raise InvalidJobStateError(msg)
+        return row
+
+
+_ALLOWED_TRANSITIONS: dict[
+    LifecycleEvalRunStatus, frozenset[LifecycleEvalRunStatus]
+] = {
+    LifecycleEvalRunStatus.pending: frozenset(
+        {
+            LifecycleEvalRunStatus.in_progress,
+            LifecycleEvalRunStatus.succeeded,
+            LifecycleEvalRunStatus.partial_failure,
+            LifecycleEvalRunStatus.failed,
+        }
+    ),
+    LifecycleEvalRunStatus.in_progress: frozenset(
+        {
+            LifecycleEvalRunStatus.succeeded,
+            LifecycleEvalRunStatus.partial_failure,
+            LifecycleEvalRunStatus.failed,
+        }
+    ),
+}
+
+
+def _is_allowed_transition(
+    current: LifecycleEvalRunStatus, new: LifecycleEvalRunStatus
+) -> bool:
+    return new in _ALLOWED_TRANSITIONS.get(current, frozenset())

--- a/tests/storage/lifecycle_eval_run_store_test.py
+++ b/tests/storage/lifecycle_eval_run_store_test.py
@@ -1,0 +1,524 @@
+"""Tests for ``LifecycleEvalRunStore`` and lifecycle_eval constraints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import structlog
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import LifecycleEvalRunStatus, OrganizationCreate
+from docverse.dbschema.lifecycle_eval_run import SqlLifecycleEvalRun
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
+from docverse.domain.queue import JobKind, JobStatus
+from docverse.exceptions import InvalidJobStateError
+from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
+from docverse.storage.organization_store import OrganizationStore
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org(db_session: AsyncSession, *, slug: str = "ler-org") -> int:
+    org_store = OrganizationStore(session=db_session, logger=_logger())
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=slug,
+            title=f"LER Org {slug}",
+            base_domain=f"{slug}.example.com",
+        )
+    )
+    return org.id
+
+
+def _seed_queue_job(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    run_id: int,
+    status: JobStatus,
+    date_created: datetime | None = None,
+    date_started: datetime | None = None,
+    date_completed: datetime | None = None,
+    subject_label: str | None = None,
+) -> None:
+    row = SqlQueueJob(
+        public_id=validate_base32_id(generate_base32_id()),
+        kind=JobKind.lifecycle_eval.value,
+        status=status.value,
+        org_id=org_id,
+        lifecycle_eval_run_id=run_id,
+        subject_label=subject_label,
+        date_started=date_started,
+        date_completed=date_completed,
+    )
+    if date_created is not None:
+        row.date_created = date_created
+    db_session.add(row)
+
+
+@pytest.mark.asyncio
+async def test_partial_unique_index_blocks_two_pending_runs(
+    db_session: AsyncSession,
+) -> None:
+    """Two ``pending`` lifecycle_eval rows are rejected by the partial UQ."""
+    async with db_session.begin():
+        db_session.add(SqlLifecycleEvalRun(status="pending"))
+
+    with pytest.raises(IntegrityError):
+        async with db_session.begin():
+            db_session.add(SqlLifecycleEvalRun(status="pending"))
+
+
+@pytest.mark.asyncio
+async def test_partial_unique_index_blocks_pending_and_in_progress(
+    db_session: AsyncSession,
+) -> None:
+    """An ``in_progress`` row blocks a second non-terminal row globally."""
+    async with db_session.begin():
+        db_session.add(SqlLifecycleEvalRun(status="in_progress"))
+
+    with pytest.raises(IntegrityError):
+        async with db_session.begin():
+            db_session.add(SqlLifecycleEvalRun(status="pending"))
+
+
+@pytest.mark.asyncio
+async def test_partial_unique_index_allows_terminal_alongside_pending(
+    db_session: AsyncSession,
+) -> None:
+    """Terminal rows do not participate in the non-terminal uniqueness."""
+    async with db_session.begin():
+        db_session.add(SqlLifecycleEvalRun(status="succeeded"))
+        db_session.add(SqlLifecycleEvalRun(status="failed"))
+        db_session.add(SqlLifecycleEvalRun(status="partial_failure"))
+
+    async with db_session.begin():
+        db_session.add(SqlLifecycleEvalRun(status="pending"))
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_runs_status_check_rejects_invalid(
+    db_session: AsyncSession,
+) -> None:
+    """A status outside the allowed set fails the CHECK constraint."""
+    with pytest.raises(IntegrityError):
+        async with db_session.begin():
+            db_session.add(SqlLifecycleEvalRun(status="pendng"))
+
+
+@pytest.mark.asyncio
+async def test_queue_jobs_lifecycle_eval_per_org_mutex(
+    db_session: AsyncSession,
+) -> None:
+    """Two active ``lifecycle_eval`` queue_jobs for one org collide."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        db_session.add(
+            SqlQueueJob(
+                public_id=validate_base32_id(generate_base32_id()),
+                kind=JobKind.lifecycle_eval.value,
+                status=JobStatus.queued.value,
+                org_id=org_id,
+                subject_label=str(org_id),
+            )
+        )
+
+    with pytest.raises(IntegrityError):
+        async with db_session.begin():
+            db_session.add(
+                SqlQueueJob(
+                    public_id=validate_base32_id(generate_base32_id()),
+                    kind=JobKind.lifecycle_eval.value,
+                    status=JobStatus.in_progress.value,
+                    org_id=org_id,
+                    subject_label=str(org_id),
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_queue_jobs_lifecycle_eval_mutex_terminal_alongside_active(
+    db_session: AsyncSession,
+) -> None:
+    """A terminal sibling does not block a fresh active row for the org."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        db_session.add(
+            SqlQueueJob(
+                public_id=validate_base32_id(generate_base32_id()),
+                kind=JobKind.lifecycle_eval.value,
+                status=JobStatus.completed.value,
+                org_id=org_id,
+                subject_label=str(org_id),
+            )
+        )
+        db_session.add(
+            SqlQueueJob(
+                public_id=validate_base32_id(generate_base32_id()),
+                kind=JobKind.lifecycle_eval.value,
+                status=JobStatus.failed.value,
+                org_id=org_id,
+                subject_label=str(org_id),
+            )
+        )
+
+    async with db_session.begin():
+        db_session.add(
+            SqlQueueJob(
+                public_id=validate_base32_id(generate_base32_id()),
+                kind=JobKind.lifecycle_eval.value,
+                status=JobStatus.queued.value,
+                org_id=org_id,
+                subject_label=str(org_id),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_queue_jobs_lifecycle_eval_mutex_distinct_orgs_coexist(
+    db_session: AsyncSession,
+) -> None:
+    """Two distinct orgs may each hold an active lifecycle_eval row."""
+    async with db_session.begin():
+        first_org = await _seed_org(db_session, slug="ler-org-a")
+        second_org = await _seed_org(db_session, slug="ler-org-b")
+        db_session.add(
+            SqlQueueJob(
+                public_id=validate_base32_id(generate_base32_id()),
+                kind=JobKind.lifecycle_eval.value,
+                status=JobStatus.queued.value,
+                org_id=first_org,
+                subject_label=str(first_org),
+            )
+        )
+        db_session.add(
+            SqlQueueJob(
+                public_id=validate_base32_id(generate_base32_id()),
+                kind=JobKind.lifecycle_eval.value,
+                status=JobStatus.queued.value,
+                org_id=second_org,
+                subject_label=str(second_org),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_returns_pending_run(
+    db_session: AsyncSession,
+) -> None:
+    """``create`` inserts a pending row and returns the domain model."""
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        run = await store.create()
+
+    assert run.id > 0
+    assert run.status is LifecycleEvalRunStatus.pending
+    assert run.date_finished is None
+    assert run.summary is None
+
+
+@pytest.mark.asyncio
+async def test_create_raises_integrity_error_on_second_non_terminal(
+    db_session: AsyncSession,
+) -> None:
+    """``create`` surfaces the partial-UQ violation as ``IntegrityError``.
+
+    The store does not translate the error; callers (the dispatcher
+    pre-check + handler) own the policy for whether a concurrent tick
+    is a 409 or a clean skip.
+    """
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        await store.create()
+
+    async def _create_again() -> None:
+        async with db_session.begin():
+            other = LifecycleEvalRunStore(session=db_session, logger=_logger())
+            await other.create()
+
+    with pytest.raises(IntegrityError):
+        await _create_again()
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_when_missing(
+    db_session: AsyncSession,
+) -> None:
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        result = await store.get(99999)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_returns_persisted_run(
+    db_session: AsyncSession,
+) -> None:
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        created = await store.create()
+
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        fetched = await store.get(created.id)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.status is LifecycleEvalRunStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_has_non_terminal_run_true_for_pending(
+    db_session: AsyncSession,
+) -> None:
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        await store.create()
+
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        assert await store.has_non_terminal_run() is True
+
+
+@pytest.mark.asyncio
+async def test_has_non_terminal_run_false_when_only_terminal(
+    db_session: AsyncSession,
+) -> None:
+    """A terminal row alone is not non-terminal — singleton check is honest."""
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        run = await store.create()
+        await store.transition_status(
+            run_id=run.id,
+            new_status=LifecycleEvalRunStatus.succeeded,
+        )
+
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        assert await store.has_non_terminal_run() is False
+
+
+@pytest.mark.asyncio
+async def test_has_non_terminal_run_false_when_empty(
+    db_session: AsyncSession,
+) -> None:
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        assert await store.has_non_terminal_run() is False
+
+
+@pytest.mark.asyncio
+async def test_transition_status_forward_progression(
+    db_session: AsyncSession,
+) -> None:
+    """``pending → in_progress → succeeded`` is the dispatcher path."""
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        run = await store.create()
+        in_progress = await store.transition_status(
+            run_id=run.id,
+            new_status=LifecycleEvalRunStatus.in_progress,
+        )
+        assert in_progress.status is LifecycleEvalRunStatus.in_progress
+        assert in_progress.date_finished is None
+
+        succeeded = await store.transition_status(
+            run_id=run.id,
+            new_status=LifecycleEvalRunStatus.succeeded,
+        )
+        assert succeeded.status is LifecycleEvalRunStatus.succeeded
+        assert succeeded.date_finished is not None
+
+
+@pytest.mark.asyncio
+async def test_transition_status_idempotent(
+    db_session: AsyncSession,
+) -> None:
+    """Same-status transition is a no-op, not an error."""
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        run = await store.create()
+        same = await store.transition_status(
+            run_id=run.id,
+            new_status=LifecycleEvalRunStatus.pending,
+        )
+
+    assert same.status is LifecycleEvalRunStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_transition_status_rejects_backwards_move(
+    db_session: AsyncSession,
+) -> None:
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        run = await store.create()
+        await store.transition_status(
+            run_id=run.id,
+            new_status=LifecycleEvalRunStatus.succeeded,
+        )
+
+    async def _try_backwards() -> None:
+        async with db_session.begin():
+            store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+            await store.transition_status(
+                run_id=run.id,
+                new_status=LifecycleEvalRunStatus.in_progress,
+            )
+
+    with pytest.raises(InvalidJobStateError):
+        await _try_backwards()
+
+
+@pytest.mark.asyncio
+async def test_transition_status_pending_can_go_terminal(
+    db_session: AsyncSession,
+) -> None:
+    """``pending`` may transition directly to any terminal state.
+
+    The dispatcher pre-flight finds zero orgs to enqueue and finalises
+    the run as ``succeeded`` without ever transitioning through
+    ``in_progress``; this path must be permitted.
+    """
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        run = await store.create()
+        terminal = await store.transition_status(
+            run_id=run.id,
+            new_status=LifecycleEvalRunStatus.succeeded,
+        )
+
+    assert terminal.status is LifecycleEvalRunStatus.succeeded
+    assert terminal.date_finished is not None
+
+
+@pytest.mark.asyncio
+async def test_transition_status_raises_when_missing(
+    db_session: AsyncSession,
+) -> None:
+    async def _try_transition_missing() -> None:
+        async with db_session.begin():
+            store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+            await store.transition_status(
+                run_id=99999,
+                new_status=LifecycleEvalRunStatus.in_progress,
+            )
+
+    with pytest.raises(InvalidJobStateError):
+        await _try_transition_missing()
+
+
+@pytest.mark.asyncio
+async def test_aggregate_activity_groups_jobs_by_status(
+    db_session: AsyncSession,
+) -> None:
+    """Counters bucket queued/in_progress as pending and completed as success.
+
+    Mirrors ``KeeperSyncRunStore.aggregate_activity`` bucketing:
+    ``completed_with_errors`` is failure, not success, so soft-failure
+    distinguishes from clean success.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        run = await store.create()
+        all_statuses = [
+            JobStatus.queued,
+            JobStatus.in_progress,
+            JobStatus.completed,
+            JobStatus.failed,
+            JobStatus.cancelled,
+            JobStatus.completed_with_errors,
+        ]
+        for index, status in enumerate(all_statuses):
+            # Per-row distinct ``subject_label`` so the per-org
+            # active-status mutex does not block the two non-terminal
+            # rows from coexisting. The test exercises the aggregator's
+            # bucketing, not the mutex.
+            _seed_queue_job(
+                db_session,
+                org_id=org_id,
+                run_id=run.id,
+                status=status,
+                subject_label=f"org-{org_id}-{index}",
+            )
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        activity = await store.aggregate_activity(run_id=run.id)
+
+    assert activity.pending_count == 2
+    assert activity.succeeded_count == 1
+    assert activity.failed_count == 3
+    assert activity.total_count == 6
+
+
+@pytest.mark.asyncio
+async def test_aggregate_activity_null_when_no_jobs(
+    db_session: AsyncSession,
+) -> None:
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        run = await store.create()
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        activity = await store.aggregate_activity(run_id=run.id)
+
+    assert activity.total_count == 0
+    assert activity.date_last_activity is None
+
+
+@pytest.mark.asyncio
+async def test_aggregate_activity_picks_max_coalesced_timestamp(
+    db_session: AsyncSession,
+) -> None:
+    """``date_last_activity`` is MAX(coalesce(completed, started, created))."""
+    base = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        run = await store.create()
+        _seed_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run.id,
+            status=JobStatus.queued,
+            date_created=base,
+            subject_label="alpha",
+        )
+        _seed_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run.id,
+            status=JobStatus.in_progress,
+            date_created=base,
+            date_started=base + timedelta(minutes=10),
+            subject_label="beta",
+        )
+        latest = base + timedelta(minutes=30)
+        _seed_queue_job(
+            db_session,
+            org_id=org_id,
+            run_id=run.id,
+            status=JobStatus.completed,
+            date_created=base,
+            date_started=base + timedelta(minutes=5),
+            date_completed=latest,
+            subject_label="gamma",
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        activity = await store.aggregate_activity(run_id=run.id)
+
+    assert activity.date_last_activity == latest


### PR DESCRIPTION
## Summary

- Add `lifecycle_eval_runs` aggregate table that mirrors `keeper_sync_runs`: status enum, start/finish timestamps, JSONB summary. A partial unique index on `(true) WHERE status IN ('pending', 'in_progress')` enforces the singleton non-terminal-tick invariant at the DB level so a slow dispatcher tick cannot be doubled up by the next cron firing.
- Add nullable `queue_jobs.lifecycle_eval_run_id` FK with `ON DELETE SET NULL` (mirrors `keeper_sync_run_id`) so the new `LifecycleEvalRunStore.aggregate_activity` can group child rows by parent run with the same single-`GROUP BY` shape as keeper-sync.
- Add per-org mutex index `idx_queue_jobs_lifecycle_eval_active_uq` on `(org_id, subject_label) WHERE kind = 'lifecycle_eval' AND status IN ('queued', 'in_progress')`. The dispatcher will write `subject_label = str(org_id)` so this is effectively one active row per org while the per-org evaluator is running.
- Ship `LifecycleEvalRunStore` with the methods needed by the upcoming dispatcher / per-org / reaper trio: `create`, `get`, `has_non_terminal_run`, `transition_status` (forward-only state machine, idempotent on same-status), and `aggregate_activity`.

## Validation steps

- [ ] Run `alembic upgrade head` on a DB at the prior revision (`u9v0w1x2y3z4`) and confirm the new table, both new `queue_jobs` indexes, and the FK constraint are all created.
- [ ] Insert two `pending` rows directly into `lifecycle_eval_runs` and confirm PostgreSQL returns a unique-violation error on the second insert (the singleton non-terminal invariant).
- [ ] Insert one `pending` row alongside one `succeeded` row and one `failed` row and confirm both terminal rows coexist with the pending one — terminal status does not participate in the partial-unique predicate.
- [ ] Insert two active `queue_jobs` with `kind='lifecycle_eval'`, the same `org_id`, and `subject_label=str(org_id)` and confirm the second insert is rejected by the per-org mutex; then confirm two distinct orgs each holding one active lifecycle_eval row coexist.
- [ ] Run `alembic downgrade -1` from head and confirm the table, both new indexes, the FK constraint, and the `queue_jobs.lifecycle_eval_run_id` column are all removed cleanly with no leftover objects in `pg_indexes` / `information_schema.columns`.

## References

- Closes #352
- PRD: #337
- Jira: https://rubinobs.atlassian.net/browse/DM-54688