### PR TITLE
DM-54688: Hourly lifecycle_eval_dispatcher cron + pre-flight skip

### DIFF
--- a/src/docverse/config.py
+++ b/src/docverse/config.py
@@ -164,6 +164,21 @@ class Configuration(BaseSettings):
         ),
     )
 
+    lifecycle_eval_job_timeout_seconds: int = Field(
+        3600,
+        title="Lifecycle-eval per-job timeout, in seconds",
+        description=(
+            "Wraps the ``lifecycle_eval_dispatcher`` and per-org"
+            " ``lifecycle_eval`` arq functions on"
+            " ``LifecycleEvalWorkerSettings``: arq cancels a job that"
+            " runs past this. The cron-driven ``lifecycle_reaper`` is"
+            " the second backstop (covers OOM-killed workers / arq"
+            " losing a job), so this should sit well below"
+            " ``lifecycle_reaper_threshold_seconds``. Lower this in"
+            " test/staging to surface stuck-worker behaviour quickly."
+        ),
+    )
+
     superadmin_usernames: Annotated[
         list[str], BeforeValidator(_parse_comma_separated)
     ] = Field(

--- a/src/docverse/storage/lifecycle_eval_run_store.py
+++ b/src/docverse/storage/lifecycle_eval_run_store.py
@@ -128,10 +128,12 @@ class LifecycleEvalRunStore:
         """Replace the run row's JSONB ``summary`` column.
 
         Called by the dispatcher to record per-tick metadata
-        (``orgs_enqueued``, ``orgs_skipped``) once the fan-out commits.
-        Distinct from ``transition_status`` so the summary can be
-        written from inside the dispatcher's fan-out transaction
-        without coupling the status state machine to summary writes.
+        (``orgs_enqueued``, ``orgs_skipped``) in the same transaction
+        as the run-row insert, so the counts represent the dispatcher's
+        intent and are captured atomically with the run — the summary
+        is never missing, even if the per-child fan-out dies later.
+        Distinct from ``transition_status`` so the summary write does
+        not couple the status state machine to summary writes.
         """
         row = await self._get_row(run_id)
         row.summary = summary

--- a/src/docverse/storage/lifecycle_eval_run_store.py
+++ b/src/docverse/storage/lifecycle_eval_run_store.py
@@ -10,6 +10,7 @@ pattern transfers between subsystems.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 import structlog
 from sqlalchemy import func, select
@@ -117,6 +118,23 @@ class LifecycleEvalRunStore:
         row.status = new_status.value
         if new_status not in _NON_TERMINAL_STATUSES:
             row.date_finished = datetime.now(tz=UTC)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return LifecycleEvalRun.model_validate(row)
+
+    async def set_summary(
+        self, *, run_id: int, summary: dict[str, Any]
+    ) -> LifecycleEvalRun:
+        """Replace the run row's JSONB ``summary`` column.
+
+        Called by the dispatcher to record per-tick metadata
+        (``orgs_enqueued``, ``orgs_skipped``) once the fan-out commits.
+        Distinct from ``transition_status`` so the summary can be
+        written from inside the dispatcher's fan-out transaction
+        without coupling the status state machine to summary writes.
+        """
+        row = await self._get_row(run_id)
+        row.summary = summary
         await self._session.flush()
         await self._session.refresh(row)
         return LifecycleEvalRun.model_validate(row)

--- a/src/docverse/storage/project_store.py
+++ b/src/docverse/storage/project_store.py
@@ -95,6 +95,25 @@ class ProjectStore:
         )
         return [Project.model_validate(row) for row in result.scalars().all()]
 
+    async def list_org_ids_with_lifecycle_rules(self) -> set[int]:
+        """Return every ``org_id`` that owns a project with lifecycle rules.
+
+        The ``lifecycle_eval_dispatcher`` pre-flight uses the union of
+        this set with orgs whose own ``lifecycle_rules`` column is
+        non-null to decide which orgs are in-scope for the tick.
+        Soft-deleted projects are excluded so an org whose only
+        rule-bearing project has been deleted is correctly classified
+        as "no rules anywhere" — otherwise the dispatcher would burn a
+        queue slot on a per-org pass that the evaluator would short-
+        circuit anyway.
+        """
+        stmt = select(SqlProject.org_id).where(
+            SqlProject.lifecycle_rules.is_not(None),
+            SqlProject.date_deleted.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        return set(result.scalars().all())
+
     async def list_all_by_org(self, org_id: int) -> list[Project]:
         """List every non-deleted project for an organization.
 

--- a/src/docverse/storage/queue_job_store.py
+++ b/src/docverse/storage/queue_job_store.py
@@ -40,6 +40,7 @@ class QueueJobStore:
         build_id: int | None = None,
         edition_id: int | None = None,
         keeper_sync_run_id: int | None = None,
+        lifecycle_eval_run_id: int | None = None,
         subject_label: str | None = None,
     ) -> QueueJob:
         """Insert a new QueueJob row with status=queued.
@@ -57,6 +58,7 @@ class QueueJobStore:
             build_id=build_id,
             edition_id=edition_id,
             keeper_sync_run_id=keeper_sync_run_id,
+            lifecycle_eval_run_id=lifecycle_eval_run_id,
             subject_label=subject_label,
         )
         self._session.add(row)

--- a/src/docverse/worker/functions/__init__.py
+++ b/src/docverse/worker/functions/__init__.py
@@ -12,6 +12,7 @@ from .keeper_sync import (
     keeper_sync_tier_other,
 )
 from .lifecycle_eval import lifecycle_eval
+from .lifecycle_eval_dispatcher import lifecycle_eval_dispatcher
 from .ping import ping
 from .publish_edition import publish_edition
 
@@ -26,6 +27,7 @@ __all__ = [
     "keeper_sync_tier_main",
     "keeper_sync_tier_other",
     "lifecycle_eval",
+    "lifecycle_eval_dispatcher",
     "ping",
     "publish_edition",
 ]

--- a/src/docverse/worker/functions/lifecycle_eval_dispatcher.py
+++ b/src/docverse/worker/functions/lifecycle_eval_dispatcher.py
@@ -7,32 +7,35 @@ job. On each firing the dispatcher:
    OR any non-deleted project with non-empty rules. Orgs with no rules
    anywhere are skipped — no ``queue_jobs`` row, no per-org pass.
 
-2. Creates one ``lifecycle_eval_runs`` row in ``pending`` status. The
-   partial-unique non-terminal index on that table is the DB-level
-   backstop against two ticks racing; the dispatcher pre-checks
-   ``has_non_terminal_run`` *and* catches the ``IntegrityError`` from
-   the index (the pre-check and the insert are in separate
-   transactions, so two ticks can both clear the pre-check) so a
-   slow prior tick surfaces as a clean ``"skipped"`` result rather
-   than an ``IntegrityError`` traceback.
+2. Inserts the ``lifecycle_eval_runs`` row, its ``summary`` JSONB
+   (``orgs_enqueued`` / ``orgs_skipped``), the per-org ``queue_jobs``
+   children, and — when there is at least one child — the
+   ``pending → in_progress`` transition, **all in a single
+   transaction**. Either every row is durable together or none of
+   them are: there is no window in which a ``lifecycle_eval_runs``
+   row can exist without its children, so the
+   ``has_non_terminal_run`` pre-flight cannot get wedged by a
+   partial fan-out. The partial-unique non-terminal index on
+   ``lifecycle_eval_runs`` is the DB-level backstop against two
+   ticks racing; the dispatcher pre-checks ``has_non_terminal_run``
+   *and* catches the ``IntegrityError`` from the index so a slow
+   prior tick surfaces as a clean ``"skipped"`` result rather than
+   an ``IntegrityError`` traceback. The per-org mutex partial-unique
+   index on ``queue_jobs`` keeps concurrent ticks from doubling up
+   on a single org.
 
