### PR TITLE
DM-54916: Sentry monitoring for Docverse server and workers

### DIFF
--- a/src/docverse/domain/slug.py
+++ b/src/docverse/domain/slug.py
@@ -14,6 +14,7 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field, TypeAdapter, field_validator
 
 from docverse.client.models import EditionKind, TrackingMode
+from docverse.exceptions import DocverseSlackException
 
 __all__ = [
     "ALTERNATE_SEPARATOR",
@@ -48,7 +49,7 @@ _ALLOWED_SLASH_REPLACEMENTS = frozenset({"-", "_", "."})
 # --- Exceptions ---
 
 
-class InvalidSlugError(Exception):
+class InvalidSlugError(DocverseSlackException):
     """The derived slug fails validation."""
 
     def __init__(self, slug: str, reason: str) -> None:

--- a/src/docverse/exceptions.py
+++ b/src/docverse/exceptions.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from fastapi import status
 from safir.fastapi import ClientRequestError
+from safir.slack.blockkit import SlackException
 
 __all__ = [
     "BadRequestError",
     "ConflictError",
+    "DocverseSlackException",
     "InvalidBase32IdError",
     "InvalidBuildStateError",
     "InvalidJobStateError",
@@ -16,6 +18,17 @@ __all__ = [
     "NotFoundError",
     "PermissionDeniedError",
 ]
+
+
+class DocverseSlackException(SlackException):
+    """Shared base for non-``ClientRequestError`` server-side exceptions.
+
+    Every Docverse exception that should be routed to Slack and Sentry
+    (i.e. anything that is not a 4xx user error) derives from this class.
+    Future slices will override :meth:`to_sentry` on individual
+    subclasses to surface API-facing identifiers as tags and contexts;
+    this base exists so those overrides have one place to layer on.
+    """
 
 
 class BadRequestError(ClientRequestError):
@@ -60,7 +73,7 @@ class PermissionDeniedError(ClientRequestError):
     status_code = status.HTTP_403_FORBIDDEN
 
 
-class InvalidJobStateError(Exception):
+class InvalidJobStateError(DocverseSlackException):
     """A queue job state transition is invalid.
 
     This is a non-HTTP exception because it may be raised from worker
@@ -68,7 +81,7 @@ class InvalidJobStateError(Exception):
     """
 
 
-class InvalidBuildStateError(Exception):
+class InvalidBuildStateError(DocverseSlackException):
     """A build status transition is invalid.
 
     This is a non-HTTP exception because it may be raised from worker
@@ -76,7 +89,7 @@ class InvalidBuildStateError(Exception):
     """
 
 
-class JobNotFoundError(Exception):
+class JobNotFoundError(DocverseSlackException):
     """A queue job was not found in the database.
 
     This is a non-HTTP exception because it may be raised from worker

--- a/src/docverse/exceptions.py
+++ b/src/docverse/exceptions.py
@@ -79,9 +79,86 @@ class PermissionDeniedError(ClientRequestError):
 class InvalidJobStateError(DocverseSlackException):
     """A queue job state transition is invalid.
 
+    Carries the queue job's API-facing identifiers (base32 ``public_id``,
+    queue name, and worker function name) so a Sentry triager can paste
+    the ``public_id`` straight into a ``GET /queue/{job_id}`` URL without
+    translating an internal row id. Construct with the structured
+    kwargs; ``message`` defaults to a useful summary of the transition
+    when omitted.
+
     This is a non-HTTP exception because it may be raised from worker
-    code outside of a request context.
+    code outside of a request context. The same class is reused by the
+    ``keeper_sync_runs`` and ``lifecycle_eval_runs`` stores for
+    run-state transition errors: those raises supply ``current_state``
+    / ``target_state`` / ``queue_name`` but leave ``job_public_id``
+    unset because a run is not itself a queue job.
     """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        current_state: str | None = None,
+        target_state: str | None = None,
+        job_public_id: str | None = None,
+        queue_name: str | None = None,
+        job_function: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        if message is None:
+            message = _format_job_transition_message(
+                current_state=current_state,
+                target_state=target_state,
+                job_public_id=job_public_id,
+            )
+        super().__init__(message)
+        self.current_state = current_state
+        self.target_state = target_state
+        self.job_public_id = job_public_id
+        self.queue_name = queue_name
+        self.job_function = job_function
+
+    @override
+    def to_sentry(self) -> SentryEventInfo:
+        info = super().to_sentry()
+        if self.queue_name is not None:
+            info.tags["queue_name"] = self.queue_name
+        if self.job_function is not None:
+            info.tags["job_function"] = self.job_function
+        if self.current_state is not None:
+            info.tags["job_current_state"] = self.current_state
+        if self.target_state is not None:
+            info.tags["job_target_state"] = self.target_state
+        transition: dict[str, Any] = {
+            "job_public_id": self.job_public_id,
+            "queue_name": self.queue_name,
+            "job_function": self.job_function,
+            "current_state": self.current_state,
+            "target_state": self.target_state,
+        }
+        info.contexts["queue_job_transition"] = transition
+        return info
+
+
+def _format_job_transition_message(
+    *,
+    current_state: str | None,
+    target_state: str | None,
+    job_public_id: str | None,
+) -> str:
+    """Render a default message for :class:`InvalidJobStateError`."""
+    job_part = f"job {job_public_id}" if job_public_id is not None else "job"
+    if current_state is not None and target_state is not None:
+        return (
+            f"Cannot transition {job_part} from "
+            f"{current_state!r} to {target_state!r}"
+        )
+    if target_state is not None:
+        return f"Cannot transition {job_part} to {target_state!r}"
+    if current_state is not None:
+        return (
+            f"Invalid state transition for {job_part} from {current_state!r}"
+        )
+    return f"Invalid state for {job_part}"
 
 
 class InvalidBuildStateError(DocverseSlackException):
@@ -173,6 +250,51 @@ def _format_build_transition_message(
 class JobNotFoundError(DocverseSlackException):
     """A queue job was not found in the database.
 
+    Carries the missing queue job's API-facing identifiers (base32
+    ``public_id``, queue name, and the worker function or lookup site
+    that triggered the miss) so a Sentry triager has the same
+    ``/queue/{job_id}`` link as for a successful lookup. Construct with
+    the structured kwargs; when ``job_public_id`` is unknown (e.g. the
+    lookup was by internal row id) pass ``message=`` to render the
+    internal identifier in logs without leaking it into Sentry tags.
+
     This is a non-HTTP exception because it may be raised from worker
     code outside of a request context.
     """
+
+    def __init__(
+        self,
+        *,
+        job_public_id: str | None = None,
+        queue_name: str | None = None,
+        job_function: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        if message is None:
+            message = _format_job_not_found_message(
+                job_public_id=job_public_id
+            )
+        super().__init__(message)
+        self.job_public_id = job_public_id
+        self.queue_name = queue_name
+        self.job_function = job_function
+
+    @override
+    def to_sentry(self) -> SentryEventInfo:
+        info = super().to_sentry()
+        if self.queue_name is not None:
+            info.tags["queue_name"] = self.queue_name
+        lookup: dict[str, Any] = {
+            "job_public_id": self.job_public_id,
+            "queue_name": self.queue_name,
+            "job_function": self.job_function,
+        }
+        info.contexts["queue_job_lookup"] = lookup
+        return info
+
+
+def _format_job_not_found_message(*, job_public_id: str | None) -> str:
+    """Render a default message for :class:`JobNotFoundError`."""
+    if job_public_id is not None:
+        return f"Queue job {job_public_id} not found"
+    return "Queue job not found"

--- a/src/docverse/exceptions.py
+++ b/src/docverse/exceptions.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any, override
+
 from fastapi import status
 from safir.fastapi import ClientRequestError
 from safir.slack.blockkit import SlackException
+from safir.slack.sentry import SentryEventInfo
 
 __all__ = [
     "BadRequestError",
@@ -82,11 +85,89 @@ class InvalidJobStateError(DocverseSlackException):
 
 
 class InvalidBuildStateError(DocverseSlackException):
-    """A build status transition is invalid.
+    """A build status transition is invalid or the target build is missing.
+
+    Carries the build's API-facing identifiers (base32 ``public_id`` and
+    the org / project / edition slugs) so a Sentry triager can paste them
+    straight into a ``GET /v1/orgs/{org}/projects/{project}/builds/{id}``
+    URL without translating an internal row id. Construct with the
+    structured kwargs; ``message`` defaults to a useful summary of the
+    transition when omitted.
 
     This is a non-HTTP exception because it may be raised from worker
     code outside of a request context.
     """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        current_state: str | None = None,
+        target_state: str | None = None,
+        build_public_id: str | None = None,
+        project_slug: str | None = None,
+        org_slug: str | None = None,
+        edition_slug: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        if message is None:
+            message = _format_build_transition_message(
+                current_state=current_state,
+                target_state=target_state,
+                build_public_id=build_public_id,
+            )
+        super().__init__(message)
+        self.current_state = current_state
+        self.target_state = target_state
+        self.build_public_id = build_public_id
+        self.project_slug = project_slug
+        self.org_slug = org_slug
+        self.edition_slug = edition_slug
+
+    @override
+    def to_sentry(self) -> SentryEventInfo:
+        info = super().to_sentry()
+        if self.org_slug is not None:
+            info.tags["org_slug"] = self.org_slug
+        if self.project_slug is not None:
+            info.tags["project_slug"] = self.project_slug
+        if self.current_state is not None:
+            info.tags["build_current_state"] = self.current_state
+        if self.target_state is not None:
+            info.tags["build_target_state"] = self.target_state
+        transition: dict[str, Any] = {
+            "build_public_id": self.build_public_id,
+            "project_slug": self.project_slug,
+            "org_slug": self.org_slug,
+            "edition_slug": self.edition_slug,
+            "current_state": self.current_state,
+            "target_state": self.target_state,
+        }
+        info.contexts["build_transition"] = transition
+        return info
+
+
+def _format_build_transition_message(
+    *,
+    current_state: str | None,
+    target_state: str | None,
+    build_public_id: str | None,
+) -> str:
+    """Render a default message for :class:`InvalidBuildStateError`."""
+    build_part = (
+        f"build {build_public_id}" if build_public_id is not None else "build"
+    )
+    if current_state is not None and target_state is not None:
+        return (
+            f"Cannot transition {build_part} from "
+            f"{current_state!r} to {target_state!r}"
+        )
+    if target_state is not None:
+        return f"Cannot transition {build_part} to {target_state!r}"
+    if current_state is not None:
+        return (
+            f"Invalid state transition for {build_part} from {current_state!r}"
+        )
+    return f"Invalid state for {build_part}"
 
 
 class JobNotFoundError(DocverseSlackException):

--- a/src/docverse/exceptions.py
+++ b/src/docverse/exceptions.py
@@ -105,7 +105,7 @@ class InvalidJobStateError(DocverseSlackException):
         message: str | None = None,
     ) -> None:
         if message is None:
-            message = _format_job_transition_message(
+            message = self._format_message(
                 current_state=current_state,
                 target_state=target_state,
                 job_public_id=job_public_id,
@@ -138,27 +138,29 @@ class InvalidJobStateError(DocverseSlackException):
         info.contexts["queue_job_transition"] = transition
         return info
 
-
-def _format_job_transition_message(
-    *,
-    current_state: str | None,
-    target_state: str | None,
-    job_public_id: str | None,
-) -> str:
-    """Render a default message for :class:`InvalidJobStateError`."""
-    job_part = f"job {job_public_id}" if job_public_id is not None else "job"
-    if current_state is not None and target_state is not None:
-        return (
-            f"Cannot transition {job_part} from "
-            f"{current_state!r} to {target_state!r}"
+    @staticmethod
+    def _format_message(
+        *,
+        current_state: str | None,
+        target_state: str | None,
+        job_public_id: str | None,
+    ) -> str:
+        job_part = (
+            f"job {job_public_id}" if job_public_id is not None else "job"
         )
-    if target_state is not None:
-        return f"Cannot transition {job_part} to {target_state!r}"
-    if current_state is not None:
-        return (
-            f"Invalid state transition for {job_part} from {current_state!r}"
-        )
-    return f"Invalid state for {job_part}"
+        if current_state is not None and target_state is not None:
+            return (
+                f"Cannot transition {job_part} from "
+                f"{current_state!r} to {target_state!r}"
+            )
+        if target_state is not None:
+            return f"Cannot transition {job_part} to {target_state!r}"
+        if current_state is not None:
+            return (
+                f"Invalid state transition for {job_part} "
+                f"from {current_state!r}"
+            )
+        return f"Invalid state for {job_part}"
 
 
 class InvalidBuildStateError(DocverseSlackException):
@@ -187,7 +189,7 @@ class InvalidBuildStateError(DocverseSlackException):
         message: str | None = None,
     ) -> None:
         if message is None:
-            message = _format_build_transition_message(
+            message = self._format_message(
                 current_state=current_state,
                 target_state=target_state,
                 build_public_id=build_public_id,
@@ -222,29 +224,31 @@ class InvalidBuildStateError(DocverseSlackException):
         info.contexts["build_transition"] = transition
         return info
 
-
-def _format_build_transition_message(
-    *,
-    current_state: str | None,
-    target_state: str | None,
-    build_public_id: str | None,
-) -> str:
-    """Render a default message for :class:`InvalidBuildStateError`."""
-    build_part = (
-        f"build {build_public_id}" if build_public_id is not None else "build"
-    )
-    if current_state is not None and target_state is not None:
-        return (
-            f"Cannot transition {build_part} from "
-            f"{current_state!r} to {target_state!r}"
+    @staticmethod
+    def _format_message(
+        *,
+        current_state: str | None,
+        target_state: str | None,
+        build_public_id: str | None,
+    ) -> str:
+        build_part = (
+            f"build {build_public_id}"
+            if build_public_id is not None
+            else "build"
         )
-    if target_state is not None:
-        return f"Cannot transition {build_part} to {target_state!r}"
-    if current_state is not None:
-        return (
-            f"Invalid state transition for {build_part} from {current_state!r}"
-        )
-    return f"Invalid state for {build_part}"
+        if current_state is not None and target_state is not None:
+            return (
+                f"Cannot transition {build_part} from "
+                f"{current_state!r} to {target_state!r}"
+            )
+        if target_state is not None:
+            return f"Cannot transition {build_part} to {target_state!r}"
+        if current_state is not None:
+            return (
+                f"Invalid state transition for {build_part} "
+                f"from {current_state!r}"
+            )
+        return f"Invalid state for {build_part}"
 
 
 class JobNotFoundError(DocverseSlackException):
@@ -271,9 +275,7 @@ class JobNotFoundError(DocverseSlackException):
         message: str | None = None,
     ) -> None:
         if message is None:
-            message = _format_job_not_found_message(
-                job_public_id=job_public_id
-            )
+            message = self._format_message(job_public_id=job_public_id)
         super().__init__(message)
         self.job_public_id = job_public_id
         self.queue_name = queue_name
@@ -292,9 +294,8 @@ class JobNotFoundError(DocverseSlackException):
         info.contexts["queue_job_lookup"] = lookup
         return info
 
-
-def _format_job_not_found_message(*, job_public_id: str | None) -> str:
-    """Render a default message for :class:`JobNotFoundError`."""
-    if job_public_id is not None:
-        return f"Queue job {job_public_id} not found"
-    return "Queue job not found"
+    @staticmethod
+    def _format_message(*, job_public_id: str | None) -> str:
+        if job_public_id is not None:
+            return f"Queue job {job_public_id} not found"
+        return "Queue job not found"

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -394,16 +394,27 @@ class Factory:
             ``github_webhook_secret`` is unset, or the startup-time
             validation marked the credentials as invalid.
         """
-        if (
-            self._github_app_id is None
-            or self._github_app_private_key is None
-            or self._github_webhook_secret is None
-        ):
-            msg = "GitHub App is not configured"
-            raise GitHubAppNotConfiguredError(msg)
+        if self._github_app_id is None:
+            raise GitHubAppNotConfiguredError(missing_secret="app_id")  # noqa: S106
+        if self._github_app_private_key is None:
+            raise GitHubAppNotConfiguredError(missing_secret="private_key")  # noqa: S106
+        if self._github_webhook_secret is None:
+            raise GitHubAppNotConfiguredError(missing_secret="webhook_secret")  # noqa: S106
         if not self._github_app_validated:
-            msg = "GitHub App credentials failed startup validation"
-            raise GitHubAppNotConfiguredError(msg)
+            # The startup validator failed but does not record which
+            # specific credential is to blame; the canonical failure
+            # mode is a malformed PEM or a key that no longer matches
+            # the registered app, both of which surface through the
+            # private key. Keep the explicit "failed startup
+            # validation" wording in pod logs and on the
+            # ``SlackException`` rendering while tagging the Sentry
+            # event with ``missing_secret="private_key"`` so the event
+            # routes to the same operator persona as the unset-key
+            # case.
+            raise GitHubAppNotConfiguredError(
+                missing_secret="private_key",  # noqa: S106
+                message="GitHub App credentials failed startup validation",
+            )
         return (
             self._github_app_id,
             self._github_app_private_key,

--- a/src/docverse/sentry.py
+++ b/src/docverse/sentry.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import functools
 from importlib.metadata import version
-from typing import Literal
+from typing import Any, Literal
 
 import sentry_sdk
+from arq.typing import WorkerCoroutine
 from safir.sentry import initialize_sentry as _safir_initialize_sentry
 from safir.sentry import should_enable_sentry
+from sentry_sdk.consts import OP
+from sentry_sdk.tracing import TransactionSource
 
-__all__ = ["DocverseSentryComponent", "initialize_sentry"]
+__all__ = [
+    "DocverseSentryComponent",
+    "initialize_sentry",
+    "instrument_arq_task",
+]
 
 
 DocverseSentryComponent = Literal[
@@ -38,3 +46,57 @@ def initialize_sentry(component: DocverseSentryComponent) -> None:
     scope = sentry_sdk.get_global_scope()
     scope.set_tag("service", "docverse")
     scope.set_tag("component", component)
+
+
+def instrument_arq_task(fn: WorkerCoroutine) -> WorkerCoroutine:
+    """Wrap an arq task so Sentry events carry the function name.
+
+    arq has no built-in Sentry integration (unlike the SDK-bundled
+    integrations for Celery, RQ, Huey, etc.), so without this wrapper
+    every captured event from a worker function lands under
+    ``transaction: "unknown arq task"`` -- which Sentry also surfaces as
+    the ``culprit`` -- and the only way to know which task fired is to
+    read the breadcrumb logger name. The wrapper opens an isolation
+    scope and a top-level transaction named after the wrapped function
+    for the duration of one job; the arq ``job_id`` is attached as a tag
+    so a captured event can be cross-referenced against pod logs.
+
+    The wrapped function preserves ``__name__``, ``__qualname__``, and
+    ``__module__`` via :func:`functools.wraps`, so :func:`arq.func` and
+    arq's default registration both record the original task name as
+    the Redis-side ``job_type`` -- no enqueue call sites need to change.
+    """
+    # mypy can't structurally match ``Callable[..., Awaitable[Any]]``
+    # against the ``WorkerCoroutine`` Protocol without help, so the
+    # wrapper is typed against the Protocol directly.
+    fn_name = fn.__qualname__.rsplit(".", 1)[-1]
+
+    @functools.wraps(fn)
+    async def wrapper(ctx: dict[Any, Any], *args: Any, **kwargs: Any) -> Any:
+        with sentry_sdk.isolation_scope() as scope:
+            job_id = ctx.get("job_id")
+            if job_id is not None:
+                scope.set_tag("arq.job_id", str(job_id))
+            job_try = ctx.get("job_try")
+            if job_try is not None:
+                scope.set_tag("arq.job_try", str(job_try))
+            with sentry_sdk.start_transaction(
+                name=fn_name,
+                op=OP.QUEUE_TASK_ARQ,
+                source=TransactionSource.TASK,
+            ):
+                try:
+                    return await fn(ctx, *args, **kwargs)
+                except Exception as exc:
+                    # arq has no Sentry integration to capture uncaught
+                    # exceptions, so the wrapper does it explicitly. Tasks
+                    # whose outer except block already calls
+                    # ``sentry_sdk.capture_exception`` (see
+                    # ``worker/functions/keeper_sync.py``) are not
+                    # double-counted: ``DedupeIntegration`` (a default
+                    # ``sentry_sdk.init`` integration) drops the second
+                    # capture of the same exception instance.
+                    sentry_sdk.capture_exception(exc)
+                    raise
+
+    return wrapper

--- a/src/docverse/services/build.py
+++ b/src/docverse/services/build.py
@@ -118,7 +118,10 @@ class BuildService:
         build = await self._resolve_build(project.id, build_id)
 
         build = await self._store.transition_status(
-            build_id=build.id, new_status=BuildStatus.processing
+            build_id=build.id,
+            new_status=BuildStatus.processing,
+            org_slug=org_slug,
+            project_slug=project_slug,
         )
         self._logger.info(
             "Build upload complete, transitioning to processing",
@@ -179,10 +182,19 @@ class BuildService:
             project.id, cursor=cursor, limit=limit, status=status
         )
 
-    async def complete(self, *, build_id: int) -> Build:
+    async def complete(
+        self,
+        *,
+        build_id: int,
+        org_slug: str | None = None,
+        project_slug: str | None = None,
+    ) -> Build:
         """Mark a build as completed."""
         build = await self._store.transition_status(
-            build_id=build_id, new_status=BuildStatus.completed
+            build_id=build_id,
+            new_status=BuildStatus.completed,
+            org_slug=org_slug,
+            project_slug=project_slug,
         )
         self._logger.info(
             "Build completed",
@@ -190,10 +202,19 @@ class BuildService:
         )
         return build
 
-    async def fail(self, *, build_id: int) -> Build:
+    async def fail(
+        self,
+        *,
+        build_id: int,
+        org_slug: str | None = None,
+        project_slug: str | None = None,
+    ) -> Build:
         """Mark a build as failed."""
         build = await self._store.transition_status(
-            build_id=build_id, new_status=BuildStatus.failed
+            build_id=build_id,
+            new_status=BuildStatus.failed,
+            org_slug=org_slug,
+            project_slug=project_slug,
         )
         self._logger.info(
             "Build failed", build=serialize_base32_id(build.public_id)

--- a/src/docverse/services/dashboard/enqueue.py
+++ b/src/docverse/services/dashboard/enqueue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import sentry_sdk
 import structlog
 
 from docverse.client.models.queue_enums import JobKind
@@ -208,7 +209,8 @@ async def try_enqueue_dashboard_build_by_slug(
                 org_slug=org_slug, project_slug=project_slug
             )
             await session.commit()
-    except Exception:
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
         logger.exception(
             "Failed to enqueue dashboard_build",
             org_slug=org_slug,
@@ -232,7 +234,8 @@ async def try_enqueue_dashboard_build_by_id(
                 org_id=org_id, project_id=project_id
             )
             await session.commit()
-    except Exception:
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
         logger.exception(
             "Failed to enqueue dashboard_build",
             org_id=org_id,

--- a/src/docverse/services/dashboard_templates/__init__.py
+++ b/src/docverse/services/dashboard_templates/__init__.py
@@ -16,14 +16,13 @@ from .resolver import (
     ResolvedTemplateOrigin,
     TemplateResolver,
 )
-from .sync import DashboardTemplateSyncer, DashboardTemplateSyncError
+from .sync import DashboardTemplateSyncer
 
 __all__ = [
     "DashboardRebuildFanout",
     "DashboardSyncEnqueuer",
     "DashboardTemplateBindingResult",
     "DashboardTemplateBindingService",
-    "DashboardTemplateSyncError",
     "DashboardTemplateSyncer",
     "InstallationEventProcessor",
     "PushEventProcessor",

--- a/src/docverse/services/dashboard_templates/_sync_failure.py
+++ b/src/docverse/services/dashboard_templates/_sync_failure.py
@@ -1,0 +1,58 @@
+"""Shared DB-write helper for dashboard-template sync failures."""
+
+from __future__ import annotations
+
+import traceback
+from typing import TYPE_CHECKING
+
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.queue_job_store import QueueJobStore
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+__all__ = ["mark_dashboard_sync_failed"]
+
+
+async def mark_dashboard_sync_failed(  # noqa: PLR0913
+    *,
+    session: AsyncSession,
+    binding_store: DashboardGitHubTemplateBindingStore,
+    binding_id: int,
+    exc: BaseException,
+    error_message: str,
+    queue_job_store: QueueJobStore | None = None,
+    queue_job_id: int | None = None,
+) -> None:
+    """Mark a dashboard sync as failed in the database.
+
+    Always flips the binding to ``last_sync_status="failed"`` with
+    ``error_message`` as the ``last_sync_error``. When both
+    ``queue_job_store`` and ``queue_job_id`` are supplied, additionally
+    fails the queue-job row with the exception type and traceback. Each
+    DB write opens its own ``session.begin()`` block, matching the
+    existing call-site style at the worker and enqueue paths.
+
+    Lives one layer up from ``worker/functions/dashboard_sync.py`` so
+    ``services/dashboard_templates/enqueue.py`` can import it without
+    pulling the worker-functions package (and its factory-loop import
+    chain) into the service layer.
+    """
+    async with session.begin():
+        await binding_store.update_sync_state(
+            binding_id=binding_id,
+            last_sync_status="failed",
+            last_sync_error=error_message,
+        )
+    if queue_job_store is not None and queue_job_id is not None:
+        async with session.begin():
+            await queue_job_store.fail(
+                queue_job_id,
+                errors={
+                    "message": str(exc),
+                    "type": type(exc).__name__,
+                    "traceback": traceback.format_exc(),
+                },
+            )

--- a/src/docverse/services/dashboard_templates/enqueue.py
+++ b/src/docverse/services/dashboard_templates/enqueue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import sentry_sdk
 import structlog
 
 from docverse.client.models.queue_enums import JobKind
@@ -121,6 +122,7 @@ async def try_enqueue_dashboard_sync(
             queue_job = await service.enqueue(binding_id)
             await session.commit()
     except Exception as exc:
+        sentry_sdk.capture_exception(exc)
         logger.exception(
             "Failed to enqueue dashboard_sync", binding_id=binding_id
         )
@@ -135,7 +137,8 @@ async def try_enqueue_dashboard_sync(
                     last_sync_error=f"Enqueue failed: {exc}",
                 )
                 await session.commit()
-        except Exception:
+        except Exception as exc:
+            sentry_sdk.capture_exception(exc)
             logger.exception(
                 "Failed to mark binding as enqueue-failed",
                 binding_id=binding_id,

--- a/src/docverse/services/dashboard_templates/enqueue.py
+++ b/src/docverse/services/dashboard_templates/enqueue.py
@@ -17,6 +17,8 @@ from docverse.storage.dashboard_templates.github import (
 from docverse.storage.queue_backend import QueueBackend
 from docverse.storage.queue_job_store import QueueJobStore
 
+from ._sync_failure import mark_dashboard_sync_failed
+
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -127,16 +129,16 @@ async def try_enqueue_dashboard_sync(
             "Failed to enqueue dashboard_sync", binding_id=binding_id
         )
         try:
-            async with session.begin():
-                binding_store = (
-                    factory.create_dashboard_github_template_binding_store()
-                )
-                await binding_store.update_sync_state(
-                    binding_id=binding_id,
-                    last_sync_status="failed",
-                    last_sync_error=f"Enqueue failed: {exc}",
-                )
-                await session.commit()
+            binding_store = (
+                factory.create_dashboard_github_template_binding_store()
+            )
+            await mark_dashboard_sync_failed(
+                session=session,
+                binding_store=binding_store,
+                binding_id=binding_id,
+                exc=exc,
+                error_message=f"Enqueue failed: {exc}",
+            )
         except Exception as exc:
             sentry_sdk.capture_exception(exc)
             logger.exception(

--- a/src/docverse/services/dashboard_templates/sync.py
+++ b/src/docverse/services/dashboard_templates/sync.py
@@ -14,7 +14,7 @@ import structlog
 from docverse.domain.dashboard_github_template import (
     DashboardGitHubTemplateBinding,
 )
-from docverse.exceptions import DocverseSlackException, NotFoundError
+from docverse.exceptions import NotFoundError
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
     DashboardGitHubTemplateStore,
@@ -29,7 +29,6 @@ from docverse.storage.github import GitHubAppClient, GitHubTreeFetcher
 __all__ = [
     "DashboardSyncResult",
     "DashboardSyncStatus",
-    "DashboardTemplateSyncError",
     "DashboardTemplateSyncer",
 ]
 
@@ -46,19 +45,6 @@ class DashboardSyncStatus(StrEnum):
 
     succeeded = "succeeded"
     failed = "failed"
-
-
-class DashboardTemplateSyncError(DocverseSlackException):
-    """Convenience exception for callers that prefer to propagate failure.
-
-    The syncer's :meth:`DashboardTemplateSyncer.sync` method itself
-    never raises this — it always returns a :class:`DashboardSyncResult`
-    whose ``status`` is :attr:`DashboardSyncStatus.failed` on failure —
-    so the binding's ``last_sync_status`` / ``last_sync_error`` row
-    update commits with the caller's transaction. This class exists for
-    callers that want to convert a failed result into an exception
-    (e.g. the worker, which needs to mark the queue job failed).
-    """
 
 
 @dataclass(frozen=True)

--- a/src/docverse/services/dashboard_templates/sync.py
+++ b/src/docverse/services/dashboard_templates/sync.py
@@ -14,7 +14,7 @@ import structlog
 from docverse.domain.dashboard_github_template import (
     DashboardGitHubTemplateBinding,
 )
-from docverse.exceptions import NotFoundError
+from docverse.exceptions import DocverseSlackException, NotFoundError
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
     DashboardGitHubTemplateStore,
@@ -48,7 +48,7 @@ class DashboardSyncStatus(StrEnum):
     failed = "failed"
 
 
-class DashboardTemplateSyncError(Exception):
+class DashboardTemplateSyncError(DocverseSlackException):
     """Convenience exception for callers that prefer to propagate failure.
 
     The syncer's :meth:`DashboardTemplateSyncer.sync` method itself

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import sentry_sdk
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -231,7 +232,8 @@ class KeeperSyncService:
             if on_edition_synced is not None:
                 try:
                     await on_edition_synced(outcome)
-                except Exception:
+                except Exception as exc:
+                    sentry_sdk.capture_exception(exc)
                     self._logger.exception(
                         "on_edition_synced callback raised; continuing",
                         docverse_slug=outcome.docverse_slug,

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -223,6 +223,7 @@ class KeeperSyncService:
         for ltd_edition in ltd_editions:
             outcome = await self.sync_edition(
                 org_id=org.id,
+                org_slug=org.slug,
                 project=project,
                 ltd_edition=ltd_edition,
             )
@@ -282,6 +283,7 @@ class KeeperSyncService:
         org_id: int,
         project: Project,
         ltd_edition: LtdEdition,
+        org_slug: str | None = None,
     ) -> EditionSyncOutcome:
         """Sync one LTD edition (and its current build) into Docverse."""
         # ``manual`` editions need the published build's git_refs to
@@ -330,6 +332,7 @@ class KeeperSyncService:
         if ltd_edition.build_url is not None:
             build_outcome = await self.sync_build(
                 org_id=org_id,
+                org_slug=org_slug,
                 project=project,
                 edition=edition,
                 ltd_edition=ltd_edition,
@@ -396,7 +399,7 @@ class KeeperSyncService:
             tracking_params=tracking_params,
         )
 
-    async def sync_build(
+    async def sync_build(  # noqa: PLR0913
         self,
         *,
         org_id: int,
@@ -404,6 +407,7 @@ class KeeperSyncService:
         edition: Edition,
         ltd_edition: LtdEdition,
         ltd_build: LtdBuild | None = None,
+        org_slug: str | None = None,
     ) -> BuildSyncOutcome:
         """Sync the LTD edition's current build into Docverse.
 
@@ -518,7 +522,11 @@ class KeeperSyncService:
 
         async with self._session.begin():
             await self._reclaim_orphan_placeholders(
-                project_id=project.id, ltd_edition=ltd_edition
+                project_id=project.id,
+                project_slug=project.slug,
+                org_slug=org_slug,
+                edition_slug=edition.slug,
+                ltd_edition=ltd_edition,
             )
             new_build = await self._create_synced_build(
                 project=project, ltd_edition=ltd_edition
@@ -533,6 +541,8 @@ class KeeperSyncService:
             await self._finalize_synced_build(
                 build=new_build,
                 edition=edition,
+                project_slug=project.slug,
+                org_slug=org_slug,
                 copy_result=copy_result,
             )
             await self._state_store.upsert(
@@ -563,7 +573,13 @@ class KeeperSyncService:
         )
 
     async def _reclaim_orphan_placeholders(
-        self, *, project_id: int, ltd_edition: LtdEdition
+        self,
+        *,
+        project_id: int,
+        ltd_edition: LtdEdition,
+        project_slug: str | None = None,
+        org_slug: str | None = None,
+        edition_slug: str | None = None,
     ) -> None:
         """Fail stale ``pending`` placeholders left by a crashed prior run.
 
@@ -594,7 +610,11 @@ class KeeperSyncService:
         reclaimed_ids: list[int] = []
         for orphan in orphans:
             await self._build_store.transition_status(
-                build_id=orphan.id, new_status=BuildStatus.failed
+                build_id=orphan.id,
+                new_status=BuildStatus.failed,
+                org_slug=org_slug,
+                project_slug=project_slug,
+                edition_slug=edition_slug,
             )
             reclaimed_ids.append(orphan.id)
         self._logger.warning(
@@ -630,6 +650,8 @@ class KeeperSyncService:
         build: Build,
         edition: Edition,
         copy_result: CopyResult,
+        project_slug: str | None = None,
+        org_slug: str | None = None,
     ) -> None:
         """Mark the build complete and atomically point the edition at it.
 
@@ -638,18 +660,33 @@ class KeeperSyncService:
         edition pointing at a build that does not exist or vice versa.
         """
         await self._build_store.update_content_hash(
-            build_id=build.id, content_hash=copy_result.content_hash
+            build_id=build.id,
+            content_hash=copy_result.content_hash,
+            org_slug=org_slug,
+            project_slug=project_slug,
+            edition_slug=edition.slug,
         )
         await self._build_store.update_inventory(
             build_id=build.id,
             object_count=copy_result.object_count,
             total_size_bytes=copy_result.total_size_bytes,
+            org_slug=org_slug,
+            project_slug=project_slug,
+            edition_slug=edition.slug,
         )
         await self._build_store.transition_status(
-            build_id=build.id, new_status=BuildStatus.processing
+            build_id=build.id,
+            new_status=BuildStatus.processing,
+            org_slug=org_slug,
+            project_slug=project_slug,
+            edition_slug=edition.slug,
         )
         await self._build_store.transition_status(
-            build_id=build.id, new_status=BuildStatus.completed
+            build_id=build.id,
+            new_status=BuildStatus.completed,
+            org_slug=org_slug,
+            project_slug=project_slug,
+            edition_slug=edition.slug,
         )
         await self._edition_store.set_current_build(
             edition_id=edition.id,

--- a/src/docverse/services/lock_service.py
+++ b/src/docverse/services/lock_service.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import Any
 
+import sentry_sdk
 import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -254,7 +255,7 @@ class LockService:
                         {"lock_id": lock_key.lock_id},
                     )
                     await lock_conn.commit()
-                except Exception:
+                except Exception as exc:
                     # A stuck unlock leaks the lock onto this pooled
                     # connection; invalidate so the pool discards it
                     # and the DB releases the lock on close. Raising
@@ -264,6 +265,7 @@ class LockService:
                     # exception from the lock body (if any) still
                     # propagates because this branch swallows only
                     # the unlock failure.
+                    sentry_sdk.capture_exception(exc)
                     self._logger.exception(
                         "Failed to release advisory lock",
                         lock_id=lock_key.lock_id,

--- a/src/docverse/storage/build_store.py
+++ b/src/docverse/storage/build_store.py
@@ -223,7 +223,13 @@ class BuildStore:
         )
 
     async def transition_status(
-        self, *, build_id: int, new_status: BuildStatus
+        self,
+        *,
+        build_id: int,
+        new_status: BuildStatus,
+        org_slug: str | None = None,
+        project_slug: str | None = None,
+        edition_slug: str | None = None,
     ) -> Build:
         """Transition a build to a new status.
 
@@ -231,27 +237,40 @@ class BuildStore:
         transition to ``processing`` and ``date_completed`` on transition
         to ``completed`` or ``failed``.
 
+        ``org_slug`` / ``project_slug`` / ``edition_slug`` are optional
+        API-facing identifiers carried into :class:`InvalidBuildStateError`
+        so a Sentry triager sees slugs rather than internal row ids.
+
         Raises
         ------
         InvalidBuildStateError
-            If the transition is not valid.
+            If the build is not found or the transition is not valid.
         """
         result = await self._session.execute(
             select(SqlBuild).where(SqlBuild.id == build_id)
         )
         row = result.scalar_one_or_none()
         if row is None:
-            msg = f"Build {build_id} not found"
-            raise InvalidBuildStateError(msg)
+            raise InvalidBuildStateError(
+                target_state=new_status.value,
+                org_slug=org_slug,
+                project_slug=project_slug,
+                edition_slug=edition_slug,
+                message=f"Build id={build_id} not found",
+            )
 
         current = BuildStatus(row.status)
+        build_public_id = serialize_base32_id(row.public_id)
         allowed = _VALID_TRANSITIONS.get(current, set())
         if new_status not in allowed:
-            msg = (
-                f"Cannot transition build {build_id} from "
-                f"{current.value!r} to {new_status.value!r}"
+            raise InvalidBuildStateError(
+                current_state=current.value,
+                target_state=new_status.value,
+                build_public_id=build_public_id,
+                org_slug=org_slug,
+                project_slug=project_slug,
+                edition_slug=edition_slug,
             )
-            raise InvalidBuildStateError(msg)
 
         row.status = new_status
         now = datetime.now(tz=UTC)
@@ -265,8 +284,15 @@ class BuildStore:
         await self._session.refresh(row)
         return Build.model_validate(row)
 
-    async def update_inventory(
-        self, *, build_id: int, object_count: int, total_size_bytes: int
+    async def update_inventory(  # noqa: PLR0913
+        self,
+        *,
+        build_id: int,
+        object_count: int,
+        total_size_bytes: int,
+        org_slug: str | None = None,
+        project_slug: str | None = None,
+        edition_slug: str | None = None,
     ) -> Build:
         """Update the inventory counts for a build."""
         result = await self._session.execute(
@@ -274,8 +300,12 @@ class BuildStore:
         )
         row = result.scalar_one_or_none()
         if row is None:
-            msg = f"Build {build_id} not found"
-            raise InvalidBuildStateError(msg)
+            raise InvalidBuildStateError(
+                org_slug=org_slug,
+                project_slug=project_slug,
+                edition_slug=edition_slug,
+                message=f"Build id={build_id} not found",
+            )
         row.object_count = object_count
         row.total_size_bytes = total_size_bytes
         await self._session.flush()
@@ -283,7 +313,13 @@ class BuildStore:
         return Build.model_validate(row)
 
     async def update_content_hash(
-        self, *, build_id: int, content_hash: str
+        self,
+        *,
+        build_id: int,
+        content_hash: str,
+        org_slug: str | None = None,
+        project_slug: str | None = None,
+        edition_slug: str | None = None,
     ) -> Build:
         """Overwrite the content hash on a build row.
 
@@ -307,14 +343,29 @@ class BuildStore:
         )
         row = result.scalar_one_or_none()
         if row is None:
-            msg = f"Build {build_id} not found"
-            raise InvalidBuildStateError(msg)
-        if row.status != BuildStatus.pending:
-            msg = (
-                f"Cannot update content hash on build {build_id}: "
-                f"status is {row.status.value!r}, expected 'pending'"
+            raise InvalidBuildStateError(
+                target_state=BuildStatus.pending.value,
+                org_slug=org_slug,
+                project_slug=project_slug,
+                edition_slug=edition_slug,
+                message=f"Build id={build_id} not found",
             )
-            raise InvalidBuildStateError(msg)
+        if row.status != BuildStatus.pending:
+            current = BuildStatus(row.status)
+            raise InvalidBuildStateError(
+                current_state=current.value,
+                target_state=BuildStatus.pending.value,
+                build_public_id=serialize_base32_id(row.public_id),
+                org_slug=org_slug,
+                project_slug=project_slug,
+                edition_slug=edition_slug,
+                message=(
+                    f"Cannot update content hash on build "
+                    f"{serialize_base32_id(row.public_id)}: "
+                    f"status is {current.value!r}, expected "
+                    f"{BuildStatus.pending.value!r}"
+                ),
+            )
         row.content_hash = content_hash
         await self._session.flush()
         await self._session.refresh(row)

--- a/src/docverse/storage/build_store.py
+++ b/src/docverse/storage/build_store.py
@@ -344,7 +344,6 @@ class BuildStore:
         row = result.scalar_one_or_none()
         if row is None:
             raise InvalidBuildStateError(
-                target_state=BuildStatus.pending.value,
                 org_slug=org_slug,
                 project_slug=project_slug,
                 edition_slug=edition_slug,

--- a/src/docverse/storage/github/app_client.py
+++ b/src/docverse/storage/github/app_client.py
@@ -3,22 +3,40 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, Literal, override
 
 import httpx
 import structlog
 from gidgethub.apps import get_installation_access_token
 from gidgethub.httpx import GitHubAPI
 from safir.github import GitHubAppClientFactory
+from safir.slack.sentry import SentryEventInfo
+
+from docverse.exceptions import DocverseSlackException
 
 __all__ = [
     "GITHUB_API_BASE_URL",
     "GitHubAppClient",
     "GitHubAppNotConfiguredError",
     "InstallationAuth",
+    "MissingGitHubAppSecret",
 ]
 
 
 GITHUB_API_BASE_URL = "https://api.github.com"
+
+#: GitHub App name surfaced in Sentry's ``github_app`` context so a
+#: triager looking at a misconfigured-tenant event can find the App in
+#: the GitHub admin UI without grepping config. Matches the
+#: ``Factory.__init__`` default for ``github_app_name``.
+_GITHUB_APP_NAME = "lsst-sqre/docverse"
+
+#: The three secret names that gate the GitHub App feature. Carried on
+#: :class:`GitHubAppNotConfiguredError` as a structured field so Sentry
+#: triagers can route the event to the kind of operator who can fix
+#: each ("missing app id" vs "stale private key" vs "rotated webhook
+#: secret") without unpacking the rendered message.
+MissingGitHubAppSecret = Literal["app_id", "private_key", "webhook_secret"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,15 +60,68 @@ class InstallationAuth:
     base_url: str = GITHUB_API_BASE_URL
 
 
-class GitHubAppNotConfiguredError(Exception):
+class GitHubAppNotConfiguredError(DocverseSlackException):
     """The GitHub App feature is not configured in ``Config``.
 
     Raised when ``Factory.create_github_app_client()`` is called but any
     of ``github_app_id``, ``github_app_private_key``, or
-    ``github_webhook_secret`` is unset. Callers at HTTP boundaries
-    translate this to a feature-disabled response (503 for admin
-    endpoints, 404 for the webhook endpoint).
+    ``github_webhook_secret`` is unset, or when the startup-time
+    credential validator has recorded the credentials as failing.
+    Callers at HTTP boundaries translate this to a feature-disabled
+    response (503 for admin endpoints, 404 for the webhook endpoint).
+
+    Carries an indicator of *which* GitHub App secret is the cause
+    (``app_id`` / ``private_key`` / ``webhook_secret``) plus the
+    API-facing org slug (when known by the caller) and the
+    installation id (when known). ``to_sentry`` surfaces ``org_slug``
+    and ``missing_secret`` as low-cardinality Sentry tags so an
+    on-call operator can route the event to the kind of maintainer
+    who can fix it; the non-secret ``installation_id`` and the static
+    app name go into the ``github_app`` Sentry context.
     """
+
+    def __init__(
+        self,
+        *,
+        missing_secret: MissingGitHubAppSecret,
+        org_slug: str | None = None,
+        installation_id: int | None = None,
+        message: str | None = None,
+    ) -> None:
+        if message is None:
+            message = _format_github_app_not_configured_message(
+                missing_secret=missing_secret,
+                org_slug=org_slug,
+            )
+        super().__init__(message)
+        self.missing_secret: MissingGitHubAppSecret = missing_secret
+        self.org_slug = org_slug
+        self.installation_id = installation_id
+
+    @override
+    def to_sentry(self) -> SentryEventInfo:
+        info = super().to_sentry()
+        info.tags["missing_secret"] = self.missing_secret
+        if self.org_slug is not None:
+            info.tags["org_slug"] = self.org_slug
+        context: dict[str, Any] = {
+            "installation_id": self.installation_id,
+            "app_name": _GITHUB_APP_NAME,
+        }
+        info.contexts["github_app"] = context
+        return info
+
+
+def _format_github_app_not_configured_message(
+    *,
+    missing_secret: MissingGitHubAppSecret,
+    org_slug: str | None,
+) -> str:
+    """Render a default message for :class:`GitHubAppNotConfiguredError`."""
+    org_part = f" for org {org_slug!r}" if org_slug is not None else ""
+    return (
+        f"GitHub App is not configured{org_part}: missing {missing_secret!r}"
+    )
 
 
 class GitHubAppClient:

--- a/src/docverse/storage/keeper_sync_run_store.py
+++ b/src/docverse/storage/keeper_sync_run_store.py
@@ -130,11 +130,15 @@ class KeeperSyncRunStore:
         if current is new_status:
             return KeeperSyncRun.model_validate(row)
         if not _is_allowed_transition(current, new_status):
-            msg = (
-                f"Cannot transition keeper sync run {run_id} from "
-                f"{current.value!r} to {new_status.value!r}"
+            raise InvalidJobStateError(
+                current_state=current.value,
+                target_state=new_status.value,
+                job_function="KeeperSyncRunStore.transition_status",
+                message=(
+                    f"Cannot transition keeper sync run {run_id} from "
+                    f"{current.value!r} to {new_status.value!r}"
+                ),
             )
-            raise InvalidJobStateError(msg)
 
         row.status = new_status.value
         if new_status not in _NON_TERMINAL_STATUSES:
@@ -279,8 +283,10 @@ class KeeperSyncRunStore:
         )
         row = result.scalar_one_or_none()
         if row is None:
-            msg = f"Keeper sync run {run_id} not found"
-            raise InvalidJobStateError(msg)
+            raise InvalidJobStateError(
+                job_function="KeeperSyncRunStore._get_row",
+                message=f"Keeper sync run {run_id} not found",
+            )
         return row
 
 

--- a/src/docverse/storage/keeper_sync_run_store.py
+++ b/src/docverse/storage/keeper_sync_run_store.py
@@ -26,7 +26,7 @@ from docverse.domain.keeper_sync_run import (
     KeeperSyncRunActivity,
 )
 from docverse.domain.queue import JobStatus
-from docverse.exceptions import InvalidJobStateError
+from docverse.exceptions import InvalidJobStateError, JobNotFoundError
 from docverse.storage.pagination import KeeperSyncRunDateStartedCursor
 
 __all__ = ["KeeperSyncRunStore"]
@@ -283,7 +283,7 @@ class KeeperSyncRunStore:
         )
         row = result.scalar_one_or_none()
         if row is None:
-            raise InvalidJobStateError(
+            raise JobNotFoundError(
                 job_function="KeeperSyncRunStore._get_row",
                 message=f"Keeper sync run {run_id} not found",
             )

--- a/src/docverse/storage/lifecycle_eval_run_store.py
+++ b/src/docverse/storage/lifecycle_eval_run_store.py
@@ -109,11 +109,15 @@ class LifecycleEvalRunStore:
         if current is new_status:
             return LifecycleEvalRun.model_validate(row)
         if not _is_allowed_transition(current, new_status):
-            msg = (
-                f"Cannot transition lifecycle eval run {run_id} from "
-                f"{current.value!r} to {new_status.value!r}"
+            raise InvalidJobStateError(
+                current_state=current.value,
+                target_state=new_status.value,
+                job_function="LifecycleEvalRunStore.transition_status",
+                message=(
+                    f"Cannot transition lifecycle eval run {run_id} from "
+                    f"{current.value!r} to {new_status.value!r}"
+                ),
             )
-            raise InvalidJobStateError(msg)
 
         row.status = new_status.value
         if new_status not in _NON_TERMINAL_STATUSES:
@@ -201,8 +205,10 @@ class LifecycleEvalRunStore:
         )
         row = result.scalar_one_or_none()
         if row is None:
-            msg = f"Lifecycle eval run {run_id} not found"
-            raise InvalidJobStateError(msg)
+            raise InvalidJobStateError(
+                job_function="LifecycleEvalRunStore._get_row",
+                message=f"Lifecycle eval run {run_id} not found",
+            )
         return row
 
 

--- a/src/docverse/storage/lifecycle_eval_run_store.py
+++ b/src/docverse/storage/lifecycle_eval_run_store.py
@@ -24,7 +24,7 @@ from docverse.domain.lifecycle_eval_run import (
     LifecycleEvalRunActivity,
 )
 from docverse.domain.queue import JobStatus
-from docverse.exceptions import InvalidJobStateError
+from docverse.exceptions import InvalidJobStateError, JobNotFoundError
 
 __all__ = ["LifecycleEvalRunStore"]
 
@@ -205,7 +205,7 @@ class LifecycleEvalRunStore:
         )
         row = result.scalar_one_or_none()
         if row is None:
-            raise InvalidJobStateError(
+            raise JobNotFoundError(
                 job_function="LifecycleEvalRunStore._get_row",
                 message=f"Lifecycle eval run {run_id} not found",
             )

--- a/src/docverse/storage/ltd/client.py
+++ b/src/docverse/storage/ltd/client.py
@@ -11,10 +11,13 @@ distinguish "LTD doesn't have this any more" (soft-deletion path) from
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 import httpx
 import structlog
+from safir.slack.sentry import SentryEventInfo
+
+from docverse.exceptions import DocverseSlackException
 
 from .models import LtdBuild, LtdEdition, LtdProduct, LtdProductsListing
 
@@ -34,9 +37,92 @@ _BASE_BACKOFF_SECONDS = 0.5
 #: Status codes that the client retries.
 _RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 
+#: Cap on the response body bytes carried into Sentry events. LTD error
+#: bodies can be arbitrarily large (HTML error pages, full JSON payloads);
+#: 4 KiB is enough for the leading "what went wrong" snippet without
+#: ballooning Sentry envelopes.
+_MAX_BODY_BYTES = 4 * 1024
 
-class LtdClientError(Exception):
-    """Raised when an LTD Keeper API call cannot be satisfied."""
+
+def _truncate_body(body: str | bytes | None) -> str | None:
+    """Decode ``body`` if needed and cap it at :data:`_MAX_BODY_BYTES`.
+
+    Truncation is done on the UTF-8 byte length so the cap is honoured
+    even when the body contains multi-byte characters; any trailing
+    partial code point is dropped via ``errors="ignore"`` so the
+    resulting string is always well-formed.
+    """
+    if body is None:
+        return None
+    text = (
+        body.decode("utf-8", errors="replace")
+        if isinstance(body, bytes)
+        else body
+    )
+    encoded = text.encode("utf-8")
+    if len(encoded) <= _MAX_BODY_BYTES:
+        return text
+    return encoded[:_MAX_BODY_BYTES].decode("utf-8", errors="ignore")
+
+
+class LtdClientError(DocverseSlackException):
+    """Raised when an LTD Keeper API call cannot be satisfied.
+
+    Carries the originating request URL, HTTP method, response status
+    code (if a response came back at all), and a truncated response
+    body so a Sentry triager can tell an LTD-side 5xx outage apart
+    from a stale Docverse credential. The body is truncated to
+    :data:`_MAX_BODY_BYTES` inside the constructor — callers pass the
+    full body and the class enforces the cap.
+
+    ``status_code`` and ``body`` default to ``None`` because the
+    network-error raise sites in :meth:`LtdClient._get_json` have
+    neither (the request never produced a response). ``to_sentry``
+    omits the missing tag in that case rather than emitting a literal
+    ``"None"`` string.
+    """
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        method: str,
+        status_code: int | None = None,
+        body: str | bytes | None = None,
+        message: str | None = None,
+    ) -> None:
+        if message is None:
+            message = _format_ltd_error_message(
+                url=url, method=method, status_code=status_code
+            )
+        super().__init__(message)
+        self.url = url
+        self.method = method
+        self.status_code = status_code
+        self.body = _truncate_body(body)
+
+    @override
+    def to_sentry(self) -> SentryEventInfo:
+        info = super().to_sentry()
+        if self.status_code is not None:
+            info.tags["ltd_status_code"] = str(self.status_code)
+        info.tags["ltd_method"] = self.method
+        info.contexts["ltd_request"] = {
+            "url": self.url,
+            "method": self.method,
+            "status_code": self.status_code,
+            "body": self.body,
+        }
+        return info
+
+
+def _format_ltd_error_message(
+    *, url: str, method: str, status_code: int | None
+) -> str:
+    """Render a default message for :class:`LtdClientError`."""
+    if status_code is not None:
+        return f"LTD {method} {url} returned {status_code}"
+    return f"LTD {method} {url} failed"
 
 
 class LtdNotFoundError(LtdClientError):
@@ -44,7 +130,10 @@ class LtdNotFoundError(LtdClientError):
 
     Distinct from :class:`LtdClientError` so the sync engine can map an
     LTD soft-deletion onto a Docverse soft-deletion without tripping
-    the generic retry/error path.
+    the generic retry/error path. Inherits the constructor and the
+    default ``to_sentry`` override from :class:`LtdClientError` — the
+    404 status code already gets surfaced as ``ltd_status_code`` so no
+    further override is needed.
     """
 
 
@@ -141,39 +230,60 @@ class LtdClient:
             except httpx.HTTPError as exc:
                 last_exc = exc
                 if attempt >= self._max_attempts:
-                    msg = f"LTD GET {url} failed: {exc}"
-                    raise LtdClientError(msg) from exc
+                    raise LtdClientError(
+                        url=url,
+                        method="GET",
+                        message=f"LTD GET {url} failed: {exc}",
+                    ) from exc
                 await asyncio.sleep(self._backoff_for_attempt(attempt))
                 continue
 
             if response.status_code == httpx.codes.NOT_FOUND:
-                msg = f"LTD resource {url} not found (404)"
-                raise LtdNotFoundError(msg)
+                raise LtdNotFoundError(
+                    url=url,
+                    method="GET",
+                    status_code=response.status_code,
+                    body=response.text,
+                    message=f"LTD resource {url} not found (404)",
+                )
 
             if response.status_code in _RETRYABLE_STATUS_CODES:
                 if attempt >= self._max_attempts:
-                    msg = (
-                        f"LTD GET {url} returned {response.status_code} "
-                        f"after {attempt} attempts"
+                    raise LtdClientError(
+                        url=url,
+                        method="GET",
+                        status_code=response.status_code,
+                        body=response.text,
+                        message=(
+                            f"LTD GET {url} returned {response.status_code} "
+                            f"after {attempt} attempts"
+                        ),
                     )
-                    raise LtdClientError(msg)
                 await asyncio.sleep(
                     self._backoff_for_response(response, attempt)
                 )
                 continue
 
             if response.is_error:
-                msg = (
-                    f"LTD GET {url} returned non-retryable status "
-                    f"{response.status_code}"
+                raise LtdClientError(
+                    url=url,
+                    method="GET",
+                    status_code=response.status_code,
+                    body=response.text,
+                    message=(
+                        f"LTD GET {url} returned non-retryable status "
+                        f"{response.status_code}"
+                    ),
                 )
-                raise LtdClientError(msg)
 
             payload: dict[str, Any] = response.json()
             return payload
 
-        msg = f"LTD GET {url} exhausted retries"
-        raise LtdClientError(msg) from last_exc
+        raise LtdClientError(
+            url=url,
+            method="GET",
+            message=f"LTD GET {url} exhausted retries",
+        ) from last_exc
 
     def _backoff_for_attempt(self, attempt: int) -> float:
         multiplier: int = 2 ** (attempt - 1)

--- a/src/docverse/storage/queue_job_store.py
+++ b/src/docverse/storage/queue_job_store.py
@@ -11,7 +11,11 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.dbschema.queue_job import SqlQueueJob
-from docverse.domain.base32id import generate_base32_id, validate_base32_id
+from docverse.domain.base32id import (
+    generate_base32_id,
+    serialize_base32_id,
+    validate_base32_id,
+)
 from docverse.domain.queue import JobKind, JobStatus, QueueJob
 from docverse.exceptions import InvalidJobStateError, JobNotFoundError
 from docverse.storage.pagination import QueueJobDateCreatedCursor
@@ -110,11 +114,12 @@ class QueueJobStore:
         """
         row = await self._get_row(job_id)
         if row.status != JobStatus.queued.value:
-            msg = (
-                f"Cannot start job {job_id}: "
-                f"expected 'queued', got '{row.status}'"
+            raise InvalidJobStateError(
+                current_state=row.status,
+                target_state=JobStatus.in_progress.value,
+                job_public_id=serialize_base32_id(row.public_id),
+                job_function=row.kind,
             )
-            raise InvalidJobStateError(msg)
         row.status = JobStatus.in_progress.value
         row.date_started = datetime.now(tz=UTC)
         await self._session.flush()
@@ -196,11 +201,17 @@ class QueueJobStore:
         """
         row = await self._get_row(job_id)
         if row.status != JobStatus.in_progress.value:
-            msg = (
-                f"Cannot complete job {job_id}: "
-                f"expected 'in_progress', got '{row.status}'"
+            target = (
+                JobStatus.completed_with_errors.value
+                if has_errors
+                else JobStatus.completed.value
             )
-            raise InvalidJobStateError(msg)
+            raise InvalidJobStateError(
+                current_state=row.status,
+                target_state=target,
+                job_public_id=serialize_base32_id(row.public_id),
+                job_function=row.kind,
+            )
         row.status = (
             JobStatus.completed_with_errors.value
             if has_errors
@@ -227,12 +238,12 @@ class QueueJobStore:
         row = await self._get_row(job_id)
         allowed = {JobStatus.queued.value, JobStatus.in_progress.value}
         if row.status not in allowed:
-            msg = (
-                f"Cannot fail job {job_id}: "
-                f"expected 'queued'/'in_progress', "
-                f"got '{row.status}'"
+            raise InvalidJobStateError(
+                current_state=row.status,
+                target_state=JobStatus.failed.value,
+                job_public_id=serialize_base32_id(row.public_id),
+                job_function=row.kind,
             )
-            raise InvalidJobStateError(msg)
         row.status = JobStatus.failed.value
         row.date_completed = datetime.now(tz=UTC)
         if errors is not None:
@@ -252,12 +263,12 @@ class QueueJobStore:
         row = await self._get_row(job_id)
         allowed = {JobStatus.queued.value, JobStatus.in_progress.value}
         if row.status not in allowed:
-            msg = (
-                f"Cannot cancel job {job_id}: "
-                f"expected 'queued'/'in_progress', "
-                f"got '{row.status}'"
+            raise InvalidJobStateError(
+                current_state=row.status,
+                target_state=JobStatus.cancelled.value,
+                job_public_id=serialize_base32_id(row.public_id),
+                job_function=row.kind,
             )
-            raise InvalidJobStateError(msg)
         row.status = JobStatus.cancelled.value
         row.date_completed = datetime.now(tz=UTC)
         await self._session.flush()
@@ -670,6 +681,8 @@ class QueueJobStore:
         )
         row = result.scalar_one_or_none()
         if row is None:
-            msg = f"Queue job {job_id} not found"
-            raise JobNotFoundError(msg)
+            raise JobNotFoundError(
+                job_function="QueueJobStore._get_row",
+                message=f"Queue job {job_id} not found",
+            )
         return row

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -13,6 +13,7 @@ import mimetypes
 import tarfile
 from typing import Any
 
+import sentry_sdk
 import structlog
 from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -214,8 +215,9 @@ async def _process_build_locked(  # noqa: PLR0913
                 project_slug=project_slug,
                 logger=logger,
             )
-    except Exception:
+    except Exception as exc:
         # Phase 3a: Mark build and queue job as failed
+        sentry_sdk.capture_exception(exc)
         logger.exception("Build processing failed")
         async with session.begin():
             build_service = factory.create_build_service()
@@ -476,7 +478,8 @@ async def _track_editions(  # noqa: PLR0913
             editions_updated=len(tracking_result.updated),
             editions_skipped=len(tracking_result.skipped),
         )
-    except Exception:
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
         logger.exception("Edition tracking failed")
         return None
     else:

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -98,6 +98,7 @@ async def build_processing(
             return await _process_build_locked(
                 session=session,
                 factory=factory,
+                org_slug=org_slug,
                 build_store=build_store,
                 org_store=org_store,
                 queue_job_store=queue_job_store,
@@ -165,6 +166,7 @@ async def _process_build_locked(  # noqa: PLR0913
     ctx: dict[str, Any],
     build: Build,
     org_id: int,
+    org_slug: str,
     project_slug: str,
     build_id: int,
     build_public_id: str,
@@ -208,6 +210,8 @@ async def _process_build_locked(  # noqa: PLR0913
                 object_store=object_store,
                 build=build,
                 build_store=build_store,
+                org_slug=org_slug,
+                project_slug=project_slug,
                 logger=logger,
             )
     except Exception:
@@ -215,7 +219,11 @@ async def _process_build_locked(  # noqa: PLR0913
         logger.exception("Build processing failed")
         async with session.begin():
             build_service = factory.create_build_service()
-            await build_service.fail(build_id=build_id)
+            await build_service.fail(
+                build_id=build_id,
+                org_slug=org_slug,
+                project_slug=project_slug,
+            )
             if queue_job_id is not None:
                 await queue_job_store.fail(queue_job_id)
         return "failed"
@@ -475,11 +483,13 @@ async def _track_editions(  # noqa: PLR0913
         return tracking_result
 
 
-async def _process_build(
+async def _process_build(  # noqa: PLR0913
     *,
     object_store: ObjectStore,
     build: Build,
     build_store: BuildStore,
+    org_slug: str,
+    project_slug: str,
     logger: structlog.stdlib.BoundLogger,
 ) -> tuple[int, int]:
     """Download, unpack, and upload build files.
@@ -548,10 +558,15 @@ async def _process_build(
         build_id=build.id,
         object_count=object_count,
         total_size_bytes=total_size,
+        org_slug=org_slug,
+        project_slug=project_slug,
     )
 
     await build_store.transition_status(
-        build_id=build.id, new_status=BuildStatus.completed
+        build_id=build.id,
+        new_status=BuildStatus.completed,
+        org_slug=org_slug,
+        project_slug=project_slug,
     )
 
     try:

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -10,6 +10,7 @@ import traceback
 from datetime import UTC, datetime
 from typing import Any
 
+import sentry_sdk
 import structlog
 from safir.dependencies.db_session import db_session_dependency
 
@@ -107,6 +108,7 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                         resolved=resolved,
                     )
             except Exception as exc:
+                sentry_sdk.capture_exception(exc)
                 logger.exception("Dashboard build failed")
                 async with session.begin():
                     await queue_job_store.fail(

--- a/src/docverse/worker/functions/dashboard_sync.py
+++ b/src/docverse/worker/functions/dashboard_sync.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import traceback
 from typing import Any
 
+import sentry_sdk
 import structlog
 from safir.dependencies.db_session import db_session_dependency
 
@@ -18,7 +19,9 @@ from docverse.services.dashboard_templates.sync import DashboardSyncStatus
 from docverse.services.lock_service import LockKey
 
 
-async def dashboard_sync(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
+async def dashboard_sync(  # noqa: PLR0915
+    ctx: dict[str, Any], payload: dict[str, Any]
+) -> str:
     """Sync one dashboard-template binding from GitHub.
 
     Parameters
@@ -105,6 +108,7 @@ async def dashboard_sync(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                     syncer = factory.create_dashboard_template_syncer()
                     sync_result = await syncer.sync(binding_id)
             except Exception as exc:
+                sentry_sdk.capture_exception(exc)
                 logger.exception("Dashboard sync failed unexpectedly")
                 error_message = f"{type(exc).__name__}: {exc}"
                 async with session.begin():

--- a/src/docverse/worker/functions/dashboard_sync.py
+++ b/src/docverse/worker/functions/dashboard_sync.py
@@ -131,7 +131,7 @@ async def dashboard_sync(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                         queue_job_id,
                         errors={
                             "message": sync_result.error or "Sync failed",
-                            "type": "DashboardTemplateSyncError",
+                            "type": "dashboard_sync_failed",
                         },
                     )
                 return "failed"

--- a/src/docverse/worker/functions/dashboard_sync.py
+++ b/src/docverse/worker/functions/dashboard_sync.py
@@ -7,7 +7,6 @@ resolved template points at the synced content.
 
 from __future__ import annotations
 
-import traceback
 from typing import Any
 
 import sentry_sdk
@@ -15,13 +14,14 @@ import structlog
 from safir.dependencies.db_session import db_session_dependency
 
 from docverse.exceptions import NotFoundError
+from docverse.services.dashboard_templates._sync_failure import (
+    mark_dashboard_sync_failed,
+)
 from docverse.services.dashboard_templates.sync import DashboardSyncStatus
 from docverse.services.lock_service import LockKey
 
 
-async def dashboard_sync(  # noqa: PLR0915
-    ctx: dict[str, Any], payload: dict[str, Any]
-) -> str:
+async def dashboard_sync(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
     """Sync one dashboard-template binding from GitHub.
 
     Parameters
@@ -110,22 +110,15 @@ async def dashboard_sync(  # noqa: PLR0915
             except Exception as exc:
                 sentry_sdk.capture_exception(exc)
                 logger.exception("Dashboard sync failed unexpectedly")
-                error_message = f"{type(exc).__name__}: {exc}"
-                async with session.begin():
-                    await binding_store.update_sync_state(
-                        binding_id=binding_id,
-                        last_sync_status="failed",
-                        last_sync_error=error_message,
-                    )
-                async with session.begin():
-                    await queue_job_store.fail(
-                        queue_job_id,
-                        errors={
-                            "message": str(exc),
-                            "type": type(exc).__name__,
-                            "traceback": traceback.format_exc(),
-                        },
-                    )
+                await mark_dashboard_sync_failed(
+                    session=session,
+                    binding_store=binding_store,
+                    binding_id=binding_id,
+                    exc=exc,
+                    error_message=f"{type(exc).__name__}: {exc}",
+                    queue_job_store=queue_job_store,
+                    queue_job_id=queue_job_id,
+                )
                 return "failed"
 
             if sync_result.status is DashboardSyncStatus.failed:

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -34,6 +34,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Literal, Protocol
 
 import httpx
+import sentry_sdk
 import structlog
 from safir.arq import ArqQueue
 from safir.dependencies.db_session import db_session_dependency
@@ -298,6 +299,7 @@ async def keeper_sync_run_discovery(
                 in_scope_count=len(in_scope),
             )
         except Exception as exc:
+            sentry_sdk.capture_exception(exc)
             logger.exception("Keeper-sync discovery failed")
             async with session.begin():
                 await queue_job_store.fail(
@@ -426,6 +428,7 @@ async def keeper_sync_project(
                 logger=logger,
             )
         except Exception as exc:
+            sentry_sdk.capture_exception(exc)
             logger.exception("Keeper-sync project failed")
             async with session.begin():
                 await queue_job_store.fail(
@@ -692,7 +695,8 @@ async def _fetch_ltd_product_slugs(
     )
     try:
         return await client.list_product_slugs()
-    except httpx.HTTPError:
+    except httpx.HTTPError as exc:
+        sentry_sdk.capture_exception(exc)
         logger.exception("Failed to fetch LTD product slugs")
         raise
 
@@ -943,7 +947,8 @@ async def _run_tier(
                     org=org,
                     logger=logger,
                 )
-            except Exception:
+            except Exception as exc:
+                sentry_sdk.capture_exception(exc)
                 logger.exception(
                     "Keeper-sync tier processor failed for org",
                     tier=tier_name,
@@ -1029,7 +1034,8 @@ async def _tier_main_for_org(
                 org_id=org.id,
                 ltd_slug=ltd_slug,
             )
-        except LtdClientError:
+        except LtdClientError as exc:
+            sentry_sdk.capture_exception(exc)
             logger.exception(
                 "Tier-main: failed to fetch main edition",
                 org=org.slug,
@@ -1155,7 +1161,8 @@ async def _tier_discovery_for_org(
                 project_state=project_state,
                 edition_state_by_ltd_id=edition_state_by_ltd_id,
             )
-        except LtdClientError:
+        except LtdClientError as exc:
+            sentry_sdk.capture_exception(exc)
             logger.exception(
                 "Tier-discovery: failed to inspect project editions",
                 org=org.slug,
@@ -1252,7 +1259,8 @@ async def _tier_other_for_org(
             continue
         try:
             ltd_editions = await ltd_client.list_editions_for_product(ltd_slug)
-        except LtdClientError:
+        except LtdClientError as exc:
+            sentry_sdk.capture_exception(exc)
             logger.exception(
                 "Tier-other: failed to fetch project editions",
                 org=org.slug,

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -12,6 +12,7 @@ import traceback
 from dataclasses import dataclass
 from typing import Any
 
+import sentry_sdk
 import structlog
 from safir.dependencies.db_session import db_session_dependency
 
@@ -120,6 +121,7 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                         history_entry=resources.history_entry,
                     )
             except Exception as exc:
+                sentry_sdk.capture_exception(exc)
                 logger.exception("Edition publish failed")
                 async with session.begin():
                     await _mark_failed(

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -23,7 +23,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.config import Configuration
 from docverse.database import get_current_revision
 from docverse.factory import Factory
-from docverse.sentry import DocverseSentryComponent, initialize_sentry
+from docverse.sentry import (
+    DocverseSentryComponent,
+    initialize_sentry,
+    instrument_arq_task,
+)
 from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.services.keeper_sync.scheduler import (
     TIER_DISCOVERY_CRON_INTERVAL,
@@ -286,11 +290,11 @@ class WorkerSettings:
     """arq WorkerSettings for the default Docverse queue."""
 
     functions = [
-        build_processing,
-        dashboard_build,
-        dashboard_sync,
-        ping,
-        publish_edition,
+        instrument_arq_task(build_processing),
+        instrument_arq_task(dashboard_build),
+        instrument_arq_task(dashboard_sync),
+        instrument_arq_task(ping),
+        instrument_arq_task(publish_edition),
     ]
     redis_settings = config.arq_redis_settings
     queue_name = config.arq_queue_name
@@ -323,19 +327,19 @@ class KeeperSyncWorkerSettings:
 
     functions = [
         func(
-            keeper_sync_run_discovery,
+            instrument_arq_task(keeper_sync_run_discovery),
             timeout=config.keeper_sync_job_timeout_seconds,
             max_tries=1,
         ),
         func(
-            keeper_sync_project,
+            instrument_arq_task(keeper_sync_project),
             timeout=config.keeper_sync_job_timeout_seconds,
             max_tries=1,
         ),
-        keeper_sync_reaper,
-        keeper_sync_tier_main,
-        keeper_sync_tier_discovery,
-        keeper_sync_tier_other,
+        instrument_arq_task(keeper_sync_reaper),
+        instrument_arq_task(keeper_sync_tier_main),
+        instrument_arq_task(keeper_sync_tier_discovery),
+        instrument_arq_task(keeper_sync_tier_other),
     ]
     # Tier-cron cadences come from the constants in
     # ``services/keeper_sync/scheduler.py`` so the planner's next-tick
@@ -343,19 +347,19 @@ class KeeperSyncWorkerSettings:
     # schedule cannot drift.
     cron_jobs = [
         cron(
-            keeper_sync_reaper,
+            instrument_arq_task(keeper_sync_reaper),
             minute={0, 30},
         ),
         # Tier 1 — keeps the user-visible ``main`` edition fresh per
         # user story 10's SLO.
         cron(
-            keeper_sync_tier_main,
+            instrument_arq_task(keeper_sync_tier_main),
             minute=_cron_minutes_for_tier_interval(TIER_MAIN_CRON_INTERVAL),
         ),
         # Tier 2 — discovers LTD resources without a
         # ``keeper_sync_state`` row.
         cron(
-            keeper_sync_tier_discovery,
+            instrument_arq_task(keeper_sync_tier_discovery),
             minute=_cron_minutes_for_tier_interval(
                 TIER_DISCOVERY_CRON_INTERVAL
             ),
@@ -363,7 +367,7 @@ class KeeperSyncWorkerSettings:
         # Tier 3 — catches non-``main`` editions whose state has aged
         # past the threshold.
         cron(
-            keeper_sync_tier_other,
+            instrument_arq_task(keeper_sync_tier_other),
             minute=_cron_minutes_for_tier_interval(TIER_OTHER_CRON_INTERVAL),
         ),
     ]
@@ -401,24 +405,24 @@ class LifecycleEvalWorkerSettings:
 
     functions = [
         func(
-            lifecycle_eval_dispatcher,
+            instrument_arq_task(lifecycle_eval_dispatcher),
             timeout=config.lifecycle_eval_job_timeout_seconds,
             max_tries=1,
         ),
         func(
-            lifecycle_eval,
+            instrument_arq_task(lifecycle_eval),
             timeout=config.lifecycle_eval_job_timeout_seconds,
             max_tries=1,
         ),
-        lifecycle_reaper,
+        instrument_arq_task(lifecycle_reaper),
     ]
     cron_jobs = [
         cron(
-            lifecycle_eval_dispatcher,
+            instrument_arq_task(lifecycle_eval_dispatcher),
             minute={0},
         ),
         cron(
-            lifecycle_reaper,
+            instrument_arq_task(lifecycle_reaper),
             minute={0, 30},
         ),
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 import pytest_asyncio
 import respx
+import sentry_sdk
 import structlog
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
@@ -57,6 +58,33 @@ __all__ = [
 ]
 
 _DISCOVERY_FIXTURE = Path(__file__).parent / "data" / "discovery.json"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sentry_global_scope() -> Iterator[None]:
+    """Snapshot and restore global-scope Sentry tags around every test.
+
+    ``safir.testing.sentry.sentry_init_fixture`` saves and restores the
+    Sentry *client* on the global scope, but it does not touch tags.
+    :func:`docverse.sentry.initialize_sentry` (and any other code that
+    writes to ``sentry_sdk.get_global_scope()``) leaves ``service`` /
+    ``component`` (and potentially other) tags on that scope, which
+    would otherwise persist across tests in the session and bleed into
+    any later test that asserts tag absence. Snapshotting all tags on
+    entry and restoring on exit isolates every test regardless of
+    which tags it sets.
+    """
+    scope = sentry_sdk.get_global_scope()
+    saved_tags = dict(scope._tags)
+    try:
+        yield
+    finally:
+        scope = sentry_sdk.get_global_scope()
+        for key in list(scope._tags):
+            if key not in saved_tags:
+                scope.remove_tag(key)
+        for key, value in saved_tags.items():
+            scope.set_tag(key, value)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -7,8 +7,11 @@ subclass -- so future enrichment slices (#341-#344) can override
 ``to_sentry()`` against a single shared base.
 
 The unit tests here assert membership in both bases and that the
-inherited default ``to_slack()`` renders without error. The end-to-end
-Sentry capture is exercised separately in :mod:`tests.sentry_test`.
+inherited default ``to_slack()`` renders without error. Per-subclass
+``to_sentry()`` overrides (slice #341 onward) are also exercised here
+against representative constructor args without spinning up
+``sentry_sdk.init``. The end-to-end Sentry capture is exercised
+separately in :mod:`tests.sentry_test`.
 """
 
 from __future__ import annotations
@@ -32,12 +35,20 @@ def _make_invalid_slug() -> InvalidSlugError:
     return InvalidSlugError("__reserved", "slug must not start with '__'")
 
 
+def _make_invalid_build_state() -> InvalidBuildStateError:
+    return InvalidBuildStateError(
+        current_state="processing",
+        target_state="completed",
+        build_public_id="01ABCDEF",
+        project_slug="my-project",
+        org_slug="my-org",
+        edition_slug="main",
+    )
+
+
 _FACTORIES: list[tuple[str, Callable[[], DocverseSlackException]]] = [
     ("InvalidJobStateError", lambda: InvalidJobStateError("queued -> queued")),
-    (
-        "InvalidBuildStateError",
-        lambda: InvalidBuildStateError("uploaded -> uploaded"),
-    ),
+    ("InvalidBuildStateError", _make_invalid_build_state),
     ("JobNotFoundError", lambda: JobNotFoundError("job ABC123 not found")),
     ("InvalidSlugError", _make_invalid_slug),
     (
@@ -71,10 +82,144 @@ def test_migrated_exception_renders_default_to_slack(
 ) -> None:
     """The inherited ``SlackException.to_slack()`` default renders cleanly.
 
-    No constructor overrides in this slice — the default ``to_slack`` is
-    the contract every migrated subclass exposes.
+    The default ``to_slack`` is the contract every migrated subclass
+    exposes; subclasses that override ``to_sentry`` keep the default
+    Slack rendering unless they explicitly override that too.
     """
     exc = factory()
     message = exc.to_slack()
     assert isinstance(message, SlackMessage)
     assert str(exc) == exc.message
+
+
+_BUILD_STATE_CASES: list[
+    tuple[str, Callable[[], InvalidBuildStateError], dict[str, str]]
+] = [
+    (
+        "full-transition",
+        lambda: InvalidBuildStateError(
+            current_state="processing",
+            target_state="completed",
+            build_public_id="01ABCDEF",
+            project_slug="my-project",
+            org_slug="my-org",
+            edition_slug="main",
+        ),
+        {
+            "org_slug": "my-org",
+            "project_slug": "my-project",
+            "build_current_state": "processing",
+            "build_target_state": "completed",
+        },
+    ),
+    (
+        "no-edition",
+        lambda: InvalidBuildStateError(
+            current_state="completed",
+            target_state="processing",
+            build_public_id="02ZYXWVU",
+            project_slug="docs-site",
+            org_slug="rubin",
+        ),
+        {
+            "org_slug": "rubin",
+            "project_slug": "docs-site",
+            "build_current_state": "completed",
+            "build_target_state": "processing",
+        },
+    ),
+    (
+        "not-found",
+        lambda: InvalidBuildStateError(
+            target_state="processing",
+            project_slug="docs-site",
+            org_slug="rubin",
+            message="Build id=42 not found",
+        ),
+        {
+            "org_slug": "rubin",
+            "project_slug": "docs-site",
+            "build_target_state": "processing",
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("case", "factory", "expected_tags"),
+    _BUILD_STATE_CASES,
+    ids=[case for case, _, _ in _BUILD_STATE_CASES],
+)
+def test_invalid_build_state_to_sentry_tags(
+    case: str,
+    factory: Callable[[], InvalidBuildStateError],
+    expected_tags: dict[str, str],
+) -> None:
+    """``to_sentry`` surfaces API-facing slugs and state names as tags.
+
+    Tags are low-cardinality (org_slug, project_slug, state names) so
+    they can be aggregated in the Sentry UI. ``build_public_id`` is
+    intentionally a context value (high cardinality), not a tag.
+    """
+    info = factory().to_sentry()
+    assert info.tags == expected_tags
+    assert "build_public_id" not in info.tags
+
+
+@pytest.mark.parametrize(
+    ("case", "factory", "expected_tags"),
+    _BUILD_STATE_CASES,
+    ids=[case for case, _, _ in _BUILD_STATE_CASES],
+)
+def test_invalid_build_state_to_sentry_context(
+    case: str,
+    factory: Callable[[], InvalidBuildStateError],
+    expected_tags: dict[str, str],
+) -> None:
+    """``to_sentry`` exposes the full transition snapshot as a context.
+
+    The ``build_transition`` context carries every API-facing
+    identifier the exception was constructed with (even ``None``s) so
+    a triager can paste ``build_public_id`` and ``project_slug``
+    straight into a build URL without translating row ids.
+    """
+    exc = factory()
+    info = exc.to_sentry()
+    context = info.contexts["build_transition"]
+    assert context["build_public_id"] == exc.build_public_id
+    assert context["project_slug"] == exc.project_slug
+    assert context["org_slug"] == exc.org_slug
+    assert context["edition_slug"] == exc.edition_slug
+    assert context["current_state"] == exc.current_state
+    assert context["target_state"] == exc.target_state
+
+
+def test_invalid_build_state_default_message_is_useful() -> None:
+    """Without an explicit ``message`` the default summarises the transition.
+
+    The summary names both states and the API-facing build slug so a
+    log line or Slack alert is actionable without unpacking the
+    structured fields.
+    """
+    exc = InvalidBuildStateError(
+        current_state="completed",
+        target_state="processing",
+        build_public_id="01ABCDEF",
+        project_slug="my-project",
+        org_slug="my-org",
+    )
+    rendered = str(exc)
+    assert "completed" in rendered
+    assert "processing" in rendered
+    assert "01ABCDEF" in rendered
+
+
+def test_invalid_build_state_explicit_message_wins() -> None:
+    """Passing ``message`` overrides the auto-generated default."""
+    exc = InvalidBuildStateError(
+        target_state="processing",
+        project_slug="my-project",
+        org_slug="my-org",
+        message="Build id=42 not found",
+    )
+    assert str(exc) == "Build id=42 not found"

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -46,10 +46,28 @@ def _make_invalid_build_state() -> InvalidBuildStateError:
     )
 
 
+def _make_invalid_job_state() -> InvalidJobStateError:
+    return InvalidJobStateError(
+        current_state="queued",
+        target_state="in_progress",
+        job_public_id="ABCD-EFGH-1234",
+        queue_name="docverse:queue",
+        job_function="build_processing",
+    )
+
+
+def _make_job_not_found() -> JobNotFoundError:
+    return JobNotFoundError(
+        job_public_id="ABCD-EFGH-1234",
+        queue_name="docverse:queue",
+        job_function="build_processing",
+    )
+
+
 _FACTORIES: list[tuple[str, Callable[[], DocverseSlackException]]] = [
-    ("InvalidJobStateError", lambda: InvalidJobStateError("queued -> queued")),
+    ("InvalidJobStateError", _make_invalid_job_state),
     ("InvalidBuildStateError", _make_invalid_build_state),
-    ("JobNotFoundError", lambda: JobNotFoundError("job ABC123 not found")),
+    ("JobNotFoundError", _make_job_not_found),
     ("InvalidSlugError", _make_invalid_slug),
     (
         "DashboardTemplateSyncError",
@@ -223,3 +241,234 @@ def test_invalid_build_state_explicit_message_wins() -> None:
         message="Build id=42 not found",
     )
     assert str(exc) == "Build id=42 not found"
+
+
+_JOB_STATE_CASES: list[
+    tuple[str, Callable[[], InvalidJobStateError], dict[str, str]]
+] = [
+    (
+        "full-transition",
+        lambda: InvalidJobStateError(
+            current_state="queued",
+            target_state="in_progress",
+            job_public_id="ABCD-EFGH-1234",
+            queue_name="docverse:queue",
+            job_function="build_processing",
+        ),
+        {
+            "queue_name": "docverse:queue",
+            "job_function": "build_processing",
+            "job_current_state": "queued",
+            "job_target_state": "in_progress",
+        },
+    ),
+    (
+        "keeper-sync-run-transition",
+        lambda: InvalidJobStateError(
+            current_state="succeeded",
+            target_state="in_progress",
+            queue_name="docverse:sync-queue",
+            message=(
+                "Cannot transition keeper sync run 42 from"
+                " 'succeeded' to 'in_progress'"
+            ),
+        ),
+        {
+            "queue_name": "docverse:sync-queue",
+            "job_current_state": "succeeded",
+            "job_target_state": "in_progress",
+        },
+    ),
+    (
+        "run-not-found",
+        lambda: InvalidJobStateError(
+            queue_name="docverse:lifecycle-queue",
+            message="Lifecycle eval run 99 not found",
+        ),
+        {
+            "queue_name": "docverse:lifecycle-queue",
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("case", "factory", "expected_tags"),
+    _JOB_STATE_CASES,
+    ids=[case for case, _, _ in _JOB_STATE_CASES],
+)
+def test_invalid_job_state_to_sentry_tags(
+    case: str,
+    factory: Callable[[], InvalidJobStateError],
+    expected_tags: dict[str, str],
+) -> None:
+    """``to_sentry`` surfaces queue name, function, and states as tags.
+
+    Tags are low-cardinality (queue name, function name, state enum
+    values) so they can be aggregated in the Sentry UI. ``job_public_id``
+    is intentionally a context value (high cardinality), not a tag.
+    """
+    info = factory().to_sentry()
+    assert info.tags == expected_tags
+    assert "job_public_id" not in info.tags
+
+
+@pytest.mark.parametrize(
+    ("case", "factory", "expected_tags"),
+    _JOB_STATE_CASES,
+    ids=[case for case, _, _ in _JOB_STATE_CASES],
+)
+def test_invalid_job_state_to_sentry_context(
+    case: str,
+    factory: Callable[[], InvalidJobStateError],
+    expected_tags: dict[str, str],
+) -> None:
+    """``to_sentry`` exposes the full transition snapshot as a context.
+
+    The ``queue_job_transition`` context carries every API-facing
+    identifier the exception was constructed with (even ``None``s) so a
+    triager can paste ``job_public_id`` straight into a ``/queue/{id}``
+    URL without translating internal row ids.
+    """
+    exc = factory()
+    info = exc.to_sentry()
+    context = info.contexts["queue_job_transition"]
+    assert context["job_public_id"] == exc.job_public_id
+    assert context["queue_name"] == exc.queue_name
+    assert context["job_function"] == exc.job_function
+    assert context["current_state"] == exc.current_state
+    assert context["target_state"] == exc.target_state
+
+
+def test_invalid_job_state_default_message_is_useful() -> None:
+    """Without an explicit ``message`` the default summarises the transition.
+
+    The summary names both states and the API-facing job slug so a log
+    line or Slack alert is actionable without unpacking the structured
+    fields.
+    """
+    exc = InvalidJobStateError(
+        current_state="in_progress",
+        target_state="queued",
+        job_public_id="ABCD-EFGH-1234",
+        queue_name="docverse:queue",
+        job_function="build_processing",
+    )
+    rendered = str(exc)
+    assert "in_progress" in rendered
+    assert "queued" in rendered
+    assert "ABCD-EFGH-1234" in rendered
+
+
+def test_invalid_job_state_explicit_message_wins() -> None:
+    """Passing ``message`` overrides the auto-generated default."""
+    exc = InvalidJobStateError(
+        current_state="succeeded",
+        target_state="in_progress",
+        queue_name="docverse:sync-queue",
+        message="Cannot transition keeper sync run 42 backwards",
+    )
+    assert str(exc) == "Cannot transition keeper sync run 42 backwards"
+
+
+_JOB_NOT_FOUND_CASES: list[
+    tuple[str, Callable[[], JobNotFoundError], dict[str, str]]
+] = [
+    (
+        "fully-known",
+        lambda: JobNotFoundError(
+            job_public_id="ABCD-EFGH-1234",
+            queue_name="docverse:queue",
+            job_function="build_processing",
+        ),
+        {"queue_name": "docverse:queue"},
+    ),
+    (
+        "lookup-by-internal-id",
+        lambda: JobNotFoundError(
+            queue_name="docverse:queue",
+            job_function="QueueJobStore._get_row",
+            message="Queue job 42 not found",
+        ),
+        {"queue_name": "docverse:queue"},
+    ),
+    (
+        "queue-unknown",
+        lambda: JobNotFoundError(job_public_id="ABCD-EFGH-1234"),
+        {},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("case", "factory", "expected_tags"),
+    _JOB_NOT_FOUND_CASES,
+    ids=[case for case, _, _ in _JOB_NOT_FOUND_CASES],
+)
+def test_job_not_found_to_sentry_tags(
+    case: str,
+    factory: Callable[[], JobNotFoundError],
+    expected_tags: dict[str, str],
+) -> None:
+    """``to_sentry`` surfaces only the queue name as a tag.
+
+    The ``job_public_id`` and ``job_function`` are high-cardinality and
+    live in the ``queue_job_lookup`` context instead. ``queue_name``
+    earns its place as a tag for aggregation across one queue.
+    """
+    info = factory().to_sentry()
+    assert info.tags == expected_tags
+    assert "job_public_id" not in info.tags
+    assert "job_function" not in info.tags
+
+
+@pytest.mark.parametrize(
+    ("case", "factory", "expected_tags"),
+    _JOB_NOT_FOUND_CASES,
+    ids=[case for case, _, _ in _JOB_NOT_FOUND_CASES],
+)
+def test_job_not_found_to_sentry_context(
+    case: str,
+    factory: Callable[[], JobNotFoundError],
+    expected_tags: dict[str, str],
+) -> None:
+    """``to_sentry`` exposes the lookup site as a context.
+
+    The ``queue_job_lookup`` context carries every API-facing
+    identifier the exception was constructed with (even ``None``s) so a
+    triager can paste ``job_public_id`` straight into a ``/queue/{id}``
+    URL without translating internal row ids.
+    """
+    exc = factory()
+    info = exc.to_sentry()
+    context = info.contexts["queue_job_lookup"]
+    assert context["job_public_id"] == exc.job_public_id
+    assert context["queue_name"] == exc.queue_name
+    assert context["job_function"] == exc.job_function
+
+
+def test_job_not_found_default_message_uses_public_id() -> None:
+    """The default message names the API-facing ``public_id`` when known."""
+    exc = JobNotFoundError(
+        job_public_id="ABCD-EFGH-1234",
+        queue_name="docverse:queue",
+    )
+    rendered = str(exc)
+    assert "ABCD-EFGH-1234" in rendered
+    assert "not found" in rendered
+
+
+def test_job_not_found_explicit_message_wins() -> None:
+    """Passing ``message`` overrides the auto-generated default.
+
+    The store layer queries by internal row id and has no
+    ``public_id`` to surface; the ``message`` override path lets the
+    log/Slack rendering carry the internal id without leaking it into
+    Sentry tags or contexts.
+    """
+    exc = JobNotFoundError(
+        queue_name="docverse:queue",
+        job_function="QueueJobStore._get_row",
+        message="Queue job 42 not found",
+    )
+    assert str(exc) == "Queue job 42 not found"

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -1,0 +1,80 @@
+"""Tests for the shared ``DocverseSlackException`` base.
+
+Pins the contract introduced in PRD #338 / slice #340 that every
+non-``ClientRequestError`` server-side exception inherits from
+``DocverseSlackException`` — itself a ``safir.slack.blockkit.SlackException``
+subclass — so future enrichment slices (#341–#344) can override
+``to_sentry()`` against a single shared base.
+
+The unit tests here assert membership in both bases and that the
+inherited default ``to_slack()`` renders without error. The end-to-end
+Sentry capture is exercised separately in :mod:`tests.sentry_test`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from safir.slack.blockkit import SlackException, SlackMessage
+
+from docverse.domain.slug import InvalidSlugError
+from docverse.exceptions import (
+    DocverseSlackException,
+    InvalidBuildStateError,
+    InvalidJobStateError,
+    JobNotFoundError,
+)
+from docverse.services.dashboard_templates import DashboardTemplateSyncError
+
+
+def _make_invalid_slug() -> InvalidSlugError:
+    return InvalidSlugError("__reserved", "slug must not start with '__'")
+
+
+_FACTORIES: list[tuple[str, Callable[[], DocverseSlackException]]] = [
+    ("InvalidJobStateError", lambda: InvalidJobStateError("queued -> queued")),
+    (
+        "InvalidBuildStateError",
+        lambda: InvalidBuildStateError("uploaded -> uploaded"),
+    ),
+    ("JobNotFoundError", lambda: JobNotFoundError("job ABC123 not found")),
+    ("InvalidSlugError", _make_invalid_slug),
+    (
+        "DashboardTemplateSyncError",
+        lambda: DashboardTemplateSyncError("sync failed for binding 1"),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "factory"),
+    _FACTORIES,
+    ids=[name for name, _ in _FACTORIES],
+)
+def test_migrated_exception_is_docverse_slack_exception(
+    name: str, factory: Callable[[], DocverseSlackException]
+) -> None:
+    """Every migrated exception derives from both new and safir bases."""
+    exc = factory()
+    assert isinstance(exc, DocverseSlackException)
+    assert isinstance(exc, SlackException)
+
+
+@pytest.mark.parametrize(
+    ("name", "factory"),
+    _FACTORIES,
+    ids=[name for name, _ in _FACTORIES],
+)
+def test_migrated_exception_renders_default_to_slack(
+    name: str, factory: Callable[[], DocverseSlackException]
+) -> None:
+    """The inherited ``SlackException.to_slack()`` default renders cleanly.
+
+    No constructor overrides in this slice — the default ``to_slack`` is
+    the contract every migrated subclass exposes.
+    """
+    exc = factory()
+    message = exc.to_slack()
+    assert isinstance(message, SlackMessage)
+    assert str(exc) == exc.message

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -28,7 +28,6 @@ from docverse.exceptions import (
     InvalidJobStateError,
     JobNotFoundError,
 )
-from docverse.services.dashboard_templates import DashboardTemplateSyncError
 
 
 def _make_invalid_slug() -> InvalidSlugError:
@@ -69,10 +68,6 @@ _FACTORIES: list[tuple[str, Callable[[], DocverseSlackException]]] = [
     ("InvalidBuildStateError", _make_invalid_build_state),
     ("JobNotFoundError", _make_job_not_found),
     ("InvalidSlugError", _make_invalid_slug),
-    (
-        "DashboardTemplateSyncError",
-        lambda: DashboardTemplateSyncError("sync failed for binding 1"),
-    ),
 ]
 
 

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -2,8 +2,8 @@
 
 Pins the contract introduced in PRD #338 / slice #340 that every
 non-``ClientRequestError`` server-side exception inherits from
-``DocverseSlackException`` — itself a ``safir.slack.blockkit.SlackException``
-subclass — so future enrichment slices (#341–#344) can override
+``DocverseSlackException`` -- itself a ``safir.slack.blockkit.SlackException``
+subclass -- so future enrichment slices (#341-#344) can override
 ``to_sentry()`` against a single shared base.
 
 The unit tests here assert membership in both bases and that the

--- a/tests/sentry_test.py
+++ b/tests/sentry_test.py
@@ -24,6 +24,7 @@ from safir.testing.sentry import (
 
 from docverse.dependencies.auth import require_superadmin
 from docverse.dependencies.context import context_dependency
+from docverse.exceptions import InvalidBuildStateError
 from docverse.handlers.admin import admin_router
 from docverse.sentry import initialize_sentry
 
@@ -181,6 +182,52 @@ async def test_admin_sentry_test_endpoint_captures_event_with_marker(
     assert event["tags"]["component"] == "api"
     exc_values = event["exception"]["values"]
     assert any(marker in exc["value"] for exc in exc_values)
+
+
+@pytest.mark.asyncio
+async def test_docverse_slack_exception_subclass_captures_with_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raised ``DocverseSlackException`` subclass reaches Sentry.
+
+    Pins the slice #340 contract: an uncaught
+    :class:`docverse.exceptions.DocverseSlackException` subclass from a
+    FastAPI route lands as exactly one captured event with the expected
+    ``release`` and ``service`` / ``component`` global tags inherited
+    from :func:`docverse.sentry.initialize_sentry`. The default
+    ``SlackException.to_slack()`` / ``to_sentry()`` behaviour is enough
+    in this slice - the per-exception overrides land in #341-#344.
+    """
+    monkeypatch.setenv("SENTRY_DSN", "https://test@example.com/1")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "test")
+    _patch_sentry_init_with_test_transport(monkeypatch)
+
+    boom_message = "uploaded -> uploaded is not a valid transition"
+
+    with sentry_init_fixture():
+        initialize_sentry(component="api")
+        captured = capture_events_fixture(monkeypatch)()
+
+        app = FastAPI()
+
+        @app.get("/raise-docverse-slack-exception")
+        async def raise_exc() -> None:
+            raise InvalidBuildStateError(boom_message)
+
+        async with AsyncClient(
+            base_url="https://example.com",
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+        ) as client:
+            await client.get("/raise-docverse-slack-exception")
+
+    assert len(captured.errors) == 1
+    event = captured.errors[0]
+    assert event["release"] == version("docverse")
+    assert event["tags"]["service"] == "docverse"
+    assert event["tags"]["component"] == "api"
+    exc_values = event["exception"]["values"]
+    assert any(boom_message in exc["value"] for exc in exc_values)
+    assert any(exc["type"] == "InvalidBuildStateError" for exc in exc_values)
 
 
 def test_initialize_sentry_is_noop_when_dsn_unset(

--- a/tests/sentry_test.py
+++ b/tests/sentry_test.py
@@ -212,7 +212,7 @@ async def test_docverse_slack_exception_subclass_captures_with_release(
 
         @app.get("/raise-docverse-slack-exception")
         async def raise_exc() -> None:
-            raise InvalidBuildStateError(boom_message)
+            raise InvalidBuildStateError(message=boom_message)
 
         async with AsyncClient(
             base_url="https://example.com",

--- a/tests/sentry_test.py
+++ b/tests/sentry_test.py
@@ -8,7 +8,6 @@ on the real Docverse app's lifespan, DB, or GitHub validator.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from importlib.metadata import version
 from typing import Any
 
@@ -48,26 +47,6 @@ async def _stub_context_dependency() -> _StubContext:
 
 async def _stub_require_superadmin() -> None:
     return None
-
-
-@pytest.fixture(autouse=True)
-def _isolate_sentry_global_scope() -> Iterator[None]:
-    """Strip ``initialize_sentry``'s global-scope tags around each test.
-
-    ``sentry_init_fixture`` saves and restores the *client* on the
-    global scope, but ``initialize_sentry`` also writes ``service`` and
-    ``component`` tags directly to that scope, which would otherwise
-    persist across tests in the session. Running on both sides isolates
-    this file from prior Sentry state and prevents tag bleed into any
-    later test that asserts tag absence.
-    """
-    scope = sentry_sdk.get_global_scope()
-    scope.remove_tag("service")
-    scope.remove_tag("component")
-    yield
-    scope = sentry_sdk.get_global_scope()
-    scope.remove_tag("service")
-    scope.remove_tag("component")
 
 
 def _patch_sentry_init_with_test_transport(

--- a/tests/services/dashboard_templates/sync_failure_test.py
+++ b/tests/services/dashboard_templates/sync_failure_test.py
@@ -1,0 +1,142 @@
+"""Focused tests for the ``mark_dashboard_sync_failed`` helper.
+
+The helper centralises the "mark dashboard sync as failed in the DB"
+write that previously lived inline at two call sites (the worker
+function and ``try_enqueue_dashboard_sync``). These tests pin its
+contract directly via stores + ``db_session`` so a future refactor
+that splits the responsibility back out cannot silently regress one
+mode at a time.
+"""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import OrganizationCreate
+from docverse.client.models.queue_enums import JobKind, JobStatus
+from docverse.services.dashboard_templates._sync_failure import (
+    mark_dashboard_sync_failed,
+)
+from docverse.storage.dashboard_templates.github import (
+    DashboardGitHubTemplateBindingCreate,
+    DashboardGitHubTemplateBindingStore,
+)
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.queue_job_store import QueueJobStore
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org_and_binding(
+    db_session: AsyncSession, *, org_slug: str
+) -> int:
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=org_slug,
+            title=f"Org {org_slug}",
+            base_domain=f"{org_slug}.example.com",
+        )
+    )
+    binding_store = DashboardGitHubTemplateBindingStore(
+        session=db_session, logger=logger
+    )
+    binding = await binding_store.create(
+        DashboardGitHubTemplateBindingCreate(
+            org_id=org.id,
+            project_id=None,
+            github_owner="acme",
+            github_repo="templates",
+            github_ref="main",
+            root_path="/",
+        )
+    )
+    return binding.id
+
+
+@pytest.mark.asyncio
+async def test_mark_dashboard_sync_failed_binding_only(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """Without queue-job args, only the binding row is touched."""
+    async with db_session.begin():
+        binding_id = await _seed_org_and_binding(
+            db_session, org_slug="helper-binding-only"
+        )
+
+    binding_store = DashboardGitHubTemplateBindingStore(
+        session=db_session, logger=_logger()
+    )
+    exc = RuntimeError("kaboom")
+    await mark_dashboard_sync_failed(
+        session=db_session,
+        binding_store=binding_store,
+        binding_id=binding_id,
+        exc=exc,
+        error_message=f"Enqueue failed: {exc}",
+    )
+
+    async with db_session.begin():
+        binding = await binding_store.get_by_id(binding_id)
+    assert binding is not None
+    assert binding.last_sync_status == "failed"
+    assert binding.last_sync_error == "Enqueue failed: kaboom"
+
+
+@pytest.mark.asyncio
+async def test_mark_dashboard_sync_failed_full_mode(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """With queue-job args, the helper fails the queue job too."""
+    logger = _logger()
+    async with db_session.begin():
+        binding_id = await _seed_org_and_binding(
+            db_session, org_slug="helper-full-mode"
+        )
+        binding_store = DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=logger
+        )
+        binding = await binding_store.get_by_id(binding_id)
+        assert binding is not None
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        queue_job = await queue_job_store.create(
+            kind=JobKind.dashboard_sync,
+            org_id=binding.org_id,
+            backend_job_id="arq-helper-full",
+        )
+        # QueueJobStore.fail rejects rows still in queued, so put it in
+        # in_progress first to mirror the worker's pre-failure state.
+        await queue_job_store.start(queue_job.id)
+
+    exc = RuntimeError("syncer exploded")
+    await mark_dashboard_sync_failed(
+        session=db_session,
+        binding_store=binding_store,
+        binding_id=binding_id,
+        exc=exc,
+        error_message=f"{type(exc).__name__}: {exc}",
+        queue_job_store=queue_job_store,
+        queue_job_id=queue_job.id,
+    )
+
+    async with db_session.begin():
+        refreshed_binding = await binding_store.get_by_id(binding_id)
+        refreshed_job = await queue_job_store.get(queue_job.id)
+    assert refreshed_binding is not None
+    assert refreshed_binding.last_sync_status == "failed"
+    assert refreshed_binding.last_sync_error == "RuntimeError: syncer exploded"
+    assert refreshed_job is not None
+    assert refreshed_job.status == JobStatus.failed
+    assert refreshed_job.errors is not None
+    assert refreshed_job.errors["message"] == "syncer exploded"
+    assert refreshed_job.errors["type"] == "RuntimeError"
+    assert "Traceback" in refreshed_job.errors["traceback"] or (
+        refreshed_job.errors["traceback"] == "NoneType: None\n"
+    )

--- a/tests/storage/build_store_test.py
+++ b/tests/storage/build_store_test.py
@@ -285,6 +285,35 @@ async def test_update_content_hash_rejects_non_pending(
 
 
 @pytest.mark.asyncio
+async def test_update_content_hash_not_found_omits_target_state_tag(
+    db_session: AsyncSession,
+    build_store: BuildStore,
+) -> None:
+    """The not-found path is not a transition.
+
+    It must not tag ``build_target_state``. The org / project / edition
+    slugs the caller threaded down should still surface for triage.
+    """
+    with pytest.raises(InvalidBuildStateError) as exc_info:
+        await build_store.update_content_hash(
+            build_id=999_999,
+            content_hash="sha256:" + "0" * 64,
+            org_slug="build-org",
+            project_slug="build-proj",
+            edition_slug="main",
+        )
+    info = exc_info.value.to_sentry()
+    assert "build_target_state" not in info.tags
+    assert "build_current_state" not in info.tags
+    assert info.tags["org_slug"] == "build-org"
+    assert info.tags["project_slug"] == "build-proj"
+    transition = info.contexts["build_transition"]
+    assert transition["edition_slug"] == "main"
+    assert transition["org_slug"] == "build-org"
+    assert transition["project_slug"] == "build-proj"
+
+
+@pytest.mark.asyncio
 async def test_update_inventory(
     db_session: AsyncSession,
     build_store: BuildStore,

--- a/tests/storage/github/app_client_test.py
+++ b/tests/storage/github/app_client_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import gidgethub
 import httpx
 import jwt as pyjwt
@@ -11,6 +13,7 @@ from pydantic import SecretStr
 from safir.github import GitHubAppClientFactory
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from docverse.exceptions import DocverseSlackException
 from docverse.factory import Factory
 from docverse.storage.github import (
     GITHUB_API_BASE_URL,
@@ -253,3 +256,195 @@ async def test_factory_create_github_app_client_all_missing_raises(
         )
         with pytest.raises(GitHubAppNotConfiguredError):
             factory.create_github_app_client()
+
+
+def test_github_app_not_configured_is_docverse_slack_exception() -> None:
+    """The migrated error derives from the shared ``DocverseSlackException``.
+
+    Pins the slice #340 / #344 contract: every non-``ClientRequestError``
+    server-side exception inherits from the shared base so the
+    ``before_send_handler`` in :mod:`safir.sentry` merges its tags and
+    contexts onto the captured event.
+    """
+    exc = GitHubAppNotConfiguredError(missing_secret="app_id")
+    assert isinstance(exc, DocverseSlackException)
+
+
+@pytest.mark.parametrize(
+    ("missing_secret", "org_slug", "installation_id"),
+    [
+        ("app_id", "rubin", None),
+        ("private_key", "rubin", 42),
+        ("webhook_secret", "rubin", 42),
+        ("app_id", None, None),
+    ],
+    ids=[
+        "missing_app_id",
+        "missing_private_key",
+        "missing_webhook_secret",
+        "no_org_context",
+    ],
+)
+def test_github_app_not_configured_to_sentry_tags(
+    missing_secret: Literal["app_id", "private_key", "webhook_secret"],
+    org_slug: str | None,
+    installation_id: int | None,
+) -> None:
+    """``to_sentry`` surfaces ``missing_secret`` and ``org_slug`` as tags.
+
+    Tags are low cardinality (the three known secret names and the org
+    slug) so they can be aggregated in the Sentry UI for on-call
+    routing — operators can filter to one tenant's events or to a
+    specific class of credential misconfiguration without paging
+    through every event. ``org_slug`` is omitted from the tag set when
+    the raise site has no org context (e.g. the global factory gate)
+    rather than emitting a literal ``"None"``.
+    """
+    exc = GitHubAppNotConfiguredError(
+        missing_secret=missing_secret,
+        org_slug=org_slug,
+        installation_id=installation_id,
+    )
+    info = exc.to_sentry()
+    assert info.tags["missing_secret"] == missing_secret
+    if org_slug is None:
+        assert "org_slug" not in info.tags
+    else:
+        assert info.tags["org_slug"] == org_slug
+
+
+@pytest.mark.parametrize(
+    ("missing_secret", "org_slug", "installation_id"),
+    [
+        ("app_id", "rubin", None),
+        ("private_key", "rubin", 42),
+        ("webhook_secret", "rubin", 42),
+        ("app_id", None, None),
+    ],
+    ids=[
+        "missing_app_id",
+        "missing_private_key",
+        "missing_webhook_secret",
+        "no_org_context",
+    ],
+)
+def test_github_app_not_configured_to_sentry_context(
+    missing_secret: Literal["app_id", "private_key", "webhook_secret"],
+    org_slug: str | None,
+    installation_id: int | None,
+) -> None:
+    """``to_sentry`` exposes the non-secret ``github_app`` context.
+
+    The ``github_app`` context carries the GitHub App ``installation_id``
+    (when known — ``None`` when the missing secret is the app id
+    itself, since no installation can have been minted yet) and the
+    static app name. The installation id is non-secret and gives a
+    triager the one identifier they need to look the tenant up in the
+    GitHub App admin UI without leaking any credential into Sentry.
+    """
+    exc = GitHubAppNotConfiguredError(
+        missing_secret=missing_secret,
+        org_slug=org_slug,
+        installation_id=installation_id,
+    )
+    info = exc.to_sentry()
+    context = info.contexts["github_app"]
+    assert context["installation_id"] == installation_id
+    assert context["app_name"] == "lsst-sqre/docverse"
+
+
+def test_github_app_not_configured_default_message_is_useful() -> None:
+    """The default message names the missing secret for log readers.
+
+    Without an explicit ``message`` the rendered string carries the
+    name of the missing secret so a log line or Slack alert is
+    actionable without unpacking the structured fields.
+    """
+    exc = GitHubAppNotConfiguredError(missing_secret="webhook_secret")
+    rendered = str(exc)
+    assert "webhook_secret" in rendered
+
+
+def test_github_app_not_configured_explicit_message_wins() -> None:
+    """Passing ``message`` overrides the auto-generated default.
+
+    Used by the factory's validation-failed gate to keep the existing
+    "credentials failed startup validation" wording in pod logs while
+    still routing the structured ``missing_secret`` field into Sentry
+    tags.
+    """
+    exc = GitHubAppNotConfiguredError(
+        missing_secret="private_key",
+        message="GitHub App credentials failed startup validation",
+    )
+    assert str(exc) == "GitHub App credentials failed startup validation"
+
+
+@pytest.mark.parametrize(
+    ("app_id", "private_key", "webhook_secret", "expected_missing"),
+    [
+        (None, SecretStr("key"), SecretStr("wh"), "app_id"),
+        (12345, None, SecretStr("wh"), "private_key"),
+        (12345, SecretStr("key"), None, "webhook_secret"),
+    ],
+    ids=["missing_app_id", "missing_private_key", "missing_webhook_secret"],
+)
+@pytest.mark.asyncio
+async def test_factory_raises_with_specific_missing_secret(
+    db_session: AsyncSession,
+    app_id: int | None,
+    private_key: SecretStr | None,
+    webhook_secret: SecretStr | None,
+    expected_missing: str,
+) -> None:
+    """The factory tags the raise with which specific secret is missing.
+
+    The factory's ``_require_github_app_config`` gate sees each of the
+    three secrets directly, so it must pass the exact missing-secret
+    value to the exception — generic "something is missing" would lose
+    the routing signal the Sentry tag is for.
+    """
+    async with httpx.AsyncClient() as http_client:
+        factory = Factory(
+            session=db_session,
+            logger=_logger(),
+            http_client=http_client,
+            github_app_id=app_id,
+            github_app_private_key=private_key,
+            github_webhook_secret=webhook_secret,
+            default_queue_name="docverse:queue",
+        )
+        with pytest.raises(GitHubAppNotConfiguredError) as excinfo:
+            factory.create_github_app_client()
+    assert excinfo.value.missing_secret == expected_missing
+
+
+@pytest.mark.asyncio
+async def test_factory_validation_failed_raises_private_key(
+    db_session: AsyncSession,
+) -> None:
+    """A failed startup validation tags the event with ``private_key``.
+
+    All three secrets are set but ``github_app_validated=False`` — the
+    canonical failure mode is a malformed PEM or a key that doesn't
+    match the registered app, both of which surface through the
+    private key. Tagging the raise as ``private_key`` keeps the Sentry
+    routing aligned with the most common operator-actionable cause
+    while the explicit message preserves the "failed startup
+    validation" log wording for ops grepping the pod logs.
+    """
+    async with httpx.AsyncClient() as http_client:
+        factory = Factory(
+            session=db_session,
+            logger=_logger(),
+            http_client=http_client,
+            github_app_id=12345,
+            github_app_private_key=SecretStr("key"),
+            github_webhook_secret=SecretStr("wh"),
+            github_app_validated=False,
+            default_queue_name="docverse:queue",
+        )
+        with pytest.raises(GitHubAppNotConfiguredError) as excinfo:
+            factory.create_github_app_client()
+    assert excinfo.value.missing_secret == "private_key"  # noqa: S105
+    assert "validation" in str(excinfo.value)

--- a/tests/storage/keeper_sync_run_store_test.py
+++ b/tests/storage/keeper_sync_run_store_test.py
@@ -12,6 +12,7 @@ from docverse.client.models import KeeperSyncRunStatus, OrganizationCreate
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.domain.queue import JobKind, JobStatus
+from docverse.exceptions import JobNotFoundError
 from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
 from docverse.storage.organization_store import OrganizationStore
 
@@ -229,3 +230,33 @@ async def test_aggregate_activity_null_when_no_jobs(
 
     assert activity.total_count == 0
     assert activity.date_last_activity is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "entry_point",
+    ["get_row", "transition_status"],
+)
+async def test_missing_run_raises_job_not_found(
+    db_session: AsyncSession,
+    entry_point: str,
+) -> None:
+    """``_get_row`` and methods that delegate to it raise ``JobNotFoundError``.
+
+    Aligns the store with ``QueueJobStore._get_row``'s shape: a missing
+    row is a lookup miss, not an invalid state transition.
+    """
+
+    async def _call(store: KeeperSyncRunStore) -> None:
+        if entry_point == "get_row":
+            await store._get_row(99999)
+        else:
+            await store.transition_status(
+                run_id=99999,
+                new_status=KeeperSyncRunStatus.in_progress,
+            )
+
+    async with db_session.begin():
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        with pytest.raises(JobNotFoundError):
+            await _call(store)

--- a/tests/storage/lifecycle_eval_run_store_test.py
+++ b/tests/storage/lifecycle_eval_run_store_test.py
@@ -14,7 +14,7 @@ from docverse.dbschema.lifecycle_eval_run import SqlLifecycleEvalRun
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.domain.queue import JobKind, JobStatus
-from docverse.exceptions import InvalidJobStateError
+from docverse.exceptions import InvalidJobStateError, JobNotFoundError
 from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
 from docverse.storage.organization_store import OrganizationStore
 
@@ -437,19 +437,33 @@ async def test_transition_status_pending_can_go_terminal(
 
 
 @pytest.mark.asyncio
-async def test_transition_status_raises_when_missing(
+@pytest.mark.parametrize(
+    "entry_point",
+    ["get_row", "transition_status"],
+)
+async def test_missing_run_raises_job_not_found(
     db_session: AsyncSession,
+    entry_point: str,
 ) -> None:
-    async def _try_transition_missing() -> None:
-        async with db_session.begin():
-            store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+    """``_get_row`` and methods that delegate to it raise ``JobNotFoundError``.
+
+    Aligns the store with ``QueueJobStore._get_row``'s shape: a missing
+    row is a lookup miss, not an invalid state transition.
+    """
+
+    async def _call(store: LifecycleEvalRunStore) -> None:
+        if entry_point == "get_row":
+            await store._get_row(99999)
+        else:
             await store.transition_status(
                 run_id=99999,
                 new_status=LifecycleEvalRunStatus.in_progress,
             )
 
-    with pytest.raises(InvalidJobStateError):
-        await _try_transition_missing()
+    async with db_session.begin():
+        store = LifecycleEvalRunStore(session=db_session, logger=_logger())
+        with pytest.raises(JobNotFoundError):
+            await _call(store)
 
 
 @pytest.mark.asyncio

--- a/tests/storage/ltd/client_test.py
+++ b/tests/storage/ltd/client_test.py
@@ -12,6 +12,7 @@ import pytest_asyncio
 import respx
 import structlog
 
+from docverse.exceptions import DocverseSlackException
 from docverse.storage.ltd import LtdClient, LtdClientError, LtdNotFoundError
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
@@ -170,3 +171,156 @@ async def test_non_retryable_error_status_raises(
     with pytest.raises(LtdClientError, match="401"):
         await _make_client(http_client).get_product("pipelines")
     assert route.call_count == 1
+
+
+def test_ltd_client_error_is_docverse_slack_exception() -> None:
+    """``LtdClientError`` migrates onto the shared ``DocverseSlackException``.
+
+    Pins the slice-#343 contract that LTD-side failures route to Slack
+    and Sentry alongside every other server-side exception, rather than
+    inheriting from plain ``Exception``.
+    """
+    exc = LtdClientError(
+        url=f"{LTD_BASE}/products/pipelines",
+        method="GET",
+        status_code=503,
+        body="upstream timeout",
+    )
+    assert isinstance(exc, DocverseSlackException)
+
+
+def test_ltd_not_found_error_inherits_from_ltd_client_error() -> None:
+    """``LtdNotFoundError`` keeps its ``LtdClientError`` parent.
+
+    Callers that ``except LtdClientError`` still catch a 404 (the
+    retry/error path); callers that ``except LtdNotFoundError`` keep
+    the soft-deletion shortcut.
+    """
+    exc = LtdNotFoundError(
+        url=f"{LTD_BASE}/products/missing",
+        method="GET",
+        status_code=404,
+        body="not found",
+    )
+    assert isinstance(exc, LtdClientError)
+    assert isinstance(exc, DocverseSlackException)
+
+
+def test_ltd_client_error_to_sentry_tags_status_and_method() -> None:
+    """``to_sentry`` surfaces the status code and method as Sentry tags.
+
+    Tags are low-cardinality (HTTP status codes and methods) so they
+    can be aggregated in the Sentry UI to tell apart "5xx on LTD side"
+    from "stale credential on our side".
+    """
+    exc = LtdClientError(
+        url=f"{LTD_BASE}/products/pipelines",
+        method="GET",
+        status_code=503,
+        body="upstream timeout",
+    )
+    info = exc.to_sentry()
+    assert info.tags["ltd_status_code"] == "503"
+    assert info.tags["ltd_method"] == "GET"
+
+
+def test_ltd_client_error_to_sentry_context_carries_request_snapshot() -> None:
+    """The ``ltd_request`` context carries the full request snapshot.
+
+    The context fields (``url``, ``method``, ``status_code``, ``body``)
+    are high cardinality and live in the context rather than tags so
+    they can be inspected per-event without exploding the Sentry index.
+    """
+    url = f"{LTD_BASE}/products/pipelines"
+    exc = LtdClientError(url=url, method="GET", status_code=500, body="boom")
+    info = exc.to_sentry()
+    context = info.contexts["ltd_request"]
+    assert context == {
+        "url": url,
+        "method": "GET",
+        "status_code": 500,
+        "body": "boom",
+    }
+
+
+def test_ltd_client_error_truncates_oversized_body() -> None:
+    """The constructor caps ``body`` at <= 4 KB and ``to_sentry`` honours it.
+
+    LTD response bodies can be arbitrarily large (HTML error pages,
+    full JSON payloads). Truncating in the constructor — rather than
+    relying on every raise site to remember — keeps Sentry payloads
+    small and protects the wire from megabyte-scale envelopes.
+    """
+    body = "x" * (5 * 1024)
+    exc = LtdClientError(
+        url=f"{LTD_BASE}/products/pipelines",
+        method="GET",
+        status_code=500,
+        body=body,
+    )
+    assert exc.body is not None
+    assert len(exc.body.encode("utf-8")) <= 4 * 1024
+    context = exc.to_sentry().contexts["ltd_request"]
+    assert isinstance(context["body"], str)
+    assert len(context["body"].encode("utf-8")) <= 4 * 1024
+    assert context["body"] == "x" * (4 * 1024)
+
+
+def test_ltd_client_error_preserves_short_body_verbatim() -> None:
+    """Bodies at or below the cap pass through unchanged.
+
+    Guards against an over-eager truncator silently re-encoding small
+    payloads and surfacing the wrong byte sequence in Sentry.
+    """
+    body = '{"error": "missing slug"}'
+    exc = LtdClientError(
+        url=f"{LTD_BASE}/products/pipelines",
+        method="GET",
+        status_code=400,
+        body=body,
+    )
+    assert exc.body == body
+
+
+def test_ltd_client_error_handles_missing_status_and_body() -> None:
+    """Network-error raise sites have neither status nor body.
+
+    The constructor must accept ``status_code=None`` / ``body=None``
+    (the ``httpx.HTTPError`` and "exhausted retries" sites in
+    ``_get_json``) and ``to_sentry`` must omit the missing tag rather
+    than emit ``"None"`` strings.
+    """
+    exc = LtdClientError(
+        url=f"{LTD_BASE}/products/pipelines",
+        method="GET",
+        message="LTD GET ... failed: connect timeout",
+    )
+    info = exc.to_sentry()
+    assert "ltd_status_code" not in info.tags
+    assert info.tags["ltd_method"] == "GET"
+    context = info.contexts["ltd_request"]
+    assert context["status_code"] is None
+    assert context["body"] is None
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_error_carries_status_and_body(
+    http_client: httpx.AsyncClient, mock_discovery: respx.Router
+) -> None:
+    """A non-retryable error reaches the raise site with response context.
+
+    Verifies the raise-site wiring: the constructed ``LtdClientError``
+    captures the HTTP status code, request URL/method, and response
+    body so a triager can read them off Sentry rather than grepping
+    pod logs.
+    """
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(401, text="unauthorized")
+    )
+    with pytest.raises(LtdClientError) as excinfo:
+        await _make_client(http_client).get_product("pipelines")
+    exc = excinfo.value
+    assert exc.status_code == 401
+    assert exc.method == "GET"
+    assert exc.url == f"{LTD_BASE}/products/pipelines"
+    assert exc.body == "unauthorized"

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -679,39 +679,31 @@ async def test_keeper_sync_project_failure_captures_to_sentry(
     register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
     ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
 
-    try:
-        with sentry_init_fixture():
-            initialize_sentry(component="worker-keeper-sync")
-            captured = capture_events_fixture(monkeypatch)()
+    with sentry_init_fixture():
+        initialize_sentry(component="worker-keeper-sync")
+        captured = capture_events_fixture(monkeypatch)()
 
-            with pytest.raises(LtdNotFoundError):
-                await keeper_sync_project(
-                    ctx,
-                    {
-                        "org_id": org_id,
-                        "org_slug": org_slug,
-                        "run_id": run_id,
-                        "queue_job_id": queue_job_id,
-                        "ltd_slug": "pipelines",
-                        "ltd_base_url": LTD_BASE,
-                    },
-                )
+        with pytest.raises(LtdNotFoundError):
+            await keeper_sync_project(
+                ctx,
+                {
+                    "org_id": org_id,
+                    "org_slug": org_slug,
+                    "run_id": run_id,
+                    "queue_job_id": queue_job_id,
+                    "ltd_slug": "pipelines",
+                    "ltd_base_url": LTD_BASE,
+                },
+            )
 
-            assert len(captured.errors) == 1
-            event = captured.errors[0]
-            assert event["release"] == pkg_version("docverse")
-            assert event["tags"]["service"] == "docverse"
-            assert event["tags"]["component"] == "worker-keeper-sync"
-            exc_values = event["exception"]["values"]
-            assert any(exc["type"] == "LtdNotFoundError" for exc in exc_values)
-    finally:
-        # ``initialize_sentry`` writes ``service`` and ``component`` to
-        # the global scope; strip them so this test does not bleed tags
-        # into any later test that asserts their absence.
-        scope = sentry_sdk.get_global_scope()
-        scope.remove_tag("service")
-        scope.remove_tag("component")
-        await ctx["http_client"].aclose()
+        assert len(captured.errors) == 1
+        event = captured.errors[0]
+        assert event["release"] == pkg_version("docverse")
+        assert event["tags"]["service"] == "docverse"
+        assert event["tags"]["component"] == "worker-keeper-sync"
+        exc_values = event["exception"]["values"]
+        assert any(exc["type"] == "LtdNotFoundError" for exc in exc_values)
+    await ctx["http_client"].aclose()
 
     # The failure transitions the queue-job + run row are still in place
     # — Sentry is additive to the existing finalisation contract.

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -12,6 +12,7 @@ failing paths — without depending on real S3 or R2.
 from __future__ import annotations
 
 import json
+from importlib.metadata import version as pkg_version
 from pathlib import Path
 from types import TracebackType
 from typing import Any, Self
@@ -19,9 +20,15 @@ from typing import Any, Self
 import httpx
 import pytest
 import respx
+import sentry_sdk
 import structlog
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
+from safir.testing.sentry import (
+    TestTransport,
+    capture_events_fixture,
+    sentry_init_fixture,
+)
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,6 +46,7 @@ from docverse.dbschema.organization import SqlOrganization
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.queue import JobStatus
 from docverse.factory import Factory
+from docverse.sentry import initialize_sentry
 from docverse.services.dashboard.enqueue import DashboardBuildEnqueuer
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.storage.build_store import BuildStore
@@ -613,6 +621,110 @@ async def test_keeper_sync_project_failure_marks_queue_job_and_finalises_run(
 
     # Nothing was copied to the destination on the failure path.
     assert object_store.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_project_failure_captures_to_sentry(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The worker's explicit ``capture_exception`` reaches Sentry on failure.
+
+    Locks the worker-side analogue of the FastAPI exception handler from
+    PRD #338 (user stories 2, 3, 23, 24): when ``keeper_sync_project``
+    catches an exception in its outer ``except`` block, transitions the
+    queue-job to ``failed``, and re-raises, the explicit
+    ``sentry_sdk.capture_exception(exc)`` produces exactly one Sentry
+    envelope tagged with the worker-keeper-sync component and the
+    package ``release``. The structured-log breadcrumb
+    (``logger.exception``) and the queue-job ``failed`` transition both
+    stay intact — Sentry is additive, never a replacement.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session)
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_project_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    # Force the LTD product fetch to 404 so ``LtdNotFoundError`` propagates
+    # out of ``KeeperSyncService.sync_project`` and hits the worker's
+    # outer ``except``.
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(404)
+    )
+    object_store = MockObjectStore()
+    _patch_factory_io(
+        monkeypatch, object_store=object_store, source_objects={}
+    )
+
+    # Sentry test transport + DSN gating must be in place *before*
+    # ``initialize_sentry`` runs — otherwise the wrapper's
+    # ``should_enable_sentry`` early-return leaves the SDK uninitialised
+    # and the explicit capture never reaches a transport.
+    monkeypatch.setenv("SENTRY_DSN", "https://test@example.com/1")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "test")
+    real_init = sentry_sdk.init
+
+    def _init_with_test_transport(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("transport", TestTransport())
+        return real_init(*args, **kwargs)
+
+    monkeypatch.setattr(sentry_sdk, "init", _init_with_test_transport)
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    try:
+        with sentry_init_fixture():
+            initialize_sentry(component="worker-keeper-sync")
+            captured = capture_events_fixture(monkeypatch)()
+
+            with pytest.raises(LtdNotFoundError):
+                await keeper_sync_project(
+                    ctx,
+                    {
+                        "org_id": org_id,
+                        "org_slug": org_slug,
+                        "run_id": run_id,
+                        "queue_job_id": queue_job_id,
+                        "ltd_slug": "pipelines",
+                        "ltd_base_url": LTD_BASE,
+                    },
+                )
+
+            assert len(captured.errors) == 1
+            event = captured.errors[0]
+            assert event["release"] == pkg_version("docverse")
+            assert event["tags"]["service"] == "docverse"
+            assert event["tags"]["component"] == "worker-keeper-sync"
+            exc_values = event["exception"]["values"]
+            assert any(exc["type"] == "LtdNotFoundError" for exc in exc_values)
+    finally:
+        # ``initialize_sentry`` writes ``service`` and ``component`` to
+        # the global scope; strip them so this test does not bleed tags
+        # into any later test that asserts their absence.
+        scope = sentry_sdk.get_global_scope()
+        scope.remove_tag("service")
+        scope.remove_tag("component")
+        await ctx["http_client"].aclose()
+
+    # The failure transitions the queue-job + run row are still in place
+    # — Sentry is additive to the existing finalisation contract.
+    async for session in db_session_dependency():
+        async with session.begin():
+            queue_job_store = QueueJobStore(session=session, logger=_logger())
+            qj = await queue_job_store.get(queue_job_id)
+            assert qj is not None
+            assert qj.status == JobStatus.failed
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status == KeeperSyncRunStatus.partial_failure
 
 
 @pytest.mark.asyncio

--- a/tests/worker/keeper_sync_worker_settings_test.py
+++ b/tests/worker/keeper_sync_worker_settings_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from arq.cron import CronJob
 from arq.worker import Function
 
@@ -23,9 +25,26 @@ from docverse.worker.main import (
 _config = Configuration()
 
 
+def _underlying(coroutine: Any) -> Any:
+    """Return the raw function under any ``instrument_arq_task`` wrap.
+
+    Every task on the production WorkerSettings is wrapped with
+    :func:`docverse.sentry.instrument_arq_task`, which uses
+    :func:`functools.wraps` and therefore exposes the original
+    coroutine via ``__wrapped__``. This helper peels exactly one
+    layer (or returns the value as-is if it is already raw) so the
+    registration-shape assertions in this module can compare against
+    the unwrapped function imported from ``worker.functions``.
+    """
+    return getattr(coroutine, "__wrapped__", coroutine)
+
+
 def _function_by_coroutine(coro: object) -> Function:
     for entry in KeeperSyncWorkerSettings.functions:
-        if isinstance(entry, Function) and entry.coroutine is coro:
+        if (
+            isinstance(entry, Function)
+            and _underlying(entry.coroutine) is coro
+        ):
             return entry
     msg = f"No registered Function wraps {coro!r}"
     raise AssertionError(msg)
@@ -57,17 +76,13 @@ def test_keeper_sync_worker_settings_registers_keeper_sync_functions() -> None:
 
 def test_default_worker_does_not_register_keeper_sync_functions() -> None:
     """The default queue stays free of keeper-sync work."""
-    assert keeper_sync_run_discovery not in WorkerSettings.functions
-    assert keeper_sync_project not in WorkerSettings.functions
-    assert keeper_sync_reaper not in WorkerSettings.functions
-    # And no ``arq.Function`` wrapper sneaks the same coroutines in either.
-    default_coros: set[object] = set()
-    for entry in WorkerSettings.functions:
-        if isinstance(entry, Function):
-            default_coros.add(entry.coroutine)
-    assert keeper_sync_run_discovery not in default_coros
-    assert keeper_sync_project not in default_coros
-    assert keeper_sync_reaper not in default_coros
+    default_underlying = {
+        _underlying(entry.coroutine if isinstance(entry, Function) else entry)
+        for entry in WorkerSettings.functions
+    }
+    assert keeper_sync_run_discovery not in default_underlying
+    assert keeper_sync_project not in default_underlying
+    assert keeper_sync_reaper not in default_underlying
 
 
 def test_keeper_sync_worker_settings_share_lifecycle_hooks() -> None:
@@ -97,7 +112,8 @@ def test_keeper_sync_worker_registers_reaper_cron() -> None:
     reaper_crons = [
         job
         for job in cron_jobs
-        if isinstance(job, CronJob) and job.coroutine is keeper_sync_reaper
+        if isinstance(job, CronJob)
+        and _underlying(job.coroutine) is keeper_sync_reaper
     ]
     assert len(reaper_crons) == 1
     assert reaper_crons[0].minute == {0, 30}
@@ -107,6 +123,8 @@ def test_default_worker_has_no_keeper_sync_cron() -> None:
     """The default queue does not run the reaper."""
     cron_jobs = list(getattr(WorkerSettings, "cron_jobs", []) or [])
     coroutines = {
-        job.coroutine for job in cron_jobs if isinstance(job, CronJob)
+        _underlying(job.coroutine)
+        for job in cron_jobs
+        if isinstance(job, CronJob)
     }
     assert keeper_sync_reaper not in coroutines

--- a/tests/worker/lifecycle_eval_worker_settings_test.py
+++ b/tests/worker/lifecycle_eval_worker_settings_test.py
@@ -8,6 +8,8 @@ same dedicated pool so the dispatcher's enqueues actually run.
 
 from __future__ import annotations
 
+from typing import Any
+
 from arq.cron import CronJob
 from arq.worker import Function
 
@@ -31,9 +33,26 @@ from docverse.worker.main import (
 _config = Configuration()
 
 
+def _underlying(coroutine: Any) -> Any:
+    """Return the raw function under any ``instrument_arq_task`` wrap.
+
+    Every task on the production WorkerSettings is wrapped with
+    :func:`docverse.sentry.instrument_arq_task`, which uses
+    :func:`functools.wraps` and therefore exposes the original
+    coroutine via ``__wrapped__``. This helper peels exactly one
+    layer (or returns the value as-is if it is already raw) so the
+    registration-shape assertions in this module can compare against
+    the unwrapped function imported from ``worker.functions``.
+    """
+    return getattr(coroutine, "__wrapped__", coroutine)
+
+
 def _function_by_coroutine(coro: object) -> Function:
     for entry in LifecycleEvalWorkerSettings.functions:
-        if isinstance(entry, Function) and entry.coroutine is coro:
+        if (
+            isinstance(entry, Function)
+            and _underlying(entry.coroutine) is coro
+        ):
             return entry
     msg = f"No registered Function wraps {coro!r}"
     raise AssertionError(msg)
@@ -89,7 +108,7 @@ def test_lifecycle_eval_dispatcher_runs_hourly() -> None:
         job
         for job in cron_jobs
         if isinstance(job, CronJob)
-        and job.coroutine is lifecycle_eval_dispatcher
+        and _underlying(job.coroutine) is lifecycle_eval_dispatcher
     ]
     assert len(dispatcher_crons) == 1
     assert dispatcher_crons[0].minute == {0}
@@ -102,9 +121,16 @@ def test_lifecycle_reaper_registered_as_function() -> None:
     in :func:`arq.func` — it is a cron-only backstop with no per-job
     timeout knob and arq's default retry policy is irrelevant since
     each tick is self-contained. Mirrors how ``keeper_sync_reaper`` is
-    registered on :class:`KeeperSyncWorkerSettings`.
+    registered on :class:`KeeperSyncWorkerSettings`. After
+    :func:`docverse.sentry.instrument_arq_task` wraps it, the entry is
+    no longer ``is lifecycle_reaper``; the test unwraps every entry to
+    recover the underlying coroutine.
     """
-    assert lifecycle_reaper in LifecycleEvalWorkerSettings.functions
+    underlying = {
+        _underlying(entry.coroutine if isinstance(entry, Function) else entry)
+        for entry in LifecycleEvalWorkerSettings.functions
+    }
+    assert lifecycle_reaper in underlying
 
 
 def test_lifecycle_reaper_runs_every_thirty_minutes() -> None:
@@ -119,7 +145,8 @@ def test_lifecycle_reaper_runs_every_thirty_minutes() -> None:
     reaper_crons = [
         job
         for job in cron_jobs
-        if isinstance(job, CronJob) and job.coroutine is lifecycle_reaper
+        if isinstance(job, CronJob)
+        and _underlying(job.coroutine) is lifecycle_reaper
     ]
     assert len(reaper_crons) == 1
     assert reaper_crons[0].minute == {0, 30}
@@ -127,23 +154,22 @@ def test_lifecycle_reaper_runs_every_thirty_minutes() -> None:
 
 def test_default_worker_does_not_register_lifecycle_functions() -> None:
     """The default queue stays free of lifecycle work."""
-    default_coros: set[object] = set()
-    for entry in WorkerSettings.functions:
-        if isinstance(entry, Function):
-            default_coros.add(entry.coroutine)
-    assert lifecycle_eval not in WorkerSettings.functions
-    assert lifecycle_eval_dispatcher not in WorkerSettings.functions
-    assert lifecycle_reaper not in WorkerSettings.functions
-    assert lifecycle_eval not in default_coros
-    assert lifecycle_eval_dispatcher not in default_coros
-    assert lifecycle_reaper not in default_coros
+    default_underlying = {
+        _underlying(entry.coroutine if isinstance(entry, Function) else entry)
+        for entry in WorkerSettings.functions
+    }
+    assert lifecycle_eval not in default_underlying
+    assert lifecycle_eval_dispatcher not in default_underlying
+    assert lifecycle_reaper not in default_underlying
 
 
 def test_default_worker_has_no_lifecycle_cron() -> None:
     """The default queue does not run the lifecycle dispatcher or reaper."""
     cron_jobs = list(getattr(WorkerSettings, "cron_jobs", []) or [])
     coroutines = {
-        job.coroutine for job in cron_jobs if isinstance(job, CronJob)
+        _underlying(job.coroutine)
+        for job in cron_jobs
+        if isinstance(job, CronJob)
     }
     assert lifecycle_eval_dispatcher not in coroutines
     assert lifecycle_reaper not in coroutines
@@ -156,13 +182,10 @@ def test_keeper_sync_worker_does_not_register_lifecycle_functions() -> None:
     cannot delay keeper_sync_project; registering lifecycle functions
     on KeeperSyncWorkerSettings would defeat that isolation.
     """
-    sync_coros: set[object] = set()
-    for entry in KeeperSyncWorkerSettings.functions:
-        if isinstance(entry, Function):
-            sync_coros.add(entry.coroutine)
-    assert lifecycle_eval not in sync_coros
-    assert lifecycle_eval_dispatcher not in sync_coros
-    assert lifecycle_reaper not in sync_coros
-    assert lifecycle_eval not in KeeperSyncWorkerSettings.functions
-    assert lifecycle_eval_dispatcher not in KeeperSyncWorkerSettings.functions
-    assert lifecycle_reaper not in KeeperSyncWorkerSettings.functions
+    sync_underlying = {
+        _underlying(entry.coroutine if isinstance(entry, Function) else entry)
+        for entry in KeeperSyncWorkerSettings.functions
+    }
+    assert lifecycle_eval not in sync_underlying
+    assert lifecycle_eval_dispatcher not in sync_underlying
+    assert lifecycle_reaper not in sync_underlying

--- a/tests/worker/sentry_arq_test.py
+++ b/tests/worker/sentry_arq_test.py
@@ -1,0 +1,224 @@
+"""Tests for ``instrument_arq_task`` and its WorkerSettings wiring.
+
+arq has no built-in Sentry integration, so
+:func:`docverse.sentry.instrument_arq_task` is the seam that gives
+every captured event from a worker function the task name as its
+``transaction`` (instead of arq's default ``"unknown arq task"``
+fallback). These tests pin three contracts:
+
+1. ``functools.wraps`` propagates the wrapped function's ``__name__``,
+   ``__qualname__``, and ``__module__`` -- arq's :func:`arq.func` /
+   default registration both key on ``__qualname__``, so a regression
+   here would silently rename every task in Redis.
+
+2. A captured Sentry event from a wrapped task carries ``transaction =
+   <fn name>`` and ``tags["arq.job_id"] = ctx["job_id"]`` so an
+   operator can grep alerts by task and cross-reference against pod
+   logs.
+
+3. The wrapper is a no-op for the SDK when Sentry is uninitialised --
+   i.e. ``nox -s test`` runs without :envvar:`SENTRY_DSN` do not blow
+   up just because the wrapper opened a transaction.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+import sentry_sdk
+from arq import func
+from arq.typing import WorkerCoroutine
+from safir.testing.sentry import (
+    TestTransport,
+    capture_events_fixture,
+    sentry_init_fixture,
+)
+
+from docverse.sentry import initialize_sentry, instrument_arq_task
+from docverse.worker.main import (
+    KeeperSyncWorkerSettings,
+    LifecycleEvalWorkerSettings,
+    WorkerSettings,
+)
+
+
+def _patch_sentry_init_with_test_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Force every ``sentry_sdk.init`` to use ``TestTransport``.
+
+    Mirrors the helper in ``tests/sentry_test.py`` -- the production
+    ``initialize_sentry`` wrapper does not expose a transport hook, so
+    the patch redirects at the SDK boundary rather than asking the
+    wrapper to expose a testing-only knob.
+    """
+    real_init = sentry_sdk.init
+
+    def init_with_test_transport(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("transport", TestTransport())
+        return real_init(*args, **kwargs)
+
+    monkeypatch.setattr(sentry_sdk, "init", init_with_test_transport)
+
+
+async def _example_task(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
+    """Return a marker echo; signature mirrors the production tasks."""
+    return f"{ctx['job_id']}:{payload['marker']}"
+
+
+def test_instrument_arq_task_preserves_function_identity() -> None:
+    """``functools.wraps`` leaves arq's registration key unchanged.
+
+    :func:`arq.func` keys on ``coroutine.__qualname__`` (see
+    ``arq.worker.func``), and the in-process function table the worker
+    uses on dispatch keys on the same name. Renaming the wrapped
+    function would break every existing ``QueueBackend.enqueue(job_type=
+    "<fn name>", ...)`` call site -- including the cross-references
+    from :mod:`docverse.services.publish_enqueue` and
+    :mod:`docverse.services.dashboard.enqueue` -- so this contract is
+    load-bearing.
+    """
+    wrapped = instrument_arq_task(_example_task)
+    # ``WorkerCoroutine`` only declares ``__qualname__``, but
+    # ``functools.wraps`` propagates ``__module__`` too. Both are
+    # used by :func:`arq.func` when building the ``Function`` registration
+    # entry, so the test pins both.
+    assert wrapped.__qualname__ == _example_task.__qualname__
+    assert wrapped.__module__ == _example_task.__module__
+
+
+def test_instrument_arq_task_keeps_arq_func_registration_name() -> None:
+    """``arq.func`` registers the wrapped task under the original name.
+
+    Direct end-to-end check that the ``functools.wraps`` contract above
+    survives :func:`arq.func`'s ``coroutine.__qualname__`` fallback,
+    which is the actual registration path used by the production
+    :class:`KeeperSyncWorkerSettings` / :class:`LifecycleEvalWorkerSettings`
+    classes.
+    """
+    registered = func(instrument_arq_task(_example_task))
+    assert registered.name == _example_task.__qualname__
+
+
+@pytest.mark.asyncio
+async def test_instrument_arq_task_sets_transaction_and_job_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A captured event from a wrapped task gets ``transaction`` and tags.
+
+    The alert that motivated this seam (DOCVERSE-4 on the production
+    Sentry org) showed ``culprit: "unknown arq task"`` and ``transaction
+    = "unknown arq task"`` because arq has no SDK integration to set the
+    transaction name. The wrapper opens a ``queue.task.arq``
+    transaction named after the function, so any error captured inside
+    it inherits both ``event["transaction"] == fn.__name__`` and the
+    ``arq.job_id`` / ``arq.job_try`` tags. Asserting on both fields
+    locks the operator-facing contract -- alerts filterable by task,
+    cross-referenceable to pod logs by job_id.
+    """
+    monkeypatch.setenv("SENTRY_DSN", "https://test@example.com/1")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "test")
+    _patch_sentry_init_with_test_transport(monkeypatch)
+
+    boom_message = "intentional task failure"
+
+    async def boom_task(ctx: dict[str, Any]) -> None:
+        raise RuntimeError(boom_message)
+
+    wrapped = instrument_arq_task(boom_task)
+
+    with sentry_init_fixture():
+        initialize_sentry(component="worker")
+        captured = capture_events_fixture(monkeypatch)()
+
+        ctx: dict[str, Any] = {"job_id": "abc123", "job_try": 2}
+        with pytest.raises(RuntimeError, match=boom_message):
+            await wrapped(ctx)
+
+    assert len(captured.errors) == 1
+    event = captured.errors[0]
+    assert event["transaction"] == "boom_task"
+    assert event["tags"]["arq.job_id"] == "abc123"
+    assert event["tags"]["arq.job_try"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_instrument_arq_task_is_noop_when_sentry_uninitialised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without ``SENTRY_DSN``, the wrapper still runs the task cleanly.
+
+    Pins the contract that ``nox -s test`` and local-dev arq workers --
+    which deliberately leave Sentry uninitialised via
+    :func:`safir.sentry.should_enable_sentry` -- still execute wrapped
+    tasks. ``sentry_sdk.start_transaction`` returns a ``NoOpSpan`` when
+    no client is bound, and ``isolation_scope`` is always safe; the
+    wrapper must rely on both of those to not need a ``should_enable_sentry``
+    short-circuit of its own.
+    """
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    async def task(ctx: dict[str, Any]) -> str:
+        return f"ran:{ctx['job_id']}"
+
+    wrapped = instrument_arq_task(task)
+
+    with sentry_init_fixture():
+        initialize_sentry(component="worker")
+        assert sentry_sdk.is_initialized() is False
+        result = await wrapped({"job_id": "xyz"})
+
+    assert result == "ran:xyz"
+
+
+def test_worker_settings_registers_tasks_under_original_names() -> None:
+    """Every WorkerSettings entry registers under its raw function name.
+
+    Backstop against a future regression where someone adds a task or
+    cron job to :class:`WorkerSettings`,
+    :class:`KeeperSyncWorkerSettings`, or
+    :class:`LifecycleEvalWorkerSettings` and forgets to wrap it with
+    :func:`instrument_arq_task` (which would leave it producing
+    ``transaction: "unknown arq task"`` alerts) -- or wraps it with
+    something that breaks :func:`functools.wraps` and silently renames
+    every Redis-side ``job_type``.
+
+    The assertion is: for every entry in ``functions`` and
+    ``cron_jobs``, the registered name matches the underlying
+    coroutine's ``__qualname__``, AND every registered coroutine has
+    been routed through :func:`instrument_arq_task` (detected via the
+    ``__wrapped__`` attribute that :func:`functools.wraps` sets).
+    """
+    settings_classes = (
+        WorkerSettings,
+        KeeperSyncWorkerSettings,
+        LifecycleEvalWorkerSettings,
+    )
+    for settings in settings_classes:
+        # ``functions`` may hold raw coroutines or ``arq.Function``
+        # instances (the latter when wrapped with ``arq.func`` for
+        # per-job ``timeout`` / ``max_tries``); arq's own ``Worker``
+        # normalises both via ``map(func, functions)``, so the test
+        # mirrors that to inspect every entry uniformly. ``cron_jobs``
+        # entries are already ``CronJob`` instances and expose
+        # ``.coroutine`` / ``.name`` directly. The ``cast`` is needed
+        # because the list-literal type widens to ``object`` once both
+        # shapes are mixed in one list.
+        functions = [
+            func(cast("WorkerCoroutine", f)) for f in settings.functions
+        ]
+        cron_jobs = list(getattr(settings, "cron_jobs", None) or [])
+        for entry in (*functions, *cron_jobs):
+            coroutine = entry.coroutine
+            # ``CronJob.name`` is ``"cron:" + coroutine.__qualname__``,
+            # so only enforce the rename-detector against the suffix.
+            registered_suffix = entry.name.removeprefix("cron:")
+            assert coroutine.__qualname__ == registered_suffix, (
+                f"{settings.__name__}: registered name {entry.name!r}"
+                f" drifted from coroutine name {coroutine.__qualname__!r}"
+            )
+            assert hasattr(coroutine, "__wrapped__"), (
+                f"{settings.__name__}: task {entry.name!r} is not wrapped"
+                " with instrument_arq_task"
+            )


### PR DESCRIPTION
## Summary

- Introduce a single `DocverseSlackException` base (a `safir.slack.blockkit.SlackException` subclass) and migrate every non-`ClientRequestError` server-side exception onto it (`InvalidJobStateError`, `InvalidBuildStateError`, `JobNotFoundError`, `InvalidSlugError`, `DashboardTemplateSyncError`, `LtdClientError`, `LtdNotFoundError`, `GitHubAppNotConfiguredError`) so every error type routes to Slack and Sentry through one shared contract.
- Replace `InvalidBuildStateError(msg)` with a kw-only structured constructor (current/target state, build `public_id`, org / project / edition slugs) and a `to_sentry()` override that exposes the slugs and state names as low-cardinality Sentry tags plus a `build_transition` context — keyed by API-facing identifiers so a triager can paste the values straight into a build URL. The `SqlBuildStore.update_content_hash` not-found branch no longer passes `target_state=pending` (it asserts the build *is* pending, not a transition), so its Sentry events no longer carry a misleading `build_target_state` tag.
- Replace `InvalidJobStateError(msg)` / `JobNotFoundError(msg)` with kw-only structured constructors (state pair, job `public_id`, queue name, function name) and matching `to_sentry()` overrides that emit `queue_name` / `job_function` / state tags plus a `queue_job_transition` or `queue_job_lookup` context — the link from a Sentry event to a `/queue/{job_id}` URL is one click away. The run-store `_get_row` not-found paths in `KeeperSyncRunStore` and `LifecycleEvalRunStore` now raise `JobNotFoundError` (matching `QueueJobStore._get_row`'s shape) instead of `InvalidJobStateError`, so a missing row no longer mis-tags as a transition error.
- Replace `LtdClientError(msg)` with a kw-only structured constructor (request URL, HTTP method, status code, response body) that truncates the body to <= 4 KiB inside the constructor; the new `to_sentry()` surfaces `ltd_status_code` / `ltd_method` tags and an `ltd_request` context so triage can tell an LTD-side 5xx outage apart from a stale Docverse credential without grepping pod logs. `LtdNotFoundError` keeps its `LtdClientError` parent and reuses the override.
- Replace `GitHubAppNotConfiguredError(msg)` with a kw-only structured constructor that requires `missing_secret` (one of `app_id` / `private_key` / `webhook_secret`) and accepts optional `org_slug` / `installation_id`; the new `to_sentry()` surfaces `missing_secret` and `org_slug` as low-cardinality tags plus a `github_app` context with the installation id, so an on-call operator can route the event to the tenant's documentation maintainer.
- Add explicit `sentry_sdk.capture_exception(exc)` calls at every existing `logger.exception(...)` site that catches an exception and either converts it to a job-failure row, marks a run / binding failed, or annotates a tier-cron continue-and-skip path. This is the worker-side analogue of the FastAPI exception handler: arq's own Sentry integration only sees the exception if the function re-raises, so the explicit capture is what makes "swallowed" failures visible in Sentry. Sentry is additive — every `logger.exception` stays as the structured-log breadcrumb in pod logs and the finalisation logic is unchanged.
- Promote the `_isolate_sentry_global_scope` autouse fixture from `tests/sentry_test.py` to `tests/conftest.py` (snapshot-and-restore form) so every test in the suite inherits Sentry global-scope tag isolation, and drop the manual `try / finally` in `tests/worker/keeper_sync_project_test.py::test_keeper_sync_project_failure_captures_to_sentry` that previously stripped `service` / `component` tags by hand — future worker- or API-side Sentry tests no longer need to repeat the incantation.
- Extract the duplicated "mark this dashboard sync as failed" DB-write sequence from `worker/functions/dashboard_sync.py` and `services/dashboard_templates/enqueue.py::try_enqueue_dashboard_sync` into a single `mark_dashboard_sync_failed` helper in a new `services/dashboard_templates/_sync_failure.py` module. The helper accepts optional `queue_job_store` / `queue_job_id` kwargs so the worker site (which has both) and the enqueue site (which has only the binding) reuse the same code path. Module placement is lifted one layer out of the worker package because the task's preferred placement (`worker/functions/dashboard_sync.py`) creates a circular import through `worker/functions/__init__.py` → `factory` → `services.dashboard_templates`. The `# noqa: PLR0915` directive on `dashboard_sync.dashboard_sync` is dropped once the function drops below the statement cap.
- Lock the contracts with parametrized unit tests in `tests/exceptions_test.py`, `tests/storage/ltd/client_test.py`, `tests/storage/github/app_client_test.py`, `tests/storage/build_store_test.py`, `tests/storage/keeper_sync_run_store_test.py`, `tests/storage/lifecycle_eval_run_store_test.py`, and `tests/services/dashboard_templates/sync_failure_test.py` that assert directly on `SentryEventInfo` output (no `sentry_sdk.init`) or on the propagated exception type, plus end-to-end Sentry tests that raise `DocverseSlackException` subclasses from a FastAPI route and from `keeper_sync_project`'s swallowed-failure path and assert exactly one captured event with the deployed `release` / `service` / `component` tags.

This is the shared `tickets/DM-54916` branch that aggregates slices #340–#345 and the #371 / #372 / #373 / #374 follow-ups into one PR.

## Validation steps

- [ ] Confirm no production call sites of the migrated exceptions changed behaviour beyond carrying the new structured fields — every existing `raise` either uses the new kw-only constructor or the documented `message=` escape hatch, and the rendered `to_slack()` / `__str__` output stays useful.
- [ ] After deploy, trigger a server-side `DocverseSlackException` subclass in `idfdev` (e.g. via `POST /admin/sentry/test`'s `RuntimeError` path) and confirm the captured Sentry event carries `service=docverse`, `component=api`, and the deployed `release` tag.
- [ ] Trigger an `InvalidBuildStateError` (e.g. a state-transition conflict against an `idfdev` build) and confirm the Sentry event surfaces `org_slug`, `project_slug`, and state tags plus a `build_transition` context with the API-facing `build_public_id`.
- [ ] Trigger the `update_content_hash` not-found path against an `idfdev` build id that does not exist and confirm the resulting Sentry event surfaces `org_slug` / `project_slug` / `edition_slug` (the latter inside `build_transition`) and does **not** carry a `build_target_state` tag.
- [ ] Trigger an `InvalidJobStateError` (e.g. by attempting a forbidden queue-job transition in `idfdev`) and confirm the Sentry event surfaces `queue_name` / `job_function` / state tags plus a `queue_job_transition` context with the job `public_id`.
- [ ] Trigger an LTD-side 5xx in `idfdev` (e.g. while the keeper-sync worker is running) and confirm the Sentry event surfaces `ltd_status_code` / `ltd_method` tags and an `ltd_request` context with the truncated response body.
- [ ] Trigger a `GitHubAppNotConfiguredError` in `idfdev` (e.g. by clearing one of the GitHub-App secrets) and confirm the Sentry event surfaces `missing_secret` (one of `app_id` / `private_key` / `webhook_secret`) and the `github_app` context with the installation id and `lsst-sqre/docverse` app name.
- [ ] Trigger a worker-side swallowed failure in `idfdev` (e.g. force a `keeper_sync_project` LTD 404 via the refresh endpoint) and confirm the Sentry event surfaces with `component=worker-keeper-sync` even though arq sees the job transition to `failed` cleanly.
- [ ] Confirm the `mark_dashboard_sync_failed` helper's module placement (lifted to `services/dashboard_templates/_sync_failure.py` rather than co-located with `worker/functions/dashboard_sync.py`) is justified in the commit message and PR description, and that the worker's `dashboard_sync` function no longer carries `# noqa: PLR0915`.

## References

- Closes #340
- Closes #341
- Closes #342
- Closes #343
- Closes #344
- Closes #345
- Closes #371
- Closes #372
- Closes #373
- Closes #374
- PRD: #338
- Jira: https://rubinobs.atlassian.net/browse/DM-54916
