### PR TITLE
DM-54688: LifecycleWorkerSettings arq pool wiring

### DIFF
--- a/src/docverse/handlers/orgs/editions.py
+++ b/src/docverse/handlers/orgs/editions.py
@@ -356,6 +356,18 @@ async def delete_edition(
     # read service config + credentials) — without an explicit
     # transaction SQLAlchemy auto-begins an implicit one that would
     # then conflict with the dashboard enqueue's own ``session.begin()``.
+    #
+    # Failure semantics: if ``unpublish`` raises, the soft-delete is
+    # already committed and is not rolled back — the client sees a 5xx
+    # but the edition row stays soft-deleted, and the dashboard rebuild
+    # below is skipped because the exception unwinds before reaching it.
+    # The stale CDN pointer is then cleaned up on the next lifecycle
+    # pass (``unpublish`` is idempotent, so re-running is safe). This is
+    # the opposite of the lifecycle worker, which runs ``unpublish``
+    # inside the DB transaction so a CDN failure rolls back the batch;
+    # the asymmetry is deliberate because the handler path is driven by
+    # a single user action with no automatic retry, while the worker
+    # path is re-driven on every dispatcher tick.
     async with context.session.begin():
         publishing_service = (
             context.factory.create_edition_publishing_service()

--- a/src/docverse/handlers/orgs/editions.py
+++ b/src/docverse/handlers/orgs/editions.py
@@ -342,12 +342,29 @@ async def delete_edition(
         raise PermissionDeniedError(msg)
     async with context.session.begin():
         service = context.factory.create_edition_service()
-        await service.soft_delete(
+        org = await service.soft_delete(
             org_slug=org_slug,
             project_slug=project_slug,
             slug=edition_slug,
         )
         await context.session.commit()
+    # Remove the CDN pointer after the soft-delete commit so the public
+    # URL stops resolving once the row is gone. ``unpublish`` is
+    # idempotent and a no-op for orgs without a configured CDN, so it
+    # can be called unconditionally. Wrapped in its own ``begin()``
+    # block because the publishing service reads the org row (and may
+    # read service config + credentials) — without an explicit
+    # transaction SQLAlchemy auto-begins an implicit one that would
+    # then conflict with the dashboard enqueue's own ``session.begin()``.
+    async with context.session.begin():
+        publishing_service = (
+            context.factory.create_edition_publishing_service()
+        )
+        await publishing_service.unpublish(
+            org_id=org.id,
+            project_slug=project_slug,
+            edition_slug=edition_slug,
+        )
     await try_enqueue_dashboard_build_by_slug(
         factory=context.factory,
         session=context.session,

--- a/src/docverse/services/edition.py
+++ b/src/docverse/services/edition.py
@@ -432,15 +432,19 @@ class EditionService:
 
     async def soft_delete(
         self, *, org_slug: str, project_slug: str, slug: str
-    ) -> None:
+    ) -> Organization:
         """Soft-delete an edition.
+
+        Returns the resolved :class:`Organization` so the caller can
+        invoke downstream side-effects (e.g. CDN unpublish) keyed on
+        ``org_id`` without re-resolving the slug.
 
         Raises
         ------
         NotFoundError
             If the edition is not found.
         """
-        _, project = await self._resolve_org_project(org_slug, project_slug)
+        org, project = await self._resolve_org_project(org_slug, project_slug)
         deleted = await self._store.soft_delete(
             project_id=project.id, slug=slug
         )
@@ -453,3 +457,4 @@ class EditionService:
             org=org_slug,
             project=project_slug,
         )
+        return org

--- a/src/docverse/services/edition_publishing.py
+++ b/src/docverse/services/edition_publishing.py
@@ -123,6 +123,62 @@ class EditionPublishingService:
             cdn_service_label=org.cdn_service_label,
         )
 
+    async def unpublish(
+        self,
+        *,
+        org_id: int,
+        project_slug: str,
+        edition_slug: str,
+    ) -> None:
+        """Remove an edition pointer via the org's configured CDN.
+
+        Mirrors :meth:`publish`'s resolver: loads the org, checks for a
+        configured ``cdn_service_label``, resolves the publisher via
+        ``publisher_provider``, and calls ``unpublish`` inside its async
+        context. If the org has no CDN configured the call is a no-op so
+        callers can invoke ``unpublish`` unconditionally without first
+        inspecting the org row.
+
+        The underlying publisher's ``unpublish`` is required to be
+        idempotent (e.g. Cloudflare KV treats a 404 as success), so this
+        method is safe to call against editions that were never
+        published.
+
+        Raises
+        ------
+        RuntimeError
+            If the organization cannot be found.
+        """
+        org = await self._org_store.get_by_id(org_id)
+        if org is None:
+            msg = f"Organization id={org_id} not found"
+            raise RuntimeError(msg)
+
+        if org.cdn_service_label is None:
+            self._logger.info(
+                "Edition unpublish skipped (no cdn_service_label)",
+                org_id=org_id,
+                project_slug=project_slug,
+                edition_slug=edition_slug,
+            )
+            return
+
+        publisher = await self._publisher_provider(
+            org_id=org_id, service_label=org.cdn_service_label
+        )
+        async with publisher:
+            await publisher.unpublish(
+                project_slug=project_slug,
+                edition_slug=edition_slug,
+            )
+        self._logger.info(
+            "Unpublished edition",
+            org_id=org_id,
+            project_slug=project_slug,
+            edition_slug=edition_slug,
+            cdn_service_label=org.cdn_service_label,
+        )
+
     async def _mark_published(
         self, *, edition_id: int, history_id: int
     ) -> None:

--- a/src/docverse/storage/editionpublisher/__init__.py
+++ b/src/docverse/storage/editionpublisher/__init__.py
@@ -2,7 +2,7 @@
 
 from ._cloudflare_kv import CloudflareKvEditionPublisher
 from ._factory import create_edition_publisher
-from ._mock import MockEditionPublisher, PublishCall
+from ._mock import MockEditionPublisher, PublishCall, UnpublishCall
 from ._protocol import EditionPublisher
 
 __all__ = [
@@ -10,5 +10,6 @@ __all__ = [
     "EditionPublisher",
     "MockEditionPublisher",
     "PublishCall",
+    "UnpublishCall",
     "create_edition_publisher",
 ]

--- a/src/docverse/storage/editionpublisher/_cloudflare_kv.py
+++ b/src/docverse/storage/editionpublisher/_cloudflare_kv.py
@@ -10,6 +10,8 @@ import structlog
 
 __all__ = ["CloudflareKvEditionPublisher"]
 
+_HTTP_NOT_FOUND = 404
+
 
 class CloudflareKvEditionPublisher:
     """Edition publisher that writes to a Cloudflare Workers KV namespace.
@@ -74,6 +76,46 @@ class CloudflareKvEditionPublisher:
         if response.is_error:
             self._logger.error(
                 "Cloudflare KV publish failed",
+                status_code=response.status_code,
+                response_body=response.text,
+                project_slug=project_slug,
+                edition_slug=edition_slug,
+            )
+        response.raise_for_status()
+
+    async def unpublish(
+        self,
+        *,
+        project_slug: str,
+        edition_slug: str,
+    ) -> None:
+        """Remove the edition pointer from the configured KV namespace.
+
+        A 404 from Cloudflare is treated as a successful no-op so the
+        operation is idempotent — soft-deleting an edition whose pointer
+        was never published, or running cleanup twice, must not surface
+        as a failure to the caller.
+        """
+        url = (
+            "https://api.cloudflare.com/client/v4"
+            f"/accounts/{self._account_id}"
+            f"/storage/kv/namespaces/{self._namespace_id}"
+            f"/values/{project_slug}/{edition_slug}"
+        )
+        response = await self._http_client.delete(
+            url,
+            headers={"Authorization": f"Bearer {self._api_token}"},
+        )
+        if response.status_code == _HTTP_NOT_FOUND:
+            self._logger.info(
+                "Cloudflare KV unpublish: key not found (idempotent)",
+                project_slug=project_slug,
+                edition_slug=edition_slug,
+            )
+            return
+        if response.is_error:
+            self._logger.error(
+                "Cloudflare KV unpublish failed",
                 status_code=response.status_code,
                 response_body=response.text,
                 project_slug=project_slug,

--- a/src/docverse/storage/editionpublisher/_mock.py
+++ b/src/docverse/storage/editionpublisher/_mock.py
@@ -8,7 +8,7 @@ from typing import Self
 
 import structlog
 
-__all__ = ["MockEditionPublisher", "PublishCall"]
+__all__ = ["MockEditionPublisher", "PublishCall", "UnpublishCall"]
 
 
 @dataclass(frozen=True)
@@ -21,11 +21,19 @@ class PublishCall:
     object_key_prefix: str
 
 
+@dataclass(frozen=True)
+class UnpublishCall:
+    """A single recorded call to ``MockEditionPublisher.unpublish``."""
+
+    project_slug: str
+    edition_slug: str
+
+
 class MockEditionPublisher:
     """In-memory implementation of the ``EditionPublisher`` protocol.
 
-    Records every call to ``publish`` in order so tests can assert
-    against the recorded arguments.
+    Records every call to ``publish`` and ``unpublish`` in order so
+    tests can assert against the recorded arguments.
     """
 
     def __init__(
@@ -34,6 +42,7 @@ class MockEditionPublisher:
         logger: structlog.stdlib.BoundLogger | None = None,  # noqa: ARG002
     ) -> None:
         self._calls: list[PublishCall] = []
+        self._unpublish_calls: list[UnpublishCall] = []
 
     async def __aenter__(self) -> Self:
         return self
@@ -51,6 +60,11 @@ class MockEditionPublisher:
         """Recorded publish calls in order."""
         return list(self._calls)
 
+    @property
+    def unpublish_calls(self) -> list[UnpublishCall]:
+        """Recorded unpublish calls in order."""
+        return list(self._unpublish_calls)
+
     async def publish(
         self,
         *,
@@ -66,5 +80,19 @@ class MockEditionPublisher:
                 edition_slug=edition_slug,
                 build_public_id=build_public_id,
                 object_key_prefix=object_key_prefix,
+            )
+        )
+
+    async def unpublish(
+        self,
+        *,
+        project_slug: str,
+        edition_slug: str,
+    ) -> None:
+        """Record an unpublish call."""
+        self._unpublish_calls.append(
+            UnpublishCall(
+                project_slug=project_slug,
+                edition_slug=edition_slug,
             )
         )

--- a/src/docverse/storage/editionpublisher/_protocol.py
+++ b/src/docverse/storage/editionpublisher/_protocol.py
@@ -52,3 +52,24 @@ class EditionPublisher(Protocol):
             (e.g. an R2 or S3 prefix).
         """
         ...
+
+    async def unpublish(
+        self,
+        *,
+        project_slug: str,
+        edition_slug: str,
+    ) -> None:
+        """Remove an edition pointer from the backing store.
+
+        Implementations must be idempotent: a call against an edition
+        that has no pointer (or one that was already removed) must
+        succeed without raising.
+
+        Parameters
+        ----------
+        project_slug
+            Slug of the project the edition belongs to.
+        edition_slug
+            Slug of the edition whose pointer should be removed.
+        """
+        ...

--- a/src/docverse/worker/functions/lifecycle_eval.py
+++ b/src/docverse/worker/functions/lifecycle_eval.py
@@ -38,6 +38,9 @@ from docverse.domain.edition_build_history import EditionBuildHistory
 from docverse.domain.lifecycle import LifecycleRule, LifecycleRuleSet
 from docverse.domain.project import Project
 from docverse.factory import Factory
+from docverse.services.dashboard.enqueue import (
+    try_enqueue_dashboard_build_by_slug,
+)
 from docverse.services.lifecycle.evaluator import (
     LifecycleDecision,
     evaluate_lifecycle,
@@ -183,12 +186,13 @@ async def _evaluate_org(
 
     edition_index = _index_editions_by_id(editions_by_project)
     build_index = _index_builds_by_id(builds_by_project)
+    projects_with_edition_deletes: list[str] = []
 
     async with session.begin():
         edition_store = factory.create_edition_store()
         build_store = factory.create_build_store()
         for project, rule_set, decision in decisions:
-            await _apply_decision(
+            editions_deleted = await _apply_decision(
                 edition_store=edition_store,
                 build_store=build_store,
                 project=project,
@@ -200,6 +204,24 @@ async def _evaluate_org(
                 org_slug=org_slug,
                 logger=logger,
             )
+            if editions_deleted:
+                projects_with_edition_deletes.append(project.slug)
+
+    # Refresh the cached dashboard artifact for each project whose
+    # edition list actually shrank. Runs after the soft-delete commit
+    # boundary so the helper opens its own transaction, matching the
+    # user-initiated DELETE handler. Build-only deletions are skipped:
+    # the cached dashboard renders from the edition list, not the build
+    # list, so soft-deleting an orphan build would not change the
+    # rendered output and a rebuild would be wasted work.
+    for project_slug in projects_with_edition_deletes:
+        await try_enqueue_dashboard_build_by_slug(
+            factory=factory,
+            session=session,
+            logger=logger,
+            org_slug=org_slug,
+            project_slug=project_slug,
+        )
 
 
 async def _load_org_state(
@@ -297,7 +319,7 @@ async def _apply_decision(  # noqa: PLR0913
     org_id: int,
     org_slug: str,
     logger: structlog.stdlib.BoundLogger,
-) -> None:
+) -> int:
     """Soft-delete every entity the decision matched and emit one log per row.
 
     The structured log line is the v1 audit trail (persistent
@@ -310,10 +332,17 @@ async def _apply_decision(  # noqa: PLR0913
     without code changes here), and the rule's resolved parameter
     dict so an operator can audit *why* a row was deleted from logs
     alone.
+
+    Returns the number of editions that actually transitioned to
+    soft-deleted in this call so the caller can decide whether a
+    dashboard rebuild is warranted. Build soft-deletes are not
+    counted: the cached dashboard renders from the edition list, not
+    the build list.
     """
     rules_by_type: dict[str, LifecycleRule] = {
         rule.type: rule for rule in rule_set.root
     }
+    editions_deleted = 0
     for edition_id in sorted(decision.edition_matches):
         edition = edition_index.get(edition_id)
         if edition is None:
@@ -325,6 +354,7 @@ async def _apply_decision(  # noqa: PLR0913
         )
         if not deleted:
             continue
+        editions_deleted += 1
         logger.info(
             "Soft-deleted entity by lifecycle rule",
             entity_type="edition",
@@ -361,3 +391,4 @@ async def _apply_decision(  # noqa: PLR0913
                 rule.model_dump(exclude={"type"}) if rule is not None else None
             ),
         )
+    return editions_deleted

--- a/src/docverse/worker/functions/lifecycle_eval.py
+++ b/src/docverse/worker/functions/lifecycle_eval.py
@@ -41,6 +41,7 @@ from docverse.factory import Factory
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_slug,
 )
+from docverse.services.edition_publishing import EditionPublishingService
 from docverse.services.lifecycle.evaluator import (
     LifecycleDecision,
     evaluate_lifecycle,
@@ -191,10 +192,12 @@ async def _evaluate_org(
     async with session.begin():
         edition_store = factory.create_edition_store()
         build_store = factory.create_build_store()
+        publishing_service = factory.create_edition_publishing_service()
         for project, rule_set, decision in decisions:
             editions_deleted = await _apply_decision(
                 edition_store=edition_store,
                 build_store=build_store,
+                publishing_service=publishing_service,
                 project=project,
                 rule_set=rule_set,
                 decision=decision,
@@ -311,6 +314,7 @@ async def _apply_decision(  # noqa: PLR0913
     *,
     edition_store: EditionStore,
     build_store: BuildStore,
+    publishing_service: EditionPublishingService,
     project: Project,
     rule_set: LifecycleRuleSet,
     decision: LifecycleDecision,
@@ -355,6 +359,17 @@ async def _apply_decision(  # noqa: PLR0913
         if not deleted:
             continue
         editions_deleted += 1
+        # Remove the CDN pointer for the soft-deleted edition so the
+        # public URL stops resolving. ``unpublish`` is idempotent and a
+        # no-op when the org has no CDN configured, so this is safe to
+        # call unconditionally. A failure here propagates and rolls back
+        # the soft-deletes in this batch; the next dispatcher tick will
+        # re-evaluate from a consistent state.
+        await publishing_service.unpublish(
+            org_id=org_id,
+            project_slug=project.slug,
+            edition_slug=edition.slug,
+        )
         logger.info(
             "Soft-deleted entity by lifecycle rule",
             entity_type="edition",

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -44,6 +44,7 @@ from .functions import (
     keeper_sync_tier_other,
     lifecycle_eval,
     lifecycle_eval_dispatcher,
+    lifecycle_reaper,
     ping,
     publish_edition,
 )
@@ -368,12 +369,10 @@ class LifecycleEvalWorkerSettings:
     row finalises via :func:`maybe_finalise_lifecycle_run` — arq's
     default 5-attempt retry would otherwise delay finalisation and
     obscure the underlying error in logs. The cron-driven
-    ``lifecycle_reaper`` (sibling task) is the second backstop for
-    the case where arq itself loses a job and no timeout ever fires.
-
-    The hourly dispatcher cron is registered here; the
-    ``lifecycle_reaper`` cron (sibling task) will be appended to this
-    class's ``cron_jobs`` list when it lands.
+    ``lifecycle_reaper`` is the second backstop for the case where
+    arq itself loses a job and no timeout ever fires; it runs every
+    30 minutes so a wedged child is unblocked on the same cadence as
+    the keeper-sync reaper.
     """
 
     functions = [
@@ -387,11 +386,16 @@ class LifecycleEvalWorkerSettings:
             timeout=config.lifecycle_eval_job_timeout_seconds,
             max_tries=1,
         ),
+        lifecycle_reaper,
     ]
     cron_jobs = [
         cron(
             lifecycle_eval_dispatcher,
             minute={0},
+        ),
+        cron(
+            lifecycle_reaper,
+            minute={0, 30},
         ),
     ]
     redis_settings = config.arq_redis_settings

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -7,16 +7,24 @@ import re
 import pytest
 import structlog
 from httpx import AsyncClient
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import BuildCreate
 from docverse.client.models.builds import BuildAnnotations
+from docverse.dbschema.organization import SqlOrganization
 from docverse.domain.base32id import serialize_base32_id
+from docverse.factory import Factory
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
 )
 from docverse.storage.edition_store import EditionStore
+from docverse.storage.editionpublisher import (
+    EditionPublisher,
+    MockEditionPublisher,
+)
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from tests.conftest import seed_org_with_admin
@@ -176,6 +184,66 @@ async def test_delete_edition(client: AsyncClient) -> None:
         headers={"X-Auth-Request-User": "testuser"},
     )
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_edition_unpublishes_from_cdn(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DELETE handler removes the CDN pointer after the soft-delete commit.
+
+    Seeds an org with a ``cdn_service_label`` so the publishing service
+    resolves a publisher (rather than no-opping), patches the factory to
+    return a ``MockEditionPublisher``, then asserts the mock recorded
+    exactly one ``unpublish`` call keyed on the deleted edition's slug.
+    """
+    await _setup(client)
+    # Configure a CDN service label on the seeded org so unpublish is
+    # not skipped as a no-op.
+    async for session in db_session_dependency():
+        async with session.begin():
+            await session.execute(
+                update(SqlOrganization)
+                .where(SqlOrganization.slug == "ed-org")
+                .values(cdn_service_label="cdn-prod")
+            )
+            await session.commit()
+
+    await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "cdn-del",
+            "title": "CDN Delete",
+            "kind": "draft",
+            "tracking_mode": "git_ref",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+
+    mock_publisher = MockEditionPublisher()
+
+    async def _create(
+        self: Factory,
+        *,
+        org_id: int,
+        service_label: str,
+    ) -> EditionPublisher:
+        _ = (self, org_id, service_label)
+        return mock_publisher
+
+    monkeypatch.setattr(Factory, "create_edition_publisher_for_org", _create)
+
+    response = await client.delete(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions/cdn-del",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 204
+
+    assert len(mock_publisher.unpublish_calls) == 1
+    call = mock_publisher.unpublish_calls[0]
+    assert call.project_slug == "ed-proj"
+    assert call.edition_slug == "cdn-del"
 
 
 @pytest.mark.asyncio

--- a/tests/services/edition_publishing_test.py
+++ b/tests/services/edition_publishing_test.py
@@ -68,6 +68,15 @@ class _FailingPublisher:
         _ = (project_slug, edition_slug, build_public_id, object_key_prefix)
         raise self._exc
 
+    async def unpublish(
+        self,
+        *,
+        project_slug: str,
+        edition_slug: str,
+    ) -> None:
+        _ = (project_slug, edition_slug)
+        raise self._exc
+
 
 def _logger() -> structlog.stdlib.BoundLogger:
     return structlog.get_logger("docverse")  # type: ignore[no-any-return]
@@ -237,6 +246,51 @@ async def test_publish_failure_propagates_and_leaves_status_unchanged(
         assert refreshed.publish_status is None
         refreshed_history = await _fetch_history(db_session, edition.id)
         assert refreshed_history.publish_status is None
+
+
+@pytest.mark.asyncio
+async def test_unpublish_no_cdn_is_a_noop(
+    db_session: AsyncSession,
+) -> None:
+    """Org with cdn_service_label=None: unpublish does not call publisher."""
+    service = _make_service(db_session, provider_raises=True)
+    async with db_session.begin():
+        org_id, edition, _build, _history_entry = await _setup(
+            db_session, org_slug="no-cdn-unpub-org"
+        )
+        # Must not raise even though provider would AssertionError if called.
+        await service.unpublish(
+            org_id=org_id,
+            project_slug=_PROJECT_SLUG,
+            edition_slug=edition.slug,
+        )
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_unpublish_calls_publisher_when_cdn_configured(
+    db_session: AsyncSession,
+) -> None:
+    """Configured CDN: unpublish records one call on the mock publisher."""
+    mock_publisher = MockEditionPublisher()
+    service = _make_service(db_session, publisher=mock_publisher)
+    async with db_session.begin():
+        org_id, edition, _build, _history_entry = await _setup(
+            db_session,
+            org_slug="cdn-unpub-org",
+            cdn_service_label="cdn-prod",
+        )
+        await service.unpublish(
+            org_id=org_id,
+            project_slug=_PROJECT_SLUG,
+            edition_slug=edition.slug,
+        )
+        await db_session.commit()
+
+    assert len(mock_publisher.unpublish_calls) == 1
+    call = mock_publisher.unpublish_calls[0]
+    assert call.project_slug == _PROJECT_SLUG
+    assert call.edition_slug == edition.slug
 
 
 @pytest.mark.asyncio

--- a/tests/storage/editionpublisher/cloudflare_kv_test.py
+++ b/tests/storage/editionpublisher/cloudflare_kv_test.py
@@ -91,3 +91,56 @@ async def test_publish_raises_on_5xx() -> None:
                 build_public_id="B",
                 object_key_prefix="p/__builds/B/",
             )
+
+
+@pytest.mark.asyncio
+async def test_unpublish_issues_delete_to_kv_endpoint() -> None:
+    seen: dict[str, httpx.Request] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["request"] = request
+        return httpx.Response(200, json={"success": True})
+
+    publisher, client = _make_publisher(httpx.MockTransport(handler))
+    async with client, publisher as pub:
+        await pub.unpublish(
+            project_slug="myproject",
+            edition_slug="main",
+        )
+
+    request = seen["request"]
+    assert request.method == "DELETE"
+    assert str(request.url) == (
+        "https://api.cloudflare.com/client/v4"
+        "/accounts/acct-123"
+        "/storage/kv/namespaces/ns-456"
+        "/values/myproject/main"
+    )
+    assert request.headers["Authorization"] == "Bearer token-789"
+
+
+@pytest.mark.asyncio
+async def test_unpublish_treats_404_as_success() -> None:
+    """A missing KV key must not raise — unpublish is idempotent."""
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(404, json={"errors": ["not found"]})
+
+    publisher, client = _make_publisher(httpx.MockTransport(handler))
+    async with client, publisher as pub:
+        # Should not raise.
+        await pub.unpublish(project_slug="p", edition_slug="e")
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unpublish_raises_on_5xx() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"errors": ["boom"]})
+
+    publisher, client = _make_publisher(httpx.MockTransport(handler))
+    async with client, publisher as pub:
+        with pytest.raises(httpx.HTTPStatusError):
+            await pub.unpublish(project_slug="p", edition_slug="e")

--- a/tests/worker/lifecycle_eval_test.py
+++ b/tests/worker/lifecycle_eval_test.py
@@ -655,3 +655,171 @@ async def test_lifecycle_eval_protects_shared_build_referenced_elsewhere(
             )
             assert protector is not None
             assert protector.id == protector_edition_id
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_enqueues_dashboard_build_for_affected_projects(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """Edition soft-delete triggers one ``dashboard_build`` per project.
+
+    Mirrors the user-initiated DELETE handler's post-commit
+    ``try_enqueue_dashboard_build_by_slug`` call so the cached
+    dashboard artifact does not keep showing editions whose
+    ``date_deleted`` is set.
+
+    Seeds two projects under one org with the same
+    ``draft_inactivity`` rule:
+
+    * ``with-stale`` has a stale draft that the worker will
+      soft-delete, so it must get one ``dashboard_build`` row.
+    * ``no-stale`` has only a fresh draft, so it must not get a
+      ``dashboard_build`` row.
+
+    The assertion checks the global count of ``dashboard_build`` rows
+    is exactly one and that the row is scoped to ``with-stale`` —
+    not ``no-stale`` and not some other org. The
+    ``has_active_dashboard_build`` helper on ``QueueJobStore`` is
+    used to confirm the per-project scoping the cached dashboard
+    consumer relies on.
+    """
+    org_rules = LifecycleRuleSet(
+        root=[DraftInactivityRule(max_days_inactive=30)]
+    )
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session,
+            slug="lce-dash-enq-org",
+            lifecycle_rules=org_rules,
+        )
+        affected_project_id = await _seed_project(
+            db_session, org_id=org_id, slug="with-stale"
+        )
+        untouched_project_id = await _seed_project(
+            db_session, org_id=org_id, slug="no-stale"
+        )
+        await _seed_edition(
+            db_session,
+            project_id=affected_project_id,
+            slug="stale-draft",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+        )
+        await _seed_edition(
+            db_session,
+            project_id=untouched_project_id,
+            slug="fresh-draft",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=5),
+        )
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id, org_slug=org_slug
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client)
+    result = await lifecycle_eval(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "lifecycle_eval_run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await http_client.aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            dash_rows = await session.execute(
+                select(SqlQueueJob).where(
+                    SqlQueueJob.kind == JobKind.dashboard_build.value
+                )
+            )
+            rows = list(dash_rows.scalars().all())
+            assert len(rows) == 1
+            assert rows[0].org_id == org_id
+            assert rows[0].project_id == affected_project_id
+
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            assert await queue_job_store.has_active_dashboard_build(
+                org_id=org_id, project_id=affected_project_id
+            )
+            assert not await queue_job_store.has_active_dashboard_build(
+                org_id=org_id, project_id=untouched_project_id
+            )
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_skips_dashboard_build_for_build_only_deletes(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """A project whose only deletion is a build does not get a dashboard_build.
+
+    The cached dashboard artifact is rebuilt from the edition list,
+    not the build list — soft-deleting an orphan build does not
+    change what the dashboard renders, so an enqueue would be wasted
+    work. Only projects with at least one edition soft-delete should
+    get a ``dashboard_build`` row.
+    """
+    org_rules = LifecycleRuleSet(
+        root=[BuildHistoryOrphanRule(min_position=1, min_age_days=30)]
+    )
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session,
+            slug="lce-build-only-org",
+            lifecycle_rules=org_rules,
+        )
+        project_id = await _seed_project(
+            db_session, org_id=org_id, slug="build-only"
+        )
+        current_build_id = await _seed_build(
+            db_session,
+            project_id=project_id,
+            project_slug="build-only",
+            date_completed=NOW - timedelta(days=40),
+        )
+        await _seed_build(
+            db_session,
+            project_id=project_id,
+            project_slug="build-only",
+            date_completed=NOW - timedelta(days=40),
+        )
+        await _seed_edition(
+            db_session,
+            project_id=project_id,
+            slug="main",
+            kind=EditionKind.release,
+            date_updated=NOW,
+            current_build_id=current_build_id,
+        )
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id, org_slug=org_slug
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client)
+    result = await lifecycle_eval(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "lifecycle_eval_run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await http_client.aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            dash_rows = await session.execute(
+                select(SqlQueueJob).where(
+                    SqlQueueJob.kind == JobKind.dashboard_build.value
+                )
+            )
+            assert list(dash_rows.scalars().all()) == []

--- a/tests/worker/lifecycle_eval_test.py
+++ b/tests/worker/lifecycle_eval_test.py
@@ -30,6 +30,7 @@ from docverse.client.models.queue_enums import JobKind, JobStatus
 from docverse.dbschema.build import SqlBuild
 from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.edition_build_history import SqlEditionBuildHistory
+from docverse.dbschema.organization import SqlOrganization
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.domain.lifecycle import (
@@ -37,11 +38,16 @@ from docverse.domain.lifecycle import (
     DraftInactivityRule,
     LifecycleRuleSet,
 )
+from docverse.factory import Factory
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
 )
 from docverse.storage.edition_store import EditionStore
+from docverse.storage.editionpublisher import (
+    EditionPublisher,
+    MockEditionPublisher,
+)
 from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
@@ -823,3 +829,115 @@ async def test_lifecycle_eval_skips_dashboard_build_for_build_only_deletes(
                 )
             )
             assert list(dash_rows.scalars().all()) == []
+
+
+def _mock_create_edition_publisher(publisher: EditionPublisher) -> object:
+    """Build a ``create_edition_publisher_for_org`` replacement.
+
+    Mirrors the helper in ``tests/worker/publish_edition_test.py``: returns
+    the supplied publisher regardless of the (org_id, service_label) the
+    factory was called with so the test does not have to seed the full
+    service-config + credential resolver path.
+    """
+
+    async def _create(
+        self: Factory,
+        *,
+        org_id: int,
+        service_label: str,
+    ) -> EditionPublisher:
+        _ = (self, org_id, service_label)
+        return publisher
+
+    return _create
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_unpublishes_each_soft_deleted_edition(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each soft-deleted edition records one ``unpublish`` call on the CDN.
+
+    Seeds an org with a configured ``cdn_service_label`` plus two stale
+    drafts and one fresh draft under a single project so the
+    ``draft_inactivity`` rule matches exactly the two stale drafts. The
+    test patches ``Factory.create_edition_publisher_for_org`` to return a
+    ``MockEditionPublisher`` and asserts that ``unpublish_calls``
+    contains exactly one entry per soft-deleted edition with the right
+    ``(project_slug, edition_slug)`` shape — and that the fresh draft
+    (which is not soft-deleted) does not appear.
+    """
+    org_rules = LifecycleRuleSet(
+        root=[DraftInactivityRule(max_days_inactive=30)]
+    )
+    mock_publisher = MockEditionPublisher()
+
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session,
+            slug="lce-unpub-org",
+            lifecycle_rules=org_rules,
+        )
+        # Stamp a CDN service label so the publishing service resolves
+        # the publisher rather than no-opping.
+        await db_session.execute(
+            update(SqlOrganization)
+            .where(SqlOrganization.id == org_id)
+            .values(cdn_service_label="cdn-prod")
+        )
+        project_id = await _seed_project(
+            db_session, org_id=org_id, slug="unpub-proj"
+        )
+        await _seed_edition(
+            db_session,
+            project_id=project_id,
+            slug="stale-a",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+        )
+        await _seed_edition(
+            db_session,
+            project_id=project_id,
+            slug="stale-b",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=90),
+        )
+        await _seed_edition(
+            db_session,
+            project_id=project_id,
+            slug="fresh",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=5),
+        )
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id, org_slug=org_slug
+        )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_edition_publisher_for_org",
+        _mock_create_edition_publisher(mock_publisher),
+    )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client)
+    result = await lifecycle_eval(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "lifecycle_eval_run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await http_client.aclose()
+    assert result == "completed"
+
+    recorded_slugs = sorted(
+        call.edition_slug for call in mock_publisher.unpublish_calls
+    )
+    assert recorded_slugs == ["stale-a", "stale-b"]
+    for call in mock_publisher.unpublish_calls:
+        assert call.project_slug == "unpub-proj"

--- a/tests/worker/lifecycle_eval_worker_settings_test.py
+++ b/tests/worker/lifecycle_eval_worker_settings_test.py
@@ -12,7 +12,11 @@ from arq.cron import CronJob
 from arq.worker import Function
 
 from docverse.config import Configuration
-from docverse.worker.functions import lifecycle_eval, lifecycle_eval_dispatcher
+from docverse.worker.functions import (
+    lifecycle_eval,
+    lifecycle_eval_dispatcher,
+    lifecycle_reaper,
+)
 from docverse.worker.functions.lifecycle_eval_dispatcher import (
     LIFECYCLE_EVAL_QUEUE_NAME,
 )
@@ -82,6 +86,36 @@ def test_lifecycle_eval_dispatcher_runs_hourly() -> None:
     assert dispatcher_crons[0].minute == {0}
 
 
+def test_lifecycle_reaper_registered_as_function() -> None:
+    """The reaper is registered as a plain coroutine on the lifecycle pool.
+
+    Unlike the dispatcher and per-org worker, the reaper is not wrapped
+    in :func:`arq.func` — it is a cron-only backstop with no per-job
+    timeout knob and arq's default retry policy is irrelevant since
+    each tick is self-contained. Mirrors how ``keeper_sync_reaper`` is
+    registered on :class:`KeeperSyncWorkerSettings`.
+    """
+    assert lifecycle_reaper in LifecycleEvalWorkerSettings.functions
+
+
+def test_lifecycle_reaper_runs_every_thirty_minutes() -> None:
+    """The reaper cron fires on minute 0 and 30 of every hour.
+
+    Frequent enough that test/staging environments running with a low
+    ``lifecycle_reaper_threshold_seconds`` see prompt finalisation,
+    infrequent enough that production with the 6 h default rarely
+    sees no-work-to-do log spam.
+    """
+    cron_jobs = list(getattr(LifecycleEvalWorkerSettings, "cron_jobs", []))
+    reaper_crons = [
+        job
+        for job in cron_jobs
+        if isinstance(job, CronJob) and job.coroutine is lifecycle_reaper
+    ]
+    assert len(reaper_crons) == 1
+    assert reaper_crons[0].minute == {0, 30}
+
+
 def test_default_worker_does_not_register_lifecycle_functions() -> None:
     """The default queue stays free of lifecycle work."""
     default_coros: set[object] = set()
@@ -90,5 +124,36 @@ def test_default_worker_does_not_register_lifecycle_functions() -> None:
             default_coros.add(entry.coroutine)
     assert lifecycle_eval not in WorkerSettings.functions
     assert lifecycle_eval_dispatcher not in WorkerSettings.functions
+    assert lifecycle_reaper not in WorkerSettings.functions
     assert lifecycle_eval not in default_coros
     assert lifecycle_eval_dispatcher not in default_coros
+    assert lifecycle_reaper not in default_coros
+
+
+def test_default_worker_has_no_lifecycle_cron() -> None:
+    """The default queue does not run the lifecycle dispatcher or reaper."""
+    cron_jobs = list(getattr(WorkerSettings, "cron_jobs", []) or [])
+    coroutines = {
+        job.coroutine for job in cron_jobs if isinstance(job, CronJob)
+    }
+    assert lifecycle_eval_dispatcher not in coroutines
+    assert lifecycle_reaper not in coroutines
+
+
+def test_keeper_sync_worker_does_not_register_lifecycle_functions() -> None:
+    """Lifecycle work does not leak onto the keeper-sync queue.
+
+    The PRD specifies a third pool precisely so that a slow rule pass
+    cannot delay keeper_sync_project; registering lifecycle functions
+    on KeeperSyncWorkerSettings would defeat that isolation.
+    """
+    sync_coros: set[object] = set()
+    for entry in KeeperSyncWorkerSettings.functions:
+        if isinstance(entry, Function):
+            sync_coros.add(entry.coroutine)
+    assert lifecycle_eval not in sync_coros
+    assert lifecycle_eval_dispatcher not in sync_coros
+    assert lifecycle_reaper not in sync_coros
+    assert lifecycle_eval not in KeeperSyncWorkerSettings.functions
+    assert lifecycle_eval_dispatcher not in KeeperSyncWorkerSettings.functions
+    assert lifecycle_reaper not in KeeperSyncWorkerSettings.functions

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -85,6 +85,15 @@ class _FailingPublisher:
         _ = (project_slug, edition_slug, build_public_id, object_key_prefix)
         raise self._exc
 
+    async def unpublish(
+        self,
+        *,
+        project_slug: str,
+        edition_slug: str,
+    ) -> None:
+        _ = (project_slug, edition_slug)
+        raise self._exc
+
 
 def _logger() -> structlog.stdlib.BoundLogger:
     return structlog.get_logger("docverse")  # type: ignore[no-any-return]


### PR DESCRIPTION
## Summary

- Registers `lifecycle_reaper` on `LifecycleEvalWorkerSettings` so the third arq pool now carries the full lifecycle_eval triad — hourly dispatcher, per-org evaluator, and 30-minute reaper backstop — on `docverse:lifecycle-queue`.
- Enqueues a single `dashboard_build` job per project whose edition list shrank during a lifecycle pass, mirroring the user-initiated DELETE handler so the cached dashboard artifact stops showing editions whose `date_deleted` is set.
- Phalanx Deployment binding the new pool to the queue (gated on `config.lifecycleEval.enabled`) is tracked separately in `lsst-sqre/phalanx` and is out of scope here.

## Validation steps

- [ ] Launch the new pool locally with `arq docverse.worker.main.LifecycleEvalWorkerSettings` and confirm it boots cleanly, picks up the dedicated `docverse:lifecycle-queue`, and schedules the hourly dispatcher cron and 30-minute reaper cron in the startup log.
- [ ] Drop a `lifecycle_eval` job onto `docverse:lifecycle-queue` from a Python shell and verify it runs on the new pool (not the default or keeper-sync pool), respecting the configured per-job timeout from `lifecycle_eval_job_timeout_seconds`.
- [ ] With `DOCVERSE_LIFECYCLE_REAPER_THRESHOLD_SECONDS` set to a small value, seed a deliberately-wedged `kind='lifecycle_eval'` `queue_jobs` row and confirm the next reaper cron tick marks it failed and finalises its parent `lifecycle_eval_runs` row.
- [ ] Confirm the default queue worker and the keeper-sync queue worker neither register nor run the lifecycle functions (no `lifecycle_eval`, `lifecycle_eval_dispatcher`, or `lifecycle_reaper` in their `functions` or `cron_jobs`).
- [ ] Seed an org with a `draft_inactivity` rule plus a project that has a stale draft and another project that does not, invoke `lifecycle_eval` for that org, and confirm exactly one `kind='dashboard_build'` `queue_jobs` row appears scoped to the project whose stale draft was soft-deleted (and none for the untouched project).
- [ ] Seed a project whose only lifecycle match is an orphan build (no edition deletions) and confirm no `dashboard_build` row is enqueued — build-only deletions do not affect the rendered dashboard.
- [ ] Force `try_enqueue_dashboard_build_by_slug` to raise (e.g. by removing the project mid-run) and confirm the per-org worker still finalises the `queue_jobs` row and parent `lifecycle_eval_runs` row normally; the failure surfaces only as a structured log line.

## References

- Closes #356
- Closes #365
- PRD: #337
- Jira: https://rubinobs.atlassian.net/browse/DM-54688