-3. Inserts one ``queue_jobs`` row per in-scope org with
-   ``kind='lifecycle_eval'``, ``subject_label=org.slug``, and
-   ``lifecycle_eval_run_id`` set to the new run. The per-org mutex
-   partial-unique index keeps concurrent ticks from doubling up.
+3. For the all-skipped case (zero in-scope orgs) the same
+   transaction transitions the run straight to ``succeeded`` — no
+   children exist to finalise the run later.
 
-4. Writes the ``summary`` JSONB on the run row with ``orgs_enqueued``
-   and ``orgs_skipped`` counts, then transitions the run from
-   ``pending`` to ``in_progress`` once the fan-out commits — or
-   straight to ``succeeded`` when the all-skipped path leaves no
-   children to finalise the run later.
-
-5. Enqueues the actual arq jobs outside the SQL transaction (so the
-   queue_jobs row commits before any worker can pick it up) and
-   writes the arq backend job id back onto each row. The orphan-tail
-   window — row committed, ``backend_job_id IS NULL`` — is the
-   reaper's responsibility, mirroring ``keeper_sync_run_discovery``'s
-   shape.
+4. Enqueues the actual arq jobs outside the SQL transaction (so the
+   ``queue_jobs`` rows commit before any worker can pick them up)
+   and writes the arq ``backend_job_id`` back onto each row. The
+   orphan-tail window — row committed, ``backend_job_id IS NULL`` —
+   is the responsibility of ``lifecycle_reaper``, the second
+   durability backstop. The per-job arq ``timeout`` configured on
+   ``LifecycleEvalWorkerSettings`` is the first backstop (cancels a
+   runaway evaluator long before the reaper window).
 """
 
 from __future__ import annotations
@@ -47,8 +50,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.client.models import JobKind, LifecycleEvalRunStatus
 from docverse.domain.lifecycle_eval_run import LifecycleEvalRun
 from docverse.domain.organization import Organization
+from docverse.domain.queue import QueueJob
 from docverse.factory import Factory
 from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
+from docverse.storage.queue_job_store import QueueJobStore
 
 __all__ = ["LIFECYCLE_EVAL_QUEUE_NAME", "lifecycle_eval_dispatcher"]
 
@@ -77,6 +82,7 @@ async def lifecycle_eval_dispatcher(ctx: dict[str, Any]) -> str:
     async for session in db_session_dependency():
         factory = ctx["factory_builder"](session=session, logger=logger)
         run_store = factory.create_lifecycle_eval_run_store()
+        queue_job_store = factory.create_queue_job_store()
 
         async with session.begin():
             if await run_store.has_non_terminal_run():
@@ -89,26 +95,23 @@ async def lifecycle_eval_dispatcher(ctx: dict[str, Any]) -> str:
         in_scope, skipped_count = await _resolve_in_scope_orgs(
             session=session, factory=factory
         )
-        run = await _create_run_with_summary(
+        creation = await _create_run_with_children(
             session=session,
             run_store=run_store,
-            orgs_enqueued=len(in_scope),
+            queue_job_store=queue_job_store,
+            orgs=in_scope,
             orgs_skipped=skipped_count,
         )
-        if run is None:
+        if creation is None:
             logger.info(
                 "Skipping lifecycle_eval dispatcher tick: another tick "
                 "won the create race"
             )
             return "skipped"
+        run, queue_jobs = creation
         logger = logger.bind(lifecycle_eval_run_id=run.id)
 
         if not in_scope:
-            async with session.begin():
-                await run_store.transition_status(
-                    run_id=run.id,
-                    new_status=LifecycleEvalRunStatus.succeeded,
-                )
             logger.info(
                 "Lifecycle_eval dispatcher tick completed with no in-scope "
                 "orgs",
@@ -116,13 +119,13 @@ async def lifecycle_eval_dispatcher(ctx: dict[str, Any]) -> str:
             )
             return "completed"
 
-        await _enqueue_children(
+        await _enqueue_arq_jobs(
             ctx=ctx,
             session=session,
-            factory=factory,
-            run_store=run_store,
+            queue_job_store=queue_job_store,
             run_id=run.id,
             orgs=in_scope,
+            queue_jobs=queue_jobs,
             logger=logger,
         )
         logger.info(
@@ -165,24 +168,32 @@ async def _resolve_in_scope_orgs(
     return in_scope, skipped
 
 
-async def _create_run_with_summary(
+async def _create_run_with_children(
     *,
     session: AsyncSession,
     run_store: LifecycleEvalRunStore,
-    orgs_enqueued: int,
+    queue_job_store: QueueJobStore,
+    orgs: list[Organization],
     orgs_skipped: int,
-) -> LifecycleEvalRun | None:
-    """Insert the run row in one transaction and write its summary.
+) -> tuple[LifecycleEvalRun, list[QueueJob]] | None:
+    """Insert the run row, summary, all child ``queue_jobs`` atomically.
 
-    Split from the fan-out write so the run row is durable even if
-    the per-child enqueue loop dies mid-fanout — the reaper can then
-    finalise the partially-fanned-out run from the children that did
-    commit.
+    Either every row commits together or none of them do, so the
+    ``has_non_terminal_run`` pre-flight cannot get wedged by a
+    partial fan-out: a committed run row is always accompanied by
+    its full set of child ``queue_jobs`` rows (or, in the
+    all-skipped case, transitions straight to ``succeeded``). A
+    crash later — during the arq enqueue loop — degenerates to the
+    existing orphan-queued case (``backend_job_id IS NULL``) that
+    ``lifecycle_reaper`` already handles.
 
-    Returns ``None`` if the partial-unique non-terminal index rejected
-    the insert — another dispatcher tick raced past the pre-flight
-    ``has_non_terminal_run`` check and won the create. The caller
-    translates this into a clean ``"skipped"`` tick.
+    Returns ``None`` if the partial-unique non-terminal index
+    rejected the insert — another dispatcher tick raced past the
+    pre-flight ``has_non_terminal_run`` check and won the create.
+    The caller translates this into a clean ``"skipped"`` tick.
+    Returns ``(run, queue_jobs)`` otherwise; ``queue_jobs`` is in
+    the same order as ``orgs`` so the arq enqueue loop can pair
+    them up.
     """
     try:
         async with session.begin():
