### PR TITLE
DM-54688: Per-org lifecycle_eval worker + run finalisation

### DIFF
--- a/alembic/versions/20260513_0000_w1x2y3z4a5b6_lifecycle_eval_mutex_drop_subject_label.py
+++ b/alembic/versions/20260513_0000_w1x2y3z4a5b6_lifecycle_eval_mutex_drop_subject_label.py
@@ -1,0 +1,66 @@
+"""Drop ``subject_label`` from the lifecycle_eval per-org mutex index.
+
+``idx_queue_jobs_lifecycle_eval_active_uq`` was originally created
+with the shape ``UNIQUE (org_id, subject_label) WHERE
+kind = 'lifecycle_eval' AND status IN ('queued', 'in_progress')`` to
+mirror ``idx_queue_jobs_keeper_sync_project_active_uq``. The two
+mutexes encode genuinely different identities, however: keeper_sync
+is per-project within an org and needs ``subject_label`` (the LTD
+slug) as a sub-key, while lifecycle_eval is per-org by design
+(SQR-112) with no sub-key under ``org_id``. ``subject_label`` for a
+lifecycle_eval row is ``org.slug`` and so adds no extra identity to
+the mutex — the visual symmetry between the two indexes was
+misleading rather than helpful.
+
+This migration replaces the two-column form with the single-column
+form ``UNIQUE (org_id) WHERE kind = 'lifecycle_eval' AND status IN
+('queued', 'in_progress')``. The ``subject_label`` value is still
+written by the dispatcher and read by operators inspecting the
+queue; it just is not part of the mutex identity any more.
+
+Revision ID: w1x2y3z4a5b6
+Revises: v0w1x2y3z4a5
+Create Date: 2026-05-13 00:00:00.000000+00:00
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "w1x2y3z4a5b6"
+down_revision: str | None = "v0w1x2y3z4a5"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.drop_index(
+        "idx_queue_jobs_lifecycle_eval_active_uq",
+        table_name="queue_jobs",
+    )
+    op.create_index(
+        "idx_queue_jobs_lifecycle_eval_active_uq",
+        "queue_jobs",
+        ["org_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "kind = 'lifecycle_eval' AND status IN ('queued', 'in_progress')"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_queue_jobs_lifecycle_eval_active_uq",
+        table_name="queue_jobs",
+    )
+    op.create_index(
+        "idx_queue_jobs_lifecycle_eval_active_uq",
+        "queue_jobs",
+        ["org_id", "subject_label"],
+        unique=True,
+        postgresql_where=sa.text(
+            "kind = 'lifecycle_eval' AND status IN ('queued', 'in_progress')"
+        ),
+    )

--- a/src/docverse/dbschema/queue_job.py
+++ b/src/docverse/dbschema/queue_job.py
@@ -119,16 +119,24 @@ class SqlQueueJob(Base):
             ),
         ),
         # Per-org mutex for ``lifecycle_eval`` per-org child jobs: at
-        # most one queued or in_progress row per (org_id,
-        # subject_label). The dispatcher writes
-        # ``subject_label = str(org_id)`` so this is effectively one
-        # row per org while the per-org evaluator is running. The
-        # partial WHERE means terminal rows do not participate, so a
-        # finished tick never blocks the next.
+        # most one queued or in_progress row per ``org_id`` for
+        # ``kind='lifecycle_eval'``. ``subject_label`` is deliberately
+        # **not** part of the mutex identity here, which diverges from
+        # the ``keeper_sync_project_active_uq`` shape just above. The
+        # divergence is intentional: keeper_sync_project is
+        # per-project within an org and needs ``subject_label`` (set
+        # to the LTD slug) to distinguish concurrent project syncs;
+        # lifecycle_eval is per-org by design (SQR-112) and has no
+        # sub-key under ``org_id``, so adding ``subject_label`` to the
+        # index would only make the two indexes look superficially
+        # similar without encoding any additional identity. The row
+        # itself still carries ``subject_label = org.slug`` for
+        # operator readability of the queue — it just isn't part of
+        # the mutex. The partial WHERE means terminal rows do not
+        # participate, so a finished tick never blocks the next.
         Index(
             "idx_queue_jobs_lifecycle_eval_active_uq",
             "org_id",
-            "subject_label",
             unique=True,
             postgresql_where=text(
                 "kind = 'lifecycle_eval' "

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -63,6 +63,7 @@ from .storage.editionpublisher import (
 from .storage.github import GitHubAppClient, GitHubAppNotConfiguredError
 from .storage.keeper_sync import KeeperSyncStateStore
 from .storage.keeper_sync_run_store import KeeperSyncRunStore
+from .storage.lifecycle_eval_run_store import LifecycleEvalRunStore
 from .storage.ltd import LtdClient, LtdProductsClient, LtdS3Source
 from .storage.membership_store import OrgMembershipStore
 from .storage.objectstore import ObjectStore, create_objectstore
@@ -178,6 +179,12 @@ class Factory:
     def create_keeper_sync_run_store(self) -> KeeperSyncRunStore:
         """Create a :class:`KeeperSyncRunStore`."""
         return KeeperSyncRunStore(session=self._session, logger=self._logger)
+
+    def create_lifecycle_eval_run_store(self) -> LifecycleEvalRunStore:
+        """Create a :class:`LifecycleEvalRunStore`."""
+        return LifecycleEvalRunStore(
+            session=self._session, logger=self._logger
+        )
 
     def create_keeper_sync_run_service(self) -> KeeperSyncRunService:
         """Create a :class:`KeeperSyncRunService`."""

--- a/src/docverse/services/lifecycle/evaluator.py
+++ b/src/docverse/services/lifecycle/evaluator.py
@@ -23,28 +23,49 @@ __all__ = ["LifecycleDecision", "evaluate_lifecycle", "resolve_rule_set"]
 class LifecycleDecision(BaseModel):
     """Decision returned by :func:`evaluate_lifecycle`.
 
