### PR TITLE
DM-54688: lifecycle_reaper cron + reaper threshold config

### DIFF
--- a/src/docverse/config.py
+++ b/src/docverse/config.py
@@ -179,6 +179,22 @@ class Configuration(BaseSettings):
         ),
     )
 
+    lifecycle_reaper_threshold_seconds: int = Field(
+        21600,
+        title="Lifecycle_eval stuck-run reaper threshold, in seconds",
+        description=(
+            "Cron-driven backstop for arq losing a ``lifecycle_eval``"
+            " per-org job (e.g. an OOM-killed worker pod)."
+            " ``lifecycle_reaper`` fails any ``kind='lifecycle_eval'``"
+            " ``queue_jobs`` row that has been ``in_progress`` longer"
+            " than this without ``date_completed``. Mirrors"
+            " ``keeper_sync_reaper_threshold_seconds`` so the operator"
+            " knob shape is identical across the two reapers; the"
+            " env-overridable default lets non-prod environments drive"
+            " the threshold down to seconds for fast verification."
+        ),
+    )
+
     superadmin_usernames: Annotated[
         list[str], BeforeValidator(_parse_comma_separated)
     ] = Field(

--- a/src/docverse/storage/queue_job_store.py
+++ b/src/docverse/storage/queue_job_store.py
@@ -517,6 +517,105 @@ class QueueJobStore:
             await self._session.flush()
         return failed
 
+    async def fail_silent_lifecycle_eval_jobs(
+        self,
+        *,
+        idle_after: timedelta,
+    ) -> list[QueueJob]:
+        """Fail ``lifecycle_eval`` rows stuck ``in_progress`` past the window.
+
+        ``lifecycle_reaper``'s silent-row sweep. Mirrors
+        :meth:`fail_silent_run_children` but scoped to
+        ``kind='lifecycle_eval'`` rather than the keeper-sync row's
+        ``keeper_sync_run_id IS NOT NULL`` filter, because the dispatcher
+        always writes a ``lifecycle_eval_run_id`` so the run attribution
+        is implied by ``kind`` alone. Rows that the worker actually
+        picked up but never finished (``status='in_progress'``,
+        ``date_completed IS NULL``, ``date_started`` older than
+        ``now - idle_after``) are reaped here; ``queued`` rows whose
+        worker crashed before arq enqueue go to
+        :meth:`fail_orphaned_lifecycle_eval_jobs`.
+
+        Reaped rows carry ``errors.type='SilentWorker'`` matching the
+        keeper-sync precedent so postmortem queries that group by
+        ``errors.type`` can compare the two subsystems on the same axis.
+        """
+        cutoff = datetime.now(tz=UTC) - idle_after
+        stmt = select(SqlQueueJob).where(
+            SqlQueueJob.kind == JobKind.lifecycle_eval.value,
+            SqlQueueJob.status == JobStatus.in_progress.value,
+            SqlQueueJob.date_completed.is_(None),
+            SqlQueueJob.date_started.is_not(None),
+            SqlQueueJob.date_started < cutoff,
+        )
+        result = await self._session.execute(stmt)
+        rows = list(result.scalars().all())
+        now = datetime.now(tz=UTC)
+        reaped: list[QueueJob] = []
+        for row in rows:
+            row.status = JobStatus.failed.value
+            row.date_completed = now
+            row.errors = {
+                "message": (
+                    "Reaped by lifecycle_reaper: worker went silent "
+                    "while job was in_progress (likely OOM-killed or "
+                    "lost by arq)"
+                ),
+                "type": "SilentWorker",
+            }
+            reaped.append(QueueJob.model_validate(row, from_attributes=True))
+        if reaped:
+            await self._session.flush()
+        return reaped
+
+    async def fail_orphaned_lifecycle_eval_jobs(
+        self,
+        *,
+        idle_after: timedelta,
+    ) -> list[QueueJob]:
+        """Fail ``lifecycle_eval`` rows that never reached arq.
+
+        ``lifecycle_reaper``'s orphan sweep. The dispatcher commits the
+        per-org ``queue_jobs`` row *before* calling ``arq_queue.enqueue``,
+        so a worker crash in that window leaves an orphan
+        (``status='queued'``, ``backend_job_id IS NULL``). Without
+        reconciliation the orphan would wedge the per-org mutex
+        ``idx_queue_jobs_lifecycle_eval_active_uq`` and block subsequent
+        dispatcher ticks from enqueueing fresh work for that org.
+
+        Scoped narrowly: ``kind='lifecycle_eval'``, ``status='queued'``,
+        ``backend_job_id IS NULL``, ``date_created`` older than
+        ``now - idle_after``. Reaped rows carry
+        ``errors.type='OrphanedQueueJob'`` matching the keeper-sync
+        precedent for run-attributed orphans.
+        """
+        cutoff = datetime.now(tz=UTC) - idle_after
+        stmt = select(SqlQueueJob).where(
+            SqlQueueJob.kind == JobKind.lifecycle_eval.value,
+            SqlQueueJob.status == JobStatus.queued.value,
+            SqlQueueJob.backend_job_id.is_(None),
+            SqlQueueJob.date_created < cutoff,
+        )
+        result = await self._session.execute(stmt)
+        rows = list(result.scalars().all())
+        now = datetime.now(tz=UTC)
+        failed: list[QueueJob] = []
+        for row in rows:
+            row.status = JobStatus.failed.value
+            row.date_completed = now
+            row.errors = {
+                "message": (
+                    "Orphaned lifecycle_eval: queue_jobs row committed "
+                    "without an arq backend_job_id (worker likely "
+                    "crashed between SQL commit and arq_queue.enqueue)"
+                ),
+                "type": "OrphanedQueueJob",
+            }
+            failed.append(QueueJob.model_validate(row, from_attributes=True))
+        if failed:
+            await self._session.flush()
+        return failed
+
     async def fail_orphaned_run_children(
         self,
         *,

--- a/src/docverse/worker/functions/__init__.py
+++ b/src/docverse/worker/functions/__init__.py
@@ -13,6 +13,7 @@ from .keeper_sync import (
 )
 from .lifecycle_eval import lifecycle_eval
 from .lifecycle_eval_dispatcher import lifecycle_eval_dispatcher
+from .lifecycle_reaper import lifecycle_reaper
 from .ping import ping
 from .publish_edition import publish_edition
 
@@ -28,6 +29,7 @@ __all__ = [
     "keeper_sync_tier_other",
     "lifecycle_eval",
     "lifecycle_eval_dispatcher",
+    "lifecycle_reaper",
     "ping",
     "publish_edition",
 ]

--- a/src/docverse/worker/functions/lifecycle_reaper.py
+++ b/src/docverse/worker/functions/lifecycle_reaper.py
@@ -1,0 +1,109 @@
+"""arq worker function for the ``lifecycle_reaper`` cron backstop.
+
+Mirrors :func:`docverse.worker.functions.keeper_sync.keeper_sync_reaper`
+for ``kind='lifecycle_eval'`` rows. Per the PRD (SQR-112 §"Reaper"),
+one wedged per-org evaluator must not block subsequent dispatcher
+ticks for that org indefinitely. The reaper sweeps stuck ``queue_jobs``
+rows and triggers ``maybe_finalise_lifecycle_run`` for each distinct
+parent run so an operator never sees a lifecycle_eval run stuck in
+``in_progress`` forever.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import structlog
+from safir.dependencies.db_session import db_session_dependency
+
+from docverse.config import config
+from docverse.services.lifecycle_finalisation import (
+    maybe_finalise_lifecycle_run,
+)
+
+__all__ = ["lifecycle_reaper"]
+
+
+# Window before a queued ``lifecycle_eval`` row with no ``backend_job_id``
+# is treated as orphaned. Matches ``keeper_sync.py``'s
+# :data:`_ORPHAN_IDLE_WINDOW` (5 min) so the staleness checks across the
+# two reapers stay aligned — long enough never to race a healthy
+# concurrent dispatcher mid-fanout, short enough to free a stuck mutex
+# on the next reaper tick.
+_ORPHAN_IDLE_WINDOW = timedelta(minutes=5)
+
+
+async def lifecycle_reaper(ctx: dict[str, Any]) -> str:
+    """Cron-driven backstop that finalises silently-stuck lifecycle_eval rows.
+
+    Mirrors :func:`docverse.worker.functions.keeper_sync.keeper_sync_reaper`'s
+    silent / orphan split for the lifecycle_eval subsystem. arq's
+    per-function ``timeout`` covers the common case (a job actually runs
+    past the timeout and arq cancels it), but a worker pod that's
+    OOM-killed mid-job or a job that arq itself loses leaves a per-org
+    ``queue_jobs`` row stuck in ``in_progress`` (or ``queued``, if the
+    dispatcher crashed between SQL commit and arq enqueue) — and with
+    it the parent ``lifecycle_eval_runs`` row, which can never finalise
+    while ``pending_count > 0``. The per-org mutex
+    ``idx_queue_jobs_lifecycle_eval_active_uq`` then blocks all
+    subsequent dispatcher ticks for that org.
+
+    Sweeps two populations in one transaction:
+
+    1. Silent rows
+       (:meth:`QueueJobStore.fail_silent_lifecycle_eval_jobs`) —
+       ``status='in_progress'`` past
+       ``config.lifecycle_reaper_threshold_seconds`` (default 6 h,
+       env-overridable for fast verification in non-prod).
+    2. Orphan rows
+       (:meth:`QueueJobStore.fail_orphaned_lifecycle_eval_jobs`) —
+       ``status='queued'`` with ``backend_job_id IS NULL`` past
+       :data:`_ORPHAN_IDLE_WINDOW` (5 min, matching the keeper-sync
+       orphan window).
+
+    After both sweeps run, :func:`maybe_finalise_lifecycle_run` is
+    invoked once per distinct ``lifecycle_eval_run_id`` seen across the
+    reaped rows so the parent aggregate row rolls to its terminal
+    status. Returns a one-line status string for arq's result log; the
+    structured ``logger.warning`` carries the detail when anything was
+    reaped.
+    """
+    logger = structlog.get_logger("docverse.worker.lifecycle_reaper")
+    threshold = timedelta(seconds=config.lifecycle_reaper_threshold_seconds)
+
+    async for session in db_session_dependency():
+        factory = ctx["factory_builder"](session=session, logger=logger)
+        queue_job_store = factory.create_queue_job_store()
+        run_store = factory.create_lifecycle_eval_run_store()
+
+        async with session.begin():
+            silent = await queue_job_store.fail_silent_lifecycle_eval_jobs(
+                idle_after=threshold
+            )
+            orphan = await queue_job_store.fail_orphaned_lifecycle_eval_jobs(
+                idle_after=_ORPHAN_IDLE_WINDOW
+            )
+            run_ids = {qj.lifecycle_eval_run_id for qj in (*silent, *orphan)}
+            for run_id in run_ids:
+                if run_id is None:
+                    continue
+                await maybe_finalise_lifecycle_run(
+                    run_store=run_store, run_id=run_id
+                )
+
+        total_reaped = len(silent) + len(orphan)
+        if total_reaped:
+            logger.warning(
+                "Reaped stuck lifecycle_eval queue jobs",
+                reaped_count=total_reaped,
+                silent_count=len(silent),
+                orphan_count=len(orphan),
+                run_ids=sorted(r for r in run_ids if r is not None),
+            )
+        else:
+            logger.debug("No stuck lifecycle_eval queue jobs to reap")
+        return "completed"
+
+    msg = "No database session available"
+    raise RuntimeError(msg)

--- a/tests/storage/queue_job_store_test.py
+++ b/tests/storage/queue_job_store_test.py
@@ -17,6 +17,7 @@ from docverse.client.models import (
 )
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.domain.queue import JobKind, JobStatus
 from docverse.exceptions import InvalidJobStateError
 from docverse.storage.edition_store import EditionStore
@@ -1332,3 +1333,198 @@ async def test_fail_orphaned_run_children_scoped_to_run(
         refetched = await store.get(orphan_b.id)
     assert refetched is not None
     assert refetched.status == JobStatus.queued
+
+
+# ---------------------------------------------------------------------
+# lifecycle_eval reaper helpers
+# ---------------------------------------------------------------------
+
+
+async def _seed_lifecycle_eval_row(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    status: JobStatus,
+    backend_job_id: str | None,
+    date_started: datetime | None = None,
+    date_created_offset: timedelta | None = None,
+) -> int:
+    """Insert one ``kind='lifecycle_eval'`` row with explicit timestamps.
+
+    The store's ``create`` does not expose ``lifecycle_eval_run_id`` (the
+    dispatcher sibling task adds that), and ``status`` defaults to
+    ``queued``. The reaper-helper tests drive every field that the
+    sweep predicates consult, so direct ``SqlQueueJob`` construction is
+    cleaner than threading two-step setup through ``create`` +
+    ``start``.
+    """
+    row = SqlQueueJob(
+        public_id=validate_base32_id(generate_base32_id()),
+        backend_job_id=backend_job_id,
+        kind=JobKind.lifecycle_eval.value,
+        status=status.value,
+        org_id=org_id,
+        date_started=date_started,
+    )
+    db_session.add(row)
+    await db_session.flush()
+    if date_created_offset is not None:
+        row.date_created = datetime.now(tz=UTC) - date_created_offset
+        await db_session.flush()
+    return row.id
+
+
+@pytest.mark.asyncio
+async def test_fail_silent_lifecycle_eval_jobs_reaps_old_in_progress(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """An ``in_progress`` lifecycle_eval row past the threshold is failed."""
+    async with db_session.begin():
+        org_id = await _seed_org_only(db_session, slug="lce-reap-1")
+        stuck_id = await _seed_lifecycle_eval_row(
+            db_session,
+            org_id=org_id,
+            status=JobStatus.in_progress,
+            backend_job_id="arq-lce-stuck",
+            date_started=datetime.now(tz=UTC) - timedelta(hours=10),
+        )
+
+        reaped = await store.fail_silent_lifecycle_eval_jobs(
+            idle_after=timedelta(hours=6)
+        )
+        await db_session.commit()
+
+    assert len(reaped) == 1
+    assert reaped[0].id == stuck_id
+    assert reaped[0].status == JobStatus.failed
+    assert reaped[0].errors is not None
+    assert reaped[0].errors["type"] == "SilentWorker"
+
+
+@pytest.mark.asyncio
+async def test_fail_silent_lifecycle_eval_jobs_skips_recent(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """An ``in_progress`` row within the idle window is left alone."""
+    async with db_session.begin():
+        org_id = await _seed_org_only(db_session, slug="lce-reap-2")
+        await _seed_lifecycle_eval_row(
+            db_session,
+            org_id=org_id,
+            status=JobStatus.in_progress,
+            backend_job_id="arq-lce-fresh",
+            date_started=datetime.now(tz=UTC),
+        )
+
+        reaped = await store.fail_silent_lifecycle_eval_jobs(
+            idle_after=timedelta(hours=6)
+        )
+        await db_session.commit()
+
+    assert reaped == []
+
+
+@pytest.mark.asyncio
+async def test_fail_silent_lifecycle_eval_jobs_skips_other_kinds(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """Other ``kind`` values stay out of scope, mirroring keeper-sync split."""
+    async with db_session.begin():
+        org_id = await _seed_org_only(db_session, slug="lce-reap-3")
+        unrelated = await store.create(
+            kind=JobKind.build_processing,
+            org_id=org_id,
+            backend_job_id="arq-build",
+        )
+        await store.start(unrelated.id)
+        row = await db_session.get(SqlQueueJob, unrelated.id)
+        assert row is not None
+        row.date_started = datetime.now(tz=UTC) - timedelta(hours=10)
+        await db_session.flush()
+
+        reaped = await store.fail_silent_lifecycle_eval_jobs(
+            idle_after=timedelta(hours=6)
+        )
+        await db_session.commit()
+
+    assert reaped == []
+
+
+@pytest.mark.asyncio
+async def test_fail_orphaned_lifecycle_eval_jobs_reaps_old_orphan(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """A ``queued`` lifecycle_eval row with no ``backend_job_id`` is failed."""
+    async with db_session.begin():
+        org_id = await _seed_org_only(db_session, slug="lce-orphan-1")
+        orphan_id = await _seed_lifecycle_eval_row(
+            db_session,
+            org_id=org_id,
+            status=JobStatus.queued,
+            backend_job_id=None,
+            date_created_offset=timedelta(minutes=10),
+        )
+
+        failed = await store.fail_orphaned_lifecycle_eval_jobs(
+            idle_after=timedelta(minutes=5)
+        )
+        await db_session.commit()
+
+    assert len(failed) == 1
+    assert failed[0].id == orphan_id
+    assert failed[0].status == JobStatus.failed
+    assert failed[0].errors is not None
+    assert failed[0].errors["type"] == "OrphanedQueueJob"
+
+
+@pytest.mark.asyncio
+async def test_fail_orphaned_lifecycle_eval_jobs_skips_rows_with_backend_id(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """A queued row that already has a backend_job_id is not an orphan."""
+    async with db_session.begin():
+        org_id = await _seed_org_only(db_session, slug="lce-orphan-2")
+        await _seed_lifecycle_eval_row(
+            db_session,
+            org_id=org_id,
+            status=JobStatus.queued,
+            backend_job_id="arq-lce-enqueued",
+            date_created_offset=timedelta(minutes=30),
+        )
+
+        failed = await store.fail_orphaned_lifecycle_eval_jobs(
+            idle_after=timedelta(minutes=5)
+        )
+        await db_session.commit()
+
+    assert failed == []
+
+
+@pytest.mark.asyncio
+async def test_fail_orphaned_lifecycle_eval_jobs_skips_started_rows(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """An ``in_progress`` row is not an orphan; silent sweep owns it."""
+    async with db_session.begin():
+        org_id = await _seed_org_only(db_session, slug="lce-orphan-3")
+        await _seed_lifecycle_eval_row(
+            db_session,
+            org_id=org_id,
+            status=JobStatus.in_progress,
+            backend_job_id=None,
+            date_started=datetime.now(tz=UTC) - timedelta(hours=1),
+            date_created_offset=timedelta(minutes=30),
+        )
+
+        failed = await store.fail_orphaned_lifecycle_eval_jobs(
+            idle_after=timedelta(minutes=5)
+        )
+        await db_session.commit()
+
+    assert failed == []

--- a/tests/worker/lifecycle_reaper_test.py
+++ b/tests/worker/lifecycle_reaper_test.py
@@ -1,0 +1,445 @@
+"""Tests for the ``lifecycle_reaper`` cron worker function.
+
+Mirrors :mod:`tests.worker.keeper_sync_reaper_test` for the
+lifecycle_eval subsystem. The reaper is the cron-driven backstop for
+the case where arq itself loses a ``lifecycle_eval`` per-org job — a
+worker pod OOM-killed mid-job that never gets to surface a timeout, or
+a dispatcher that crashed between the ``queue_jobs`` SQL commit and
+``arq_queue.enqueue``. It marks any silently-stuck child as ``failed``,
+sweeps orphan queued rows the dispatcher never finished enqueueing,
+and finalises the parent ``lifecycle_eval_runs`` row so an operator
+never sees a lifecycle run stuck in ``in_progress`` forever.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+import structlog
+from safir.arq import MockArqQueue
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import (
+    JobKind,
+    LifecycleEvalRunStatus,
+    OrganizationCreate,
+)
+from docverse.config import config as runtime_config
+from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
+from docverse.domain.queue import JobStatus
+from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.queue_job_store import QueueJobStore
+from docverse.worker.functions.lifecycle_reaper import lifecycle_reaper
+from tests.worker.conftest import make_worker_ctx
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org(db_session: AsyncSession, *, slug: str) -> tuple[int, str]:
+    org_store = OrganizationStore(session=db_session, logger=_logger())
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=slug,
+            title=f"LCR Org {slug}",
+            base_domain=f"{slug}.example.com",
+        )
+    )
+    return org.id, org.slug
+
+
+async def _seed_run(
+    db_session: AsyncSession,
+    *,
+    transition_to_in_progress: bool = True,
+) -> int:
+    """Create a ``lifecycle_eval_runs`` row, optionally bumped to in_progress.
+
+    The reaper acts on rows whose parent run is in any non-terminal
+    state; the dispatcher transitions ``pending → in_progress`` atomically
+    with its first child enqueue, so the realistic seed for a stuck
+    child is a run that has already moved to ``in_progress``.
+    """
+    run_store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+    run = await run_store.create()
+    if transition_to_in_progress:
+        await run_store.transition_status(
+            run_id=run.id, new_status=LifecycleEvalRunStatus.in_progress
+        )
+    return run.id
+
+
+async def _seed_silent_child(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    org_slug: str,
+    run_id: int,
+    backend_job_id: str,
+    started_minutes_ago: int,
+) -> int:
+    """Insert a ``kind='lifecycle_eval'`` row stuck in ``in_progress``.
+
+    Goes via direct ``SqlQueueJob`` insertion rather than
+    ``QueueJobStore.create`` because the store's ``create`` signature
+    does not expose ``lifecycle_eval_run_id`` (the dispatcher sibling
+    task will add that — for now the reaper test mirrors the test-seed
+    pattern already used in
+    :mod:`tests.worker.lifecycle_eval_test`).
+    """
+    row = SqlQueueJob(
+        public_id=validate_base32_id(generate_base32_id()),
+        backend_job_id=backend_job_id,
+        kind=JobKind.lifecycle_eval.value,
+        status=JobStatus.in_progress.value,
+        org_id=org_id,
+        lifecycle_eval_run_id=run_id,
+        subject_label=org_slug,
+        date_started=(
+            datetime.now(tz=UTC) - timedelta(minutes=started_minutes_ago)
+        ),
+    )
+    db_session.add(row)
+    await db_session.flush()
+    await db_session.refresh(row)
+    return row.id
+
+
+async def _seed_orphan_child(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    org_slug: str,
+    run_id: int,
+    created_minutes_ago: int,
+) -> int:
+    """Insert a ``kind='lifecycle_eval'`` orphan: queued, no backend_job_id."""
+    row = SqlQueueJob(
+        public_id=validate_base32_id(generate_base32_id()),
+        backend_job_id=None,
+        kind=JobKind.lifecycle_eval.value,
+        status=JobStatus.queued.value,
+        org_id=org_id,
+        lifecycle_eval_run_id=run_id,
+        subject_label=org_slug,
+    )
+    db_session.add(row)
+    await db_session.flush()
+    # ``date_created`` defaults to ``func.now()`` at the DB layer; backdate
+    # it on the row after flush so the reaper's ``date_created < cutoff``
+    # filter actually matches.
+    row.date_created = datetime.now(tz=UTC) - timedelta(
+        minutes=created_minutes_ago
+    )
+    await db_session.flush()
+    return row.id
+
+
+def _make_ctx(http_client: httpx.AsyncClient) -> dict[str, Any]:
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    return make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+
+@pytest.mark.asyncio
+async def test_reaper_fails_stuck_in_progress_and_finalises_run(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A stuck ``in_progress`` child rolls its parent to partial_failure."""
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, slug="lcr-1")
+        run_id = await _seed_run(db_session)
+        stuck_id = await _seed_silent_child(
+            db_session,
+            org_id=org_id,
+            org_slug=org_slug,
+            run_id=run_id,
+            backend_job_id="arq-stuck-1",
+            started_minutes_ago=600,
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        await lifecycle_reaper(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            qj_store = QueueJobStore(session=session, logger=_logger())
+            qj = await qj_store.get(stuck_id)
+            assert qj is not None
+            assert qj.status == JobStatus.failed
+            assert qj.errors is not None
+            assert qj.errors["type"] == "SilentWorker"
+            assert qj.date_completed is not None
+
+            run_store = LifecycleEvalRunStore(
+                session=session, logger=_logger()
+            )
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status is LifecycleEvalRunStatus.partial_failure
+            assert run.date_finished is not None
+
+
+@pytest.mark.asyncio
+async def test_reaper_skips_recent_in_progress_rows(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A child within the idle window leaves its parent run untouched."""
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, slug="lcr-2")
+        run_id = await _seed_run(db_session)
+        # Started just now — well within any sane idle window.
+        fresh_id = await _seed_silent_child(
+            db_session,
+            org_id=org_id,
+            org_slug=org_slug,
+            run_id=run_id,
+            backend_job_id="arq-fresh",
+            started_minutes_ago=0,
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        await lifecycle_reaper(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            qj_store = QueueJobStore(session=session, logger=_logger())
+            qj = await qj_store.get(fresh_id)
+            assert qj is not None
+            assert qj.status == JobStatus.in_progress
+
+            run_store = LifecycleEvalRunStore(
+                session=session, logger=_logger()
+            )
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status is LifecycleEvalRunStatus.in_progress
+
+
+@pytest.mark.asyncio
+async def test_reaper_sweeps_orphan_queued_rows(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A ``queued`` orphan past the idle window is reaped to ``failed``.
+
+    Models the dispatcher crash window: the per-org ``queue_jobs`` row
+    is committed before ``arq_queue.enqueue`` is called, so a worker
+    crash between those two operations leaves a row that no arq job
+    will ever pick up. Without the orphan sweep the per-org mutex
+    keeps observing the stale row and the next dispatcher tick can't
+    enqueue fresh work for that org.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, slug="lcr-3")
+        run_id = await _seed_run(db_session)
+        orphan_id = await _seed_orphan_child(
+            db_session,
+            org_id=org_id,
+            org_slug=org_slug,
+            run_id=run_id,
+            created_minutes_ago=10,
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        await lifecycle_reaper(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            qj_store = QueueJobStore(session=session, logger=_logger())
+            qj = await qj_store.get(orphan_id)
+            assert qj is not None
+            assert qj.status == JobStatus.failed
+            assert qj.errors is not None
+            assert qj.errors["type"] == "OrphanedQueueJob"
+
+            # Per-org mutex unblocked for this org: a fresh dispatcher
+            # tick can now enqueue another lifecycle_eval row.
+            active = await qj_store.has_active_for_subject(
+                org_id=org_id,
+                kind=JobKind.lifecycle_eval,
+                subject_label=org_slug,
+            )
+            assert active is False
+
+            run_store = LifecycleEvalRunStore(
+                session=session, logger=_logger()
+            )
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status is LifecycleEvalRunStatus.partial_failure
+
+
+@pytest.mark.asyncio
+async def test_reaper_finalises_each_distinct_parent_run(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """Stuck children on multiple runs each trigger their own finalisation.
+
+    The reaper collects ``lifecycle_eval_run_id`` across every reaped
+    row and calls ``maybe_finalise_lifecycle_run`` once per distinct
+    parent. Two separate non-terminal runs cannot coexist (the partial
+    unique index on ``lifecycle_eval_runs`` forbids it), so we drive
+    one stuck child through the reaper, observe its parent rolling to
+    a terminal state, then seed a second run + stuck child and observe
+    the same outcome — verifying the reaper does not lazily memoise
+    the first run's id across invocations.
+    """
+    async with db_session.begin():
+        org_a_id, org_a_slug = await _seed_org(db_session, slug="lcr-4a")
+        run_a_id = await _seed_run(db_session)
+        await _seed_silent_child(
+            db_session,
+            org_id=org_a_id,
+            org_slug=org_a_slug,
+            run_id=run_a_id,
+            backend_job_id="arq-stuck-a",
+            started_minutes_ago=600,
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        await lifecycle_reaper(ctx)
+
+        async for session in db_session_dependency():
+            async with session.begin():
+                run_store = LifecycleEvalRunStore(
+                    session=session, logger=_logger()
+                )
+                run_a = await run_store.get(run_a_id)
+                assert run_a is not None
+                assert run_a.status is LifecycleEvalRunStatus.partial_failure
+
+        async for session in db_session_dependency():
+            async with session.begin():
+                org_b_id, org_b_slug = await _seed_org(session, slug="lcr-4b")
+                run_b_id = await _seed_run(session)
+                await _seed_silent_child(
+                    session,
+                    org_id=org_b_id,
+                    org_slug=org_b_slug,
+                    run_id=run_b_id,
+                    backend_job_id="arq-stuck-b",
+                    started_minutes_ago=600,
+                )
+
+        await lifecycle_reaper(ctx)
+
+        async for session in db_session_dependency():
+            async with session.begin():
+                run_store = LifecycleEvalRunStore(
+                    session=session, logger=_logger()
+                )
+                run_b = await run_store.get(run_b_id)
+                assert run_b is not None
+                assert run_b.status is LifecycleEvalRunStatus.partial_failure
+    finally:
+        await ctx["http_client"].aclose()
+
+
+@pytest.mark.asyncio
+async def test_reaper_no_op_when_nothing_stuck(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A clean tick with nothing to reap returns ``completed`` without error.
+
+    The dispatcher's empty-orgs branch and the steady-state happy path
+    both produce ticks where the reaper finds zero candidate rows.
+    The function must return cleanly with no side effects.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, slug="lcr-5")
+        run_id = await _seed_run(db_session)
+        # One child within the idle window — nothing to reap.
+        fresh_id = await _seed_silent_child(
+            db_session,
+            org_id=org_id,
+            org_slug=org_slug,
+            run_id=run_id,
+            backend_job_id="arq-clean",
+            started_minutes_ago=0,
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        result = await lifecycle_reaper(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            qj_store = QueueJobStore(session=session, logger=_logger())
+            qj = await qj_store.get(fresh_id)
+            assert qj is not None
+            assert qj.status == JobStatus.in_progress
+
+
+@pytest.mark.asyncio
+async def test_reaper_threshold_is_configurable(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reducing the threshold shrinks the silent window.
+
+    Operators in non-prod set ``DOCVERSE_LIFECYCLE_REAPER_THRESHOLD_
+    SECONDS`` to a small value so a deliberately-wedged job surfaces
+    in seconds rather than the production-default 6 hours. The reaper
+    must observe the configured value at invocation time rather than
+    a baked-in default.
+    """
+    monkeypatch.setattr(
+        runtime_config, "lifecycle_reaper_threshold_seconds", 60
+    )
+
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, slug="lcr-6")
+        run_id = await _seed_run(db_session)
+        stuck_id = await _seed_silent_child(
+            db_session,
+            org_id=org_id,
+            org_slug=org_slug,
+            run_id=run_id,
+            backend_job_id="arq-shortwindow",
+            started_minutes_ago=5,
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        await lifecycle_reaper(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            qj_store = QueueJobStore(session=session, logger=_logger())
+            qj = await qj_store.get(stuck_id)
+            assert qj is not None
+            assert qj.status == JobStatus.failed


### PR DESCRIPTION
## Summary

- Adds the `lifecycle_reaper` arq cron-driven backstop that sweeps `kind='lifecycle_eval'` `queue_jobs` rows stuck in `queued` / `in_progress` past the configured threshold, marks them `failed`, and calls `maybe_finalise_lifecycle_run` for each distinct parent run so a wedged per-org evaluator can't block subsequent dispatcher ticks for that org indefinitely.
- Mirrors `keeper_sync_reaper`'s silent vs orphan split: silent sweep (`fail_silent_lifecycle_eval_jobs`) uses the new `lifecycle_reaper_threshold_seconds` config (default 6h, env-overridable for non-prod fast verification); orphan sweep (`fail_orphaned_lifecycle_eval_jobs`) uses a 5-min idle window matching the keeper-sync orphan-window precedent.
- The reaper is callable directly today; the sibling dispatcher task (#354) creates the new `LifecycleEvalWorkerSettings` and will wire `cron(lifecycle_reaper, minute={0, 30})` plus `lifecycle_reaper` in its `functions` list.

## Validation steps

- [ ] Run the integration test suite and confirm `tests/worker/lifecycle_reaper_test.py` and the new `fail_silent_lifecycle_eval_jobs` / `fail_orphaned_lifecycle_eval_jobs` cases in `tests/storage/queue_job_store_test.py` all pass against a real testcontainers Postgres.
- [ ] Seed a `lifecycle_eval` `queue_jobs` row with `status='in_progress'` and `date_started` 7+ hours in the past (production threshold default 6h), invoke `lifecycle_reaper(ctx)` directly, and confirm the row transitions to `failed` with `errors.type='SilentWorker'` and the parent `lifecycle_eval_runs` row finalises to `partial_failure`.
- [ ] Seed a `queued` `lifecycle_eval` row with `backend_job_id IS NULL` and `date_created` 10+ minutes in the past (orphan window 5 min), invoke the reaper, and confirm the row transitions to `failed` with `errors.type='OrphanedQueueJob'` and the per-org mutex (`idx_queue_jobs_lifecycle_eval_active_uq`) unblocks the next dispatcher tick for that org.
- [ ] Override `DOCVERSE_LIFECYCLE_REAPER_THRESHOLD_SECONDS=60` in a non-prod env and confirm a deliberately-wedged `in_progress` row is reaped after one minute rather than the default six hours.

## References

- Closes #355
- PRD: #337
- Jira: https://rubinobs.atlassian.net/browse/DM-54688