@@ -190,49 +201,55 @@ async def _create_run_with_summary(
             await run_store.set_summary(
                 run_id=run.id,
                 summary={
-                    "orgs_enqueued": orgs_enqueued,
+                    "orgs_enqueued": len(orgs),
                     "orgs_skipped": orgs_skipped,
                 },
             )
+            queue_jobs: list[QueueJob] = []
+            for org in orgs:
+                queue_job = await queue_job_store.create(
+                    kind=JobKind.lifecycle_eval,
+                    org_id=org.id,
+                    lifecycle_eval_run_id=run.id,
+                    subject_label=org.slug,
+                )
+                queue_jobs.append(queue_job)
+            if orgs:
+                await run_store.transition_status(
+                    run_id=run.id,
+                    new_status=LifecycleEvalRunStatus.in_progress,
+                )
+            else:
+                await run_store.transition_status(
+                    run_id=run.id,
+                    new_status=LifecycleEvalRunStatus.succeeded,
+                )
     except IntegrityError:
         return None
-    return run
+    return run, queue_jobs
 
 
-async def _enqueue_children(  # noqa: PLR0913
+async def _enqueue_arq_jobs(  # noqa: PLR0913
     *,
     ctx: dict[str, Any],
     session: AsyncSession,
-    factory: Factory,
-    run_store: LifecycleEvalRunStore,
+    queue_job_store: QueueJobStore,
     run_id: int,
     orgs: list[Organization],
+    queue_jobs: list[QueueJob],
     logger: structlog.stdlib.BoundLogger,
 ) -> None:
-    """Fan out one per-org ``queue_jobs`` row + arq enqueue per org.
+    """Enqueue one arq job per pre-created ``queue_jobs`` row.
 
-    Each iteration commits the ``queue_jobs`` row *before* enqueuing
-    the arq job so a crash between the SQL commit and ``arq_queue.
-    enqueue`` leaves an orphan-tail row (``backend_job_id IS NULL``)
-    the reaper can sweep — mirrors ``_enqueue_children`` in
-    ``keeper_sync.py``. The run's ``pending → in_progress`` transition
-    is atomic with the first successful child create.
+    The ``queue_jobs`` rows are already committed by
+    :func:`_create_run_with_children`, so a crash between the
+    arq enqueue and the ``backend_job_id`` write leaves an
+    orphan-queued row (``backend_job_id IS NULL``) the
+    ``lifecycle_reaper`` will sweep — mirrors the orphan-tail
+    contract documented on ``KeeperSyncWorkerSettings``.
     """
     arq_queue = ctx["arq_queue"]
-    queue_job_store = factory.create_queue_job_store()
-    for index, org in enumerate(orgs):
-        async with session.begin():
-            queue_job = await queue_job_store.create(
-                kind=JobKind.lifecycle_eval,
-                org_id=org.id,
-                lifecycle_eval_run_id=run_id,
-                subject_label=org.slug,
-            )
-            if index == 0:
-                await run_store.transition_status(
-                    run_id=run_id,
-                    new_status=LifecycleEvalRunStatus.in_progress,
-                )
+    for org, queue_job in zip(orgs, queue_jobs, strict=True):
         metadata = await arq_queue.enqueue(
             "lifecycle_eval",
             _queue_name=LIFECYCLE_EVAL_QUEUE_NAME,

--- a/src/docverse/worker/functions/lifecycle_eval_dispatcher.py
+++ b/src/docverse/worker/functions/lifecycle_eval_dispatcher.py
@@ -9,9 +9,12 @@ job. On each firing the dispatcher:
 
 2. Creates one ``lifecycle_eval_runs`` row in ``pending`` status. The
    partial-unique non-terminal index on that table is the DB-level
-   backstop against two ticks racing; the dispatcher also pre-checks
-   ``has_non_terminal_run`` so a slow prior tick surfaces as a clean
-   ``"skipped"`` result rather than an ``IntegrityError`` traceback.
+   backstop against two ticks racing; the dispatcher pre-checks
+   ``has_non_terminal_run`` *and* catches the ``IntegrityError`` from
+   the index (the pre-check and the insert are in separate
+   transactions, so two ticks can both clear the pre-check) so a
+   slow prior tick surfaces as a clean ``"skipped"`` result rather
+   than an ``IntegrityError`` traceback.
 
 3. Inserts one ``queue_jobs`` row per in-scope org with
    ``kind='lifecycle_eval'``, ``subject_label=org.slug``, and
@@ -38,6 +41,7 @@ from typing import Any
 
 import structlog
 from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import JobKind, LifecycleEvalRunStatus
@@ -91,6 +95,12 @@ async def lifecycle_eval_dispatcher(ctx: dict[str, Any]) -> str:
             orgs_enqueued=len(in_scope),
             orgs_skipped=skipped_count,
         )
+        if run is None:
+            logger.info(
+                "Skipping lifecycle_eval dispatcher tick: another tick "
+                "won the create race"
+            )
+            return "skipped"
         logger = logger.bind(lifecycle_eval_run_id=run.id)
 
         if not in_scope:
@@ -161,23 +171,31 @@ async def _create_run_with_summary(
     run_store: LifecycleEvalRunStore,
     orgs_enqueued: int,
     orgs_skipped: int,
-) -> LifecycleEvalRun:
+) -> LifecycleEvalRun | None:
     """Insert the run row in one transaction and write its summary.
 
     Split from the fan-out write so the run row is durable even if
     the per-child enqueue loop dies mid-fanout — the reaper can then
     finalise the partially-fanned-out run from the children that did
     commit.
+
+    Returns ``None`` if the partial-unique non-terminal index rejected
+    the insert — another dispatcher tick raced past the pre-flight
+    ``has_non_terminal_run`` check and won the create. The caller
+    translates this into a clean ``"skipped"`` tick.
     """
-    async with session.begin():
-        run = await run_store.create()
-        await run_store.set_summary(
-            run_id=run.id,
-            summary={
-                "orgs_enqueued": orgs_enqueued,
-                "orgs_skipped": orgs_skipped,
-            },
-        )
+    try:
+        async with session.begin():
+            run = await run_store.create()
+            await run_store.set_summary(
+                run_id=run.id,
+                summary={
+                    "orgs_enqueued": orgs_enqueued,
+                    "orgs_skipped": orgs_skipped,
+                },
+            )
+    except IntegrityError:
+        return None
     return run
 
 

--- a/src/docverse/worker/functions/lifecycle_eval_dispatcher.py
+++ b/src/docverse/worker/functions/lifecycle_eval_dispatcher.py
@@ -1,0 +1,234 @@
+"""arq cron worker that fans out per-org ``lifecycle_eval`` jobs.
+
+Hourly cron entrypoint for the ``lifecycle_eval`` periodic background
+job. On each firing the dispatcher:
+
+1. Runs a cheap pre-flight that finds orgs with any rule at org level
+   OR any non-deleted project with non-empty rules. Orgs with no rules
+   anywhere are skipped — no ``queue_jobs`` row, no per-org pass.
+
+2. Creates one ``lifecycle_eval_runs`` row in ``pending`` status. The
+   partial-unique non-terminal index on that table is the DB-level
+   backstop against two ticks racing; the dispatcher also pre-checks
+   ``has_non_terminal_run`` so a slow prior tick surfaces as a clean
+   ``"skipped"`` result rather than an ``IntegrityError`` traceback.
+
+3. Inserts one ``queue_jobs`` row per in-scope org with
+   ``kind='lifecycle_eval'``, ``subject_label=org.slug``, and
+   ``lifecycle_eval_run_id`` set to the new run. The per-org mutex
+   partial-unique index keeps concurrent ticks from doubling up.
+
+4. Writes the ``summary`` JSONB on the run row with ``orgs_enqueued``
+   and ``orgs_skipped`` counts, then transitions the run from
+   ``pending`` to ``in_progress`` once the fan-out commits — or
+   straight to ``succeeded`` when the all-skipped path leaves no
+   children to finalise the run later.
+
+5. Enqueues the actual arq jobs outside the SQL transaction (so the
+   queue_jobs row commits before any worker can pick it up) and
+   writes the arq backend job id back onto each row. The orphan-tail
+   window — row committed, ``backend_job_id IS NULL`` — is the
+   reaper's responsibility, mirroring ``keeper_sync_run_discovery``'s
+   shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import JobKind, LifecycleEvalRunStatus
+from docverse.domain.lifecycle_eval_run import LifecycleEvalRun
+from docverse.domain.organization import Organization
+from docverse.factory import Factory
+from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
+
+__all__ = ["LIFECYCLE_EVAL_QUEUE_NAME", "lifecycle_eval_dispatcher"]
+
+
+LIFECYCLE_EVAL_QUEUE_NAME = "docverse:lifecycle-queue"
+"""arq queue name dedicated to ``lifecycle_eval`` work.
+
+The queue is isolated from the default ``docverse:queue`` and the
+``docverse:sync-queue`` so a slow lifecycle pass cannot starve
+``build_processing`` / ``publish_edition`` or keeper-sync jobs. The
+PRD calls for "a new dedicated arq worker pool (the third pool,
+alongside the default and keeper-sync pools)" — this constant is the
+queue name those pools bind to.
+"""
+
+
+async def lifecycle_eval_dispatcher(ctx: dict[str, Any]) -> str:
+    """Fan out one ``lifecycle_eval`` job per in-scope org.
+
+    Returns ``"completed"`` for a clean fan-out (including the
+    all-skipped case, which still records a run row), ``"skipped"``
+    when a prior non-terminal run is in flight.
+    """
+    logger = structlog.get_logger("docverse.worker.lifecycle_eval_dispatcher")
+
+    async for session in db_session_dependency():
+        factory = ctx["factory_builder"](session=session, logger=logger)
+        run_store = factory.create_lifecycle_eval_run_store()
+
+        async with session.begin():
+            if await run_store.has_non_terminal_run():
+                logger.info(
+                    "Skipping lifecycle_eval dispatcher tick: "
+                    "a prior run is still in flight"
+                )
+                return "skipped"
+
+        in_scope, skipped_count = await _resolve_in_scope_orgs(
+            session=session, factory=factory
+        )
+        run = await _create_run_with_summary(
+            session=session,
+            run_store=run_store,
+            orgs_enqueued=len(in_scope),
+            orgs_skipped=skipped_count,
+        )
+        logger = logger.bind(lifecycle_eval_run_id=run.id)
+
+        if not in_scope:
+            async with session.begin():
+                await run_store.transition_status(
+                    run_id=run.id,
+                    new_status=LifecycleEvalRunStatus.succeeded,
+                )
+            logger.info(
+                "Lifecycle_eval dispatcher tick completed with no in-scope "
+                "orgs",
+                orgs_skipped=skipped_count,
+            )
+            return "completed"
+
+        await _enqueue_children(
+            ctx=ctx,
+            session=session,
+            factory=factory,
+            run_store=run_store,
+            run_id=run.id,
+            orgs=in_scope,
+            logger=logger,
+        )
+        logger.info(
+            "Lifecycle_eval dispatcher tick completed",
+            orgs_enqueued=len(in_scope),
+            orgs_skipped=skipped_count,
+        )
+        return "completed"
+
+    msg = "No database session available"
+    raise RuntimeError(msg)
+
+
+async def _resolve_in_scope_orgs(
+    *, session: AsyncSession, factory: Factory
+) -> tuple[list[Organization], int]:
+    """Return ``(in_scope_orgs, skipped_count)`` from a pre-flight read.
+
+    An org is in-scope iff its own ``lifecycle_rules`` column is
+    populated *or* it owns at least one non-deleted project whose
+    ``lifecycle_rules`` column is populated. The two-query shape
+    (one read of every org, one read of every org_id that has a
+    rule-bearing project) keeps the dispatcher round-trip count
+    constant in the number of orgs.
+    """
+    org_store = factory.create_org_store()
+    project_store = factory.create_project_store()
+    async with session.begin():
+        orgs = await org_store.list_all()
+        project_org_ids = (
+            await project_store.list_org_ids_with_lifecycle_rules()
+        )
+    in_scope: list[Organization] = []
+    skipped = 0
+    for org in orgs:
+        if org.lifecycle_rules is not None or org.id in project_org_ids:
+            in_scope.append(org)
+        else:
+            skipped += 1
+    return in_scope, skipped
+
+
+async def _create_run_with_summary(
+    *,
+    session: AsyncSession,
+    run_store: LifecycleEvalRunStore,
+    orgs_enqueued: int,
+    orgs_skipped: int,
+) -> LifecycleEvalRun:
+    """Insert the run row in one transaction and write its summary.
+
+    Split from the fan-out write so the run row is durable even if
+    the per-child enqueue loop dies mid-fanout — the reaper can then
+    finalise the partially-fanned-out run from the children that did
+    commit.
+    """
+    async with session.begin():
+        run = await run_store.create()
+        await run_store.set_summary(
+            run_id=run.id,
+            summary={
+                "orgs_enqueued": orgs_enqueued,
+                "orgs_skipped": orgs_skipped,
+            },
+        )
+    return run
+
+
+async def _enqueue_children(  # noqa: PLR0913
+    *,
+    ctx: dict[str, Any],
+    session: AsyncSession,
+    factory: Factory,
+    run_store: LifecycleEvalRunStore,
+    run_id: int,
+    orgs: list[Organization],
+    logger: structlog.stdlib.BoundLogger,
+) -> None:
+    """Fan out one per-org ``queue_jobs`` row + arq enqueue per org.
+
+    Each iteration commits the ``queue_jobs`` row *before* enqueuing
+    the arq job so a crash between the SQL commit and ``arq_queue.
+    enqueue`` leaves an orphan-tail row (``backend_job_id IS NULL``)
+    the reaper can sweep — mirrors ``_enqueue_children`` in
+    ``keeper_sync.py``. The run's ``pending → in_progress`` transition
+    is atomic with the first successful child create.
+    """
+    arq_queue = ctx["arq_queue"]
+    queue_job_store = factory.create_queue_job_store()
+    for index, org in enumerate(orgs):
+        async with session.begin():
+            queue_job = await queue_job_store.create(
+                kind=JobKind.lifecycle_eval,
+                org_id=org.id,
+                lifecycle_eval_run_id=run_id,
+                subject_label=org.slug,
+            )
+            if index == 0:
+                await run_store.transition_status(
+                    run_id=run_id,
+                    new_status=LifecycleEvalRunStatus.in_progress,
+                )
+        metadata = await arq_queue.enqueue(
+            "lifecycle_eval",
+            _queue_name=LIFECYCLE_EVAL_QUEUE_NAME,
+            payload={
+                "org_id": org.id,
+                "org_slug": org.slug,
+                "lifecycle_eval_run_id": run_id,
+                "queue_job_id": queue_job.id,
+            },
+        )
+        async with session.begin():
+            await queue_job_store.set_backend_job_id(queue_job.id, metadata.id)
+        logger.debug(
+            "Enqueued lifecycle_eval for org",
+            org=org.slug,
+            queue_job_id=queue_job.id,
+        )

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -42,9 +42,12 @@ from .functions import (
     keeper_sync_tier_discovery,
     keeper_sync_tier_main,
     keeper_sync_tier_other,
+    lifecycle_eval,
+    lifecycle_eval_dispatcher,
     ping,
     publish_edition,
 )
+from .functions.lifecycle_eval_dispatcher import LIFECYCLE_EVAL_QUEUE_NAME
 
 config = Configuration()
 
@@ -341,5 +344,52 @@ class KeeperSyncWorkerSettings:
     ]
     redis_settings = config.arq_redis_settings
     queue_name = KEEPER_SYNC_QUEUE_NAME
+    on_startup = startup
+    on_shutdown = shutdown
+
+
+class LifecycleEvalWorkerSettings:
+    """arq WorkerSettings for the dedicated ``lifecycle_eval`` queue.
+
+    Bound to ``docverse:lifecycle-queue`` (see
+    :data:`LIFECYCLE_EVAL_QUEUE_NAME`) so a slow lifecycle pass cannot
+    starve the default queue's ``build_processing`` and
+    ``publish_edition`` jobs or the keeper-sync queue's
+    ``keeper_sync_project`` jobs. The PRD §"Orchestration" specifies a
+    third pool alongside the default and keeper-sync pools; this class
+    is the binding.
+
+    Both the dispatcher and the per-org worker are wrapped with
+    :func:`arq.func` so the dedicated queue inherits a single-attempt
+    policy. A failure must surface promptly so the per-org worker's
+    ``except Exception`` block can route to ``queue_job_store.fail()``
+    and the parent ``lifecycle_eval_runs`` row finalises via
+    :func:`maybe_finalise_lifecycle_run` — arq's default 5-attempt
+    retry would otherwise delay finalisation and obscure the
+    underlying error in logs.
+
+    The hourly dispatcher cron is registered here; the
+    ``lifecycle_reaper`` cron (sibling task) will be appended to this
+    class's ``cron_jobs`` list when it lands.
+    """
+
+    functions = [
+        func(
+            lifecycle_eval_dispatcher,
+            max_tries=1,
+        ),
+        func(
+            lifecycle_eval,
+            max_tries=1,
+        ),
+    ]
+    cron_jobs = [
+        cron(
+            lifecycle_eval_dispatcher,
+            minute={0},
+        ),
+    ]
+    redis_settings = config.arq_redis_settings
+    queue_name = LIFECYCLE_EVAL_QUEUE_NAME
     on_startup = startup
     on_shutdown = shutdown

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -360,13 +360,16 @@ class LifecycleEvalWorkerSettings:
     is the binding.
 
     Both the dispatcher and the per-org worker are wrapped with
-    :func:`arq.func` so the dedicated queue inherits a single-attempt
-    policy. A failure must surface promptly so the per-org worker's
-    ``except Exception`` block can route to ``queue_job_store.fail()``
-    and the parent ``lifecycle_eval_runs`` row finalises via
-    :func:`maybe_finalise_lifecycle_run` — arq's default 5-attempt
-    retry would otherwise delay finalisation and obscure the
-    underlying error in logs.
+    :func:`arq.func` so the dedicated queue inherits a per-job
+    ``timeout`` (sourced from ``Config.lifecycle_eval_job_timeout_seconds``)
+    and a single-attempt policy. A failure must surface promptly so
+    the per-org worker's ``except Exception`` block can route to
+    ``queue_job_store.fail()`` and the parent ``lifecycle_eval_runs``
+    row finalises via :func:`maybe_finalise_lifecycle_run` — arq's
+    default 5-attempt retry would otherwise delay finalisation and
+    obscure the underlying error in logs. The cron-driven
+    ``lifecycle_reaper`` (sibling task) is the second backstop for
+    the case where arq itself loses a job and no timeout ever fires.
 
     The hourly dispatcher cron is registered here; the
     ``lifecycle_reaper`` cron (sibling task) will be appended to this
@@ -376,10 +379,12 @@ class LifecycleEvalWorkerSettings:
     functions = [
         func(
             lifecycle_eval_dispatcher,
+            timeout=config.lifecycle_eval_job_timeout_seconds,
             max_tries=1,
         ),
         func(
             lifecycle_eval,
+            timeout=config.lifecycle_eval_job_timeout_seconds,
             max_tries=1,
         ),
     ]

--- a/tests/worker/lifecycle_eval_dispatcher_test.py
+++ b/tests/worker/lifecycle_eval_dispatcher_test.py
@@ -237,6 +237,76 @@ async def test_dispatcher_with_no_in_scope_orgs_terminates_run_succeeded(
 
 
 @pytest.mark.asyncio
+async def test_dispatcher_skips_when_create_loses_race(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The IntegrityError from a lost create race surfaces as ``"skipped"``.
+
+    The pre-flight ``has_non_terminal_run`` check and the
+    ``create`` insert run in separate transactions, so two cron
+    firings can both clear the pre-check and both attempt the
+    insert. The partial-unique non-terminal index rejects one of
+    them with ``IntegrityError``. The dispatcher must catch that
+    and return ``"skipped"`` — the run_store docstring promises
+    the caller will translate the IntegrityError into a clean skip.
+
+    Simulated by stubbing ``has_non_terminal_run`` to return False
+    even though a non-terminal run already exists, which is the
+    state a racing tick would observe between its pre-check commit
+    and the other tick's create commit.
+    """
+    async with db_session.begin():
+        org_id, _ = await _seed_org(
+            db_session, slug="org-race", lifecycle_rules=_ORG_RULES
+        )
+        run_store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        existing_run = await run_store.create()
+        await run_store.transition_status(
+            run_id=existing_run.id,
+            new_status=LifecycleEvalRunStatus.in_progress,
+        )
+        queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+        await queue_job_store.create(
+            kind=JobKind.lifecycle_eval,
+            org_id=org_id,
+            subject_label="org-race",
+            lifecycle_eval_run_id=existing_run.id,
+        )
+
+    async def _pretend_no_run_in_flight(self: LifecycleEvalRunStore) -> bool:
+        return False
+
+    monkeypatch.setattr(
+        LifecycleEvalRunStore,
+        "has_non_terminal_run",
+        _pretend_no_run_in_flight,
+    )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await lifecycle_eval_dispatcher(ctx)
+    await http_client.aclose()
+    assert result == "skipped"
+
+    eval_jobs = get_jobs_by_name(
+        mock_arq, "lifecycle_eval", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+    )
+    assert eval_jobs == []
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            run_stmt = select(SqlLifecycleEvalRun)
+            runs = (await session.execute(run_stmt)).scalars().all()
+            assert len(runs) == 1
+            assert runs[0].id == existing_run.id
+
+
+@pytest.mark.asyncio
 async def test_dispatcher_skips_tick_when_prior_run_in_flight(
     app: None,
     db_session: AsyncSession,

--- a/tests/worker/lifecycle_eval_dispatcher_test.py
+++ b/tests/worker/lifecycle_eval_dispatcher_test.py
@@ -1,0 +1,290 @@
+"""Tests for the ``lifecycle_eval_dispatcher`` worker function.
+
+Seeds a mix of orgs (rules at org level, rules only on a child project,
+no rules anywhere) and asserts the cron handler creates one
+``lifecycle_eval_runs`` row plus one per-org ``queue_jobs`` row for each
+in-scope org, leaving the unconfigured org untouched.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import structlog
+from safir.arq import MockArqQueue
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import (
+    JobKind,
+    LifecycleEvalRunStatus,
+    OrganizationCreate,
+    ProjectCreate,
+)
+from docverse.dbschema.lifecycle_eval_run import SqlLifecycleEvalRun
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.lifecycle import DraftInactivityRule, LifecycleRuleSet
+from docverse.domain.queue import JobStatus
+from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+from docverse.storage.queue_job_store import QueueJobStore
+from docverse.worker.functions.lifecycle_eval_dispatcher import (
+    LIFECYCLE_EVAL_QUEUE_NAME,
+    lifecycle_eval_dispatcher,
+)
+from tests.support.arq_testing import get_jobs_by_name, register_queue
+from tests.worker.conftest import make_worker_ctx
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+_ORG_RULES = LifecycleRuleSet(root=[DraftInactivityRule(max_days_inactive=30)])
+_PROJECT_RULES = LifecycleRuleSet(
+    root=[DraftInactivityRule(max_days_inactive=14)]
+)
+
+
+async def _seed_org(
+    db_session: AsyncSession,
+    *,
+    slug: str,
+    lifecycle_rules: LifecycleRuleSet | None = None,
+) -> tuple[int, str]:
+    org_store = OrganizationStore(session=db_session, logger=_logger())
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=slug,
+            title=f"LED Org {slug}",
+            base_domain=f"{slug}.example.com",
+            lifecycle_rules=lifecycle_rules,
+        )
+    )
+    return org.id, org.slug
+
+
+async def _seed_project(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    slug: str,
+    lifecycle_rules: LifecycleRuleSet | None = None,
+) -> int:
+    project_store = ProjectStore(session=db_session, logger=_logger())
+    project = await project_store.create(
+        org_id=org_id,
+        data=ProjectCreate(
+            slug=slug,
+            title=f"Project {slug}",
+            doc_repo=f"https://example.com/{slug}",
+            lifecycle_rules=lifecycle_rules,
+        ),
+    )
+    return project.id
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_fans_out_per_in_scope_org(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """One run row + one queue_job per in-scope org; unconfigured org skipped.
+
+    Three orgs are seeded:
+
+    * ``org-with-org-rules`` has org-level ``lifecycle_rules`` and is
+      in-scope.
+    * ``org-with-project-rules`` has *no* org-level rules but one of its
+      projects has rules, so it is in-scope via the per-project signal.
+    * ``org-without-rules`` has no rules at any level and must be
+      skipped — no queue_jobs row written.
+
+    The dispatcher must produce one ``lifecycle_eval_runs`` row, two
+    ``queue_jobs`` rows of ``kind='lifecycle_eval'`` (one per in-scope
+    org), a ``summary`` of ``{"orgs_enqueued": 2, "orgs_skipped": 1}``,
+    and transition the run from ``pending`` to ``in_progress`` once the
+    fan-out commits.
+    """
+    async with db_session.begin():
+        org_a_id, org_a_slug = await _seed_org(
+            db_session,
+            slug="org-with-org-rules",
+            lifecycle_rules=_ORG_RULES,
+        )
+        await _seed_project(db_session, org_id=org_a_id, slug="a-project")
+
+        org_b_id, org_b_slug = await _seed_org(
+            db_session, slug="org-with-project-rules"
+        )
+        await _seed_project(
+            db_session,
+            org_id=org_b_id,
+            slug="b-project",
+            lifecycle_rules=_PROJECT_RULES,
+        )
+
+        _, _ = await _seed_org(db_session, slug="org-without-rules")
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await lifecycle_eval_dispatcher(ctx)
+    await http_client.aclose()
+    assert result == "completed"
+
+    # Two child ``lifecycle_eval`` jobs were enqueued on the dedicated
+    # queue — one per in-scope org — and zero on the default queue.
+    eval_jobs = get_jobs_by_name(
+        mock_arq, "lifecycle_eval", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+    )
+    assert len(eval_jobs) == 2
+    default_jobs = get_jobs_by_name(
+        mock_arq, "lifecycle_eval", queue_name="docverse:queue"
+    )
+    assert default_jobs == []
+    payload_slugs = {job.kwargs["payload"]["org_slug"] for job in eval_jobs}
+    assert payload_slugs == {org_a_slug, org_b_slug}
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            run_stmt = select(SqlLifecycleEvalRun)
+            runs = (await session.execute(run_stmt)).scalars().all()
+            assert len(runs) == 1
+            run = runs[0]
+            assert run.status == LifecycleEvalRunStatus.in_progress.value
+            assert run.summary == {
+                "orgs_enqueued": 2,
+                "orgs_skipped": 1,
+            }
+
+            qj_stmt = select(SqlQueueJob).where(
+                SqlQueueJob.kind == JobKind.lifecycle_eval.value
+            )
+            queue_jobs = (await session.execute(qj_stmt)).scalars().all()
+            assert len(queue_jobs) == 2
+            assert {qj.org_id for qj in queue_jobs} == {org_a_id, org_b_id}
+            assert {qj.subject_label for qj in queue_jobs} == {
+                org_a_slug,
+                org_b_slug,
+            }
+            assert all(qj.lifecycle_eval_run_id == run.id for qj in queue_jobs)
+            assert all(qj.backend_job_id is not None for qj in queue_jobs)
+            assert all(
+                qj.status == JobStatus.queued.value for qj in queue_jobs
+            )
+
+            run_store = LifecycleEvalRunStore(
+                session=session, logger=_logger()
+            )
+            fetched = await run_store.get(run.id)
+            assert fetched is not None
+            assert fetched.status is LifecycleEvalRunStatus.in_progress
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_with_no_in_scope_orgs_terminates_run_succeeded(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """An all-skipped tick finalises the run as ``succeeded`` immediately.
+
+    When every org is filtered out by the pre-flight check, the
+    dispatcher still records a run row (so operators can confirm the
+    tick fired) and transitions it straight to ``succeeded`` — there
+    are no per-org children that would otherwise drive finalisation.
+    """
+    async with db_session.begin():
+        await _seed_org(db_session, slug="empty-org-1")
+        await _seed_org(db_session, slug="empty-org-2")
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await lifecycle_eval_dispatcher(ctx)
+    await http_client.aclose()
+    assert result == "completed"
+
+    eval_jobs = get_jobs_by_name(
+        mock_arq, "lifecycle_eval", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+    )
+    assert eval_jobs == []
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            run_stmt = select(SqlLifecycleEvalRun)
+            runs = (await session.execute(run_stmt)).scalars().all()
+            assert len(runs) == 1
+            run = runs[0]
+            assert run.status == LifecycleEvalRunStatus.succeeded.value
+            assert run.date_finished is not None
+            assert run.summary == {
+                "orgs_enqueued": 0,
+                "orgs_skipped": 2,
+            }
+
+            qj_stmt = select(SqlQueueJob).where(
+                SqlQueueJob.kind == JobKind.lifecycle_eval.value
+            )
+            queue_jobs = (await session.execute(qj_stmt)).scalars().all()
+            assert queue_jobs == []
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_skips_tick_when_prior_run_in_flight(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A pre-existing non-terminal run causes this tick to no-op.
+
+    The partial-unique index on ``lifecycle_eval_runs`` enforces a
+    singleton non-terminal run globally; the dispatcher pre-checks the
+    same condition so the cron firing surfaces as a clean skip rather
+    than an ``IntegrityError`` traceback.
+    """
+    async with db_session.begin():
+        org_id, _ = await _seed_org(
+            db_session, slug="org-x", lifecycle_rules=_ORG_RULES
+        )
+        run_store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        existing_run = await run_store.create()
+        await run_store.transition_status(
+            run_id=existing_run.id,
+            new_status=LifecycleEvalRunStatus.in_progress,
+        )
+        queue_job_store = QueueJobStore(session=db_session, logger=_logger())
+        await queue_job_store.create(
+            kind=JobKind.lifecycle_eval,
+            org_id=org_id,
+            subject_label="org-x",
+            lifecycle_eval_run_id=existing_run.id,
+        )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await lifecycle_eval_dispatcher(ctx)
+    await http_client.aclose()
+    assert result == "skipped"
+
+    eval_jobs = get_jobs_by_name(
+        mock_arq, "lifecycle_eval", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+    )
+    assert eval_jobs == []
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            run_stmt = select(SqlLifecycleEvalRun)
+            runs = (await session.execute(run_stmt)).scalars().all()
+            # No new run row was written; only the pre-existing one
+            # remains.
+            assert len(runs) == 1
+            assert runs[0].id == existing_run.id

--- a/tests/worker/lifecycle_eval_dispatcher_test.py
+++ b/tests/worker/lifecycle_eval_dispatcher_test.py
@@ -32,6 +32,7 @@ from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.lifecycle_eval_dispatcher import (
     LIFECYCLE_EVAL_QUEUE_NAME,
+    _create_run_with_children,
     lifecycle_eval_dispatcher,
 )
 from tests.support.arq_testing import get_jobs_by_name, register_queue
@@ -166,6 +167,11 @@ async def test_dispatcher_fans_out_per_in_scope_org(
                 SqlQueueJob.kind == JobKind.lifecycle_eval.value
             )
             queue_jobs = (await session.execute(qj_stmt)).scalars().all()
+            # The run row and its full set of per-org children are
+            # created in the same transaction by
+            # ``_create_run_with_children``; the run is never visible
+            # without its children, so the reaper never has to chase
+            # a partially-fanned-out parent.
             assert len(queue_jobs) == 2
             assert {qj.org_id for qj in queue_jobs} == {org_a_id, org_b_id}
             assert {qj.subject_label for qj in queue_jobs} == {
@@ -358,3 +364,94 @@ async def test_dispatcher_skips_tick_when_prior_run_in_flight(
             # remains.
             assert len(runs) == 1
             assert runs[0].id == existing_run.id
+
+
+@pytest.mark.asyncio
+async def test_create_run_with_children_is_atomic(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crash mid-fanout rolls back the run row and every child row.
+
+    ``_create_run_with_children`` writes the ``lifecycle_eval_runs``
+    row, its ``summary``, every per-org ``queue_jobs`` child, and the
+    ``pending → in_progress`` transition inside a single
+    ``session.begin()`` block. If any child insert fails, the whole
+    transaction must roll back — leaving neither a partial run row
+    (which would wedge the next tick's ``has_non_terminal_run``
+    pre-flight) nor an orphan ``queue_jobs`` row (which would mislead
+    ``lifecycle_reaper``).
+
+    Simulated by stubbing ``QueueJobStore.create`` to raise on the
+    second per-org insert. The dispatcher's helper must propagate the
+    exception and leave the database exactly as it was before the
+    call.
+    """
+    async with db_session.begin():
+        await _seed_org(
+            db_session,
+            slug="org-a-atomic",
+            lifecycle_rules=_ORG_RULES,
+        )
+        await _seed_org(
+            db_session,
+            slug="org-b-atomic",
+            lifecycle_rules=_ORG_RULES,
+        )
+
+    class _BoomError(RuntimeError):
+        """Sentinel exception raised mid-fanout to trigger rollback."""
+
+    original_create = QueueJobStore.create
+    call_count = 0
+
+    async def _flaky_create(self: QueueJobStore, **kwargs: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            msg = "simulated mid-fanout crash"
+            raise _BoomError(msg)
+        return await original_create(self, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(QueueJobStore, "create", _flaky_create)
+
+    async for session in db_session_dependency():
+        run_store = LifecycleEvalRunStore(session=session, logger=_logger())
+        queue_job_store = QueueJobStore(session=session, logger=_logger())
+        org_store = OrganizationStore(session=session, logger=_logger())
+        async with session.begin():
+            orgs = await org_store.list_all()
+        assert len(orgs) == 2
+
+        with pytest.raises(_BoomError):
+            await _create_run_with_children(
+                session=session,
+                run_store=run_store,
+                queue_job_store=queue_job_store,
+                orgs=orgs,
+                orgs_skipped=0,
+            )
+
+    # The whole transaction must have rolled back: no runs row and no
+    # queue_jobs row should be visible from a fresh session.
+    async for session in db_session_dependency():
+        async with session.begin():
+            runs = (
+                (await session.execute(select(SqlLifecycleEvalRun)))
+                .scalars()
+                .all()
+            )
+            assert runs == []
+            queue_jobs = (
+                (
+                    await session.execute(
+                        select(SqlQueueJob).where(
+                            SqlQueueJob.kind == JobKind.lifecycle_eval.value
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert queue_jobs == []

--- a/tests/worker/lifecycle_eval_worker_settings_test.py
+++ b/tests/worker/lifecycle_eval_worker_settings_test.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from arq.cron import CronJob
 from arq.worker import Function
 
+from docverse.config import Configuration
 from docverse.worker.functions import lifecycle_eval, lifecycle_eval_dispatcher
 from docverse.worker.functions.lifecycle_eval_dispatcher import (
     LIFECYCLE_EVAL_QUEUE_NAME,
@@ -22,6 +23,8 @@ from docverse.worker.main import (
     shutdown,
     startup,
 )
+
+_config = Configuration()
 
 
 def _function_by_coroutine(coro: object) -> Function:
@@ -43,9 +46,19 @@ def test_lifecycle_eval_worker_settings_uses_dedicated_queue() -> None:
 
 
 def test_lifecycle_eval_worker_settings_registers_functions() -> None:
-    """Dispatcher and per-org worker are both registered, single-attempt."""
+    """Dispatcher and per-org worker are both registered, single-attempt.
+
+    Both are wrapped with :func:`arq.func` carrying the configured
+    per-job ``timeout`` so a runaway evaluator or wedged dispatcher
+    tick is cancelled by arq long before the cron-driven
+    ``lifecycle_reaper`` window — the timeout is the first
+    durability backstop and the reaper is the second.
+    """
     dispatcher = _function_by_coroutine(lifecycle_eval_dispatcher)
     per_org = _function_by_coroutine(lifecycle_eval)
+    expected_timeout = float(_config.lifecycle_eval_job_timeout_seconds)
+    assert dispatcher.timeout_s == expected_timeout
+    assert per_org.timeout_s == expected_timeout
     assert dispatcher.max_tries == 1
     assert per_org.max_tries == 1
 

--- a/tests/worker/lifecycle_eval_worker_settings_test.py
+++ b/tests/worker/lifecycle_eval_worker_settings_test.py
@@ -1,0 +1,81 @@
+"""Tests for the ``LifecycleEvalWorkerSettings`` arq config.
+
+Pins the contract operators rely on: the lifecycle queue is isolated
+from both the default queue and the keeper-sync queue, the dispatcher
+fires on an hourly cron, and the per-org worker is registered on the
+same dedicated pool so the dispatcher's enqueues actually run.
+"""
+
+from __future__ import annotations
+
+from arq.cron import CronJob
+from arq.worker import Function
+
+from docverse.worker.functions import lifecycle_eval, lifecycle_eval_dispatcher
+from docverse.worker.functions.lifecycle_eval_dispatcher import (
+    LIFECYCLE_EVAL_QUEUE_NAME,
+)
+from docverse.worker.main import (
+    KeeperSyncWorkerSettings,
+    LifecycleEvalWorkerSettings,
+    WorkerSettings,
+    shutdown,
+    startup,
+)
+
+
+def _function_by_coroutine(coro: object) -> Function:
+    for entry in LifecycleEvalWorkerSettings.functions:
+        if isinstance(entry, Function) and entry.coroutine is coro:
+            return entry
+    msg = f"No registered Function wraps {coro!r}"
+    raise AssertionError(msg)
+
+
+def test_lifecycle_eval_worker_settings_uses_dedicated_queue() -> None:
+    """The lifecycle queue is isolated from default and sync queues."""
+    assert LifecycleEvalWorkerSettings.queue_name == LIFECYCLE_EVAL_QUEUE_NAME
+    assert LifecycleEvalWorkerSettings.queue_name != WorkerSettings.queue_name
+    assert (
+        LifecycleEvalWorkerSettings.queue_name
+        != KeeperSyncWorkerSettings.queue_name
+    )
+
+
+def test_lifecycle_eval_worker_settings_registers_functions() -> None:
+    """Dispatcher and per-org worker are both registered, single-attempt."""
+    dispatcher = _function_by_coroutine(lifecycle_eval_dispatcher)
+    per_org = _function_by_coroutine(lifecycle_eval)
+    assert dispatcher.max_tries == 1
+    assert per_org.max_tries == 1
+
+
+def test_lifecycle_eval_worker_settings_share_lifecycle_hooks() -> None:
+    """All three WorkerSettings classes share startup/shutdown."""
+    assert LifecycleEvalWorkerSettings.on_startup is startup
+    assert LifecycleEvalWorkerSettings.on_shutdown is shutdown
+
+
+def test_lifecycle_eval_dispatcher_runs_hourly() -> None:
+    """The dispatcher cron fires at minute 0 of every hour."""
+    cron_jobs = list(getattr(LifecycleEvalWorkerSettings, "cron_jobs", []))
+    dispatcher_crons = [
+        job
+        for job in cron_jobs
+        if isinstance(job, CronJob)
+        and job.coroutine is lifecycle_eval_dispatcher
+    ]
+    assert len(dispatcher_crons) == 1
+    assert dispatcher_crons[0].minute == {0}
+
+
+def test_default_worker_does_not_register_lifecycle_functions() -> None:
+    """The default queue stays free of lifecycle work."""
+    default_coros: set[object] = set()
+    for entry in WorkerSettings.functions:
+        if isinstance(entry, Function):
+            default_coros.add(entry.coroutine)
+    assert lifecycle_eval not in WorkerSettings.functions
+    assert lifecycle_eval_dispatcher not in WorkerSettings.functions
+    assert lifecycle_eval not in default_coros
+    assert lifecycle_eval_dispatcher not in default_coros


### PR DESCRIPTION
## Summary

- Adds the cron-driven `lifecycle_eval_dispatcher` worker that fans out one `lifecycle_eval` job per in-scope org each hour, recording an aggregate `lifecycle_eval_runs` row with `orgs_enqueued` / `orgs_skipped` summary counts and a pre-flight skip for orgs with no rules anywhere.
- Wires a dedicated third arq worker pool (`LifecycleEvalWorkerSettings`, queue `docverse:lifecycle-queue`) isolated from the default and keeper-sync queues, registering both the dispatcher and the per-org worker with `max_tries=1` and an hourly dispatcher cron at minute 0.
- Adds the supporting storage primitives the dispatcher needs: `LifecycleEvalRunStore.set_summary` for the JSONB summary write, `ProjectStore.list_org_ids_with_lifecycle_rules` for the two-query pre-flight, and a new `lifecycle_eval_run_id` kwarg on `QueueJobStore.create` that mirrors the existing `keeper_sync_run_id` attribution path.

## Validation steps

- [ ] On a staging deployment with the new lifecycle worker pool running, seed one org with a `draft_inactivity` rule at org level, one org with rules only on a child project, and one org with no rules anywhere. Wait for (or trigger) the hourly cron and confirm: a new `lifecycle_eval_runs` row appears with `summary = {"orgs_enqueued": 2, "orgs_skipped": 1}`, two `queue_jobs` rows of `kind='lifecycle_eval'` are created (one per in-scope org, `subject_label = org.slug`), and the unconfigured org has no queue_jobs row.
- [ ] Confirm a second cron firing while the previous tick is still in-flight is skipped cleanly (worker log shows "Skipping lifecycle_eval dispatcher tick: a prior run is still in flight"; no second `lifecycle_eval_runs` row is created).
- [ ] Confirm the dispatcher's enqueued `lifecycle_eval` jobs land on `docverse:lifecycle-queue` and are picked up by the lifecycle worker Deployment — not by the default Deployment or the keeper-sync Deployment.
- [ ] Confirm an all-skipped tick (every org has no rules) still writes a `lifecycle_eval_runs` row, transitions it straight to `succeeded`, and records `summary.orgs_enqueued = 0` so the tick is auditable in run history.

## References

- Closes #354
- PRD: #337
- Jira: https://rubinobs.atlassian.net/browse/DM-54688