-    ``edition_ids`` and ``build_ids`` are the soft-delete candidates.
-    ``rule_match_counts`` maps each rule ``type`` present in the rule
-    set to the number of entities that rule matched, for structured
-    logging by the per-org worker.
+    ``edition_matches`` and ``build_matches`` map each matched entity
+    id to the ``type`` discriminator of the rule that matched it, so
+    the per-org worker can attribute each soft-delete to the right
+    rule (and emit it in the audit-trail log) without re-deriving the
+    mapping from entity type. ``edition_ids`` / ``build_ids`` expose
+    the same id sets as frozensets for callers that only need the
+    soft-delete candidates. ``rule_match_counts`` maps each rule
+    ``type`` present in the rule set to the number of entities that
+    rule matched.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    edition_ids: frozenset[int] = Field(
-        default_factory=frozenset,
-        description="Edition ids to soft-delete.",
+    edition_matches: Mapping[int, str] = Field(
+        default_factory=dict,
+        description=(
+            "Edition ids to soft-delete, keyed on the ``type``"
+            " discriminator of the rule that matched them."
+        ),
     )
 
-    build_ids: frozenset[int] = Field(
-        default_factory=frozenset,
-        description="Build ids to soft-delete.",
+    build_matches: Mapping[int, str] = Field(
+        default_factory=dict,
+        description=(
+            "Build ids to soft-delete, keyed on the ``type``"
+            " discriminator of the rule that matched them."
+        ),
     )
 
     rule_match_counts: Mapping[str, int] = Field(
         default_factory=dict,
         description="Per-rule match count keyed on the rule's ``type``.",
     )
+
+    @property
+    def edition_ids(self) -> frozenset[int]:
+        """Edition ids to soft-delete (derived from ``edition_matches``)."""
+        return frozenset(self.edition_matches)
+
+    @property
+    def build_ids(self) -> frozenset[int]:
+        """Build ids to soft-delete (derived from ``build_matches``)."""
+        return frozenset(self.build_matches)
 
 
 def evaluate_lifecycle(
@@ -60,14 +81,15 @@ def evaluate_lifecycle(
     No database access. The caller hands in already-loaded editions,
     builds, and per-edition build-history rows; the function returns
     a :class:`LifecycleDecision` listing the entities the rule set
-    has matched for soft-delete.
+    has matched for soft-delete, each tagged with the matching rule's
+    ``type`` discriminator.
     """
     editions_list = list(editions)
     builds_list = list(builds)
     history_list = list(edition_build_history)
 
-    matched_edition_ids: set[int] = set()
-    matched_build_ids: set[int] = set()
+    edition_matches: dict[int, str] = {}
+    build_matches: dict[int, str] = {}
     rule_match_counts: dict[str, int] = {}
 
     for rule in rule_set.root:
@@ -76,7 +98,8 @@ def evaluate_lifecycle(
                 matches = _eval_draft_inactivity(
                     rule=rule, editions=editions_list, now=now
                 )
-                matched_edition_ids.update(matches)
+                for edition_id in matches:
+                    edition_matches.setdefault(edition_id, rule.type)
                 rule_match_counts[rule.type] = len(matches)
             case BuildHistoryOrphanRule():
                 matches = _eval_build_history_orphan(
@@ -86,7 +109,8 @@ def evaluate_lifecycle(
                     history=history_list,
                     now=now,
                 )
-                matched_build_ids.update(matches)
+                for build_id in matches:
+                    build_matches.setdefault(build_id, rule.type)
                 rule_match_counts[rule.type] = len(matches)
             case RefDeletedRule():
                 # DM-54913 will swap in the real predicate; until then the
@@ -97,8 +121,8 @@ def evaluate_lifecycle(
                 raise RuntimeError(msg)
 
     return LifecycleDecision(
-        edition_ids=frozenset(matched_edition_ids),
-        build_ids=frozenset(matched_build_ids),
+        edition_matches=edition_matches,
+        build_matches=build_matches,
         rule_match_counts=rule_match_counts,
     )
 

--- a/src/docverse/services/lifecycle_finalisation.py
+++ b/src/docverse/services/lifecycle_finalisation.py
@@ -1,0 +1,58 @@
+"""Shared helper for finalising a lifecycle_eval run.
+
+Mirrors :mod:`docverse.services.keeper_sync_finalisation` so per-org
+``lifecycle_eval`` workers can roll the parent ``lifecycle_eval_runs``
+row to its terminal status once every attributed child ``queue_jobs``
+row is terminal. Lives next to the keeper-sync helper rather than
+inside the evaluator package because the evaluator is deliberately
+pure and unaware of run-level orchestration.
+"""
+
+from __future__ import annotations
+
+from docverse.client.models import LifecycleEvalRunStatus
+from docverse.exceptions import NotFoundError
+from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
+
+__all__ = ["maybe_finalise_lifecycle_run"]
+
+
+async def maybe_finalise_lifecycle_run(
+    *,
+    run_store: LifecycleEvalRunStore,
+    run_id: int,
+) -> None:
+    """Transition a lifecycle_eval run to terminal once all children terminal.
+
+    Mirrors ``maybe_finalise_run`` from the keeper-sync subsystem (see
+    :func:`docverse.services.keeper_sync_finalisation.maybe_finalise_run`
+    for the rationale on the terminal pre-check). Two per-org workers
+    finishing concurrently can each compute a different terminal status
+    (one sees every child completed and picks ``succeeded`` just as the
+    second's failure commits, so the second picks ``partial_failure``).
+    Without the terminal pre-check the second caller would hit the
+    transition state machine's terminal→terminal guard and raise
+    ``InvalidJobStateError``, rolling back the surrounding
+    ``session.begin()`` and undoing that child's terminal transition.
+    Swallow the conflict here so the loser of the race exits cleanly
+    and lets the winning terminal status stand.
+    """
+    activity = await run_store.aggregate_activity(run_id=run_id)
+    if activity.total_count == 0 or activity.pending_count > 0:
+        return
+    new_status = (
+        LifecycleEvalRunStatus.partial_failure
+        if activity.failed_count > 0
+        else LifecycleEvalRunStatus.succeeded
+    )
+    run = await run_store.get(run_id)
+    if run is None:
+        msg = f"Lifecycle eval run {run_id} not found"
+        raise NotFoundError(msg)
+    if run.status in {
+        LifecycleEvalRunStatus.succeeded,
+        LifecycleEvalRunStatus.partial_failure,
+        LifecycleEvalRunStatus.failed,
+    }:
+        return
+    await run_store.transition_status(run_id=run_id, new_status=new_status)

--- a/src/docverse/storage/build_store.py
+++ b/src/docverse/storage/build_store.py
@@ -99,6 +99,29 @@ class BuildStore:
             return None
         return Build.model_validate(row)
 
+    async def list_all_by_project_ids(
+        self, project_ids: list[int]
+    ) -> list[Build]:
+        """List every non-deleted build across the given projects.
+
+        Single-query batch over multiple projects, ordered by
+        ``(project_id, id)`` for stable iteration. Used by the
+        ``lifecycle_eval`` per-org worker to load every project's
+        builds in one round-trip rather than N. Passing an empty
+        ``project_ids`` returns ``[]`` without hitting the database.
+        """
+        if not project_ids:
+            return []
+        result = await self._session.execute(
+            select(SqlBuild)
+            .where(
+                SqlBuild.project_id.in_(project_ids),
+                SqlBuild.date_deleted.is_(None),
+            )
+            .order_by(SqlBuild.project_id, SqlBuild.id)
+        )
+        return [Build.model_validate(row) for row in result.scalars().all()]
+
     async def list_pending_older_than(
         self,
         *,

--- a/src/docverse/storage/edition_build_history_store.py
+++ b/src/docverse/storage/edition_build_history_store.py
@@ -106,6 +106,33 @@ class EditionBuildHistoryStore:
             EditionBuildHistory.model_validate(r) for r in result.scalars()
         ]
 
+    async def list_by_edition_ids(
+        self, edition_ids: list[int]
+    ) -> list[EditionBuildHistory]:
+        """List history rows for the given editions in a single round-trip.
+
+        Ordered by ``(edition_id, position)`` so callers that group by
+        edition see each edition's history sorted oldest-position-first.
+        Used by the ``lifecycle_eval`` per-org worker to load every
+        edition's rollback history in one query rather than N. Passing
+        an empty ``edition_ids`` returns ``[]`` without hitting the
+        database.
+        """
+        if not edition_ids:
+            return []
+        stmt = (
+            select(SqlEditionBuildHistory)
+            .where(SqlEditionBuildHistory.edition_id.in_(edition_ids))
+            .order_by(
+                SqlEditionBuildHistory.edition_id,
+                SqlEditionBuildHistory.position.asc(),
+            )
+        )
+        result = await self._session.execute(stmt)
+        return [
+            EditionBuildHistory.model_validate(r) for r in result.scalars()
+        ]
+
     async def list_by_edition_with_build_info(
         self,
         edition_id: int,

--- a/src/docverse/storage/edition_store.py
+++ b/src/docverse/storage/edition_store.py
@@ -239,6 +239,34 @@ class EditionStore:
             for edition_row, build_public_id, build_git_ref in rows
         ]
 
+    async def list_all_by_project_ids(
+        self, project_ids: list[int]
+    ) -> list[Edition]:
+        """List every non-deleted edition across the given projects.
+
+        Single-query batch over multiple projects, ordered by
+        ``(project_id, slug)`` for stable iteration. Used by the
+        ``lifecycle_eval`` per-org worker to load every project's
+        editions in one round-trip rather than N. Passing an empty
+        ``project_ids`` returns ``[]`` without hitting the database.
+        """
+        if not project_ids:
+            return []
+        stmt = (
+            self._base_query()
+            .where(
+                SqlEdition.project_id.in_(project_ids),
+                SqlEdition.date_deleted.is_(None),
+            )
+            .order_by(SqlEdition.project_id, SqlEdition.slug)
+        )
+        result = await self._session.execute(stmt)
+        rows = result.all()
+        return [
+            self._validate(edition_row, build_public_id, build_git_ref)
+            for edition_row, build_public_id, build_git_ref in rows
+        ]
+
     async def list_by_project(
         self,
         project_id: int,

--- a/src/docverse/worker/functions/__init__.py
+++ b/src/docverse/worker/functions/__init__.py
@@ -11,6 +11,7 @@ from .keeper_sync import (
     keeper_sync_tier_main,
     keeper_sync_tier_other,
 )
+from .lifecycle_eval import lifecycle_eval
 from .ping import ping
 from .publish_edition import publish_edition
 
@@ -24,6 +25,7 @@ __all__ = [
     "keeper_sync_tier_discovery",
     "keeper_sync_tier_main",
     "keeper_sync_tier_other",
+    "lifecycle_eval",
     "ping",
     "publish_edition",
 ]

--- a/src/docverse/worker/functions/lifecycle_eval.py
+++ b/src/docverse/worker/functions/lifecycle_eval.py
@@ -32,7 +32,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
 from docverse.domain.edition_build_history import EditionBuildHistory
-from docverse.domain.lifecycle import LifecycleRuleSet
+from docverse.domain.lifecycle import LifecycleRule, LifecycleRuleSet
 from docverse.domain.project import Project
 from docverse.factory import Factory
 from docverse.services.lifecycle.evaluator import (
@@ -43,6 +43,8 @@ from docverse.services.lifecycle.evaluator import (
 from docverse.services.lifecycle_finalisation import (
     maybe_finalise_lifecycle_run,
 )
+from docverse.storage.build_store import BuildStore
+from docverse.storage.edition_store import EditionStore
 
 __all__ = ["lifecycle_eval"]
 
@@ -169,7 +171,7 @@ async def _evaluate_org(
             edition_build_history=history_by_project.get(project.id, []),
             now=now,
         )
-        if decision.edition_ids or decision.build_ids:
+        if decision.edition_matches or decision.build_matches:
             decisions.append((project, rule_set, decision))
 
     if not decisions:
@@ -282,8 +284,8 @@ def _index_builds_by_id(
 
 async def _apply_decision(  # noqa: PLR0913
     *,
-    edition_store: Any,
-    build_store: Any,
+    edition_store: EditionStore,
+    build_store: BuildStore,
     project: Project,
     rule_set: LifecycleRuleSet,
     decision: LifecycleDecision,
@@ -299,16 +301,22 @@ async def _apply_decision(  # noqa: PLR0913
     ``delete_reason`` columns are deferred to DM-54914 per the PRD).
     Each event identifies the entity type and id, the project's
     ``(org_id, org_slug, project_id, project_slug)`` for cross-row
-    correlation, the matched rule's ``type`` discriminator, and the
-    rule's resolved parameter dict so an operator can audit *why* a
-    row was deleted from logs alone.
+    correlation, the matched rule's ``type`` discriminator (read from
+    ``decision.edition_matches`` / ``decision.build_matches`` so any
+    future rule that matches editions or builds attributes correctly
+    without code changes here), and the rule's resolved parameter
+    dict so an operator can audit *why* a row was deleted from logs
+    alone.
     """
-    rules_by_type = {rule.type: rule for rule in rule_set.root}
-    for edition_id in sorted(decision.edition_ids):
+    rules_by_type: dict[str, LifecycleRule] = {
+        rule.type: rule for rule in rule_set.root
+    }
+    for edition_id in sorted(decision.edition_matches):
         edition = edition_index.get(edition_id)
         if edition is None:
             continue
-        rule = rules_by_type.get("draft_inactivity")
+        rule_type = decision.edition_matches[edition_id]
+        rule = rules_by_type.get(rule_type)
         deleted = await edition_store.soft_delete(
             project_id=project.id, slug=edition.slug
         )
@@ -323,16 +331,17 @@ async def _apply_decision(  # noqa: PLR0913
             org=org_slug,
             project_id=project.id,
             project=project.slug,
-            rule_type=rule.type if rule is not None else None,
+            rule_type=rule_type,
             rule_params=(
                 rule.model_dump(exclude={"type"}) if rule is not None else None
             ),
         )
-    for build_id in sorted(decision.build_ids):
+    for build_id in sorted(decision.build_matches):
         build = build_index.get(build_id)
         if build is None:
             continue
-        rule = rules_by_type.get("build_history_orphan")
+        rule_type = decision.build_matches[build_id]
+        rule = rules_by_type.get(rule_type)
         deleted = await build_store.soft_delete(build_id=build.id)
         if not deleted:
             continue
@@ -344,7 +353,7 @@ async def _apply_decision(  # noqa: PLR0913
             org=org_slug,
             project_id=project.id,
             project=project.slug,
-            rule_type=rule.type if rule is not None else None,
+            rule_type=rule_type,
             rule_params=(
                 rule.model_dump(exclude={"type"}) if rule is not None else None
             ),

--- a/src/docverse/worker/functions/lifecycle_eval.py
+++ b/src/docverse/worker/functions/lifecycle_eval.py
@@ -2,10 +2,13 @@
 
 The dispatcher cron (sibling task) writes one ``lifecycle_eval_runs``
 row per tick, then fans out one ``queue_jobs`` row per in-scope org
-with ``kind='lifecycle_eval'`` and ``subject_label=str(org_id)``. This
-worker is the per-org body of that fan-out: for one org it loads the
-org row, every non-deleted project, every project's editions, builds,
-and rollback-history rows in batched reads (no N+1), evaluates the
+with ``kind='lifecycle_eval'`` and ``subject_label=org.slug`` (the
+human-readable org slug — never the internal database id, mirroring
+``keeper_sync_project``'s ``subject_label=ltd_slug`` convention so an
+operator inspecting the queue sees a meaningful subject). This worker
+is the per-org body of that fan-out: for one org it loads the org row,
+every non-deleted project, every project's editions, builds, and
+rollback-history rows in batched reads (no N+1), evaluates the
 effective lifecycle rule set per project via the pure
 :func:`docverse.services.lifecycle.evaluator.evaluate_lifecycle`
 function, soft-deletes matched editions and builds, and emits one

--- a/src/docverse/worker/functions/lifecycle_eval.py
+++ b/src/docverse/worker/functions/lifecycle_eval.py
@@ -1,0 +1,351 @@
+"""arq worker function for the ``lifecycle_eval`` per-org pass.
+
+The dispatcher cron (sibling task) writes one ``lifecycle_eval_runs``
+row per tick, then fans out one ``queue_jobs`` row per in-scope org
+with ``kind='lifecycle_eval'`` and ``subject_label=str(org_id)``. This
+worker is the per-org body of that fan-out: for one org it loads the
+org row, every non-deleted project, every project's editions, builds,
+and rollback-history rows in batched reads (no N+1), evaluates the
+effective lifecycle rule set per project via the pure
+:func:`docverse.services.lifecycle.evaluator.evaluate_lifecycle`
+function, soft-deletes matched editions and builds, and emits one
+structured log event per deletion identifying the matched rule.
+
+The worker owns the ``queue_jobs`` row lifecycle: it transitions to
+``in_progress`` on entry and to ``completed`` / ``failed`` on exit,
+then calls
+:func:`docverse.services.lifecycle_finalisation.maybe_finalise_lifecycle_run`
+so the parent ``lifecycle_eval_runs`` row rolls to its terminal status
+once every per-org child is terminal.
+"""
+
+from __future__ import annotations
+
+import traceback
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.domain.build import Build
+from docverse.domain.edition import Edition
+from docverse.domain.edition_build_history import EditionBuildHistory
+from docverse.domain.lifecycle import LifecycleRuleSet
+from docverse.domain.project import Project
+from docverse.factory import Factory
+from docverse.services.lifecycle.evaluator import (
+    LifecycleDecision,
+    evaluate_lifecycle,
+    resolve_rule_set,
+)
+from docverse.services.lifecycle_finalisation import (
+    maybe_finalise_lifecycle_run,
+)
+
+__all__ = ["lifecycle_eval"]
+
+
+async def lifecycle_eval(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
+    """Evaluate lifecycle rules for one org's projects and soft-delete matches.
+
+    Parameters
+    ----------
+    ctx
+        arq worker context (``factory_builder``).
+    payload
+        Job payload with ``org_id``, ``org_slug``, ``lifecycle_eval_run_id``,
+        and ``queue_job_id`` (the per-org ``queue_jobs`` row the
+        dispatcher created for this org).
+
+    Returns
+    -------
+    str
+        ``"completed"`` on a clean pass (including the empty-rule-set
+        no-op case). Raises on failure after marking the queue job
+        failed and rolling the parent run, mirroring ``keeper_sync_
+        project``'s contract so arq logs the job as failed.
+    """
+    org_id: int = payload["org_id"]
+    org_slug: str = payload["org_slug"]
+    run_id: int = payload["lifecycle_eval_run_id"]
+    queue_job_id: int = payload["queue_job_id"]
+    logger = structlog.get_logger("docverse.worker.lifecycle_eval").bind(
+        org=org_slug, lifecycle_eval_run_id=run_id
+    )
+
+    async for session in db_session_dependency():
+        factory = ctx["factory_builder"](session=session, logger=logger)
+        queue_job_store = factory.create_queue_job_store()
+        run_store = factory.create_lifecycle_eval_run_store()
+
+        async with session.begin():
+            await queue_job_store.start(queue_job_id)
+
+        try:
+            await _evaluate_org(
+                session=session,
+                factory=factory,
+                org_id=org_id,
+                org_slug=org_slug,
+                logger=logger,
+            )
+        except Exception as exc:
+            logger.exception("Lifecycle evaluation failed for org")
+            async with session.begin():
+                await queue_job_store.fail(
+                    queue_job_id,
+                    errors={
+                        "message": str(exc),
+                        "type": type(exc).__name__,
+                        "traceback": traceback.format_exc(),
+                    },
+                )
+                await maybe_finalise_lifecycle_run(
+                    run_store=run_store, run_id=run_id
+                )
+            raise
+
+        async with session.begin():
+            await queue_job_store.complete(queue_job_id)
+            await maybe_finalise_lifecycle_run(
+                run_store=run_store, run_id=run_id
+            )
+        logger.info("Lifecycle evaluation completed for org")
+        return "completed"
+
+    msg = "No database session available"
+    raise RuntimeError(msg)
+
+
+async def _evaluate_org(
+    *,
+    session: AsyncSession,
+    factory: Factory,
+    org_id: int,
+    org_slug: str,
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    """Load the org's state, evaluate per-project rules, and apply deletions.
+
+    Splits into a single read transaction that loads org + projects +
+    editions + builds + history (all batched), then a single write
+    transaction that flips ``date_deleted`` on every matched row. The
+    write transaction is one atomic commit per org so a crash mid-loop
+    cannot leave the org half-deleted; the next dispatcher tick will
+    re-evaluate from a consistent state.
+    """
+    state = await _load_org_state(
+        session=session, factory=factory, org_id=org_id
+    )
+    if state is None:
+        logger.warning("Lifecycle eval skipped: organization not found")
+        return
+    (
+        org_rules,
+        projects,
+        editions_by_project,
+        builds_by_project,
+        history_by_project,
+    ) = state
+
+    if not projects:
+        logger.debug("Lifecycle eval: no projects for org")
+        return
+
+    now = datetime.now(tz=UTC)
+    decisions: list[tuple[Project, LifecycleRuleSet, LifecycleDecision]] = []
+    for project in projects:
+        rule_set = resolve_rule_set(
+            org_rules=org_rules, project_rules=project.lifecycle_rules
+        )
+        if not rule_set.root:
+            continue
+        decision = evaluate_lifecycle(
+            rule_set=rule_set,
+            editions=editions_by_project.get(project.id, []),
+            builds=builds_by_project.get(project.id, []),
+            edition_build_history=history_by_project.get(project.id, []),
+            now=now,
+        )
+        if decision.edition_ids or decision.build_ids:
+            decisions.append((project, rule_set, decision))
+
+    if not decisions:
+        logger.debug("Lifecycle eval: no matches across projects")
+        return
+
+    edition_index = _index_editions_by_id(editions_by_project)
+    build_index = _index_builds_by_id(builds_by_project)
+
+    async with session.begin():
+        edition_store = factory.create_edition_store()
+        build_store = factory.create_build_store()
+        for project, rule_set, decision in decisions:
+            await _apply_decision(
+                edition_store=edition_store,
+                build_store=build_store,
+                project=project,
+                rule_set=rule_set,
+                decision=decision,
+                edition_index=edition_index,
+                build_index=build_index,
+                org_id=org_id,
+                org_slug=org_slug,
+                logger=logger,
+            )
+
+
+async def _load_org_state(
+    *,
+    session: AsyncSession,
+    factory: Factory,
+    org_id: int,
+) -> (
+    tuple[
+        LifecycleRuleSet | None,
+        list[Project],
+        dict[int, list[Edition]],
+        dict[int, list[Build]],
+        dict[int, list[EditionBuildHistory]],
+    ]
+    | None
+):
+    """Batch-load the data the evaluator needs for every project in one org.
+
+    Five round-trips total, regardless of project count: org, projects,
+    editions, builds, history. The ``IN (project_ids)`` and
+    ``IN (edition_ids)`` filters do the per-project / per-edition
+    grouping in memory after the load. Returns ``None`` when the org
+    has been deleted between the dispatcher's pre-flight and the
+    worker picking up the job.
+    """
+    org_store = factory.create_org_store()
+    project_store = factory.create_project_store()
+    edition_store = factory.create_edition_store()
+    build_store = factory.create_build_store()
+    history_store = factory.create_edition_build_history_store()
+
+    async with session.begin():
+        org = await org_store.get_by_id(org_id)
+        if org is None:
+            return None
+        projects = await project_store.list_all_by_org(org_id)
+        project_ids = [p.id for p in projects]
+        editions = await edition_store.list_all_by_project_ids(project_ids)
+        builds = await build_store.list_all_by_project_ids(project_ids)
+        history = await history_store.list_by_edition_ids(
+            [e.id for e in editions]
+        )
+
+    editions_by_project: dict[int, list[Edition]] = {
+        pid: [] for pid in project_ids
+    }
+    for edition in editions:
+        editions_by_project[edition.project_id].append(edition)
+    builds_by_project: dict[int, list[Build]] = {
+        pid: [] for pid in project_ids
+    }
+    for build in builds:
+        builds_by_project[build.project_id].append(build)
+    edition_to_project: dict[int, int] = {e.id: e.project_id for e in editions}
+    history_by_project: dict[int, list[EditionBuildHistory]] = {
+        pid: [] for pid in project_ids
+    }
+    for row in history:
+        project_id = edition_to_project.get(row.edition_id)
+        if project_id is not None:
+            history_by_project[project_id].append(row)
+    return (
+        org.lifecycle_rules,
+        projects,
+        editions_by_project,
+        builds_by_project,
+        history_by_project,
+    )
+
+
+def _index_editions_by_id(
+    editions_by_project: dict[int, list[Edition]],
+) -> dict[int, Edition]:
+    return {
+        e.id: e for editions in editions_by_project.values() for e in editions
+    }
+
+
+def _index_builds_by_id(
+    builds_by_project: dict[int, list[Build]],
+) -> dict[int, Build]:
+    return {b.id: b for builds in builds_by_project.values() for b in builds}
+
+
+async def _apply_decision(  # noqa: PLR0913
+    *,
+    edition_store: Any,
+    build_store: Any,
+    project: Project,
+    rule_set: LifecycleRuleSet,
+    decision: LifecycleDecision,
+    edition_index: dict[int, Edition],
+    build_index: dict[int, Build],
+    org_id: int,
+    org_slug: str,
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    """Soft-delete every entity the decision matched and emit one log per row.
+
+    The structured log line is the v1 audit trail (persistent
+    ``delete_reason`` columns are deferred to DM-54914 per the PRD).
+    Each event identifies the entity type and id, the project's
+    ``(org_id, org_slug, project_id, project_slug)`` for cross-row
+    correlation, the matched rule's ``type`` discriminator, and the
+    rule's resolved parameter dict so an operator can audit *why* a
+    row was deleted from logs alone.
+    """
+    rules_by_type = {rule.type: rule for rule in rule_set.root}
+    for edition_id in sorted(decision.edition_ids):
+        edition = edition_index.get(edition_id)
+        if edition is None:
+            continue
+        rule = rules_by_type.get("draft_inactivity")
+        deleted = await edition_store.soft_delete(
+            project_id=project.id, slug=edition.slug
+        )
+        if not deleted:
+            continue
+        logger.info(
+            "Soft-deleted entity by lifecycle rule",
+            entity_type="edition",
+            entity_id=edition.id,
+            entity_slug=edition.slug,
+            org_id=org_id,
+            org=org_slug,
+            project_id=project.id,
+            project=project.slug,
+            rule_type=rule.type if rule is not None else None,
+            rule_params=(
+                rule.model_dump(exclude={"type"}) if rule is not None else None
+            ),
+        )
+    for build_id in sorted(decision.build_ids):
+        build = build_index.get(build_id)
+        if build is None:
+            continue
+        rule = rules_by_type.get("build_history_orphan")
+        deleted = await build_store.soft_delete(build_id=build.id)
+        if not deleted:
+            continue
+        logger.info(
+            "Soft-deleted entity by lifecycle rule",
+            entity_type="build",
+            entity_id=build.id,
+            org_id=org_id,
+            org=org_slug,
+            project_id=project.id,
+            project=project.slug,
+            rule_type=rule.type if rule is not None else None,
+            rule_params=(
+                rule.model_dump(exclude={"type"}) if rule is not None else None
+            ),
+        )

--- a/tests/storage/lifecycle_eval_run_store_test.py
+++ b/tests/storage/lifecycle_eval_run_store_test.py
@@ -23,7 +23,9 @@ def _logger() -> structlog.stdlib.BoundLogger:
     return structlog.get_logger("docverse")  # type: ignore[no-any-return]
 
 
-async def _seed_org(db_session: AsyncSession, *, slug: str = "ler-org") -> int:
+async def _seed_org(
+    db_session: AsyncSession, *, slug: str = "ler-org"
+) -> tuple[int, str]:
     org_store = OrganizationStore(session=db_session, logger=_logger())
     org = await org_store.create(
         OrganizationCreate(
@@ -32,7 +34,7 @@ async def _seed_org(db_session: AsyncSession, *, slug: str = "ler-org") -> int:
             base_domain=f"{slug}.example.com",
         )
     )
-    return org.id
+    return org.id, org.slug
 
 
 def _seed_queue_job(
@@ -117,14 +119,14 @@ async def test_queue_jobs_lifecycle_eval_per_org_mutex(
 ) -> None:
     """Two active ``lifecycle_eval`` queue_jobs for one org collide."""
     async with db_session.begin():
-        org_id = await _seed_org(db_session)
+        org_id, org_slug = await _seed_org(db_session)
         db_session.add(
             SqlQueueJob(
                 public_id=validate_base32_id(generate_base32_id()),
                 kind=JobKind.lifecycle_eval.value,
                 status=JobStatus.queued.value,
                 org_id=org_id,
-                subject_label=str(org_id),
+                subject_label=org_slug,
             )
         )
 
@@ -136,7 +138,43 @@ async def test_queue_jobs_lifecycle_eval_per_org_mutex(
                     kind=JobKind.lifecycle_eval.value,
                     status=JobStatus.in_progress.value,
                     org_id=org_id,
-                    subject_label=str(org_id),
+                    subject_label=org_slug,
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_queue_jobs_lifecycle_eval_mutex_ignores_subject_label(
+    db_session: AsyncSession,
+) -> None:
+    """Mutex is keyed on ``org_id`` alone — divergent labels still collide.
+
+    The previous mutex shape included ``subject_label``; the index is
+    now single-column on ``org_id``. This test pins that property so a
+    future revision cannot silently restore ``subject_label`` to the
+    index without flagging itself here.
+    """
+    async with db_session.begin():
+        org_id, _ = await _seed_org(db_session)
+        db_session.add(
+            SqlQueueJob(
+                public_id=validate_base32_id(generate_base32_id()),
+                kind=JobKind.lifecycle_eval.value,
+                status=JobStatus.queued.value,
+                org_id=org_id,
+                subject_label="ler-org",
+            )
+        )
+
+    with pytest.raises(IntegrityError):
+        async with db_session.begin():
+            db_session.add(
+                SqlQueueJob(
+                    public_id=validate_base32_id(generate_base32_id()),
+                    kind=JobKind.lifecycle_eval.value,
+                    status=JobStatus.in_progress.value,
+                    org_id=org_id,
+                    subject_label="some-other-label",
                 )
             )
 
@@ -147,14 +185,14 @@ async def test_queue_jobs_lifecycle_eval_mutex_terminal_alongside_active(
 ) -> None:
     """A terminal sibling does not block a fresh active row for the org."""
     async with db_session.begin():
-        org_id = await _seed_org(db_session)
+        org_id, org_slug = await _seed_org(db_session)
         db_session.add(
             SqlQueueJob(
                 public_id=validate_base32_id(generate_base32_id()),
                 kind=JobKind.lifecycle_eval.value,
                 status=JobStatus.completed.value,
                 org_id=org_id,
-                subject_label=str(org_id),
+                subject_label=org_slug,
             )
         )
         db_session.add(
@@ -163,7 +201,7 @@ async def test_queue_jobs_lifecycle_eval_mutex_terminal_alongside_active(
                 kind=JobKind.lifecycle_eval.value,
                 status=JobStatus.failed.value,
                 org_id=org_id,
-                subject_label=str(org_id),
+                subject_label=org_slug,
             )
         )
 
@@ -174,7 +212,7 @@ async def test_queue_jobs_lifecycle_eval_mutex_terminal_alongside_active(
                 kind=JobKind.lifecycle_eval.value,
                 status=JobStatus.queued.value,
                 org_id=org_id,
-                subject_label=str(org_id),
+                subject_label=org_slug,
             )
         )
 
@@ -185,15 +223,15 @@ async def test_queue_jobs_lifecycle_eval_mutex_distinct_orgs_coexist(
 ) -> None:
     """Two distinct orgs may each hold an active lifecycle_eval row."""
     async with db_session.begin():
-        first_org = await _seed_org(db_session, slug="ler-org-a")
-        second_org = await _seed_org(db_session, slug="ler-org-b")
+        first_org, first_slug = await _seed_org(db_session, slug="ler-org-a")
+        second_org, second_slug = await _seed_org(db_session, slug="ler-org-b")
         db_session.add(
             SqlQueueJob(
                 public_id=validate_base32_id(generate_base32_id()),
                 kind=JobKind.lifecycle_eval.value,
                 status=JobStatus.queued.value,
                 org_id=first_org,
-                subject_label=str(first_org),
+                subject_label=first_slug,
             )
         )
         db_session.add(
@@ -202,7 +240,7 @@ async def test_queue_jobs_lifecycle_eval_mutex_distinct_orgs_coexist(
                 kind=JobKind.lifecycle_eval.value,
                 status=JobStatus.queued.value,
                 org_id=second_org,
-                subject_label=str(second_org),
+                subject_label=second_slug,
             )
         )
 
@@ -425,7 +463,6 @@ async def test_aggregate_activity_groups_jobs_by_status(
     distinguishes from clean success.
     """
     async with db_session.begin():
-        org_id = await _seed_org(db_session)
         store = LifecycleEvalRunStore(session=db_session, logger=_logger())
         run = await store.create()
         all_statuses = [
@@ -437,16 +474,19 @@ async def test_aggregate_activity_groups_jobs_by_status(
             JobStatus.completed_with_errors,
         ]
         for index, status in enumerate(all_statuses):
-            # Per-row distinct ``subject_label`` so the per-org
-            # active-status mutex does not block the two non-terminal
-            # rows from coexisting. The test exercises the aggregator's
+            # One org per row so the per-``org_id`` active-status
+            # mutex does not block the two non-terminal rows from
+            # coexisting. The test exercises the aggregator's
             # bucketing, not the mutex.
+            row_org_id, row_org_slug = await _seed_org(
+                db_session, slug=f"ler-org-bucket-{index}"
+            )
             _seed_queue_job(
                 db_session,
-                org_id=org_id,
+                org_id=row_org_id,
                 run_id=run.id,
                 status=status,
-                subject_label=f"org-{org_id}-{index}",
+                subject_label=row_org_slug,
             )
         await db_session.commit()
 
@@ -484,36 +524,45 @@ async def test_aggregate_activity_picks_max_coalesced_timestamp(
     """``date_last_activity`` is MAX(coalesce(completed, started, created))."""
     base = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
     async with db_session.begin():
-        org_id = await _seed_org(db_session)
+        # One org per row so the two non-terminal rows (queued +
+        # in_progress) do not collide on the per-``org_id`` mutex;
+        # the test exercises the timestamp coalescer, not the mutex.
+        alpha_id, alpha_slug = await _seed_org(
+            db_session, slug="ler-org-alpha"
+        )
+        beta_id, beta_slug = await _seed_org(db_session, slug="ler-org-beta")
+        gamma_id, gamma_slug = await _seed_org(
+            db_session, slug="ler-org-gamma"
+        )
         store = LifecycleEvalRunStore(session=db_session, logger=_logger())
         run = await store.create()
         _seed_queue_job(
             db_session,
-            org_id=org_id,
+            org_id=alpha_id,
             run_id=run.id,
             status=JobStatus.queued,
             date_created=base,
-            subject_label="alpha",
+            subject_label=alpha_slug,
         )
         _seed_queue_job(
             db_session,
-            org_id=org_id,
+            org_id=beta_id,
             run_id=run.id,
             status=JobStatus.in_progress,
             date_created=base,
             date_started=base + timedelta(minutes=10),
-            subject_label="beta",
+            subject_label=beta_slug,
         )
         latest = base + timedelta(minutes=30)
         _seed_queue_job(
             db_session,
-            org_id=org_id,
+            org_id=gamma_id,
             run_id=run.id,
             status=JobStatus.completed,
             date_created=base,
             date_started=base + timedelta(minutes=5),
             date_completed=latest,
-            subject_label="gamma",
+            subject_label=gamma_slug,
         )
         await db_session.commit()
 

--- a/tests/worker/lifecycle_eval_test.py
+++ b/tests/worker/lifecycle_eval_test.py
@@ -16,7 +16,7 @@ import pytest
 import structlog
 from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.sql import update
+from sqlalchemy.sql import select, update
 
 from docverse.client.models import (
     BuildCreate,
@@ -335,10 +335,9 @@ async def test_lifecycle_eval_soft_deletes_stale_drafts_and_orphan_builds(
             # Lookup soft-deleted edition row directly to verify
             # date_deleted set.
             sql = await session.execute(
-                update(SqlEdition)
-                .where(SqlEdition.id == stale_draft_id)
-                .returning(SqlEdition.date_deleted)
-                .values()
+                select(SqlEdition.date_deleted).where(
+                    SqlEdition.id == stale_draft_id
+                )
             )
             assert sql.scalar_one() is not None
 
@@ -492,10 +491,9 @@ async def test_lifecycle_eval_project_rules_replace_org_rules(
             assert inheriting_victim is None
             # Confirm via direct row lookup that date_deleted is set.
             row_result = await session.execute(
-                update(SqlEdition)
-                .where(SqlEdition.id == inheriting_draft_id)
-                .returning(SqlEdition.date_deleted)
-                .values()
+                select(SqlEdition.date_deleted).where(
+                    SqlEdition.id == inheriting_draft_id
+                )
             )
             assert row_result.scalar_one() is not None
 

--- a/tests/worker/lifecycle_eval_test.py
+++ b/tests/worker/lifecycle_eval_test.py
@@ -1,0 +1,652 @@
+"""Tests for the ``lifecycle_eval`` per-org worker function.
+
+Seeds an org with multiple projects plus shifted ``date_updated`` /
+``date_completed`` timestamps and asserts the worker soft-deletes the
+expected rows, transitions the ``queue_jobs`` row correctly, and
+finalises the parent ``lifecycle_eval_runs`` row when the queue is
+drained.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+import structlog
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import update
+
+from docverse.client.models import (
+    BuildCreate,
+    EditionKind,
+    LifecycleEvalRunStatus,
+    OrganizationCreate,
+    ProjectCreate,
+    TrackingMode,
+)
+from docverse.client.models.queue_enums import JobKind, JobStatus
+from docverse.dbschema.build import SqlBuild
+from docverse.dbschema.edition import SqlEdition
+from docverse.dbschema.edition_build_history import SqlEditionBuildHistory
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
+from docverse.domain.lifecycle import (
+    BuildHistoryOrphanRule,
+    DraftInactivityRule,
+    LifecycleRuleSet,
+)
+from docverse.storage.build_store import BuildStore
+from docverse.storage.edition_build_history_store import (
+    EditionBuildHistoryStore,
+)
+from docverse.storage.edition_store import EditionStore
+from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+from docverse.storage.queue_job_store import QueueJobStore
+from docverse.worker.functions.lifecycle_eval import lifecycle_eval
+from tests.worker.conftest import make_worker_ctx
+
+NOW = datetime(2026, 5, 12, 12, 0, 0, tzinfo=UTC)
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org(
+    db_session: AsyncSession,
+    *,
+    slug: str = "lce-org",
+    lifecycle_rules: LifecycleRuleSet | None = None,
+) -> tuple[int, str]:
+    org_store = OrganizationStore(session=db_session, logger=_logger())
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=slug,
+            title=f"LCE Org {slug}",
+            base_domain=f"{slug}.example.com",
+            lifecycle_rules=lifecycle_rules,
+        )
+    )
+    return org.id, org.slug
+
+
+async def _seed_project(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    slug: str,
+    lifecycle_rules: LifecycleRuleSet | None = None,
+) -> int:
+    project_store = ProjectStore(session=db_session, logger=_logger())
+    project = await project_store.create(
+        org_id=org_id,
+        data=ProjectCreate(
+            slug=slug,
+            title=f"Project {slug}",
+            doc_repo=f"https://example.com/{slug}",
+            lifecycle_rules=lifecycle_rules,
+        ),
+    )
+    return project.id
+
+
+async def _seed_edition(
+    db_session: AsyncSession,
+    *,
+    project_id: int,
+    slug: str,
+    kind: EditionKind,
+    date_updated: datetime,
+    lifecycle_exempt: bool = False,
+    current_build_id: int | None = None,
+) -> int:
+    edition_store = EditionStore(session=db_session, logger=_logger())
+    edition = await edition_store.create_internal(
+        project_id=project_id,
+        slug=slug,
+        title=f"Edition {slug}",
+        kind=kind,
+        tracking_mode=TrackingMode.git_ref,
+        lifecycle_exempt=lifecycle_exempt,
+    )
+    # Bypass ``onupdate=func.now()`` so the seeded timestamp survives.
+    await db_session.execute(
+        update(SqlEdition)
+        .where(SqlEdition.id == edition.id)
+        .values(
+            date_updated=date_updated,
+            current_build_id=current_build_id,
+        )
+    )
+    return edition.id
+
+
+async def _seed_build(
+    db_session: AsyncSession,
+    *,
+    project_id: int,
+    project_slug: str,
+    date_completed: datetime,
+) -> int:
+    build_store = BuildStore(session=db_session, logger=_logger())
+    # content_hash must be unique-per-project, so derive it from the
+    # build's eventual id by using project + completion timestamp.
+    content_hash = (
+        f"sha256:{project_id:08x}{int(date_completed.timestamp()):016x}"
+        + "0" * 40
+    )
+    build = await build_store.create(
+        project_id=project_id,
+        project_slug=project_slug,
+        data=BuildCreate(
+            git_ref="main",
+            content_hash=content_hash,
+        ),
+        uploader="seed",
+    )
+    await db_session.execute(
+        update(SqlBuild)
+        .where(SqlBuild.id == build.id)
+        .values(
+            date_created=date_completed,
+            date_completed=date_completed,
+        )
+    )
+    return build.id
+
+
+async def _seed_run_and_queue_job(
+    db_session: AsyncSession, *, org_id: int
+) -> tuple[int, int]:
+    """Create one ``lifecycle_eval_runs`` row + a per-org queue_jobs row."""
+    run_store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+    run = await run_store.create()
+    await run_store.transition_status(
+        run_id=run.id, new_status=LifecycleEvalRunStatus.in_progress
+    )
+    queue_job_row = SqlQueueJob(
+        public_id=validate_base32_id(generate_base32_id()),
+        kind=JobKind.lifecycle_eval.value,
+        status=JobStatus.queued.value,
+        org_id=org_id,
+        lifecycle_eval_run_id=run.id,
+        subject_label=str(org_id),
+    )
+    db_session.add(queue_job_row)
+    await db_session.flush()
+    return run.id, queue_job_row.id
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_soft_deletes_stale_drafts_and_orphan_builds(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """End-to-end: stale drafts + orphan builds get ``date_deleted`` set.
+
+    Seeds two projects under one org:
+
+    * ``project-a`` has org-level ``draft_inactivity(max_days_inactive=
+      30)`` so its stale draft (updated 60 days ago) becomes a soft-
+      delete candidate but its fresh draft and exempt draft do not.
+    * ``project-b`` has its own ``build_history_orphan`` rule that
+      replaces org rules — it has an unreferenced old build that must
+      be deleted and a current build that must not.
+
+    Asserts the worker correctly applies the per-project rule
+    resolution (org rules everywhere except where project overrides),
+    soft-deletes the right rows, completes the queue_job, and finalises
+    the parent run to ``succeeded``.
+    """
+    org_rules = LifecycleRuleSet(
+        root=[DraftInactivityRule(max_days_inactive=30)]
+    )
+    project_b_rules = LifecycleRuleSet(
+        root=[BuildHistoryOrphanRule(min_position=1, min_age_days=30)]
+    )
+
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, lifecycle_rules=org_rules
+        )
+        project_a_id = await _seed_project(
+            db_session, org_id=org_id, slug="project-a"
+        )
+        project_b_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="project-b",
+            lifecycle_rules=project_b_rules,
+        )
+
+        # project-a editions: stale draft (60d), fresh draft (5d), exempt
+        # stale draft (60d, lifecycle_exempt=True), and a release edition
+        # which is never a draft_inactivity candidate.
+        stale_draft_id = await _seed_edition(
+            db_session,
+            project_id=project_a_id,
+            slug="stale-draft",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+        )
+        fresh_draft_id = await _seed_edition(
+            db_session,
+            project_id=project_a_id,
+            slug="fresh-draft",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=5),
+        )
+        exempt_draft_id = await _seed_edition(
+            db_session,
+            project_id=project_a_id,
+            slug="exempt-draft",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+            lifecycle_exempt=True,
+        )
+        release_id = await _seed_edition(
+            db_session,
+            project_id=project_a_id,
+            slug="release-1",
+            kind=EditionKind.release,
+            date_updated=NOW - timedelta(days=60),
+        )
+
+        # project-b builds: one current (40d old, protected), one
+        # orphan (40d old, no edition reference).
+        current_build_id = await _seed_build(
+            db_session,
+            project_id=project_b_id,
+            project_slug="project-b",
+            date_completed=NOW - timedelta(days=40),
+        )
+        orphan_build_id = await _seed_build(
+            db_session,
+            project_id=project_b_id,
+            project_slug="project-b",
+            date_completed=NOW - timedelta(days=40),
+        )
+        # project-b also has a draft edition that references the current
+        # build. project-b has no draft_inactivity rule so the edition
+        # is not a candidate even though it's stale.
+        await _seed_edition(
+            db_session,
+            project_id=project_b_id,
+            slug="main",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+            current_build_id=current_build_id,
+        )
+
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client)
+    result = await lifecycle_eval(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "lifecycle_eval_run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await http_client.aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            edition_store = EditionStore(session=session, logger=_logger())
+            stale = await edition_store.get_by_slug(
+                project_id=project_a_id, slug="stale-draft"
+            )
+            # stale-draft is soft-deleted, so get_by_slug filters it out.
+            assert stale is None
+            fresh = await edition_store.get_by_slug(
+                project_id=project_a_id, slug="fresh-draft"
+            )
+            assert fresh is not None
+            assert fresh.id == fresh_draft_id
+            exempt = await edition_store.get_by_slug(
+                project_id=project_a_id, slug="exempt-draft"
+            )
+            assert exempt is not None
+            assert exempt.id == exempt_draft_id
+            release = await edition_store.get_by_slug(
+                project_id=project_a_id, slug="release-1"
+            )
+            assert release is not None
+            assert release.id == release_id
+
+            build_store = BuildStore(session=session, logger=_logger())
+            current_build = await build_store.get_by_id(current_build_id)
+            assert current_build is not None
+            assert current_build.date_deleted is None
+            orphan_build = await build_store.get_by_id(orphan_build_id)
+            assert orphan_build is not None
+            assert orphan_build.date_deleted is not None
+
+            # Lookup soft-deleted edition row directly to verify
+            # date_deleted set.
+            sql = await session.execute(
+                update(SqlEdition)
+                .where(SqlEdition.id == stale_draft_id)
+                .returning(SqlEdition.date_deleted)
+                .values()
+            )
+            assert sql.scalar_one() is not None
+
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            qj = await queue_job_store.get(queue_job_id)
+            assert qj is not None
+            assert qj.status == JobStatus.completed
+
+            run_store = LifecycleEvalRunStore(
+                session=session, logger=_logger()
+            )
+            run = await run_store.get(run_id)
+            assert run is not None
+            # One child queue_job, terminal → run rolls to succeeded.
+            assert run.status is LifecycleEvalRunStatus.succeeded
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_no_rules_is_a_noop(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """An org with no rules anywhere completes cleanly and deletes nothing.
+
+    Pre-flight in the dispatcher skips orgs with no rules, but this
+    test exercises the defensive path where a queue_job for an org
+    that turns out to have no rules still completes safely without
+    mutating anything.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, slug="lce-empty-org")
+        project_id = await _seed_project(
+            db_session, org_id=org_id, slug="empty-project"
+        )
+        edition_id = await _seed_edition(
+            db_session,
+            project_id=project_id,
+            slug="ancient-draft",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=365),
+        )
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client)
+    result = await lifecycle_eval(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "lifecycle_eval_run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await http_client.aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            edition_store = EditionStore(session=session, logger=_logger())
+            edition = await edition_store.get_by_slug(
+                project_id=project_id, slug="ancient-draft"
+            )
+            assert edition is not None
+            assert edition.id == edition_id
+
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            qj = await queue_job_store.get(queue_job_id)
+            assert qj is not None
+            assert qj.status == JobStatus.completed
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_project_rules_replace_org_rules(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A project's explicit ``[]`` rule set disables inherited org rules.
+
+    Per SQR-112: project rules **replace** org rules with no merging.
+    This test seeds an org with a draft_inactivity rule and one
+    project that explicitly opts out with ``LifecycleRuleSet(root=[])``,
+    plus another project that inherits the org rule. The stale draft in
+    the opt-out project survives; the stale draft in the inheriting
+    project gets soft-deleted.
+    """
+    org_rules = LifecycleRuleSet(
+        root=[DraftInactivityRule(max_days_inactive=30)]
+    )
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, slug="lce-opt-out-org", lifecycle_rules=org_rules
+        )
+        opt_out_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="opt-out",
+            lifecycle_rules=LifecycleRuleSet(root=[]),
+        )
+        inheriting_id = await _seed_project(
+            db_session, org_id=org_id, slug="inheriting"
+        )
+        opt_out_draft_id = await _seed_edition(
+            db_session,
+            project_id=opt_out_id,
+            slug="should-survive",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+        )
+        inheriting_draft_id = await _seed_edition(
+            db_session,
+            project_id=inheriting_id,
+            slug="should-be-deleted",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+        )
+
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client)
+    result = await lifecycle_eval(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "lifecycle_eval_run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await http_client.aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            edition_store = EditionStore(session=session, logger=_logger())
+            opt_out_survivor = await edition_store.get_by_slug(
+                project_id=opt_out_id, slug="should-survive"
+            )
+            assert opt_out_survivor is not None
+            assert opt_out_survivor.id == opt_out_draft_id
+
+            inheriting_victim = await edition_store.get_by_slug(
+                project_id=inheriting_id, slug="should-be-deleted"
+            )
+            # Soft-deleted → get_by_slug returns None.
+            assert inheriting_victim is None
+            # Confirm via direct row lookup that date_deleted is set.
+            row_result = await session.execute(
+                update(SqlEdition)
+                .where(SqlEdition.id == inheriting_draft_id)
+                .returning(SqlEdition.date_deleted)
+                .values()
+            )
+            assert row_result.scalar_one() is not None
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_failure_marks_queue_job_and_finalises_run(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exception inside the worker → queue_job ``failed``, run finalised.
+
+    Drives a failure inside ``_evaluate_org`` by patching
+    ``OrganizationStore.get_by_id`` to raise so the worker's
+    except-branch must mark the queue_job ``failed`` and call
+    ``maybe_finalise_lifecycle_run`` — which rolls the single-child run
+    to ``partial_failure``.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, slug="lce-fail-org")
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id
+        )
+
+    async def _raise(*args: object, **kwargs: object) -> None:
+        msg = "synthetic failure"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(OrganizationStore, "get_by_id", _raise)
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client)
+    with pytest.raises(RuntimeError, match="synthetic failure"):
+        await lifecycle_eval(
+            ctx,
+            {
+                "org_id": org_id,
+                "org_slug": org_slug,
+                "lifecycle_eval_run_id": run_id,
+                "queue_job_id": queue_job_id,
+            },
+        )
+    await http_client.aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            qj = await queue_job_store.get(queue_job_id)
+            assert qj is not None
+            assert qj.status == JobStatus.failed
+            assert qj.errors is not None
+            assert "synthetic failure" in qj.errors["message"]
+
+            run_store = LifecycleEvalRunStore(
+                session=session, logger=_logger()
+            )
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status is LifecycleEvalRunStatus.partial_failure
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_protects_shared_build_referenced_elsewhere(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A build held by another edition's ``current_build_id`` is not deleted.
+
+    Per user story 18: a build shared across two editions is kept as
+    long as at least one edition still holds it within its retention
+    window. This test exercises the worker's batched cross-project /
+    cross-edition loader path so the in-memory protection logic
+    actually sees both editions' state when deciding what to delete.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session,
+            slug="lce-shared-build-org",
+            lifecycle_rules=LifecycleRuleSet(
+                root=[BuildHistoryOrphanRule(min_position=5, min_age_days=30)]
+            ),
+        )
+        project_id = await _seed_project(
+            db_session, org_id=org_id, slug="proj-shared"
+        )
+        shared_build_id = await _seed_build(
+            db_session,
+            project_id=project_id,
+            project_slug="proj-shared",
+            date_completed=NOW - timedelta(days=60),
+        )
+        protector_edition_id = await _seed_edition(
+            db_session,
+            project_id=project_id,
+            slug="protector",
+            kind=EditionKind.release,
+            date_updated=NOW,
+            current_build_id=shared_build_id,
+        )
+        other_edition_id = await _seed_edition(
+            db_session,
+            project_id=project_id,
+            slug="other",
+            kind=EditionKind.release,
+            date_updated=NOW,
+        )
+        # Record a history row on the "other" edition that references
+        # the shared build at position 10 — high enough that, alone, the
+        # build would be orphaned by min_position=5. The protector
+        # edition holding it as current_build_id is what saves it.
+        history_store = EditionBuildHistoryStore(
+            session=db_session, logger=_logger()
+        )
+        await history_store.record(
+            edition_id=other_edition_id, build_id=shared_build_id
+        )
+        # Bump it to position 10.
+        await db_session.execute(
+            update(SqlEditionBuildHistory)
+            .where(SqlEditionBuildHistory.edition_id == other_edition_id)
+            .values(position=10)
+        )
+
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client)
+    result = await lifecycle_eval(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "lifecycle_eval_run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await http_client.aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            build_store = BuildStore(session=session, logger=_logger())
+            build = await build_store.get_by_id(shared_build_id)
+            assert build is not None
+            assert build.date_deleted is None
+
+            edition_store = EditionStore(session=session, logger=_logger())
+            protector = await edition_store.get_by_slug(
+                project_id=project_id, slug="protector"
+            )
+            assert protector is not None
+            assert protector.id == protector_edition_id

--- a/tests/worker/lifecycle_eval_test.py
+++ b/tests/worker/lifecycle_eval_test.py
@@ -160,9 +160,16 @@ async def _seed_build(
 
 
 async def _seed_run_and_queue_job(
-    db_session: AsyncSession, *, org_id: int
+    db_session: AsyncSession, *, org_id: int, org_slug: str
 ) -> tuple[int, int]:
-    """Create one ``lifecycle_eval_runs`` row + a per-org queue_jobs row."""
+    """Create one ``lifecycle_eval_runs`` row + a per-org queue_jobs row.
+
+    Mirrors the dispatcher contract documented on
+    :mod:`docverse.worker.functions.lifecycle_eval`: ``subject_label``
+    is the org's slug so the per-org mutex stays human-meaningful for
+    operators inspecting ``queue_jobs`` and the internal ``org_id``
+    is never reused as the queue's user-visible subject.
+    """
     run_store = LifecycleEvalRunStore(session=db_session, logger=_logger())
     run = await run_store.create()
     await run_store.transition_status(
@@ -174,7 +181,7 @@ async def _seed_run_and_queue_job(
         status=JobStatus.queued.value,
         org_id=org_id,
         lifecycle_eval_run_id=run.id,
-        subject_label=str(org_id),
+        subject_label=org_slug,
     )
     db_session.add(queue_job_row)
     await db_session.flush()
@@ -283,7 +290,7 @@ async def test_lifecycle_eval_soft_deletes_stale_drafts_and_orphan_builds(
         )
 
         run_id, queue_job_id = await _seed_run_and_queue_job(
-            db_session, org_id=org_id
+            db_session, org_id=org_id, org_slug=org_slug
         )
 
     http_client = httpx.AsyncClient()
@@ -380,7 +387,7 @@ async def test_lifecycle_eval_no_rules_is_a_noop(
             date_updated=NOW - timedelta(days=365),
         )
         run_id, queue_job_id = await _seed_run_and_queue_job(
-            db_session, org_id=org_id
+            db_session, org_id=org_id, org_slug=org_slug
         )
 
     http_client = httpx.AsyncClient()
@@ -458,7 +465,7 @@ async def test_lifecycle_eval_project_rules_replace_org_rules(
         )
 
         run_id, queue_job_id = await _seed_run_and_queue_job(
-            db_session, org_id=org_id
+            db_session, org_id=org_id, org_slug=org_slug
         )
 
     http_client = httpx.AsyncClient()
@@ -515,7 +522,7 @@ async def test_lifecycle_eval_failure_marks_queue_job_and_finalises_run(
     async with db_session.begin():
         org_id, org_slug = await _seed_org(db_session, slug="lce-fail-org")
         run_id, queue_job_id = await _seed_run_and_queue_job(
-            db_session, org_id=org_id
+            db_session, org_id=org_id, org_slug=org_slug
         )
 
     async def _raise(*args: object, **kwargs: object) -> None:
@@ -618,7 +625,7 @@ async def test_lifecycle_eval_protects_shared_build_referenced_elsewhere(
         )
 
         run_id, queue_job_id = await _seed_run_and_queue_job(
-            db_session, org_id=org_id
+            db_session, org_id=org_id, org_slug=org_slug
         )
 
     http_client = httpx.AsyncClient()


### PR DESCRIPTION
## Summary

- Add the per-org ``lifecycle_eval`` arq worker function that wraps the pure evaluator from #351 in batched DB I/O: loads org + projects + editions + builds + history in five queries (no N+1), evaluates per-project effective rule sets, and soft-deletes matched editions and builds in a single write transaction.
- Emit one structured log event per deletion identifying entity type, id, project, matched rule type, and resolved rule parameters — the v1 audit trail (persistent reason columns are deferred to DM-54914).
- Add ``maybe_finalise_lifecycle_run`` (mirrors ``maybe_finalise_run`` from keeper-sync) so the worker rolls the parent ``lifecycle_eval_runs`` row to a terminal status once every per-org child is terminal, with the same terminal-pre-check guard against racing finalisers.

## Validation steps

- [ ] Configure org-level ``draft_inactivity`` rules via PATCH and confirm stale draft editions are soft-deleted on the next ``lifecycle_eval`` tick.
- [ ] Configure a project-level ``LifecycleRuleSet(root=[])`` opt-out and confirm its stale drafts survive while sibling projects with no override get evaluated against the inherited org rules.
- [ ] Mark an edition ``lifecycle_exempt=True`` and confirm both the edition and every build it references survive a tick that would otherwise delete them.
- [ ] Inspect a per-org worker pod's structured logs after a tick that deletes rows; confirm each ``Soft-deleted entity by lifecycle rule`` event carries ``entity_type``, ``entity_id``, ``rule_type``, and ``rule_params``.
- [ ] Kill a per-org worker mid-evaluation and confirm the next dispatcher tick re-evaluates from a consistent state (no half-deleted org).

## References

- Closes #353
- PRD: #337
- Jira: https://rubinobs.atlassian.net/browse/DM-54688