### PR TITLE
DM-54913: Project GitHub-binding schema + migration

### DIFF
--- a/alembic/versions/20260525_0000_x2y3z4a5b6c7_projects_github_binding.py
+++ b/alembic/versions/20260525_0000_x2y3z4a5b6c7_projects_github_binding.py
@@ -1,0 +1,166 @@
+"""Add structured GitHub binding to ``projects`` and rename ``doc_repo``.
+
+Formalises a project's GitHub coordinates ahead of the ``ref_deleted``
+lifecycle-rule work (PRD #346 / DM-54913). Five new nullable columns
+land on ``projects`` for the operator-supplied owner/repo pair and the
+opportunistically-captured numeric ids + installation id, the free-form
+``doc_repo`` URL column is renamed to nullable ``source_url`` (existing
+values flow through unchanged), and a both-or-neither check constraint
+plus two webhook-lookup indexes round out the structural shape.
+
+The data step parses every existing ``doc_repo`` value as a
+``github.com`` URL and back-fills ``github_owner`` / ``github_repo``
+from the first two path segments. Any URL whose host is not
+``github.com`` aborts the migration loudly with the offending project
+ids surfaced in the error message. The expectation is zero non-GitHub
+rows in production today; the abort is the safety net so a stray row
+cannot end up with NULL structured columns silently after the rename.
+
+Revision ID: x2y3z4a5b6c7
+Revises: w1x2y3z4a5b6
+Create Date: 2026-05-25 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "x2y3z4a5b6c7"
+down_revision: str | None = "w1x2y3z4a5b6"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def _parse_github_doc_repo(url: str) -> tuple[str, str] | None:
+    """Parse a ``github.com`` URL into ``(owner, repo)``.
+
+    Returns ``None`` if the host is not ``github.com`` (case-insensitive)
+    or if the path does not contain two non-empty segments. The migration
+    treats both cases as parse failures so the abort path lists the
+    offending project id either way.
+    """
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host != "github.com":
+        return None
+    segments = [s for s in parsed.path.split("/") if s]
+    min_segments = 2
+    if len(segments) < min_segments:
+        return None
+    owner = segments[0]
+    # Trim the conventional ``.git`` suffix so the parsed repo matches
+    # what GitHub returns for the repo name.
+    repo = segments[1].removesuffix(".git")
+    return owner, repo
+
+
+def upgrade() -> None:
+    op.add_column(
+        "projects",
+        sa.Column("github_owner", sa.String(39), nullable=True),
+    )
+    op.add_column(
+        "projects",
+        sa.Column("github_repo", sa.String(100), nullable=True),
+    )
+    op.add_column(
+        "projects",
+        sa.Column("github_owner_id", sa.BigInteger, nullable=True),
+    )
+    op.add_column(
+        "projects",
+        sa.Column("github_repo_id", sa.BigInteger, nullable=True),
+    )
+    op.add_column(
+        "projects",
+        sa.Column("github_installation_id", sa.BigInteger, nullable=True),
+    )
+
+    # Backfill structured GitHub columns from the existing free-form
+    # ``doc_repo`` URLs before the rename. Any non-github.com row aborts
+    # the migration with an operator-readable list of project ids.
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT id, doc_repo FROM projects")
+    ).fetchall()
+    invalid_ids: list[int] = []
+    parsed: list[tuple[int, str, str]] = []
+    for row in rows:
+        result = _parse_github_doc_repo(row.doc_repo)
+        if result is None:
+            invalid_ids.append(row.id)
+            continue
+        owner, repo = result
+        parsed.append((row.id, owner, repo))
+    if invalid_ids:
+        invalid_ids.sort()
+        message = (
+            "Cannot rename projects.doc_repo to source_url: the following"
+            " project ids have a doc_repo value that could not be parsed as"
+            " a https://github.com/<owner>/<repo> URL (the host is not"
+            " github.com, or the path has fewer than two segments):"
+            f" {invalid_ids}. Resolve these rows (either fix the URL or"
+            " migrate them to a non-GitHub host once the source_url column"
+            " lands in a later release) and re-run the migration."
+        )
+        raise RuntimeError(message)
+    for project_id, owner, repo in parsed:
+        bind.execute(
+            sa.text(
+                "UPDATE projects SET github_owner = :owner,"
+                " github_repo = :repo WHERE id = :id"
+            ),
+            {"owner": owner, "repo": repo, "id": project_id},
+        )
+
+    # Rename ``doc_repo`` to ``source_url`` and drop its NOT NULL.
+    op.alter_column(
+        "projects",
+        "doc_repo",
+        new_column_name="source_url",
+        existing_type=sa.String(512),
+        nullable=True,
+    )
+
+    op.create_check_constraint(
+        "ck_projects_github_owner_repo_both_or_neither",
+        "projects",
+        "(github_owner IS NULL) = (github_repo IS NULL)",
+    )
+
+    op.execute(
+        "CREATE INDEX idx_projects_github_owner_repo"
+        " ON projects (lower(github_owner), lower(github_repo))"
+    )
+    op.create_index(
+        "idx_projects_github_repo_id",
+        "projects",
+        ["github_repo_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_projects_github_repo_id", table_name="projects")
+    op.drop_index("idx_projects_github_owner_repo", table_name="projects")
+    op.drop_constraint(
+        "ck_projects_github_owner_repo_both_or_neither",
+        "projects",
+        type_="check",
+    )
+    op.alter_column(
+        "projects",
+        "source_url",
+        new_column_name="doc_repo",
+        existing_type=sa.String(512),
+        nullable=False,
+    )
+    op.drop_column("projects", "github_installation_id")
+    op.drop_column("projects", "github_repo_id")
+    op.drop_column("projects", "github_owner_id")
+    op.drop_column("projects", "github_repo")
+    op.drop_column("projects", "github_owner")

--- a/alembic/versions/20260525_0001_y3z4a5b6c7d8_null_github_source_urls.py
+++ b/alembic/versions/20260525_0001_y3z4a5b6c7d8_null_github_source_urls.py
@@ -1,0 +1,87 @@
+"""Null redundant github.com ``source_url`` values on ``projects``.
+
+The structured ``github`` binding is now the single source of truth for
+GitHub-backed projects, and a project's effective source URL is derived
+from that binding on read. The free-form ``source_url`` column therefore
+stores only non-GitHub URLs (or NULL); a stored github.com value is
+redundant and can drift out of agreement with the binding. This
+data-only migration nulls every ``source_url`` that parses as a
+github.com repository URL — exactly the values the ``ProjectCreate`` /
+``ProjectUpdate`` validators now reject on the way in.
+
+The parse mirrors
+:func:`docverse.client.models.projects.parse_github_url` (host is
+``github.com``, case-insensitive; at least two non-empty path segments)
+so the rows nulled here are precisely the rows the API would now refuse
+to accept. A copy of the predicate lives in this module so the migration
+stays pinned to today's semantics even if the app helper later changes.
+
+The downgrade best-effort re-derives ``source_url`` from the binding so
+a roll-back restores the pre-migration shape for GitHub-bound rows; path
+tails and ``.git`` suffixes that the upgrade discarded cannot be
+recovered.
+
+Revision ID: y3z4a5b6c7d8
+Revises: x2y3z4a5b6c7
+Create Date: 2026-05-25 00:01:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "y3z4a5b6c7d8"
+down_revision: str | None = "x2y3z4a5b6c7"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def _is_github_url(url: str) -> bool:
+    """Return ``True`` when ``url`` is a github.com repository URL.
+
+    Mirrors ``parse_github_url``: the host must be ``github.com``
+    (case-insensitive) and the path must carry at least two non-empty
+    segments. Deeper paths (``/tree/main/docs``) and a ``.git`` suffix
+    still count as a GitHub repository URL.
+    """
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host != "github.com":
+        return False
+    segments = [s for s in parsed.path.split("/") if s]
+    min_segments = 2
+    return len(segments) >= min_segments
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, source_url FROM projects WHERE source_url IS NOT NULL"
+        )
+    ).fetchall()
+    redundant_ids = [row.id for row in rows if _is_github_url(row.source_url)]
+    for project_id in redundant_ids:
+        bind.execute(
+            sa.text("UPDATE projects SET source_url = NULL WHERE id = :id"),
+            {"id": project_id},
+        )
+
+
+def downgrade() -> None:
+    # Best-effort: re-derive the canonical github.com URL for every row
+    # that carries a binding but no stored source_url. Path tails and
+    # ``.git`` suffixes the upgrade discarded cannot be recovered.
+    op.execute(
+        "UPDATE projects"
+        " SET source_url = 'https://github.com/'"
+        " || github_owner || '/' || github_repo"
+        " WHERE github_owner IS NOT NULL"
+        " AND github_repo IS NOT NULL"
+        " AND source_url IS NULL"
+    )

--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -73,6 +73,7 @@ from .organizations import (
     UrlScheme,
 )
 from .projects import (
+    InstallationStatus,
     Project,
     ProjectCreate,
     ProjectGitHubBinding,
@@ -113,6 +114,7 @@ __all__ = [
     "EditionUpdate",
     "FastlyCredentials",
     "GcpCredentials",
+    "InstallationStatus",
     "JobKind",
     "JobStatus",
     "KeeperSyncConfig",

--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -72,7 +72,13 @@ from .organizations import (
     OrganizationUpdate,
     UrlScheme,
 )
-from .projects import Project, ProjectCreate, ProjectUpdate
+from .projects import (
+    Project,
+    ProjectCreate,
+    ProjectGitHubBinding,
+    ProjectGitHubBindingCreate,
+    ProjectUpdate,
+)
 from .queue import QueueJob
 from .queue_enums import JobKind, JobStatus, PublishStatus
 from .services import (
@@ -141,6 +147,8 @@ __all__ = [
     "PrincipalType",
     "Project",
     "ProjectCreate",
+    "ProjectGitHubBinding",
+    "ProjectGitHubBindingCreate",
     "ProjectUpdate",
     "PublishStatus",
     "QueueJob",

--- a/client/src/docverse/client/models/projects.py
+++ b/client/src/docverse/client/models/projects.py
@@ -18,8 +18,21 @@ __all__ = [
     "ProjectGitHubBinding",
     "ProjectGitHubBindingCreate",
     "ProjectUpdate",
+    "build_github_url",
     "parse_github_url",
 ]
+
+
+def build_github_url(owner: str, repo: str) -> str:
+    """Build the canonical ``github.com`` URL for ``owner``/``repo``.
+
+    Inverse of :func:`parse_github_url`: returns
+    ``https://github.com/{owner}/{repo}`` with no trailing slash, path
+    tail, or ``.git`` suffix. Used to derive a project's effective
+    source URL from its structured GitHub binding, which is the single
+    source of truth for GitHub-backed projects.
+    """
+    return f"https://github.com/{owner}/{repo}"
 
 
 def parse_github_url(url: str) -> tuple[str, str] | None:
@@ -88,31 +101,36 @@ class ProjectGitHubBinding(BaseModel):
     )
 
 
-def _validate_github_source_url_agreement(
+def _validate_source_url_github_exclusivity(
     *,
     github: ProjectGitHubBindingCreate | None,
     source_url: str | None,
 ) -> None:
-    """Reject inputs whose ``github`` disagrees with a github.com URL.
+    """Keep ``source_url`` free of GitHub repos and apart from ``github``.
 
-    Raises a ``ValueError`` (which Pydantic surfaces as a 422 response)
-    when both fields are explicitly set, the URL parses as a
-    ``github.com`` repository URL, and the parsed ``(owner, repo)`` pair
-    does not match the structured sub-object. Non-GitHub ``source_url``
-    values and ``None`` on either side short-circuit without checking,
-    so the agreement rule never blocks a project bound to a non-GitHub
-    host or a project being cleared of one side.
+    The structured ``github`` binding is the single source of truth for
+    GitHub-backed projects, so the free-form ``source_url`` column must
+    never carry a ``github.com`` URL. Two rules, both surfaced as a 422:
+
+    * Rule A — ``source_url`` parses as a ``github.com`` repository URL.
+      Reject it: the caller must use the ``github`` field instead.
+    * Rule B — both ``source_url`` (non-null) and ``github`` (non-null)
+      are supplied. Reject it: the two are mutually exclusive, since a
+      project is GitHub-bound *or* points at a non-GitHub URL, never
+      both.
+
+    ``None`` on either side short-circuits the corresponding rule, so a
+    PATCH that clears one field while setting the other (e.g.
+    ``github: null`` plus a GitLab ``source_url``) passes cleanly.
     """
-    if github is None or source_url is None:
-        return
-    parsed = parse_github_url(source_url)
-    if parsed is None:
-        return
-    if (github.owner, github.repo) != parsed:
+    if source_url is not None and parse_github_url(source_url) is not None:
         msg = (
-            f"github sub-object ({github.owner}/{github.repo}) disagrees"
-            f" with source_url ({source_url})"
+            "source_url must not be a github.com URL; use the github field"
+            " for GitHub repositories"
         )
+        raise ValueError(msg)
+    if source_url is not None and github is not None:
+        msg = "source_url and github are mutually exclusive"
         raise ValueError(msg)
 
 
@@ -149,11 +167,13 @@ class ProjectCreate(BaseModel):
             min_length=1,
             max_length=512,
             description=(
-                "URL of the documentation source repository. ``None``"
-                " for projects whose source coordinates are tracked only"
-                " by the structured ``github`` sub-object."
+                "Non-GitHub URL of the documentation source repository;"
+                " use the ``github`` field for GitHub repositories. A"
+                " ``github.com`` value is rejected with a 422. ``None``"
+                " for GitHub-bound projects and for projects with no"
+                " source coordinates."
             ),
-            examples=["https://github.com/lsst/pipelines_lsst_io"],
+            examples=["https://gitlab.com/lsst/pipelines"],
         ),
     ] = None
 
@@ -161,8 +181,7 @@ class ProjectCreate(BaseModel):
         default=None,
         description=(
             "Structured GitHub coordinates for the project's source"
-            " repository. When omitted, the server populates this from"
-            " ``source_url`` if the URL is on ``github.com``."
+            " repository. Mutually exclusive with ``source_url``."
         ),
     )
 
@@ -180,8 +199,8 @@ class ProjectCreate(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _check_github_source_url_agreement(self) -> Self:
-        _validate_github_source_url_agreement(
+    def _check_source_url_github_exclusivity(self) -> Self:
+        _validate_source_url_github_exclusivity(
             github=self.github, source_url=self.source_url
         )
         return self
@@ -215,9 +234,10 @@ class Project(BaseModel):
     source_url: str | None = Field(
         default=None,
         description=(
-            "URL of the documentation source repository. ``None`` for"
-            " projects whose source coordinates are tracked only by the"
-            " structured ``github`` sub-object."
+            "Effective URL of the documentation source repository."
+            " Derived from the ``github`` binding when present"
+            " (``https://github.com/{owner}/{repo}``); otherwise the"
+            " stored non-GitHub URL. ``None`` when neither is set."
         ),
     )
 
@@ -269,17 +289,21 @@ class ProjectUpdate(BaseModel):
     source_url: str | None = Field(
         default=None,
         description=(
-            "URL of the documentation source repository. Pass ``null``"
-            " explicitly to clear the field."
+            "Non-GitHub URL of the documentation source repository; use"
+            " the ``github`` field for GitHub repositories. A"
+            " ``github.com`` value is rejected with a 422. Pass a"
+            " non-GitHub URL to clear any existing GitHub binding, or"
+            " ``null`` explicitly to clear the field."
         ),
     )
 
     github: ProjectGitHubBindingCreate | None = Field(
         default=None,
         description=(
-            "Structured GitHub coordinates for the project. Pass ``null``"
-            " explicitly to clear the binding (and the opportunistically-"
-            "captured numeric ids that depend on it)."
+            "Structured GitHub coordinates for the project. Setting this"
+            " nulls any stored ``source_url``. Pass ``null`` explicitly"
+            " to clear the binding (and the opportunistically-captured"
+            " numeric ids that depend on it)."
         ),
     )
 
@@ -294,8 +318,8 @@ class ProjectUpdate(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _check_github_source_url_agreement(self) -> Self:
-        _validate_github_source_url_agreement(
+    def _check_source_url_github_exclusivity(self) -> Self:
+        _validate_source_url_github_exclusivity(
             github=self.github, source_url=self.source_url
         )
         return self

--- a/client/src/docverse/client/models/projects.py
+++ b/client/src/docverse/client/models/projects.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import StrEnum
 from typing import Annotated, Any, Self
 from urllib.parse import urlparse
 
@@ -13,6 +14,7 @@ from .editions import Edition as EditionResponse
 from .lifecycle import LifecycleRuleSet
 
 __all__ = [
+    "InstallationStatus",
     "Project",
     "ProjectCreate",
     "ProjectGitHubBinding",
@@ -83,6 +85,22 @@ class ProjectGitHubBindingCreate(BaseModel):
     repo: Annotated[str, _GITHUB_REPO_FIELD]
 
 
+class InstallationStatus(StrEnum):
+    """Whether the Docverse GitHub App is installed on a repository.
+
+    Derived per response from the project's GitHub binding. Today only
+    ``not_installed`` and ``installed`` are ever returned;
+    ``suspended`` and ``needs_permissions`` are reserved enum values
+    for a later slice (projects currently have no suspended state — the
+    suspend/unsuspend webhooks only touch dashboard-template bindings).
+    """
+
+    not_installed = "not_installed"
+    installed = "installed"
+    suspended = "suspended"
+    needs_permissions = "needs_permissions"
+
+
 class ProjectGitHubBinding(BaseModel):
     """Structured GitHub coordinates returned on a project resource."""
 
@@ -97,6 +115,25 @@ class ProjectGitHubBinding(BaseModel):
         description=(
             "GitHub App installation id for the repository. ``None`` when"
             " the App is not installed or has not yet been resolved."
+        ),
+    )
+
+    installation_status: InstallationStatus = Field(
+        description=(
+            "Whether the Docverse GitHub App is installed on this repo."
+            " Today only ``not_installed``/``installed`` are returned;"
+            " ``suspended`` and ``needs_permissions`` are reserved."
+        ),
+    )
+
+    app_url: str | None = Field(
+        default=None,
+        description=(
+            "Public URL of the Docverse GitHub App's install page (e.g."
+            " ``https://github.com/apps/{slug}``), so an operator can"
+            " install the App on the repository. ``None`` when the"
+            " GitHub App feature is unconfigured or its credentials"
+            " failed startup validation."
         ),
     )
 

--- a/client/src/docverse/client/models/projects.py
+++ b/client/src/docverse/client/models/projects.py
@@ -3,13 +3,117 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated, Any
+from typing import Annotated, Any, Self
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .editions import DefaultEditionConfig
 from .editions import Edition as EditionResponse
 from .lifecycle import LifecycleRuleSet
+
+__all__ = [
+    "Project",
+    "ProjectCreate",
+    "ProjectGitHubBinding",
+    "ProjectGitHubBindingCreate",
+    "ProjectUpdate",
+    "parse_github_url",
+]
+
+
+def parse_github_url(url: str) -> tuple[str, str] | None:
+    """Parse a ``github.com`` URL into ``(owner, repo)``.
+
+    Returns ``None`` if the host is not ``github.com`` (case-insensitive)
+    or if the path does not have at least two non-empty segments. The
+    conventional ``.git`` suffix on the repo segment is trimmed so the
+    parsed value matches what GitHub returns for the repository name.
+    Deeper paths (``/tree/main/docs``) are accepted; only the first two
+    segments are interpreted as ``owner``/``repo``.
+    """
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host != "github.com":
+        return None
+    segments = [s for s in parsed.path.split("/") if s]
+    min_segments = 2
+    if len(segments) < min_segments:
+        return None
+    owner = segments[0]
+    repo = segments[1].removesuffix(".git")
+    return owner, repo
+
+
+_GITHUB_OWNER_FIELD = Field(
+    min_length=1,
+    max_length=39,
+    pattern=r"^[A-Za-z0-9](?:-?[A-Za-z0-9])*$",
+    description="GitHub owner (user or organization login).",
+)
+
+_GITHUB_REPO_FIELD = Field(
+    min_length=1,
+    max_length=100,
+    pattern=r"^[A-Za-z0-9._-]+$",
+    description="GitHub repository name.",
+)
+
+
+class ProjectGitHubBindingCreate(BaseModel):
+    """Structured GitHub coordinates supplied on project create / update."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    owner: Annotated[str, _GITHUB_OWNER_FIELD]
+
+    repo: Annotated[str, _GITHUB_REPO_FIELD]
+
+
+class ProjectGitHubBinding(BaseModel):
+    """Structured GitHub coordinates returned on a project resource."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    owner: Annotated[str, _GITHUB_OWNER_FIELD]
+
+    repo: Annotated[str, _GITHUB_REPO_FIELD]
+
+    installation_id: int | None = Field(
+        default=None,
+        description=(
+            "GitHub App installation id for the repository. ``None`` when"
+            " the App is not installed or has not yet been resolved."
+        ),
+    )
+
+
+def _validate_github_source_url_agreement(
+    *,
+    github: ProjectGitHubBindingCreate | None,
+    source_url: str | None,
+) -> None:
+    """Reject inputs whose ``github`` disagrees with a github.com URL.
+
+    Raises a ``ValueError`` (which Pydantic surfaces as a 422 response)
+    when both fields are explicitly set, the URL parses as a
+    ``github.com`` repository URL, and the parsed ``(owner, repo)`` pair
+    does not match the structured sub-object. Non-GitHub ``source_url``
+    values and ``None`` on either side short-circuit without checking,
+    so the agreement rule never blocks a project bound to a non-GitHub
+    host or a project being cleared of one side.
+    """
+    if github is None or source_url is None:
+        return
+    parsed = parse_github_url(source_url)
+    if parsed is None:
+        return
+    if (github.owner, github.repo) != parsed:
+        msg = (
+            f"github sub-object ({github.owner}/{github.repo}) disagrees"
+            f" with source_url ({source_url})"
+        )
+        raise ValueError(msg)
 
 
 class ProjectCreate(BaseModel):
@@ -38,15 +142,29 @@ class ProjectCreate(BaseModel):
         ),
     ]
 
-    doc_repo: Annotated[
-        str,
+    source_url: Annotated[
+        str | None,
         Field(
+            default=None,
             min_length=1,
             max_length=512,
-            description="URL of the documentation source repository.",
+            description=(
+                "URL of the documentation source repository. ``None``"
+                " for projects whose source coordinates are tracked only"
+                " by the structured ``github`` sub-object."
+            ),
             examples=["https://github.com/lsst/pipelines_lsst_io"],
         ),
-    ]
+    ] = None
+
+    github: ProjectGitHubBindingCreate | None = Field(
+        default=None,
+        description=(
+            "Structured GitHub coordinates for the project's source"
+            " repository. When omitted, the server populates this from"
+            " ``source_url`` if the URL is on ``github.com``."
+        ),
+    )
 
     default_edition: DefaultEditionConfig | None = Field(
         default=None,
@@ -60,6 +178,13 @@ class ProjectCreate(BaseModel):
         default=None,
         description="Rules governing build lifecycle.",
     )
+
+    @model_validator(mode="after")
+    def _check_github_source_url_agreement(self) -> Self:
+        _validate_github_source_url_agreement(
+            github=self.github, source_url=self.source_url
+        )
+        return self
 
 
 class Project(BaseModel):
@@ -87,8 +212,21 @@ class Project(BaseModel):
 
     title: str = Field(description="Display title for the project.")
 
-    doc_repo: str = Field(
-        description="URL of the documentation source repository."
+    source_url: str | None = Field(
+        default=None,
+        description=(
+            "URL of the documentation source repository. ``None`` for"
+            " projects whose source coordinates are tracked only by the"
+            " structured ``github`` sub-object."
+        ),
+    )
+
+    github: ProjectGitHubBinding | None = Field(
+        default=None,
+        description=(
+            "Structured GitHub coordinates for the project. ``None`` for"
+            " projects whose source repository is not on GitHub."
+        ),
     )
 
     slug_rewrite_rules: list[dict[str, Any]] | None = Field(
@@ -128,9 +266,21 @@ class ProjectUpdate(BaseModel):
         default=None, description="Display title for the project."
     )
 
-    doc_repo: str | None = Field(
+    source_url: str | None = Field(
         default=None,
-        description="URL of the documentation source repository.",
+        description=(
+            "URL of the documentation source repository. Pass ``null``"
+            " explicitly to clear the field."
+        ),
+    )
+
+    github: ProjectGitHubBindingCreate | None = Field(
+        default=None,
+        description=(
+            "Structured GitHub coordinates for the project. Pass ``null``"
+            " explicitly to clear the binding (and the opportunistically-"
+            "captured numeric ids that depend on it)."
+        ),
     )
 
     slug_rewrite_rules: list[dict[str, Any]] | None = Field(
@@ -142,3 +292,10 @@ class ProjectUpdate(BaseModel):
         default=None,
         description="Rules governing build lifecycle.",
     )
+
+    @model_validator(mode="after")
+    def _check_github_source_url_agreement(self) -> Self:
+        _validate_github_source_url_agreement(
+            github=self.github, source_url=self.source_url
+        )
+        return self

--- a/client/tests/edition_model_test.py
+++ b/client/tests/edition_model_test.py
@@ -116,7 +116,7 @@ def test_relaxed_edition_slug_chars_stay_edition_only(slug: str) -> None:
         ProjectCreate(
             slug=slug,
             title="T",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         )
     with pytest.raises(ValidationError):
         OrganizationCreate(

--- a/client/tests/edition_model_test.py
+++ b/client/tests/edition_model_test.py
@@ -116,7 +116,7 @@ def test_relaxed_edition_slug_chars_stay_edition_only(slug: str) -> None:
         ProjectCreate(
             slug=slug,
             title="T",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         )
     with pytest.raises(ValidationError):
         OrganizationCreate(

--- a/client/tests/lifecycle_model_test.py
+++ b/client/tests/lifecycle_model_test.py
@@ -162,7 +162,7 @@ def test_project_create_accepts_typed_lifecycle_rules() -> None:
     payload = ProjectCreate(
         slug="pipelines",
         title="Pipelines",
-        source_url="https://github.com/example/pipelines",
+        source_url="https://example.com/example/pipelines",
         lifecycle_rules=[  # type: ignore[arg-type]
             {"type": "draft_inactivity", "max_days_inactive": 30},
             {"type": "ref_deleted"},
@@ -177,7 +177,7 @@ def test_project_create_rejects_unknown_lifecycle_rule_type() -> None:
         ProjectCreate(
             slug="pipelines",
             title="Pipelines",
-            source_url="https://github.com/example/pipelines",
+            source_url="https://example.com/example/pipelines",
             lifecycle_rules=[  # type: ignore[arg-type]
                 {"type": "purgatory_eviction", "enabled": True},
             ],
@@ -189,7 +189,7 @@ def test_project_create_rejects_duplicate_lifecycle_rule_types() -> None:
         ProjectCreate(
             slug="pipelines",
             title="Pipelines",
-            source_url="https://github.com/example/pipelines",
+            source_url="https://example.com/example/pipelines",
             lifecycle_rules=[  # type: ignore[arg-type]
                 {"type": "draft_inactivity", "max_days_inactive": 30},
                 {"type": "draft_inactivity", "max_days_inactive": 60},

--- a/client/tests/lifecycle_model_test.py
+++ b/client/tests/lifecycle_model_test.py
@@ -162,7 +162,7 @@ def test_project_create_accepts_typed_lifecycle_rules() -> None:
     payload = ProjectCreate(
         slug="pipelines",
         title="Pipelines",
-        doc_repo="https://github.com/example/pipelines",
+        source_url="https://github.com/example/pipelines",
         lifecycle_rules=[  # type: ignore[arg-type]
             {"type": "draft_inactivity", "max_days_inactive": 30},
             {"type": "ref_deleted"},
@@ -177,7 +177,7 @@ def test_project_create_rejects_unknown_lifecycle_rule_type() -> None:
         ProjectCreate(
             slug="pipelines",
             title="Pipelines",
-            doc_repo="https://github.com/example/pipelines",
+            source_url="https://github.com/example/pipelines",
             lifecycle_rules=[  # type: ignore[arg-type]
                 {"type": "purgatory_eviction", "enabled": True},
             ],
@@ -189,7 +189,7 @@ def test_project_create_rejects_duplicate_lifecycle_rule_types() -> None:
         ProjectCreate(
             slug="pipelines",
             title="Pipelines",
-            doc_repo="https://github.com/example/pipelines",
+            source_url="https://github.com/example/pipelines",
             lifecycle_rules=[  # type: ignore[arg-type]
                 {"type": "draft_inactivity", "max_days_inactive": 30},
                 {"type": "draft_inactivity", "max_days_inactive": 60},

--- a/client/tests/project_model_test.py
+++ b/client/tests/project_model_test.py
@@ -1,0 +1,156 @@
+"""Tests for project client models, focusing on the GitHub binding."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from docverse.client.models import (
+    ProjectCreate,
+    ProjectGitHubBinding,
+    ProjectGitHubBindingCreate,
+    ProjectUpdate,
+)
+from docverse.client.models.projects import parse_github_url
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (
+            "https://github.com/lsst/pipelines_lsst_io",
+            ("lsst", "pipelines_lsst_io"),
+        ),
+        (
+            "https://github.com/lsst/pipelines_lsst_io.git",
+            ("lsst", "pipelines_lsst_io"),
+        ),
+        (
+            "https://github.com/lsst/pipelines_lsst_io/tree/main/docs",
+            ("lsst", "pipelines_lsst_io"),
+        ),
+        (
+            "https://GITHUB.COM/lsst/pipelines_lsst_io",
+            ("lsst", "pipelines_lsst_io"),
+        ),
+        ("https://gitlab.com/lsst/pipelines", None),
+        ("https://example.com/lsst/pipelines", None),
+        ("https://github.com/lsst", None),
+        ("https://github.com/", None),
+        ("not-a-url", None),
+    ],
+)
+def test_parse_github_url(url: str, expected: tuple[str, str] | None) -> None:
+    assert parse_github_url(url) == expected
+
+
+def test_binding_create_accepts_valid_pair() -> None:
+    binding = ProjectGitHubBindingCreate(owner="lsst-sqre", repo="docverse")
+    assert binding.owner == "lsst-sqre"
+    assert binding.repo == "docverse"
+
+
+def test_binding_create_rejects_invalid_owner() -> None:
+    with pytest.raises(ValidationError):
+        ProjectGitHubBindingCreate(owner="-bad", repo="docverse")
+
+
+def test_binding_create_rejects_invalid_repo() -> None:
+    with pytest.raises(ValidationError):
+        ProjectGitHubBindingCreate(owner="lsst", repo="bad repo")
+
+
+def test_binding_create_rejects_owner_too_long() -> None:
+    with pytest.raises(ValidationError):
+        ProjectGitHubBindingCreate(owner="a" * 40, repo="docverse")
+
+
+def test_binding_create_rejects_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        ProjectGitHubBindingCreate.model_validate(
+            {"owner": "lsst", "repo": "docverse", "installation_id": 1}
+        )
+
+
+def test_binding_response_includes_installation_id() -> None:
+    expected = 42
+    binding = ProjectGitHubBinding(
+        owner="lsst", repo="docverse", installation_id=expected
+    )
+    assert binding.installation_id == expected
+
+
+def test_binding_response_installation_id_defaults_none() -> None:
+    binding = ProjectGitHubBinding(owner="lsst", repo="docverse")
+    assert binding.installation_id is None
+
+
+def test_project_create_accepts_github_without_source_url() -> None:
+    proj = ProjectCreate(
+        slug="docs",
+        title="Docs",
+        github=ProjectGitHubBindingCreate(owner="lsst", repo="docverse"),
+    )
+    assert proj.github is not None
+    assert proj.github.owner == "lsst"
+    assert proj.source_url is None
+
+
+def test_project_create_accepts_source_url_without_github() -> None:
+    proj = ProjectCreate(
+        slug="docs",
+        title="Docs",
+        source_url="https://github.com/lsst/docverse",
+    )
+    assert proj.source_url == "https://github.com/lsst/docverse"
+    assert proj.github is None
+
+
+def test_project_create_accepts_agreeing_pair() -> None:
+    proj = ProjectCreate(
+        slug="docs",
+        title="Docs",
+        source_url="https://github.com/lsst/docverse",
+        github=ProjectGitHubBindingCreate(owner="lsst", repo="docverse"),
+    )
+    assert proj.github is not None
+
+
+def test_project_create_rejects_disagreeing_pair() -> None:
+    with pytest.raises(ValidationError):
+        ProjectCreate(
+            slug="docs",
+            title="Docs",
+            source_url="https://github.com/lsst/docverse",
+            github=ProjectGitHubBindingCreate(owner="other", repo="repo"),
+        )
+
+
+def test_project_create_accepts_non_github_source_url_with_github() -> None:
+    """A non-GitHub source URL plus a github sub-object skips the check."""
+    proj = ProjectCreate(
+        slug="docs",
+        title="Docs",
+        source_url="https://gitlab.com/lsst/mirror",
+        github=ProjectGitHubBindingCreate(owner="lsst", repo="docverse"),
+    )
+    assert proj.github is not None
+    assert proj.source_url == "https://gitlab.com/lsst/mirror"
+
+
+def test_project_update_accepts_explicit_null_clears() -> None:
+    update = ProjectUpdate.model_validate({"github": None, "source_url": None})
+    assert update.github is None
+    assert update.source_url is None
+    assert "github" in update.model_fields_set
+    assert "source_url" in update.model_fields_set
+
+
+def test_project_update_rejects_disagreeing_pair() -> None:
+    with pytest.raises(ValidationError):
+        ProjectUpdate.model_validate(
+            {
+                "source_url": "https://github.com/lsst/docverse",
+                "github": {"owner": "other", "repo": "repo"},
+            }
+        )

--- a/client/tests/project_model_test.py
+++ b/client/tests/project_model_test.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from docverse.client.models import (
+    InstallationStatus,
     ProjectCreate,
     ProjectGitHubBinding,
     ProjectGitHubBindingCreate,
@@ -89,14 +90,44 @@ def test_binding_create_rejects_extra_fields() -> None:
 def test_binding_response_includes_installation_id() -> None:
     expected = 42
     binding = ProjectGitHubBinding(
-        owner="lsst", repo="docverse", installation_id=expected
+        owner="lsst",
+        repo="docverse",
+        installation_id=expected,
+        installation_status=InstallationStatus.installed,
     )
     assert binding.installation_id == expected
 
 
 def test_binding_response_installation_id_defaults_none() -> None:
-    binding = ProjectGitHubBinding(owner="lsst", repo="docverse")
+    binding = ProjectGitHubBinding(
+        owner="lsst",
+        repo="docverse",
+        installation_status=InstallationStatus.not_installed,
+    )
     assert binding.installation_id is None
+
+
+def test_binding_response_app_url_defaults_none() -> None:
+    """``app_url`` is optional and absent until startup captures it."""
+    binding = ProjectGitHubBinding(
+        owner="lsst",
+        repo="docverse",
+        installation_status=InstallationStatus.not_installed,
+    )
+    assert binding.app_url is None
+
+
+def test_binding_response_carries_status_and_app_url() -> None:
+    """Both new fields round-trip through the response model."""
+    binding = ProjectGitHubBinding(
+        owner="lsst",
+        repo="docverse",
+        installation_id=42,
+        installation_status=InstallationStatus.installed,
+        app_url="https://github.com/apps/docverse",
+    )
+    assert binding.installation_status == InstallationStatus.installed
+    assert binding.app_url == "https://github.com/apps/docverse"
 
 
 def test_project_create_accepts_github_without_source_url() -> None:

--- a/client/tests/project_model_test.py
+++ b/client/tests/project_model_test.py
@@ -11,7 +11,7 @@ from docverse.client.models import (
     ProjectGitHubBindingCreate,
     ProjectUpdate,
 )
-from docverse.client.models.projects import parse_github_url
+from docverse.client.models.projects import build_github_url, parse_github_url
 
 
 @pytest.mark.parametrize(
@@ -42,6 +42,20 @@ from docverse.client.models.projects import parse_github_url
 )
 def test_parse_github_url(url: str, expected: tuple[str, str] | None) -> None:
     assert parse_github_url(url) == expected
+
+
+def test_build_github_url() -> None:
+    assert (
+        build_github_url("lsst", "docverse")
+        == "https://github.com/lsst/docverse"
+    )
+
+
+def test_build_github_url_round_trips_parse() -> None:
+    assert parse_github_url(build_github_url("lsst", "docverse")) == (
+        "lsst",
+        "docverse",
+    )
 
 
 def test_binding_create_accepts_valid_pair() -> None:
@@ -96,46 +110,36 @@ def test_project_create_accepts_github_without_source_url() -> None:
     assert proj.source_url is None
 
 
-def test_project_create_accepts_source_url_without_github() -> None:
+def test_project_create_accepts_non_github_source_url() -> None:
+    """A non-GitHub source URL alone is the canonical non-GitHub project."""
     proj = ProjectCreate(
         slug="docs",
         title="Docs",
-        source_url="https://github.com/lsst/docverse",
+        source_url="https://gitlab.com/lsst/mirror",
     )
-    assert proj.source_url == "https://github.com/lsst/docverse"
+    assert proj.source_url == "https://gitlab.com/lsst/mirror"
     assert proj.github is None
 
 
-def test_project_create_accepts_agreeing_pair() -> None:
-    proj = ProjectCreate(
-        slug="docs",
-        title="Docs",
-        source_url="https://github.com/lsst/docverse",
-        github=ProjectGitHubBindingCreate(owner="lsst", repo="docverse"),
-    )
-    assert proj.github is not None
-
-
-def test_project_create_rejects_disagreeing_pair() -> None:
+def test_project_create_rejects_github_source_url() -> None:
+    """Rule A: a github.com source_url must use the github field instead."""
     with pytest.raises(ValidationError):
         ProjectCreate(
             slug="docs",
             title="Docs",
             source_url="https://github.com/lsst/docverse",
-            github=ProjectGitHubBindingCreate(owner="other", repo="repo"),
         )
 
 
-def test_project_create_accepts_non_github_source_url_with_github() -> None:
-    """A non-GitHub source URL plus a github sub-object skips the check."""
-    proj = ProjectCreate(
-        slug="docs",
-        title="Docs",
-        source_url="https://gitlab.com/lsst/mirror",
-        github=ProjectGitHubBindingCreate(owner="lsst", repo="docverse"),
-    )
-    assert proj.github is not None
-    assert proj.source_url == "https://gitlab.com/lsst/mirror"
+def test_project_create_rejects_source_url_and_github_together() -> None:
+    """Rule B: source_url and github are mutually exclusive."""
+    with pytest.raises(ValidationError):
+        ProjectCreate(
+            slug="docs",
+            title="Docs",
+            source_url="https://gitlab.com/lsst/mirror",
+            github=ProjectGitHubBindingCreate(owner="lsst", repo="docverse"),
+        )
 
 
 def test_project_update_accepts_explicit_null_clears() -> None:
@@ -146,11 +150,29 @@ def test_project_update_accepts_explicit_null_clears() -> None:
     assert "source_url" in update.model_fields_set
 
 
-def test_project_update_rejects_disagreeing_pair() -> None:
+def test_project_update_rejects_github_source_url() -> None:
+    """Rule A also guards PATCH input."""
+    with pytest.raises(ValidationError):
+        ProjectUpdate.model_validate(
+            {"source_url": "https://github.com/lsst/docverse"}
+        )
+
+
+def test_project_update_rejects_source_url_and_github_together() -> None:
+    """Rule B also guards PATCH input."""
     with pytest.raises(ValidationError):
         ProjectUpdate.model_validate(
             {
-                "source_url": "https://github.com/lsst/docverse",
-                "github": {"owner": "other", "repo": "repo"},
+                "source_url": "https://gitlab.com/lsst/mirror",
+                "github": {"owner": "lsst", "repo": "docverse"},
             }
         )
+
+
+def test_project_update_clears_github_with_non_github_source_url() -> None:
+    """github: null plus a non-GitHub source_url passes (one side cleared)."""
+    update = ProjectUpdate.model_validate(
+        {"github": None, "source_url": "https://gitlab.com/lsst/mirror"}
+    )
+    assert update.github is None
+    assert update.source_url == "https://gitlab.com/lsst/mirror"

--- a/src/docverse/dbschema/project.py
+++ b/src/docverse/dbschema/project.py
@@ -5,10 +5,19 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import DateTime, Index, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy.sql import func
 
 from .base import Base
 
@@ -28,7 +37,28 @@ class SqlProject(Base):
 
     org_id: Mapped[int] = mapped_column(Integer, nullable=False)
 
-    doc_repo: Mapped[str] = mapped_column(String(512), nullable=False)
+    # Free-form URL to the documentation source repository. Nullable so
+    # projects can be created GitHub-binding-only (with ``github_owner``
+    # / ``github_repo`` populated) without a redundant URL string.
+    source_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
+
+    # Structured GitHub coordinates for the documentation source repo.
+    # ``github_owner`` / ``github_repo`` are the operator-supplied source
+    # of truth; the ``_id`` and ``installation_id`` columns are captured
+    # opportunistically and may stay NULL forever for projects whose
+    # GitHub App is not installed. The check constraint enforces that
+    # ``github_owner`` and ``github_repo`` are populated together.
+    github_owner: Mapped[str | None] = mapped_column(String(39), nullable=True)
+    github_repo: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    github_owner_id: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True
+    )
+    github_repo_id: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True
+    )
+    github_installation_id: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True
+    )
 
     slug_rewrite_rules: Mapped[dict[str, Any] | None] = mapped_column(
         JSONB, nullable=True
@@ -57,6 +87,10 @@ class SqlProject(Base):
 
     __table_args__ = (
         UniqueConstraint("org_id", "slug", name="uq_projects_org_slug"),
+        CheckConstraint(
+            "(github_owner IS NULL) = (github_repo IS NULL)",
+            name="ck_projects_github_owner_repo_both_or_neither",
+        ),
         Index("idx_projects_org_id", "org_id"),
         Index(
             "idx_projects_slug_trgm",
@@ -69,5 +103,14 @@ class SqlProject(Base):
             "title",
             postgresql_using="gin",
             postgresql_ops={"title": "gin_trgm_ops"},
+        ),
+        Index(
+            "idx_projects_github_owner_repo",
+            text("lower(github_owner)"),
+            text("lower(github_repo)"),
+        ),
+        Index(
+            "idx_projects_github_repo_id",
+            "github_repo_id",
         ),
     )

--- a/src/docverse/dependencies/context.py
+++ b/src/docverse/dependencies/context.py
@@ -90,6 +90,7 @@ class ContextDependency:
         self._github_app_private_key: SecretStr | None = None
         self._github_webhook_secret: SecretStr | None = None
         self._github_app_validated: bool = True
+        self._github_app_html_url: str | None = None
 
     @property
     def github_app_enabled(self) -> bool:
@@ -145,6 +146,7 @@ class ContextDependency:
                 github_app_private_key=self._github_app_private_key,
                 github_webhook_secret=self._github_webhook_secret,
                 github_app_validated=self._github_app_validated,
+                github_app_html_url=self._github_app_html_url,
                 default_queue_name=self._arq_queue_name,
             ),
         )
@@ -214,6 +216,17 @@ class ContextDependency:
         this process without taking the service down.
         """
         self._github_app_validated = value
+
+    def set_github_app_html_url(self, html_url: str | None) -> None:
+        """Record the GitHub App's public install-page URL.
+
+        Called by the API service lifespan with the ``html_url`` the
+        startup ``GET /app`` validation returned, so the project
+        serializer can surface it as ``github.app_url`` and the UI can
+        link operators to the App's install page. ``None`` leaves the
+        field absent (feature unconfigured or validation failed).
+        """
+        self._github_app_html_url = html_url
 
     async def aclose(self) -> None:
         """Clean up the per-process configuration."""

--- a/src/docverse/domain/project.py
+++ b/src/docverse/domain/project.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from docverse.client.models.projects import build_github_url
+
 from .lifecycle import LifecycleRuleSet
 
 
@@ -28,8 +30,12 @@ class Project(BaseModel):
     source_url: str | None = Field(
         default=None,
         description=(
-            "URL of the documentation source repository. ``None`` for"
-            " projects bound to a GitHub repository only."
+            "Stored non-GitHub URL of the documentation source"
+            " repository, or ``None``. Never a ``github.com`` URL: a"
+            " GitHub repo is tracked by the structured ``github_*``"
+            " binding instead. Read"
+            " :attr:`effective_source_url` for the value consumers"
+            " should display."
         ),
     )
 
@@ -95,3 +101,19 @@ class Project(BaseModel):
         default=None,
         description="Timestamp when the project was soft-deleted.",
     )
+
+    @property
+    def effective_source_url(self) -> str | None:
+        """Derive the source-repository URL consumers should display.
+
+        The structured ``github`` binding is the single source of truth
+        for GitHub-backed projects, so it wins when present and yields
+        the canonical ``https://github.com/{owner}/{repo}``. Otherwise
+        the stored non-GitHub ``source_url`` is returned verbatim, and
+        ``None`` when the project has no source coordinates at all. This
+        lives here, once, so the API response and the dashboard context
+        derive the same value.
+        """
+        if self.github_owner is not None and self.github_repo is not None:
+            return build_github_url(self.github_owner, self.github_repo)
+        return self.source_url

--- a/src/docverse/domain/project.py
+++ b/src/docverse/domain/project.py
@@ -7,7 +7,10 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from docverse.client.models.projects import build_github_url
+from docverse.client.models.projects import (
+    InstallationStatus,
+    build_github_url,
+)
 
 from .lifecycle import LifecycleRuleSet
 
@@ -117,3 +120,20 @@ class Project(BaseModel):
         if self.github_owner is not None and self.github_repo is not None:
             return build_github_url(self.github_owner, self.github_repo)
         return self.source_url
+
+    @property
+    def github_installation_status(self) -> InstallationStatus | None:
+        """Derive the App-installation status for the github binding.
+
+        Only meaningful with a binding present. ``installation_id`` set
+        -> installed; else not_installed. Note: a not-yet-resolved or
+        transiently-failed resolve also reads as not_installed until the
+        worker or installation webhook backfills the id (acceptable for
+        the derived-only status; persisting the resolve outcome is a
+        later slice).
+        """
+        if self.github_owner is None or self.github_repo is None:
+            return None
+        if self.github_installation_id is not None:
+            return InstallationStatus.installed
+        return InstallationStatus.not_installed

--- a/src/docverse/domain/project.py
+++ b/src/docverse/domain/project.py
@@ -25,8 +25,52 @@ class Project(BaseModel):
         description="ID of the organization this project belongs to."
     )
 
-    doc_repo: str = Field(
-        description="URL of the documentation source repository."
+    source_url: str | None = Field(
+        default=None,
+        description=(
+            "URL of the documentation source repository. ``None`` for"
+            " projects bound to a GitHub repository only."
+        ),
+    )
+
+    github_owner: str | None = Field(
+        default=None,
+        description=(
+            "Owner login of the GitHub repository backing this project."
+            " Populated together with ``github_repo``."
+        ),
+    )
+
+    github_repo: str | None = Field(
+        default=None,
+        description=(
+            "Name of the GitHub repository backing this project."
+            " Populated together with ``github_owner``."
+        ),
+    )
+
+    github_owner_id: int | None = Field(
+        default=None,
+        description=(
+            "GitHub numeric owner id, captured opportunistically once the"
+            " GitHub App resolves the repository."
+        ),
+    )
+
+    github_repo_id: int | None = Field(
+        default=None,
+        description=(
+            "GitHub numeric repository id, captured opportunistically once"
+            " the GitHub App resolves the repository."
+        ),
+    )
+
+    github_installation_id: int | None = Field(
+        default=None,
+        description=(
+            "GitHub App installation id for the repository, captured"
+            " opportunistically once the App is installed."
+        ),
     )
 
     slug_rewrite_rules: list[dict[str, Any]] | None = Field(

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -840,6 +840,7 @@ class HandlerFactory(Factory):
         github_app_id: int | None = None,
         github_app_private_key: SecretStr | None = None,
         github_webhook_secret: SecretStr | None = None,
+        github_app_html_url: str | None = None,
         *,
         github_app_validated: bool = True,
         default_queue_name: str,
@@ -859,7 +860,21 @@ class HandlerFactory(Factory):
             default_queue_name=default_queue_name,
         )
         self._user_info_store = user_info_store
+        self._github_app_html_url = github_app_html_url
 
     def get_user_info_store(self) -> UserInfoStore:
         """Get the UserInfoStore instance."""
         return self._user_info_store
+
+    @property
+    def github_app_html_url(self) -> str | None:
+        """The GitHub App's public install-page URL, or ``None``.
+
+        Captured from the startup ``GET /app`` validation and threaded
+        through :class:`docverse.dependencies.context.ContextDependency`.
+        Handlers read it as ``context.factory.github_app_html_url`` to
+        populate ``github.app_url`` on project responses. ``None`` when
+        the GitHub App feature is unconfigured or its credentials failed
+        startup validation.
+        """
+        return self._github_app_html_url

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -591,10 +591,12 @@ class Factory:
         rename = RenameEventProcessor(
             binding_store=binding_store,
             template_store=template_store,
+            project_store=self.create_project_store(),
             logger=self._logger,
         )
         installation = InstallationEventProcessor(
             binding_store=binding_store,
+            project_store=self.create_project_store(),
             logger=self._logger,
         )
         return WebhookDispatch(

--- a/src/docverse/handlers/orgs/models.py
+++ b/src/docverse/handlers/orgs/models.py
@@ -207,7 +207,7 @@ class Project(_ProjectBase):
             ),
             slug=domain.slug,
             title=domain.title,
-            doc_repo=domain.doc_repo,
+            doc_repo=domain.source_url or "",
             slug_rewrite_rules=domain.slug_rewrite_rules,
             lifecycle_rules=domain.lifecycle_rules,
             default_edition=edition_response,

--- a/src/docverse/handlers/orgs/models.py
+++ b/src/docverse/handlers/orgs/models.py
@@ -17,6 +17,7 @@ from docverse.client.models import (
 from docverse.client.models import (
     DefaultEditionConfig,
     OrganizationServiceSummary,
+    ProjectGitHubBinding,
 )
 from docverse.client.models import Edition as _EditionBase
 from docverse.client.models import (
@@ -207,7 +208,17 @@ class Project(_ProjectBase):
             ),
             slug=domain.slug,
             title=domain.title,
-            doc_repo=domain.source_url or "",
+            source_url=domain.source_url,
+            github=(
+                ProjectGitHubBinding(
+                    owner=domain.github_owner,
+                    repo=domain.github_repo,
+                    installation_id=domain.github_installation_id,
+                )
+                if domain.github_owner is not None
+                and domain.github_repo is not None
+                else None
+            ),
             slug_rewrite_rules=domain.slug_rewrite_rules,
             lifecycle_rules=domain.lifecycle_rules,
             default_edition=edition_response,

--- a/src/docverse/handlers/orgs/models.py
+++ b/src/docverse/handlers/orgs/models.py
@@ -16,6 +16,7 @@ from docverse.client.models import (
 )
 from docverse.client.models import (
     DefaultEditionConfig,
+    InstallationStatus,
     OrganizationServiceSummary,
     ProjectGitHubBinding,
 )
@@ -162,8 +163,15 @@ class Project(_ProjectBase):
         org: OrganizationDomain,
         *,
         default_edition: EditionDomain | None = None,
+        app_url: str | None = None,
     ) -> Self:
-        """Create from a domain object, adding HATEOAS URLs."""
+        """Create from a domain object, adding HATEOAS URLs.
+
+        ``app_url`` is the Docverse GitHub App's public install-page URL
+        (``context.factory.github_app_html_url``), surfaced on the
+        ``github`` binding so the UI can prompt operators to install the
+        App. ``None`` when the GitHub App feature is unconfigured.
+        """
         edition_response = None
         if default_edition is not None:
             project_url = project_published_url(org, domain)
@@ -175,6 +183,21 @@ class Project(_ProjectBase):
                 published_url=edition_published_url(
                     project_url, default_edition
                 ),
+            )
+        github_binding: ProjectGitHubBinding | None = None
+        if domain.github_owner is not None and domain.github_repo is not None:
+            github_binding = ProjectGitHubBinding(
+                owner=domain.github_owner,
+                repo=domain.github_repo,
+                installation_id=domain.github_installation_id,
+                # The binding branch guarantees owner+repo are set, so
+                # the derived status is never ``None`` here; the fallback
+                # only satisfies the required-field type.
+                installation_status=(
+                    domain.github_installation_status
+                    or InstallationStatus.not_installed
+                ),
+                app_url=app_url,
             )
         return cls(
             self_url=str(
@@ -209,16 +232,7 @@ class Project(_ProjectBase):
             slug=domain.slug,
             title=domain.title,
             source_url=domain.effective_source_url,
-            github=(
-                ProjectGitHubBinding(
-                    owner=domain.github_owner,
-                    repo=domain.github_repo,
-                    installation_id=domain.github_installation_id,
-                )
-                if domain.github_owner is not None
-                and domain.github_repo is not None
-                else None
-            ),
+            github=github_binding,
             slug_rewrite_rules=domain.slug_rewrite_rules,
             lifecycle_rules=domain.lifecycle_rules,
             default_edition=edition_response,

--- a/src/docverse/handlers/orgs/models.py
+++ b/src/docverse/handlers/orgs/models.py
@@ -208,7 +208,7 @@ class Project(_ProjectBase):
             ),
             slug=domain.slug,
             title=domain.title,
-            source_url=domain.source_url,
+            source_url=domain.effective_source_url,
             github=(
                 ProjectGitHubBinding(
                     owner=domain.github_owner,

--- a/src/docverse/handlers/orgs/projects.py
+++ b/src/docverse/handlers/orgs/projects.py
@@ -17,6 +17,9 @@ from docverse.handlers.params import OrgSlugParam, ProjectSlugParam
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_slug,
 )
+from docverse.services.project_github_resolve_enqueue import (
+    try_enqueue_project_github_resolve_by_id,
+)
 from docverse.storage.pagination import (
     DEFAULT_PAGE_LIMIT,
     MAX_PAGE_LIMIT,
@@ -124,6 +127,12 @@ async def post_project(
             org_slug=org_slug, data=data
         )
         await context.session.commit()
+    await try_enqueue_project_github_resolve_by_id(
+        factory=context.factory,
+        session=context.session,
+        logger=context.logger,
+        project_id=project.id,
+    )
     return Project.from_domain(
         project,
         context.request,
@@ -184,6 +193,12 @@ async def patch_project(
         logger=context.logger,
         org_slug=org_slug,
         project_slug=project_slug,
+    )
+    await try_enqueue_project_github_resolve_by_id(
+        factory=context.factory,
+        session=context.session,
+        logger=context.logger,
+        project_id=project.id,
     )
     return Project.from_domain(
         project,

--- a/src/docverse/handlers/orgs/projects.py
+++ b/src/docverse/handlers/orgs/projects.py
@@ -104,7 +104,13 @@ async def get_projects(  # noqa: PLR0913
         context.response.headers["Link"] = link
     context.response.headers["X-Total-Count"] = str(result.count)
     return [
-        Project.from_domain(p, context.request, org) for p in result.entries
+        Project.from_domain(
+            p,
+            context.request,
+            org,
+            app_url=context.factory.github_app_html_url,
+        )
+        for p in result.entries
     ]
 
 
@@ -138,6 +144,7 @@ async def post_project(
         context.request,
         org,
         default_edition=default_edition,
+        app_url=context.factory.github_app_html_url,
     )
 
 
@@ -164,6 +171,7 @@ async def get_project(
         context.request,
         org,
         default_edition=default_edition,
+        app_url=context.factory.github_app_html_url,
     )
 
 
@@ -205,6 +213,7 @@ async def patch_project(
         context.request,
         org,
         default_edition=default_edition,
+        app_url=context.factory.github_app_html_url,
     )
 
 

--- a/src/docverse/handlers/webhooks/github.py
+++ b/src/docverse/handlers/webhooks/github.py
@@ -124,6 +124,21 @@ async def _handle_installation(
         await context.session.commit()
 
 
+@_event_router.register("installation_repositories", action="added")
+@_event_router.register("installation_repositories", action="removed")
+async def _handle_installation_repositories(
+    event: sansio.Event,
+    *,
+    installation: InstallationEventProcessor,
+    context: RequestContext,
+    **_unused: Any,
+) -> None:
+    """Backfill project github_*_id when an install's repo scope changes."""
+    async with context.session.begin():
+        await installation.process_installation_repositories(event.data)
+        await context.session.commit()
+
+
 @router.post(
     "/webhooks/github",
     status_code=status.HTTP_200_OK,

--- a/src/docverse/main.py
+++ b/src/docverse/main.py
@@ -105,7 +105,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
         github_app_private_key=config.github_app_private_key,
         github_webhook_secret=config.github_webhook_secret,
     )
-    await validate_github_app(
+    github_app_html_url = await validate_github_app(
         state=context_dependency,
         app_id=config.github_app_id,
         private_key=config.github_app_private_key,
@@ -113,6 +113,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
         http_client=http_client,
         logger=logger,
     )
+    context_dependency.set_github_app_html_url(github_app_html_url)
     yield
     await context_dependency.aclose()
     await http_client_dependency.aclose()

--- a/src/docverse/services/dashboard/context.py
+++ b/src/docverse/services/dashboard/context.py
@@ -201,7 +201,7 @@ class DashboardContextBuilder:
             project=ProjectContext(
                 slug=project.slug,
                 title=project.title,
-                source_repo_url=project.doc_repo,
+                source_repo_url=project.source_url or "",
                 published_url=project_url,
             ),
             editions=editions_context,

--- a/src/docverse/services/dashboard/context.py
+++ b/src/docverse/services/dashboard/context.py
@@ -201,7 +201,7 @@ class DashboardContextBuilder:
             project=ProjectContext(
                 slug=project.slug,
                 title=project.title,
-                source_repo_url=project.source_url or "",
+                source_repo_url=project.effective_source_url or "",
                 published_url=project_url,
             ),
             editions=editions_context,

--- a/src/docverse/services/dashboard_templates/installation_processor.py
+++ b/src/docverse/services/dashboard_templates/installation_processor.py
@@ -10,6 +10,7 @@ import structlog
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
 )
+from docverse.storage.project_store import ProjectStore
 
 __all__ = [
     "INSTALLATION_DELETED_REASON",
@@ -60,9 +61,11 @@ class InstallationEventProcessor:
         self,
         *,
         binding_store: DashboardGitHubTemplateBindingStore,
+        project_store: ProjectStore,
         logger: structlog.stdlib.BoundLogger,
     ) -> None:
         self._binding_store = binding_store
+        self._project_store = project_store
         self._logger = logger
 
     async def process(self, payload: Mapping[str, Any]) -> None:
@@ -80,12 +83,23 @@ class InstallationEventProcessor:
             return
 
         if action == "created":
-            # No DB write — the binding cannot know about the install
-            # before the operator registers it through the API. Log so
-            # the delivery is visible in audit trails.
+            # Binding-side state is still a no-op: an org-default
+            # binding cannot have referenced the install before the
+            # operator registered it through the API. Projects, by
+            # contrast, may already exist with structured
+            # ``github_owner``/``github_repo`` columns waiting for an
+            # installation to come into scope (PRD #346 user story
+            # 12), so backfill them from the payload's repository
+            # block here.
+            projects_updated = await self._backfill_projects_for_repos(
+                installation_id=installation_id,
+                installation=installation,
+                repos=payload.get("repositories"),
+            )
             self._logger.info(
-                "Processed installation.created (no-op)",
+                "Processed installation.created",
                 github_installation_id=installation_id,
+                projects_updated=projects_updated,
             )
             return
 
@@ -135,6 +149,118 @@ class InstallationEventProcessor:
             github_installation_id=installation_id,
             action=action,
         )
+
+    async def process_installation_repositories(
+        self, payload: Mapping[str, Any]
+    ) -> None:
+        """Dispatch on the ``installation_repositories`` action.
+
+        ``installation_repositories.added`` fires when an operator
+        scopes an existing app installation to new repos after the
+        fact; ``installation_repositories.removed`` fires on the
+        symmetric removal. Only ``added`` writes to projects today —
+        a removal does not in itself invalidate the captured ids
+        (the repo still exists, just outside this installation's
+        scope), and clobbering the columns there would lose stable
+        keys the rename handler still relies on.
+        """
+        action = payload.get("action")
+        installation = payload.get("installation", {})
+        installation_id = _coerce_int(installation.get("id"))
+
+        if installation_id is None or not isinstance(action, str):
+            self._logger.warning(
+                "installation_repositories payload missing id or action",
+                installation_id=installation_id,
+                action=action,
+            )
+            return
+
+        if action == "added":
+            projects_updated = await self._backfill_projects_for_repos(
+                installation_id=installation_id,
+                installation=installation,
+                repos=payload.get("repositories_added"),
+            )
+            self._logger.info(
+                "Processed installation_repositories.added",
+                github_installation_id=installation_id,
+                projects_updated=projects_updated,
+            )
+            return
+
+        self._logger.info(
+            "Ignoring installation_repositories action",
+            github_installation_id=installation_id,
+            action=action,
+        )
+
+    async def _backfill_projects_for_repos(
+        self,
+        *,
+        installation_id: int,
+        installation: Mapping[str, Any],
+        repos: object,
+    ) -> int:
+        """Apply the three github_*_id columns to matching project rows.
+
+        ``installation.account`` carries the installation's owner
+        (``login`` + ``id``); the ``repositories`` (or
+        ``repositories_added``) list carries one entry per repo with
+        ``id`` and either ``name`` or ``full_name``. The payload is
+        the only source needed — no follow-up GitHub API round-trip —
+        because all three numeric ids land in the same delivery.
+
+        Returns the count of project rows updated across every repo
+        in the payload so the caller can log a single
+        ``projects_updated=N`` summary.
+        """
+        account = installation.get("account") or {}
+        owner = account.get("login")
+        owner_id = _coerce_int(account.get("id"))
+        if (
+            not isinstance(owner, str)
+            or owner_id is None
+            or not isinstance(repos, list)
+        ):
+            return 0
+
+        total = 0
+        for repo in repos:
+            if not isinstance(repo, Mapping):
+                continue
+            repo_id = _coerce_int(repo.get("id"))
+            repo_name = repo.get("name") or _repo_name_from_full(
+                repo.get("full_name"), owner=owner
+            )
+            if repo_id is None or not isinstance(repo_name, str):
+                continue
+            updated = await self._project_store.apply_installation_scope(
+                installation_id=installation_id,
+                owner=owner,
+                owner_id=owner_id,
+                repo=repo_name,
+                repo_id=repo_id,
+            )
+            total += len(updated)
+        return total
+
+
+def _repo_name_from_full(full_name: object, *, owner: str) -> str | None:
+    """Extract the repo segment from ``"owner/repo"`` payload strings.
+
+    Some installation payloads carry only ``full_name`` rather than a
+    bare ``name`` (and a few historical deliveries flip the structure
+    entirely). Falling back to a manual split keeps the backfill
+    robust against either shape without forcing the caller into a
+    branch.
+    """
+    if not isinstance(full_name, str):
+        return None
+    prefix = f"{owner}/"
+    if not full_name.lower().startswith(prefix.lower()):
+        return None
+    return full_name[len(prefix) :] or None
 
 
 def _coerce_int(value: object) -> int | None:

--- a/src/docverse/services/dashboard_templates/rename_processor.py
+++ b/src/docverse/services/dashboard_templates/rename_processor.py
@@ -11,6 +11,7 @@ from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
     DashboardGitHubTemplateStore,
 )
+from docverse.storage.project_store import ProjectStore
 
 __all__ = ["RenameEventProcessor"]
 
@@ -37,10 +38,12 @@ class RenameEventProcessor:
         *,
         binding_store: DashboardGitHubTemplateBindingStore,
         template_store: DashboardGitHubTemplateStore,
+        project_store: ProjectStore,
         logger: structlog.stdlib.BoundLogger,
     ) -> None:
         self._binding_store = binding_store
         self._template_store = template_store
+        self._project_store = project_store
         self._logger = logger
 
     async def process_repository_renamed(
@@ -77,12 +80,16 @@ class RenameEventProcessor:
         binding_ids: list[int] = []
         template_ids: list[int] = []
         unsynced_ids: list[int] = []
+        project_ids: list[int] = []
 
         if repo_id is not None:
             binding_ids = await self._binding_store.rename_repo_by_repo_id(
                 github_repo_id=repo_id, new_repo=new_repo
             )
             template_ids = await self._template_store.rename_repo_by_repo_id(
+                github_repo_id=repo_id, new_repo=new_repo
+            )
+            project_ids = await self._project_store.rename_repo_by_repo_id(
                 github_repo_id=repo_id, new_repo=new_repo
             )
 
@@ -104,6 +111,7 @@ class RenameEventProcessor:
             bindings_updated=len(binding_ids),
             templates_updated=len(template_ids),
             bindings_updated_unsynced=len(unsynced_ids),
+            projects_updated=len(project_ids),
         )
 
     async def process_repository_transferred(
@@ -151,6 +159,12 @@ class RenameEventProcessor:
             new_owner_id=new_owner_id,
             new_repo=new_repo,
         )
+        project_ids = await self._project_store.transfer_repo_by_repo_id(
+            github_repo_id=repo_id,
+            new_owner=new_owner,
+            new_owner_id=new_owner_id,
+            new_repo=new_repo,
+        )
 
         self._logger.info(
             "Processed repository.transferred",
@@ -160,6 +174,7 @@ class RenameEventProcessor:
             new_repo=new_repo,
             bindings_updated=len(binding_ids),
             templates_updated=len(template_ids),
+            projects_updated=len(project_ids),
         )
 
     async def process_organization_renamed(

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -261,7 +261,7 @@ class KeeperSyncService:
                 data=ProjectCreate(
                     slug=ltd_product.slug,
                     title=ltd_product.title,
-                    doc_repo=str(ltd_product.doc_repo),
+                    source_url=str(ltd_product.doc_repo),
                     default_edition=DefaultEditionConfig(
                         tracking_mode=TrackingMode.git_ref,
                         tracking_params={"git_ref": "main"},

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -31,9 +31,11 @@ from docverse.client.models import (
     BuildStatus,
     EditionKind,
     ProjectCreate,
+    ProjectGitHubBindingCreate,
     TrackingMode,
 )
 from docverse.client.models.editions import DefaultEditionConfig
+from docverse.client.models.projects import parse_github_url
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
@@ -256,12 +258,28 @@ class KeeperSyncService:
             org_id=org_id, slug=ltd_product.slug
         )
         if existing is None:
+            # LTD ``doc_repo`` is almost always a github.com URL; route
+            # it into the structured ``github`` binding (the single
+            # source of truth) and leave ``source_url`` for the rare
+            # non-GitHub repo. The ProjectCreate validator rejects a
+            # github.com ``source_url`` outright, so this split is
+            # mandatory, not cosmetic.
+            doc_repo = str(ltd_product.doc_repo)
+            parsed = parse_github_url(doc_repo)
+            if parsed is not None:
+                owner, repo = parsed
+                github = ProjectGitHubBindingCreate(owner=owner, repo=repo)
+                source_url = None
+            else:
+                github = None
+                source_url = doc_repo
             org, project, _ = await self._project_service.create(
                 org_slug=org.slug,
                 data=ProjectCreate(
                     slug=ltd_product.slug,
                     title=ltd_product.title,
-                    source_url=str(ltd_product.doc_repo),
+                    source_url=source_url,
+                    github=github,
                     default_edition=DefaultEditionConfig(
                         tracking_mode=TrackingMode.git_ref,
                         tracking_params={"git_ref": "main"},

--- a/src/docverse/services/project.py
+++ b/src/docverse/services/project.py
@@ -13,7 +13,6 @@ from docverse.client.models import (
     ProjectCreate,
     ProjectUpdate,
 )
-from docverse.client.models.projects import parse_github_url
 from docverse.domain.edition import Edition
 from docverse.domain.organization import Organization
 from docverse.domain.project import Project
@@ -73,54 +72,60 @@ class ProjectService:
     ) -> tuple[str | None, str | None]:
         """Resolve ``(github_owner, github_repo)`` for ``ProjectCreate``.
 
-        Precedence: an explicit ``github`` sub-object wins; otherwise a
-        ``github.com`` ``source_url`` is parsed for the pair; otherwise
-        both columns stay NULL. Disagreement between an explicit
-        ``github`` and a ``github.com`` ``source_url`` is already
-        rejected by the model validator on ``ProjectCreate`` before we
-        reach this method.
+        The binding comes solely from the structured ``github`` sub-
+        object; both columns stay NULL when it is absent. The validator
+        on ``ProjectCreate`` guarantees ``source_url`` is never a
+        ``github.com`` URL and never co-exists with ``github``, so there
+        is nothing to parse out of ``source_url`` here.
         """
         if data.github is not None:
             return data.github.owner, data.github.repo
-        if data.source_url is not None:
-            parsed = parse_github_url(data.source_url)
-            if parsed is not None:
-                return parsed
         return None, None
 
     @staticmethod
     def _resolve_github_for_update(
         data: ProjectUpdate,
     ) -> dict[str, Any]:
-        """Resolve column updates for the github_* fields on PATCH.
+        """Resolve column updates for the github_* / source_url fields.
 
-        Returns an empty dict when ``github`` was not in the request body
-        (so the existing column values are unchanged). When ``github`` is
-        explicitly cleared (``null``), all five github_* columns are
-        cleared together. When ``github`` is explicitly set to a value,
-        ``github_owner`` and ``github_repo`` are written and the three
-        opportunistically-captured numeric columns
-        (``github_owner_id``, ``github_repo_id``,
-        ``github_installation_id``) are cleared so they can be re-
-        resolved against the new repo.
+        The structured ``github`` binding is canonical, so a PATCH that
+        touches it also reconciles the cosmetic ``source_url`` column:
+
+        * ``github`` set → write ``github_owner``/``github_repo``, clear
+          the three opportunistically-captured numeric columns so they
+          re-resolve against the new repo, **and null ``source_url``** so
+          a project that was previously non-GitHub does not keep a stale
+          free-form URL alongside its new binding.
+        * ``github: null`` → clear all five github_* columns; the binding
+          is gone and the derived URL falls back to ``source_url``.
+        * neither, but a non-null ``source_url`` (guaranteed non-GitHub
+          by the validator) → clear all five github_* columns so the
+          project flips to the non-GitHub URL.
+        * otherwise → no github_* / source_url overrides; the
+          ``exclude_unset`` model dump in the store handles a plain
+          ``source_url: null`` clear on its own.
         """
-        if "github" not in data.model_fields_set:
-            return {}
-        if data.github is None:
-            return {
-                "github_owner": None,
-                "github_repo": None,
-                "github_owner_id": None,
-                "github_repo_id": None,
-                "github_installation_id": None,
-            }
-        return {
-            "github_owner": data.github.owner,
-            "github_repo": data.github.repo,
+        cleared = {
+            "github_owner": None,
+            "github_repo": None,
             "github_owner_id": None,
             "github_repo_id": None,
             "github_installation_id": None,
         }
+        if "github" in data.model_fields_set:
+            if data.github is None:
+                return cleared
+            return {
+                "github_owner": data.github.owner,
+                "github_repo": data.github.repo,
+                "github_owner_id": None,
+                "github_repo_id": None,
+                "github_installation_id": None,
+                "source_url": None,
+            }
+        if data.source_url is not None:
+            return cleared
+        return {}
 
     async def create(
         self, *, org_slug: str, data: ProjectCreate

--- a/src/docverse/services/project.py
+++ b/src/docverse/services/project.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import structlog
 from safir.database import CountedPaginatedList, PaginationCursor
 
@@ -11,6 +13,7 @@ from docverse.client.models import (
     ProjectCreate,
     ProjectUpdate,
 )
+from docverse.client.models.projects import parse_github_url
 from docverse.domain.edition import Edition
 from docverse.domain.organization import Organization
 from docverse.domain.project import Project
@@ -64,6 +67,61 @@ class ProjectService:
             )
         return DefaultEditionConfig()
 
+    @staticmethod
+    def _resolve_github_for_create(
+        data: ProjectCreate,
+    ) -> tuple[str | None, str | None]:
+        """Resolve ``(github_owner, github_repo)`` for ``ProjectCreate``.
+
+        Precedence: an explicit ``github`` sub-object wins; otherwise a
+        ``github.com`` ``source_url`` is parsed for the pair; otherwise
+        both columns stay NULL. Disagreement between an explicit
+        ``github`` and a ``github.com`` ``source_url`` is already
+        rejected by the model validator on ``ProjectCreate`` before we
+        reach this method.
+        """
+        if data.github is not None:
+            return data.github.owner, data.github.repo
+        if data.source_url is not None:
+            parsed = parse_github_url(data.source_url)
+            if parsed is not None:
+                return parsed
+        return None, None
+
+    @staticmethod
+    def _resolve_github_for_update(
+        data: ProjectUpdate,
+    ) -> dict[str, Any]:
+        """Resolve column updates for the github_* fields on PATCH.
+
+        Returns an empty dict when ``github`` was not in the request body
+        (so the existing column values are unchanged). When ``github`` is
+        explicitly cleared (``null``), all five github_* columns are
+        cleared together. When ``github`` is explicitly set to a value,
+        ``github_owner`` and ``github_repo`` are written and the three
+        opportunistically-captured numeric columns
+        (``github_owner_id``, ``github_repo_id``,
+        ``github_installation_id``) are cleared so they can be re-
+        resolved against the new repo.
+        """
+        if "github" not in data.model_fields_set:
+            return {}
+        if data.github is None:
+            return {
+                "github_owner": None,
+                "github_repo": None,
+                "github_owner_id": None,
+                "github_repo_id": None,
+                "github_installation_id": None,
+            }
+        return {
+            "github_owner": data.github.owner,
+            "github_repo": data.github.repo,
+            "github_owner_id": None,
+            "github_repo_id": None,
+            "github_installation_id": None,
+        }
+
     async def create(
         self, *, org_slug: str, data: ProjectCreate
     ) -> tuple[Organization, Project, Edition]:
@@ -79,7 +137,13 @@ class ProjectService:
         if existing is not None:
             msg = f"Project with slug {data.slug!r} already exists"
             raise ConflictError(msg)
-        project = await self._store.create(org_id=org.id, data=data)
+        github_owner, github_repo = self._resolve_github_for_create(data)
+        project = await self._store.create(
+            org_id=org.id,
+            data=data,
+            github_owner=github_owner,
+            github_repo=github_repo,
+        )
 
         config = self._resolve_default_edition_config(
             data.default_edition, org
@@ -161,7 +225,13 @@ class ProjectService:
             If the project is not found.
         """
         org = await self._resolve_org(org_slug)
-        project = await self._store.update(org_id=org.id, slug=slug, data=data)
+        extra_updates = self._resolve_github_for_update(data)
+        project = await self._store.update(
+            org_id=org.id,
+            slug=slug,
+            data=data,
+            extra_updates=extra_updates,
+        )
         if project is None:
             msg = f"Project {slug!r} not found"
             raise NotFoundError(msg)

--- a/src/docverse/services/project_github_resolve_enqueue.py
+++ b/src/docverse/services/project_github_resolve_enqueue.py
@@ -1,0 +1,69 @@
+"""Enqueue helper for the ``project_github_resolve`` worker.
+
+Project create / update handlers call
+:func:`try_enqueue_project_github_resolve_by_id` outside the request
+transaction to fire off the opportunistic
+``installation_id`` / ``owner_id`` / ``repo_id`` resolution PRD #346
+introduces. The helper is a thin parallel to ``dashboard.enqueue
+.try_enqueue_dashboard_build_by_slug``: it owns its own transaction so
+the caller's flow is never broken by an enqueue failure, and it skips
+the enqueue cleanly when the project has no GitHub binding so the
+worker queue stays signal-only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sentry_sdk
+import structlog
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from docverse.factory import Factory
+
+__all__ = ["try_enqueue_project_github_resolve_by_id"]
+
+
+async def try_enqueue_project_github_resolve_by_id(
+    *,
+    factory: Factory,
+    session: AsyncSession,
+    logger: structlog.stdlib.BoundLogger,
+    project_id: int,
+) -> None:
+    """Enqueue one ``project_github_resolve`` job in its own transaction.
+
+    Exceptions are logged but never re-raised, so the caller's flow is
+    not broken by an enqueue failure. The enqueue runs in a freshly
+    started transaction on ``session`` — the caller must have already
+    committed any work it wants persisted.
+
+    Skipped when the project has no GitHub binding (no
+    ``github_owner`` / ``github_repo``): the worker would just return
+    ``"skipped"`` after a single DB read, and avoiding the enqueue
+    keeps the queue signal-only.
+    """
+    try:
+        async with session.begin():
+            project_store = factory.create_project_store()
+            project = await project_store.get_by_id(project_id)
+            if (
+                project is None
+                or project.github_owner is None
+                or project.github_repo is None
+            ):
+                return
+            queue_backend = factory.create_queue_backend()
+            await queue_backend.enqueue(
+                "project_github_resolve",
+                {"project_id": project_id},
+            )
+            await session.commit()
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
+        logger.exception(
+            "Failed to enqueue project_github_resolve",
+            project_id=project_id,
+        )

--- a/src/docverse/storage/github/__init__.py
+++ b/src/docverse/storage/github/__init__.py
@@ -7,6 +7,7 @@ from .app_client import (
     GitHubAppClient,
     GitHubAppNotConfiguredError,
     InstallationAuth,
+    RepositoryMetadata,
 )
 from .changed_paths import (
     extract_changed_paths_from_push,
@@ -25,6 +26,7 @@ __all__ = [
     "GitHubAppValidationState",
     "GitHubTreeFetcher",
     "InstallationAuth",
+    "RepositoryMetadata",
     "build_github_browse_url",
     "extract_changed_paths_from_push",
     "fetch_changed_paths_from_compare",

--- a/src/docverse/storage/github/__init__.py
+++ b/src/docverse/storage/github/__init__.py
@@ -6,6 +6,7 @@ from .app_client import (
     GITHUB_API_BASE_URL,
     GitHubAppClient,
     GitHubAppNotConfiguredError,
+    GitHubAppNotInstalledError,
     InstallationAuth,
     RepositoryMetadata,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "FetchedTreeFile",
     "GitHubAppClient",
     "GitHubAppNotConfiguredError",
+    "GitHubAppNotInstalledError",
     "GitHubAppValidationState",
     "GitHubTreeFetcher",
     "InstallationAuth",

--- a/src/docverse/storage/github/app_client.py
+++ b/src/docverse/storage/github/app_client.py
@@ -20,6 +20,7 @@ __all__ = [
     "GitHubAppNotConfiguredError",
     "InstallationAuth",
     "MissingGitHubAppSecret",
+    "RepositoryMetadata",
 ]
 
 
@@ -37,6 +38,23 @@ _GITHUB_APP_NAME = "lsst-sqre/docverse"
 #: each ("missing app id" vs "stale private key" vs "rotated webhook
 #: secret") without unpacking the rendered message.
 MissingGitHubAppSecret = Literal["app_id", "private_key", "webhook_secret"]
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryMetadata:
+    """Numeric ids GitHub assigns to a repository and its owner.
+
+    Returned by :meth:`GitHubAppClient.resolve_repository_metadata` so
+    the ``project_github_resolve`` worker captures all three columns
+    (``installation_id``, ``owner_id``, ``repo_id``) in a single deep
+    call rather than re-deriving the same shape at each call site.
+    The three fields together survive a GitHub-side rename or
+    transfer; the operator-visible ``owner``/``repo`` strings do not.
+    """
+
+    installation_id: int
+    owner_id: int
+    repo_id: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -201,6 +219,45 @@ class GitHubAppClient:
             private_key=self._factory.app_key,
         )
         return str(token_info["token"])
+
+    async def resolve_repository_metadata(
+        self, *, owner: str, repo: str
+    ) -> RepositoryMetadata:
+        """Resolve ``installation_id`` + ``owner_id`` + ``repo_id`` for a repo.
+
+        Combines two GitHub REST calls so the
+        :func:`docverse.worker.functions.project_github_resolve` worker
+        captures all three opportunistic-id columns in one go:
+
+        1. ``GET /repos/{owner}/{repo}/installation`` (with the app
+           JWT) — yields the installation id.
+        2. ``GET /repos/{owner}/{repo}`` (with the installation token)
+           — yields the stable numeric repo id and owner id.
+
+        Mirrors the pair of calls
+        :class:`docverse.storage.github.GitHubTreeFetcher` already
+        makes on every sync; reusing those endpoints keeps the rename-
+        robust id capture path consistent across the codebase. The
+        installation-token round-trip is required because the
+        ``/repos/{owner}/{repo}`` endpoint refuses anonymous reads on
+        private repos.
+        """
+        installation_id = await self.get_installation_id(owner, repo)
+        token = await self.exchange_installation_token(installation_id)
+        response = await self._http_client.get(
+            f"{GITHUB_API_BASE_URL}/repos/{owner}/{repo}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+        return RepositoryMetadata(
+            installation_id=installation_id,
+            owner_id=int(data["owner"]["id"]),
+            repo_id=int(data["id"]),
+        )
 
     async def get_installation_auth(
         self, *, owner: str, repo: str

--- a/src/docverse/storage/github/app_client.py
+++ b/src/docverse/storage/github/app_client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import http
 from dataclasses import dataclass
 from typing import Any, Literal, override
 
+import gidgethub
 import httpx
 import structlog
 from gidgethub.apps import get_installation_access_token
@@ -18,6 +20,7 @@ __all__ = [
     "GITHUB_API_BASE_URL",
     "GitHubAppClient",
     "GitHubAppNotConfiguredError",
+    "GitHubAppNotInstalledError",
     "InstallationAuth",
     "MissingGitHubAppSecret",
     "RepositoryMetadata",
@@ -142,6 +145,33 @@ def _format_github_app_not_configured_message(
     )
 
 
+class GitHubAppNotInstalledError(Exception):
+    """No installation grants the GitHub App access to ``owner/repo``.
+
+    Raised by :meth:`GitHubAppClient.get_installation_id` when
+    ``GET /repos/{owner}/{repo}/installation`` returns 404. A GitHub App
+    installation id is per-account, not per-repo, and that endpoint
+    finds the account's installation via a repo it can reach — so a 404
+    means *no* installation grants the App access to this repo: the App
+    is not installed on the account, it is installed with "Only select
+    repositories" and this repo is not selected, or the
+    ``owner``/``repo`` is mistyped. The JWT was accepted (a bad key is a
+    401), so this is an App-to-repo connection issue, not a credential
+    one.
+
+    Deliberately **not** a :class:`DocverseSlackException`: a
+    not-installed repo is an expected, operator-recoverable state that
+    the ``installation`` webhook backfills once the App is installed, so
+    it must stay out of Slack and Sentry. Carries ``owner``/``repo`` so
+    callers can log which repository was unreachable.
+    """
+
+    def __init__(self, *, owner: str, repo: str) -> None:
+        super().__init__(f"GitHub App is not installed on {owner}/{repo}")
+        self.owner = owner
+        self.repo = repo
+
+
 class GitHubAppClient:
     """Installation-scoped access to the GitHub REST API.
 
@@ -164,7 +194,7 @@ class GitHubAppClient:
         self._http_client = http_client
         self._logger = logger
 
-    async def validate(self) -> None:
+    async def validate(self) -> str | None:
         """Validate that the configured GitHub App credentials work.
 
         Two-step check:
@@ -180,10 +210,22 @@ class GitHubAppClient:
         Raises any exception encountered during the two steps; callers
         are expected to log the failure and disable the feature for the
         lifetime of the process.
+
+        Returns
+        -------
+        str or None
+            The App's public ``html_url`` (e.g.
+            ``https://github.com/apps/{slug}``) from the ``GET /app``
+            response — the page an operator visits to install the App on
+            a repository. ``None`` if GitHub omits the field. Callers
+            surface this through the API so the UI can link operators to
+            the install page.
         """
         jwt = self._factory.get_app_jwt()
         anon = GitHubAPI(self._http_client, self._factory.app_name)
-        await anon.getitem("/app", jwt=jwt)
+        data = await anon.getitem("/app", jwt=jwt)
+        html_url = data.get("html_url")
+        return str(html_url) if html_url is not None else None
 
     async def get_installation_id(self, owner: str, repo: str) -> int:
         """Resolve the installation ID for a repository.
@@ -193,14 +235,29 @@ class GitHubAppClient:
         ``installation.id`` value, which is stable across GitHub repo
         renames / transfers and is therefore the preferred internal key
         for later lookups.
+
+        Raises
+        ------
+        GitHubAppNotInstalledError
+            If GitHub returns 404 — no installation grants the App
+            access to ``owner/repo`` (not installed on the account,
+            installed without this repo selected, or a mistyped
+            ``owner``/``repo``).
         """
         jwt = self._factory.get_app_jwt()
         anon = GitHubAPI(self._http_client, self._factory.app_name)
-        data = await anon.getitem(
-            "/repos/{owner}/{repo}/installation",
-            url_vars={"owner": owner, "repo": repo},
-            jwt=jwt,
-        )
+        try:
+            data = await anon.getitem(
+                "/repos/{owner}/{repo}/installation",
+                url_vars={"owner": owner, "repo": repo},
+                jwt=jwt,
+            )
+        except gidgethub.BadRequest as exc:
+            if exc.status_code == http.HTTPStatus.NOT_FOUND:
+                raise GitHubAppNotInstalledError(
+                    owner=owner, repo=repo
+                ) from exc
+            raise
         return int(data["id"])
 
     async def exchange_installation_token(self, installation_id: int) -> str:

--- a/src/docverse/storage/github/startup.py
+++ b/src/docverse/storage/github/startup.py
@@ -50,7 +50,7 @@ async def validate_github_app(  # noqa: PLR0913
     app_name: str,
     http_client: httpx.AsyncClient,
     logger: structlog.stdlib.BoundLogger,
-) -> None:
+) -> str | None:
     """Validate GitHub App credentials and update ``state`` on failure.
 
     No-op when ``state.github_app_enabled`` is ``False`` — the
@@ -58,13 +58,24 @@ async def validate_github_app(  # noqa: PLR0913
     :meth:`docverse.factory.Factory._require_github_app_config` already
     keeps the feature disabled, so issuing a network call would be
     redundant and would fail anyway.
+
+    Returns
+    -------
+    str or None
+        On a successful validation, the App's public ``html_url`` from
+        the ``GET /app`` response (the install page the API surfaces so
+        the UI can prompt operators to install the App). ``None`` when
+        the feature is disabled, when GitHub omits the field, or when
+        validation failed (the failure also flips ``state`` off). The
+        API lifespan stores this value; the worker startup path
+        discards it.
     """
     if not state.github_app_enabled:
-        return
+        return None
     # ``github_app_enabled`` guarantees both are set; the explicit
     # check narrows the types for the GitHubAppClientFactory call.
     if app_id is None or private_key is None:  # pragma: no cover
-        return
+        return None
     factory = GitHubAppClientFactory(
         id=app_id,
         key=private_key.get_secret_value(),
@@ -75,7 +86,7 @@ async def validate_github_app(  # noqa: PLR0913
         factory=factory, http_client=http_client, logger=logger
     )
     try:
-        await client.validate()
+        html_url = await client.validate()
     except Exception as exc:  # noqa: BLE001
         # Validator must not crash the service. Known failure types
         # are ``jwt.exceptions.InvalidKeyError`` (PEM parse) and
@@ -89,5 +100,6 @@ async def validate_github_app(  # noqa: PLR0913
             error_type=type(exc).__name__,
         )
         state.set_github_app_validated(value=False)
-    else:
-        logger.info("GitHub App config validated", app_id=state.github_app_id)
+        return None
+    logger.info("GitHub App config validated", app_id=state.github_app_id)
+    return html_url

--- a/src/docverse/storage/project_store.py
+++ b/src/docverse/storage/project_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import structlog
 from safir.database import (
     CountedPaginatedList,
@@ -32,8 +34,21 @@ class ProjectStore:
         self._session = session
         self._logger = logger
 
-    async def create(self, *, org_id: int, data: ProjectCreate) -> Project:
-        """Insert a new project row."""
+    async def create(
+        self,
+        *,
+        org_id: int,
+        data: ProjectCreate,
+        github_owner: str | None = None,
+        github_repo: str | None = None,
+    ) -> Project:
+        """Insert a new project row.
+
+        ``github_owner`` and ``github_repo`` are passed in by the caller
+        (``ProjectService``) after resolving the ``github`` sub-object
+        from the request payload, including any auto-population from a
+        ``github.com`` ``source_url``.
+        """
         lifecycle_rules = None
         if data.lifecycle_rules is not None:
             lifecycle_rules = data.lifecycle_rules.model_dump(mode="json")
@@ -41,7 +56,9 @@ class ProjectStore:
             slug=data.slug,
             title=data.title,
             org_id=org_id,
-            source_url=data.doc_repo,
+            source_url=data.source_url,
+            github_owner=github_owner,
+            github_repo=github_repo,
             lifecycle_rules=lifecycle_rules,
         )
         self._session.add(row)
@@ -271,9 +288,22 @@ class ProjectStore:
         )
 
     async def update(
-        self, *, org_id: int, slug: str, data: ProjectUpdate
+        self,
+        *,
+        org_id: int,
+        slug: str,
+        data: ProjectUpdate,
+        extra_updates: dict[str, Any] | None = None,
     ) -> Project | None:
-        """Update a project by org_id and slug."""
+        """Update a project by org_id and slug.
+
+        ``extra_updates`` carries server-derived column updates (e.g.
+        the resolved ``github_owner``/``github_repo`` pair plus the
+        ``github_*_id`` clears that accompany a binding change) that
+        the service computed from the ``github`` sub-object on the
+        request body. The ``github`` field is removed from the model
+        dump because it has no direct column mapping.
+        """
         result = await self._session.execute(
             select(SqlProject).where(
                 SqlProject.org_id == org_id,
@@ -285,11 +315,9 @@ class ProjectStore:
         if row is None:
             return None
         updates = data.model_dump(mode="json", exclude_unset=True)
-        # The client model still exposes ``doc_repo`` while the column
-        # was renamed to ``source_url`` for the structured GitHub-binding
-        # work; translate the client field on the way into the row.
-        if "doc_repo" in updates:
-            updates["source_url"] = updates.pop("doc_repo")
+        updates.pop("github", None)
+        if extra_updates:
+            updates.update(extra_updates)
         for key, value in updates.items():
             setattr(row, key, value)
         await self._session.flush()

--- a/src/docverse/storage/project_store.py
+++ b/src/docverse/storage/project_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import structlog
 from safir.database import (
@@ -10,7 +11,7 @@ from safir.database import (
     CountedPaginatedQueryRunner,
     PaginationCursor,
 )
-from sqlalchemy import REAL, cast, select
+from sqlalchemy import REAL, cast, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import expression, func
 
@@ -21,6 +22,53 @@ from docverse.storage.pagination import ProjectSearchCursor
 
 _TRGM_SIMILARITY_THRESHOLD = 0.1
 """Minimum trigram similarity score for fuzzy search results."""
+
+
+def _rewrite_github_source_url(
+    source_url: str,
+    *,
+    old_owner: str,
+    old_repo: str,
+    new_owner: str,
+    new_repo: str,
+) -> str | None:
+    """Rewrite a ``github.com`` URL's first two path segments.
+
+    Used by the ``repository.renamed`` / ``repository.transferred``
+    handlers to keep the project's ``source_url`` consistent with its
+    structured ``(github_owner, github_repo)`` after a GitHub-side
+    flip. Returns ``None`` (caller leaves the column unchanged) when:
+
+    * The URL is not on ``github.com``.
+    * The first two path segments do not match
+      ``(old_owner, old_repo)`` case-insensitively.
+
+    Otherwise returns the rewritten URL with the path tail and a
+    ``.git`` suffix (if present) preserved verbatim.
+    """
+    parsed = urlparse(source_url)
+    host = (parsed.hostname or "").lower()
+    if host != "github.com":
+        return None
+    segments = parsed.path.split("/")
+    min_segments = 3
+    if len(segments) < min_segments:
+        return None
+    if segments[1].lower() != old_owner.lower():
+        return None
+    repo_segment = segments[2]
+    suffix = ".git" if repo_segment.endswith(".git") else ""
+    repo_bare = repo_segment.removesuffix(".git")
+    if repo_bare.lower() != old_repo.lower():
+        return None
+    new_segments = [
+        "",
+        new_owner,
+        new_repo + suffix,
+        *segments[3:],
+    ]
+    new_path = "/".join(new_segments)
+    return urlunparse(parsed._replace(path=new_path))
 
 
 class ProjectStore:
@@ -323,6 +371,199 @@ class ProjectStore:
         await self._session.flush()
         await self._session.refresh(row)
         return Project.model_validate(row)
+
+    async def rename_repo_by_repo_id(
+        self,
+        *,
+        github_repo_id: int,
+        new_repo: str,
+    ) -> list[int]:
+        """Rewrite ``github_repo`` (+ matching ``source_url``) on projects.
+
+        Used by :class:`docverse.services.dashboard_templates
+        .RenameEventProcessor` to mirror the dashboard binding's
+        ``rename_repo_by_repo_id`` for projects on the same repo. Reads
+        each affected row so the structured columns and the cosmetic
+        ``source_url`` stay consistent — the URL rewrite is opt-in
+        per-row via :func:`_rewrite_github_source_url`, which leaves
+        non-GitHub URLs and URLs whose first two path segments do not
+        match ``(github_owner, old_repo)`` untouched.
+
+        Returns the list of updated project ids.
+        """
+        result = await self._session.execute(
+            select(SqlProject).where(
+                SqlProject.github_repo_id == github_repo_id,
+                SqlProject.date_deleted.is_(None),
+            )
+        )
+        updated_ids: list[int] = []
+        for row in result.scalars().all():
+            old_repo = row.github_repo
+            row.github_repo = new_repo
+            if (
+                row.source_url is not None
+                and row.github_owner is not None
+                and old_repo is not None
+            ):
+                rewritten = _rewrite_github_source_url(
+                    row.source_url,
+                    old_owner=row.github_owner,
+                    old_repo=old_repo,
+                    new_owner=row.github_owner,
+                    new_repo=new_repo,
+                )
+                if rewritten is not None:
+                    row.source_url = rewritten
+            updated_ids.append(row.id)
+        await self._session.flush()
+        return updated_ids
+
+    async def transfer_repo_by_repo_id(
+        self,
+        *,
+        github_repo_id: int,
+        new_owner: str,
+        new_owner_id: int,
+        new_repo: str,
+    ) -> list[int]:
+        """Rewrite owner + repo strings + owner_id (+ source_url) on transfer.
+
+        Mirrors :meth:`docverse.storage.dashboard_templates.github
+        .DashboardGitHubTemplateBindingStore.transfer_repo_by_repo_id`:
+        a ``repository.transferred`` event keeps ``repository.id``
+        stable but moves the repo to a new owner namespace, so the
+        binding has to switch its owner-side identity to keep
+        matching push events from the new namespace.
+
+        The ``source_url`` is rewritten only when it parses as a
+        github.com URL whose first two path segments match the old
+        owner/repo — non-GitHub URLs and URLs whose path was
+        already pointing somewhere else are left alone.
+        """
+        result = await self._session.execute(
+            select(SqlProject).where(
+                SqlProject.github_repo_id == github_repo_id,
+                SqlProject.date_deleted.is_(None),
+            )
+        )
+        updated_ids: list[int] = []
+        for row in result.scalars().all():
+            old_owner = row.github_owner
+            old_repo = row.github_repo
+            row.github_owner = new_owner
+            row.github_owner_id = new_owner_id
+            row.github_repo = new_repo
+            if (
+                row.source_url is not None
+                and old_owner is not None
+                and old_repo is not None
+            ):
+                rewritten = _rewrite_github_source_url(
+                    row.source_url,
+                    old_owner=old_owner,
+                    old_repo=old_repo,
+                    new_owner=new_owner,
+                    new_repo=new_repo,
+                )
+                if rewritten is not None:
+                    row.source_url = rewritten
+            updated_ids.append(row.id)
+        await self._session.flush()
+        return updated_ids
+
+    async def apply_installation_scope(
+        self,
+        *,
+        installation_id: int,
+        owner: str,
+        owner_id: int,
+        repo: str,
+        repo_id: int,
+    ) -> list[int]:
+        """Backfill the three github_*_id columns from a webhook payload.
+
+        Used by :class:`docverse.services.dashboard_templates
+        .InstallationEventProcessor` to capture
+        ``(github_installation_id, github_owner_id, github_repo_id)``
+        whenever GitHub announces that ``owner/repo`` is now in scope
+        of an installation. The match is case-insensitive on
+        ``(github_owner, github_repo)`` so a project registered as
+        ``Acme/Docs`` still matches a payload that delivers
+        ``acme/docs``.
+
+        ``date_updated`` is explicitly preserved: this write is
+        sync-bookkeeping, not an operator-visible source-coordinate
+        edit, and bumping ``date_updated`` here would mislead any
+        consumer that reads it as ``last operator change``. Mirrors
+        the same discipline the dashboard binding store's
+        ``rename_*`` / ``mark_unreachable_by_installation_id``
+        methods already apply.
+
+        Returns the list of project ids that were updated, so the
+        caller can log a count (``projects_updated=N``) without a
+        separate round-trip.
+        """
+        stmt = (
+            update(SqlProject)
+            .where(
+                func.lower(SqlProject.github_owner) == owner.lower(),
+                func.lower(SqlProject.github_repo) == repo.lower(),
+                SqlProject.date_deleted.is_(None),
+            )
+            .values(
+                github_installation_id=installation_id,
+                github_owner_id=owner_id,
+                github_repo_id=repo_id,
+                date_updated=SqlProject.date_updated,
+            )
+            .returning(SqlProject.id)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return [row[0] for row in result.all()]
+
+    async def update_github_metadata(  # noqa: PLR0913
+        self,
+        *,
+        project_id: int,
+        expected_owner: str,
+        expected_repo: str,
+        installation_id: int,
+        owner_id: int,
+        repo_id: int,
+    ) -> bool:
+        """Persist the three opportunistic github_*_id columns.
+
+        Used by :func:`docverse.worker.functions.project_github_resolve`
+        after a successful GitHub round-trip. The
+        ``expected_owner``/``expected_repo`` guard short-circuits when
+        the binding has flipped between enqueue and the worker run
+        (e.g. a PATCH rewrote ``github`` to a different repo, which
+        cleared the three id columns and re-enqueued resolution). In
+        that case the stale numeric ids would clobber the new
+        binding's columns — better to lose this update than to write
+        ids that disagree with ``github_owner`` / ``github_repo``.
+
+        Returns ``True`` when the row was updated, ``False`` when no
+        row matched (project deleted, or binding changed).
+        """
+        result = await self._session.execute(
+            select(SqlProject).where(
+                SqlProject.id == project_id,
+                SqlProject.github_owner == expected_owner,
+                SqlProject.github_repo == expected_repo,
+                SqlProject.date_deleted.is_(None),
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return False
+        row.github_installation_id = installation_id
+        row.github_owner_id = owner_id
+        row.github_repo_id = repo_id
+        await self._session.flush()
+        return True
 
     async def soft_delete(self, *, org_id: int, slug: str) -> bool:
         """Soft-delete a project by setting date_deleted.

--- a/src/docverse/storage/project_store.py
+++ b/src/docverse/storage/project_store.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urlparse, urlunparse
 
 import structlog
 from safir.database import (
@@ -22,53 +21,6 @@ from docverse.storage.pagination import ProjectSearchCursor
 
 _TRGM_SIMILARITY_THRESHOLD = 0.1
 """Minimum trigram similarity score for fuzzy search results."""
-
-
-def _rewrite_github_source_url(
-    source_url: str,
-    *,
-    old_owner: str,
-    old_repo: str,
-    new_owner: str,
-    new_repo: str,
-) -> str | None:
-    """Rewrite a ``github.com`` URL's first two path segments.
-
-    Used by the ``repository.renamed`` / ``repository.transferred``
-    handlers to keep the project's ``source_url`` consistent with its
-    structured ``(github_owner, github_repo)`` after a GitHub-side
-    flip. Returns ``None`` (caller leaves the column unchanged) when:
-
-    * The URL is not on ``github.com``.
-    * The first two path segments do not match
-      ``(old_owner, old_repo)`` case-insensitively.
-
-    Otherwise returns the rewritten URL with the path tail and a
-    ``.git`` suffix (if present) preserved verbatim.
-    """
-    parsed = urlparse(source_url)
-    host = (parsed.hostname or "").lower()
-    if host != "github.com":
-        return None
-    segments = parsed.path.split("/")
-    min_segments = 3
-    if len(segments) < min_segments:
-        return None
-    if segments[1].lower() != old_owner.lower():
-        return None
-    repo_segment = segments[2]
-    suffix = ".git" if repo_segment.endswith(".git") else ""
-    repo_bare = repo_segment.removesuffix(".git")
-    if repo_bare.lower() != old_repo.lower():
-        return None
-    new_segments = [
-        "",
-        new_owner,
-        new_repo + suffix,
-        *segments[3:],
-    ]
-    new_path = "/".join(new_segments)
-    return urlunparse(parsed._replace(path=new_path))
 
 
 class ProjectStore:
@@ -94,8 +46,9 @@ class ProjectStore:
 
         ``github_owner`` and ``github_repo`` are passed in by the caller
         (``ProjectService``) after resolving the ``github`` sub-object
-        from the request payload, including any auto-population from a
-        ``github.com`` ``source_url``.
+        from the request payload. The validator guarantees a
+        GitHub-bound project sends no ``source_url``, so the column is
+        persisted NULL for those rows.
         """
         lifecycle_rules = None
         if data.lifecycle_rules is not None:
@@ -378,69 +331,40 @@ class ProjectStore:
         github_repo_id: int,
         new_repo: str,
     ) -> list[int]:
-        """Rewrite ``github_repo`` (+ matching ``source_url``) on projects.
+        """Rewrite ``github_repo`` on projects backing a renamed repo.
 
         Used by :class:`docverse.services.dashboard_templates
         .RenameEventProcessor` to mirror the dashboard binding's
-        ``rename_repo_by_repo_id`` for projects on the same repo. Reads
-        each affected row so the structured columns and the cosmetic
-        ``source_url`` stay consistent — the URL rewrite is opt-in
-        per-row via :func:`_rewrite_github_source_url`, which leaves
-        non-GitHub URLs and URLs whose first two path segments do not
-        match ``(github_owner, old_repo)`` untouched.
+        ``rename_repo_by_repo_id`` for projects on the same repo. Only
+        the structured ``github_repo`` column flips; the
+        operator-visible source URL is derived from the binding
+        (:attr:`docverse.domain.project.Project.effective_source_url`),
+        so it follows automatically without a stored value to rewrite.
 
-        ``date_updated`` is preserved on every row (the per-row
-        ``update()`` pins ``date_updated=SqlProject.date_updated`` so
-        the column's ``onupdate=func.now()`` does not fire): a
+        ``date_updated`` is explicitly preserved (pinned to its current
+        value so the column's ``onupdate=func.now()`` does not fire): a
         GitHub-side rename is sync-bookkeeping, not an operator-visible
         source-coordinate edit, which arrives through PUT/PATCH. This
         mirrors the discipline of the dashboard binding store's
         ``rename_repo_by_repo_id`` and of ``apply_installation_scope``.
-        The ``source_url`` is computed in Python rather than mutated via
-        the ORM so the write can go through a ``date_updated``-pinning
-        bulk ``update()`` even when it differs per row.
 
         Returns the list of updated project ids.
         """
-        result = await self._session.execute(
-            select(
-                SqlProject.id,
-                SqlProject.source_url,
-                SqlProject.github_owner,
-                SqlProject.github_repo,
-            ).where(
+        stmt = (
+            update(SqlProject)
+            .where(
                 SqlProject.github_repo_id == github_repo_id,
                 SqlProject.date_deleted.is_(None),
             )
-        )
-        updated_ids: list[int] = []
-        for row in result.all():
-            values: dict[str, Any] = {
-                "github_repo": new_repo,
-                "date_updated": SqlProject.date_updated,
-            }
-            if (
-                row.source_url is not None
-                and row.github_owner is not None
-                and row.github_repo is not None
-            ):
-                rewritten = _rewrite_github_source_url(
-                    row.source_url,
-                    old_owner=row.github_owner,
-                    old_repo=row.github_repo,
-                    new_owner=row.github_owner,
-                    new_repo=new_repo,
-                )
-                if rewritten is not None:
-                    values["source_url"] = rewritten
-            await self._session.execute(
-                update(SqlProject)
-                .where(SqlProject.id == row.id)
-                .values(**values)
+            .values(
+                github_repo=new_repo,
+                date_updated=SqlProject.date_updated,
             )
-            updated_ids.append(row.id)
+            .returning(SqlProject.id)
+        )
+        result = await self._session.execute(stmt)
         await self._session.flush()
-        return updated_ids
+        return [row[0] for row in result.all()]
 
     async def transfer_repo_by_repo_id(
         self,
@@ -450,72 +374,43 @@ class ProjectStore:
         new_owner_id: int,
         new_repo: str,
     ) -> list[int]:
-        """Rewrite owner + repo strings + owner_id (+ source_url) on transfer.
+        """Flip owner + owner_id + repo on projects backing a transfer.
 
         Mirrors :meth:`docverse.storage.dashboard_templates.github
         .DashboardGitHubTemplateBindingStore.transfer_repo_by_repo_id`:
         a ``repository.transferred`` event keeps ``repository.id``
         stable but moves the repo to a new owner namespace, so the
-        binding has to switch its owner-side identity to keep
-        matching push events from the new namespace.
+        binding has to switch its owner-side identity to keep matching
+        push events from the new namespace. Only the structured columns
+        flip; the operator-visible source URL is derived from the
+        binding, so it follows automatically.
 
-        The ``source_url`` is rewritten only when it parses as a
-        github.com URL whose first two path segments match the old
-        owner/repo — non-GitHub URLs and URLs whose path was
-        already pointing somewhere else are left alone.
-
-        ``date_updated`` is preserved on every row (the per-row
-        ``update()`` pins ``date_updated=SqlProject.date_updated`` so
-        the column's ``onupdate=func.now()`` does not fire): a
+        ``date_updated`` is explicitly preserved (pinned to its current
+        value so the column's ``onupdate=func.now()`` does not fire): a
         GitHub-side transfer is sync-bookkeeping, not an operator-
         visible source-coordinate edit, which arrives through PUT/PATCH.
         This mirrors the discipline of the dashboard binding store's
         ``transfer_repo_by_repo_id`` and of ``apply_installation_scope``.
-        The ``source_url`` is computed in Python rather than mutated via
-        the ORM so the write can go through a ``date_updated``-pinning
-        bulk ``update()`` even when it differs per row.
+
+        Returns the list of updated project ids.
         """
-        result = await self._session.execute(
-            select(
-                SqlProject.id,
-                SqlProject.source_url,
-                SqlProject.github_owner,
-                SqlProject.github_repo,
-            ).where(
+        stmt = (
+            update(SqlProject)
+            .where(
                 SqlProject.github_repo_id == github_repo_id,
                 SqlProject.date_deleted.is_(None),
             )
-        )
-        updated_ids: list[int] = []
-        for row in result.all():
-            values: dict[str, Any] = {
-                "github_owner": new_owner,
-                "github_owner_id": new_owner_id,
-                "github_repo": new_repo,
-                "date_updated": SqlProject.date_updated,
-            }
-            if (
-                row.source_url is not None
-                and row.github_owner is not None
-                and row.github_repo is not None
-            ):
-                rewritten = _rewrite_github_source_url(
-                    row.source_url,
-                    old_owner=row.github_owner,
-                    old_repo=row.github_repo,
-                    new_owner=new_owner,
-                    new_repo=new_repo,
-                )
-                if rewritten is not None:
-                    values["source_url"] = rewritten
-            await self._session.execute(
-                update(SqlProject)
-                .where(SqlProject.id == row.id)
-                .values(**values)
+            .values(
+                github_owner=new_owner,
+                github_owner_id=new_owner_id,
+                github_repo=new_repo,
+                date_updated=SqlProject.date_updated,
             )
-            updated_ids.append(row.id)
+            .returning(SqlProject.id)
+        )
+        result = await self._session.execute(stmt)
         await self._session.flush()
-        return updated_ids
+        return [row[0] for row in result.all()]
 
     async def apply_installation_scope(
         self,

--- a/src/docverse/storage/project_store.py
+++ b/src/docverse/storage/project_store.py
@@ -41,7 +41,7 @@ class ProjectStore:
             slug=data.slug,
             title=data.title,
             org_id=org_id,
-            doc_repo=data.doc_repo,
+            source_url=data.doc_repo,
             lifecycle_rules=lifecycle_rules,
         )
         self._session.add(row)
@@ -285,6 +285,11 @@ class ProjectStore:
         if row is None:
             return None
         updates = data.model_dump(mode="json", exclude_unset=True)
+        # The client model still exposes ``doc_repo`` while the column
+        # was renamed to ``source_url`` for the structured GitHub-binding
+        # work; translate the client field on the way into the row.
+        if "doc_repo" in updates:
+            updates["source_url"] = updates.pop("doc_repo")
         for key, value in updates.items():
             setattr(row, key, value)
         await self._session.flush()

--- a/src/docverse/storage/project_store.py
+++ b/src/docverse/storage/project_store.py
@@ -389,32 +389,55 @@ class ProjectStore:
         non-GitHub URLs and URLs whose first two path segments do not
         match ``(github_owner, old_repo)`` untouched.
 
+        ``date_updated`` is preserved on every row (the per-row
+        ``update()`` pins ``date_updated=SqlProject.date_updated`` so
+        the column's ``onupdate=func.now()`` does not fire): a
+        GitHub-side rename is sync-bookkeeping, not an operator-visible
+        source-coordinate edit, which arrives through PUT/PATCH. This
+        mirrors the discipline of the dashboard binding store's
+        ``rename_repo_by_repo_id`` and of ``apply_installation_scope``.
+        The ``source_url`` is computed in Python rather than mutated via
+        the ORM so the write can go through a ``date_updated``-pinning
+        bulk ``update()`` even when it differs per row.
+
         Returns the list of updated project ids.
         """
         result = await self._session.execute(
-            select(SqlProject).where(
+            select(
+                SqlProject.id,
+                SqlProject.source_url,
+                SqlProject.github_owner,
+                SqlProject.github_repo,
+            ).where(
                 SqlProject.github_repo_id == github_repo_id,
                 SqlProject.date_deleted.is_(None),
             )
         )
         updated_ids: list[int] = []
-        for row in result.scalars().all():
-            old_repo = row.github_repo
-            row.github_repo = new_repo
+        for row in result.all():
+            values: dict[str, Any] = {
+                "github_repo": new_repo,
+                "date_updated": SqlProject.date_updated,
+            }
             if (
                 row.source_url is not None
                 and row.github_owner is not None
-                and old_repo is not None
+                and row.github_repo is not None
             ):
                 rewritten = _rewrite_github_source_url(
                     row.source_url,
                     old_owner=row.github_owner,
-                    old_repo=old_repo,
+                    old_repo=row.github_repo,
                     new_owner=row.github_owner,
                     new_repo=new_repo,
                 )
                 if rewritten is not None:
-                    row.source_url = rewritten
+                    values["source_url"] = rewritten
+            await self._session.execute(
+                update(SqlProject)
+                .where(SqlProject.id == row.id)
+                .values(**values)
+            )
             updated_ids.append(row.id)
         await self._session.flush()
         return updated_ids
@@ -440,34 +463,56 @@ class ProjectStore:
         github.com URL whose first two path segments match the old
         owner/repo — non-GitHub URLs and URLs whose path was
         already pointing somewhere else are left alone.
+
+        ``date_updated`` is preserved on every row (the per-row
+        ``update()`` pins ``date_updated=SqlProject.date_updated`` so
+        the column's ``onupdate=func.now()`` does not fire): a
+        GitHub-side transfer is sync-bookkeeping, not an operator-
+        visible source-coordinate edit, which arrives through PUT/PATCH.
+        This mirrors the discipline of the dashboard binding store's
+        ``transfer_repo_by_repo_id`` and of ``apply_installation_scope``.
+        The ``source_url`` is computed in Python rather than mutated via
+        the ORM so the write can go through a ``date_updated``-pinning
+        bulk ``update()`` even when it differs per row.
         """
         result = await self._session.execute(
-            select(SqlProject).where(
+            select(
+                SqlProject.id,
+                SqlProject.source_url,
+                SqlProject.github_owner,
+                SqlProject.github_repo,
+            ).where(
                 SqlProject.github_repo_id == github_repo_id,
                 SqlProject.date_deleted.is_(None),
             )
         )
         updated_ids: list[int] = []
-        for row in result.scalars().all():
-            old_owner = row.github_owner
-            old_repo = row.github_repo
-            row.github_owner = new_owner
-            row.github_owner_id = new_owner_id
-            row.github_repo = new_repo
+        for row in result.all():
+            values: dict[str, Any] = {
+                "github_owner": new_owner,
+                "github_owner_id": new_owner_id,
+                "github_repo": new_repo,
+                "date_updated": SqlProject.date_updated,
+            }
             if (
                 row.source_url is not None
-                and old_owner is not None
-                and old_repo is not None
+                and row.github_owner is not None
+                and row.github_repo is not None
             ):
                 rewritten = _rewrite_github_source_url(
                     row.source_url,
-                    old_owner=old_owner,
-                    old_repo=old_repo,
+                    old_owner=row.github_owner,
+                    old_repo=row.github_repo,
                     new_owner=new_owner,
                     new_repo=new_repo,
                 )
                 if rewritten is not None:
-                    row.source_url = rewritten
+                    values["source_url"] = rewritten
+            await self._session.execute(
+                update(SqlProject)
+                .where(SqlProject.id == row.id)
+                .values(**values)
+            )
             updated_ids.append(row.id)
         await self._session.flush()
         return updated_ids
@@ -545,25 +590,35 @@ class ProjectStore:
         binding's columns — better to lose this update than to write
         ids that disagree with ``github_owner`` / ``github_repo``.
 
+        ``date_updated`` is explicitly preserved: capturing the three
+        opportunistic ``github_*_id`` columns is sync-bookkeeping, not
+        an operator-visible source-coordinate edit, so bumping
+        ``date_updated`` here would mislead any consumer that reads it
+        as ``last operator change``. Mirrors ``apply_installation_scope``
+        and the dashboard binding store.
+
         Returns ``True`` when the row was updated, ``False`` when no
         row matched (project deleted, or binding changed).
         """
-        result = await self._session.execute(
-            select(SqlProject).where(
+        stmt = (
+            update(SqlProject)
+            .where(
                 SqlProject.id == project_id,
                 SqlProject.github_owner == expected_owner,
                 SqlProject.github_repo == expected_repo,
                 SqlProject.date_deleted.is_(None),
             )
+            .values(
+                github_installation_id=installation_id,
+                github_owner_id=owner_id,
+                github_repo_id=repo_id,
+                date_updated=SqlProject.date_updated,
+            )
+            .returning(SqlProject.id)
         )
-        row = result.scalar_one_or_none()
-        if row is None:
-            return False
-        row.github_installation_id = installation_id
-        row.github_owner_id = owner_id
-        row.github_repo_id = repo_id
+        result = await self._session.execute(stmt)
         await self._session.flush()
-        return True
+        return result.first() is not None
 
     async def soft_delete(self, *, org_id: int, slug: str) -> bool:
         """Soft-delete a project by setting date_deleted.

--- a/src/docverse/worker/functions/__init__.py
+++ b/src/docverse/worker/functions/__init__.py
@@ -15,6 +15,7 @@ from .lifecycle_eval import lifecycle_eval
 from .lifecycle_eval_dispatcher import lifecycle_eval_dispatcher
 from .lifecycle_reaper import lifecycle_reaper
 from .ping import ping
+from .project_github_resolve import project_github_resolve
 from .publish_edition import publish_edition
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "lifecycle_eval_dispatcher",
     "lifecycle_reaper",
     "ping",
+    "project_github_resolve",
     "publish_edition",
 ]

--- a/src/docverse/worker/functions/project_github_resolve.py
+++ b/src/docverse/worker/functions/project_github_resolve.py
@@ -19,6 +19,8 @@ import sentry_sdk
 import structlog
 from safir.dependencies.db_session import db_session_dependency
 
+from docverse.storage.github import GitHubAppNotInstalledError
+
 __all__ = ["project_github_resolve"]
 
 
@@ -39,9 +41,12 @@ async def project_github_resolve(
     -------
     str
         ``"completed"`` on a successful resolve, ``"skipped"`` when the
-        project has no GitHub binding (or has been deleted), or
-        ``"failed"`` when GitHub returned an error or the columns
-        could not be written.
+        project has no GitHub binding (or has been deleted),
+        ``"not_installed"`` when the GitHub App is not installed on the
+        repository (an expected, operator-recoverable state — the ids
+        stay NULL and the ``installation`` webhook backfills them once
+        the App is installed), or ``"failed"`` when GitHub returned a
+        genuine error or the columns could not be written.
     """
     project_id: int = payload["project_id"]
     logger = structlog.get_logger(
@@ -71,6 +76,18 @@ async def project_github_resolve(
             metadata = await app_client.resolve_repository_metadata(
                 owner=owner, repo=repo
             )
+        except GitHubAppNotInstalledError:
+            # Expected state, not a bug: no installation grants the App
+            # access to this repo (not installed on the account,
+            # installed without this repo selected, or a mistyped URL).
+            # Leave the ids NULL and stay out of Sentry — the
+            # ``installation`` webhook backfills them once an operator
+            # installs the App. The API surfaces this as
+            # ``installation_status: "not_installed"``.
+            logger.info(
+                "GitHub App not installed on repository; leaving ids NULL"
+            )
+            return "not_installed"
         except (
             httpx.HTTPError,
             gidgethub.GitHubException,

--- a/src/docverse/worker/functions/project_github_resolve.py
+++ b/src/docverse/worker/functions/project_github_resolve.py
@@ -1,0 +1,113 @@
+"""Project GitHub binding resolver worker function.
+
+Resolves a project's GitHub App installation id and the numeric
+owner / repo ids opportunistically, after a project create or update
+that supplied a ``github`` sub-object. A failure (no installation,
+transient HTTP, etc.) is logged but never re-raised — the columns
+stay NULL and a later install of the GitHub App will backfill them
+through the ``installation`` webhook (PRD #346 user stories 12 / 13).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import gidgethub
+import httpx
+import jwt.exceptions
+import sentry_sdk
+import structlog
+from safir.dependencies.db_session import db_session_dependency
+
+__all__ = ["project_github_resolve"]
+
+
+async def project_github_resolve(
+    ctx: dict[str, Any], payload: dict[str, Any]
+) -> str:
+    """Resolve and persist a project's opportunistic GitHub ids.
+
+    Parameters
+    ----------
+    ctx
+        arq worker context (``factory_builder``, ``http_client``,
+        ``arq_queue``).
+    payload
+        Job payload with ``project_id``.
+
+    Returns
+    -------
+    str
+        ``"completed"`` on a successful resolve, ``"skipped"`` when the
+        project has no GitHub binding (or has been deleted), or
+        ``"failed"`` when GitHub returned an error or the columns
+        could not be written.
+    """
+    project_id: int = payload["project_id"]
+    logger = structlog.get_logger(
+        "docverse.worker.project_github_resolve"
+    ).bind(project_id=project_id)
+
+    async for session in db_session_dependency():
+        factory = ctx["factory_builder"](session=session, logger=logger)
+        project_store = factory.create_project_store()
+
+        async with session.begin():
+            project = await project_store.get_by_id(project_id)
+        if project is None:
+            logger.info("Skipping resolve: project not found")
+            return "skipped"
+
+        owner = project.github_owner
+        repo = project.github_repo
+        if owner is None or repo is None:
+            logger.info("Skipping resolve: project has no GitHub binding")
+            return "skipped"
+
+        logger = logger.bind(github_owner=owner, github_repo=repo)
+
+        try:
+            app_client = factory.create_github_app_client()
+            metadata = await app_client.resolve_repository_metadata(
+                owner=owner, repo=repo
+            )
+        except (
+            httpx.HTTPError,
+            gidgethub.GitHubException,
+            jwt.exceptions.InvalidKeyError,
+        ) as exc:
+            sentry_sdk.capture_exception(exc)
+            logger.warning(
+                "Failed to resolve project GitHub metadata",
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            return "failed"
+
+        async with session.begin():
+            updated = await project_store.update_github_metadata(
+                project_id=project_id,
+                expected_owner=owner,
+                expected_repo=repo,
+                installation_id=metadata.installation_id,
+                owner_id=metadata.owner_id,
+                repo_id=metadata.repo_id,
+            )
+            await session.commit()
+
+        if not updated:
+            logger.info(
+                "Skipping persist: project binding changed during resolve"
+            )
+            return "skipped"
+
+        logger.info(
+            "Resolved project GitHub metadata",
+            github_installation_id=metadata.installation_id,
+            github_owner_id=metadata.owner_id,
+            github_repo_id=metadata.repo_id,
+        )
+        return "completed"
+
+    msg = "No database session available"
+    raise RuntimeError(msg)

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -51,6 +51,7 @@ from .functions import (
     lifecycle_eval_dispatcher,
     lifecycle_reaper,
     ping,
+    project_github_resolve,
     publish_edition,
 )
 from .functions.lifecycle_eval_dispatcher import LIFECYCLE_EVAL_QUEUE_NAME
@@ -294,6 +295,7 @@ class WorkerSettings:
         instrument_arq_task(dashboard_build),
         instrument_arq_task(dashboard_sync),
         instrument_arq_task(ping),
+        instrument_arq_task(project_github_resolve),
         instrument_arq_task(publish_edition),
     ]
     redis_settings = config.arq_redis_settings

--- a/tests/dbschema/active_uq_cleanup_test.py
+++ b/tests/dbschema/active_uq_cleanup_test.py
@@ -118,7 +118,7 @@ async def _seed_duplicates(engine: AsyncEngine) -> tuple[int, int]:
                     "INSERT INTO projects"
                     " (slug, title, org_id, doc_repo)"
                     " VALUES ('cleanup-proj', 'Cleanup Project',"
-                    " :org_id, 'https://example.com/repo')"
+                    " :org_id, 'https://github.com/example/cleanup-proj')"
                     " RETURNING id"
                 ),
                 {"org_id": org_id},

--- a/tests/dbschema/projects_github_binding_test.py
+++ b/tests/dbschema/projects_github_binding_test.py
@@ -42,6 +42,12 @@ from docverse.dbschema import Base
 # Revision immediately before the projects GitHub-binding migration.
 PRE_GITHUB_BINDING_REVISION = "w1x2y3z4a5b6"
 
+# The projects GitHub-binding migration itself. The test targets this
+# revision rather than ``head`` so a later migration (e.g. the one that
+# nulls redundant github.com ``source_url`` values) does not perturb the
+# rename behaviour under test here.
+GITHUB_BINDING_REVISION = "x2y3z4a5b6c7"
+
 
 @pytest_asyncio.fixture
 async def fresh_engine() -> AsyncGenerator[AsyncEngine]:
@@ -157,7 +163,7 @@ async def test_projects_github_binding_migration_happy_path(
         doc_repo="https://github.com/example/repo.git",
     )
 
-    await _alembic_upgrade("head")
+    await _alembic_upgrade(GITHUB_BINDING_REVISION)
 
     async with fresh_engine.connect() as conn:
         rows = (
@@ -300,7 +306,7 @@ async def test_projects_github_binding_migration_aborts_on_non_github(
     )
 
     with pytest.raises(RuntimeError) as excinfo:
-        await _alembic_upgrade("head")
+        await _alembic_upgrade(GITHUB_BINDING_REVISION)
 
     # The error message must surface the offending project ids so the
     # operator can address them without grepping the table by hand.

--- a/tests/dbschema/projects_github_binding_test.py
+++ b/tests/dbschema/projects_github_binding_test.py
@@ -1,0 +1,310 @@
+"""Test the projects GitHub-binding migration (``x2y3z4a5b6c7``).
+
+The migration backfills ``github_owner`` / ``github_repo`` from every
+existing ``projects.doc_repo`` URL, renames ``doc_repo`` to nullable
+``source_url`` (existing values preserved), and adds the both-or-
+neither check constraint plus the two webhook-lookup indexes. Any
+non-``github.com`` ``doc_repo`` value aborts the migration with the
+offending project ids surfaced in the error message.
+
+This test seeds projects at the pre-migration revision and exercises
+both branches:
+
+- happy path — a mix of canonical, mixed-case, deep-path, and
+  ``.git``-suffixed ``github.com`` URLs all parse cleanly and the
+  resulting columns / indexes are correct.
+- loud failure — a single non-``github.com`` row aborts the migration
+  with the offending project ids listed in the ``RuntimeError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+import structlog
+from alembic.config import Config
+from safir.database import (
+    create_database_engine,
+    drop_database,
+    initialize_database,
+    stamp_database_async,
+)
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from alembic import command
+from docverse.config import config
+from docverse.dbschema import Base
+
+# Revision immediately before the projects GitHub-binding migration.
+PRE_GITHUB_BINDING_REVISION = "w1x2y3z4a5b6"
+
+
+@pytest_asyncio.fixture
+async def fresh_engine() -> AsyncGenerator[AsyncEngine]:
+    """Yield an engine pointing at a freshly-dropped DB.
+
+    Mirrors the fixture in ``active_uq_cleanup_test.py``: the ``app``
+    conftest fixture would jump straight to head via
+    ``initialize_database`` + ``stamp_database_async``, but this test
+    needs to step the schema forward from a known earlier revision.
+    On teardown the schema is restored to head so subsequent tests'
+    ``app`` fixtures find a clean DB.
+    """
+    logger = structlog.get_logger("docverse")
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    await drop_database(engine, Base.metadata)
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+    try:
+        yield engine
+    finally:
+        await drop_database(engine, Base.metadata)
+        async with engine.begin() as conn:
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+        await initialize_database(
+            engine, logger, schema=Base.metadata, reset=True
+        )
+        await stamp_database_async(engine)
+        await engine.dispose()
+
+
+def _alembic_config() -> Config:
+    return Config("alembic.ini")
+
+
+async def _alembic_upgrade(target: str) -> None:
+    # ``run_migrations_online`` calls ``asyncio.run`` internally, so the
+    # alembic command has to run on a thread that owns its own loop.
+    await asyncio.to_thread(command.upgrade, _alembic_config(), target)
+
+
+async def _seed_org(engine: AsyncEngine) -> int:
+    async with engine.begin() as conn:
+        org_id = (
+            await conn.execute(
+                text(
+                    "INSERT INTO organizations"
+                    " (slug, title, base_domain, url_scheme,"
+                    "  root_path_prefix, purgatory_retention_seconds)"
+                    " VALUES ('ghbindingorg', 'GitHub Binding Org',"
+                    "  'gh-binding.example.com', 'subdomain', '/',"
+                    "  2592000)"
+                    " RETURNING id"
+                )
+            )
+        ).scalar_one()
+    return int(org_id)
+
+
+async def _seed_project(
+    engine: AsyncEngine, *, org_id: int, slug: str, doc_repo: str
+) -> int:
+    async with engine.begin() as conn:
+        project_id = (
+            await conn.execute(
+                text(
+                    "INSERT INTO projects"
+                    " (slug, title, org_id, doc_repo)"
+                    " VALUES (:slug, :title, :org, :doc_repo)"
+                    " RETURNING id"
+                ),
+                {
+                    "slug": slug,
+                    "title": slug.replace("-", " ").title(),
+                    "org": org_id,
+                    "doc_repo": doc_repo,
+                },
+            )
+        ).scalar_one()
+    return int(project_id)
+
+
+@pytest.mark.asyncio
+async def test_projects_github_binding_migration_happy_path(
+    fresh_engine: AsyncEngine,
+) -> None:
+    """A mix of GitHub URLs all parse and the schema lands correctly."""
+    await _alembic_upgrade(PRE_GITHUB_BINDING_REVISION)
+    org_id = await _seed_org(fresh_engine)
+    canonical_id = await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="canonical",
+        doc_repo="https://github.com/lsst/pipelines_lsst_io",
+    )
+    mixed_case_id = await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="mixed-case",
+        doc_repo="https://GitHub.com/Owner/RepoName",
+    )
+    deep_path_id = await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="deep-path",
+        doc_repo="https://github.com/org/repo/tree/main/docs",
+    )
+    dot_git_id = await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="dot-git",
+        doc_repo="https://github.com/example/repo.git",
+    )
+
+    await _alembic_upgrade("head")
+
+    async with fresh_engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT id, source_url, github_owner, github_repo,"
+                    " github_owner_id, github_repo_id,"
+                    " github_installation_id"
+                    " FROM projects ORDER BY id"
+                )
+            )
+        ).all()
+        by_id = {row.id: row for row in rows}
+        canonical = by_id[canonical_id]
+        assert canonical.source_url == (
+            "https://github.com/lsst/pipelines_lsst_io"
+        )
+        assert canonical.github_owner == "lsst"
+        assert canonical.github_repo == "pipelines_lsst_io"
+        # Numeric / installation ids are populated opportunistically by
+        # later code paths, not the migration.
+        assert canonical.github_owner_id is None
+        assert canonical.github_repo_id is None
+        assert canonical.github_installation_id is None
+
+        mixed_case = by_id[mixed_case_id]
+        # Hostname comparison is case-insensitive, owner/repo are
+        # preserved verbatim from the URL path.
+        assert mixed_case.github_owner == "Owner"
+        assert mixed_case.github_repo == "RepoName"
+
+        deep_path = by_id[deep_path_id]
+        # Only the first two path segments are used; deeper path
+        # components (``tree/main/docs``) are ignored.
+        assert deep_path.github_owner == "org"
+        assert deep_path.github_repo == "repo"
+
+        dot_git = by_id[dot_git_id]
+        # The conventional ``.git`` suffix is stripped from the repo
+        # name to match what GitHub returns for the repo.
+        assert dot_git.github_owner == "example"
+        assert dot_git.github_repo == "repo"
+
+        # The check constraint exists and the both-or-neither predicate
+        # is what we declared.
+        constraint_def = (
+            await conn.execute(
+                text(
+                    "SELECT pg_get_constraintdef(c.oid)"
+                    " FROM pg_constraint c"
+                    " JOIN pg_class t ON t.oid = c.conrelid"
+                    " WHERE t.relname = 'projects'"
+                    " AND c.conname ="
+                    " 'ck_projects_github_owner_repo_both_or_neither'"
+                )
+            )
+        ).scalar_one()
+        assert "github_owner IS NULL" in constraint_def
+        assert "github_repo IS NULL" in constraint_def
+
+        # Both new indexes exist on the projects table.
+        idx_names = {
+            row[0]
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT indexname FROM pg_indexes"
+                        " WHERE schemaname = 'public'"
+                        " AND tablename = 'projects'"
+                    )
+                )
+            ).all()
+        }
+        assert "idx_projects_github_owner_repo" in idx_names
+        assert "idx_projects_github_repo_id" in idx_names
+
+        # The owner/repo index uses the functional ``lower(...)`` form
+        # so webhook lookups can match case-insensitively without a
+        # secondary index.
+        owner_repo_def = (
+            await conn.execute(
+                text(
+                    "SELECT pg_get_indexdef(c.oid)"
+                    " FROM pg_class c"
+                    " JOIN pg_namespace n ON n.oid = c.relnamespace"
+                    " WHERE n.nspname = 'public'"
+                    " AND c.relname = 'idx_projects_github_owner_repo'"
+                )
+            )
+        ).scalar_one()
+        assert "lower((github_owner)" in owner_repo_def
+        assert "lower((github_repo)" in owner_repo_def
+
+        # The ``doc_repo`` column is gone; ``source_url`` is the
+        # nullable replacement and carries the original URL.
+        columns = {
+            row.column_name: row
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT column_name, is_nullable, data_type,"
+                        " character_maximum_length"
+                        " FROM information_schema.columns"
+                        " WHERE table_schema = 'public'"
+                        " AND table_name = 'projects'"
+                    )
+                )
+            ).all()
+        }
+        assert "doc_repo" not in columns
+        assert "source_url" in columns
+        assert columns["source_url"].is_nullable == "YES"
+        assert columns["source_url"].character_maximum_length == 512
+
+
+@pytest.mark.asyncio
+async def test_projects_github_binding_migration_aborts_on_non_github(
+    fresh_engine: AsyncEngine,
+) -> None:
+    """A non-github.com ``doc_repo`` aborts with offending project ids."""
+    await _alembic_upgrade(PRE_GITHUB_BINDING_REVISION)
+    org_id = await _seed_org(fresh_engine)
+    await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="ok-row",
+        doc_repo="https://github.com/example/ok",
+    )
+    bad_id = await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="gitlab-row",
+        doc_repo="https://gitlab.com/example/repo",
+    )
+    bad_id_2 = await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="onprem-row",
+        doc_repo="https://git.example.com/example/repo",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await _alembic_upgrade("head")
+
+    # The error message must surface the offending project ids so the
+    # operator can address them without grepping the table by hand.
+    message = str(excinfo.value)
+    assert str(bad_id) in message
+    assert str(bad_id_2) in message
+    assert "github.com" in message

--- a/tests/dbschema/projects_null_github_source_urls_test.py
+++ b/tests/dbschema/projects_null_github_source_urls_test.py
@@ -1,0 +1,212 @@
+"""Test the null-github-source_url migration (``y3z4a5b6c7d8``).
+
+The migration nulls every ``projects.source_url`` that parses as a
+github.com repository URL, leaving the structured ``github_*`` binding
+untouched, while preserving non-GitHub URLs verbatim. After the
+migration a GitHub-bound project's effective source URL is derived from
+the binding (``Project.effective_source_url``) rather than from the
+nulled column.
+
+This test seeds projects at the revision immediately before the
+migration and asserts:
+
+- a github.com ``source_url`` alongside a binding is nulled, the binding
+  is unchanged, and the domain model still derives the canonical URL;
+- a non-GitHub ``source_url`` (no binding) survives untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+import structlog
+from alembic.config import Config
+from safir.database import (
+    create_database_engine,
+    drop_database,
+    initialize_database,
+    stamp_database_async,
+)
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from alembic import command
+from docverse.config import config
+from docverse.dbschema import Base
+from docverse.domain.project import Project as ProjectDomain
+
+# Revision immediately before the null-github-source_url migration.
+PRE_NULL_REVISION = "x2y3z4a5b6c7"
+
+
+@pytest_asyncio.fixture
+async def fresh_engine() -> AsyncGenerator[AsyncEngine]:
+    """Yield an engine pointing at a freshly-dropped DB.
+
+    Mirrors ``projects_github_binding_test.py``: the ``app`` conftest
+    fixture jumps straight to head, but this test needs to step the
+    schema forward from a known earlier revision. On teardown the schema
+    is restored to head so subsequent tests' ``app`` fixtures find a
+    clean DB.
+    """
+    logger = structlog.get_logger("docverse")
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    await drop_database(engine, Base.metadata)
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+    try:
+        yield engine
+    finally:
+        await drop_database(engine, Base.metadata)
+        async with engine.begin() as conn:
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+        await initialize_database(
+            engine, logger, schema=Base.metadata, reset=True
+        )
+        await stamp_database_async(engine)
+        await engine.dispose()
+
+
+def _alembic_config() -> Config:
+    return Config("alembic.ini")
+
+
+async def _alembic_upgrade(target: str) -> None:
+    # ``run_migrations_online`` calls ``asyncio.run`` internally, so the
+    # alembic command has to run on a thread that owns its own loop.
+    await asyncio.to_thread(command.upgrade, _alembic_config(), target)
+
+
+async def _seed_org(engine: AsyncEngine) -> int:
+    async with engine.begin() as conn:
+        org_id = (
+            await conn.execute(
+                text(
+                    "INSERT INTO organizations"
+                    " (slug, title, base_domain, url_scheme,"
+                    "  root_path_prefix, purgatory_retention_seconds)"
+                    " VALUES ('nullghorg', 'Null GH Org',"
+                    "  'null-gh.example.com', 'subdomain', '/',"
+                    "  2592000)"
+                    " RETURNING id"
+                )
+            )
+        ).scalar_one()
+    return int(org_id)
+
+
+async def _seed_project(
+    engine: AsyncEngine,
+    *,
+    org_id: int,
+    slug: str,
+    source_url: str | None,
+    github_owner: str | None = None,
+    github_repo: str | None = None,
+) -> int:
+    async with engine.begin() as conn:
+        project_id = (
+            await conn.execute(
+                text(
+                    "INSERT INTO projects"
+                    " (slug, title, org_id, source_url,"
+                    "  github_owner, github_repo)"
+                    " VALUES (:slug, :title, :org, :source_url,"
+                    "  :owner, :repo)"
+                    " RETURNING id"
+                ),
+                {
+                    "slug": slug,
+                    "title": slug.replace("-", " ").title(),
+                    "org": org_id,
+                    "source_url": source_url,
+                    "owner": github_owner,
+                    "repo": github_repo,
+                },
+            )
+        ).scalar_one()
+    return int(project_id)
+
+
+@pytest.mark.asyncio
+async def test_null_github_source_urls_migration(
+    fresh_engine: AsyncEngine,
+) -> None:
+    """github.com source_urls are nulled; bindings and non-GitHub URLs hold."""
+    await _alembic_upgrade(PRE_NULL_REVISION)
+    org_id = await _seed_org(fresh_engine)
+    bound_id = await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="bound",
+        source_url="https://github.com/lsst/pipelines_lsst_io",
+        github_owner="lsst",
+        github_repo="pipelines_lsst_io",
+    )
+    deep_path_id = await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="deep-path",
+        source_url="https://github.com/lsst/docs/tree/main/docs",
+        github_owner="lsst",
+        github_repo="docs",
+    )
+    gitlab_id = await _seed_project(
+        fresh_engine,
+        org_id=org_id,
+        slug="gitlab",
+        source_url="https://gitlab.com/lsst/mirror",
+    )
+
+    await _alembic_upgrade("head")
+
+    async with fresh_engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT id, source_url, github_owner, github_repo"
+                    " FROM projects ORDER BY id"
+                )
+            )
+        ).all()
+    by_id = {row.id: row for row in rows}
+
+    # The github.com source_url is nulled; the binding is untouched.
+    bound = by_id[bound_id]
+    assert bound.source_url is None
+    assert bound.github_owner == "lsst"
+    assert bound.github_repo == "pipelines_lsst_io"
+
+    # A deep-path github.com URL also parses as a repo URL and is nulled.
+    deep_path = by_id[deep_path_id]
+    assert deep_path.source_url is None
+    assert deep_path.github_owner == "lsst"
+    assert deep_path.github_repo == "docs"
+
+    # The non-GitHub URL survives untouched (no binding to derive from).
+    gitlab = by_id[gitlab_id]
+    assert gitlab.source_url == "https://gitlab.com/lsst/mirror"
+    assert gitlab.github_owner is None
+    assert gitlab.github_repo is None
+
+    # Reads still derive the canonical URL for the bound row from its
+    # binding even though the stored column is now NULL.
+    now = datetime.now(tz=UTC)
+    derived = ProjectDomain(
+        id=bound.id,
+        slug="bound",
+        title="Bound",
+        org_id=org_id,
+        source_url=bound.source_url,
+        github_owner=bound.github_owner,
+        github_repo=bound.github_repo,
+        date_created=now,
+        date_updated=now,
+    ).effective_source_url
+    assert derived == "https://github.com/lsst/pipelines_lsst_io"

--- a/tests/handlers/authorization_test.py
+++ b/tests/handlers/authorization_test.py
@@ -29,7 +29,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "auth-proj",
             "title": "Auth Project",
-            "doc_repo": "https://github.com/example/auth",
+            "source_url": "https://github.com/example/auth",
         },
         headers={"X-Auth-Request-User": "admin-user"},
     )
@@ -101,7 +101,7 @@ async def test_create_project_as_reader(client: AsyncClient) -> None:
         json={
             "slug": "forbidden",
             "title": "No",
-            "doc_repo": "https://github.com/example/no",
+            "source_url": "https://github.com/example/no",
         },
         headers={"X-Auth-Request-User": "read-user"},
     )
@@ -116,7 +116,7 @@ async def test_create_project_as_uploader(client: AsyncClient) -> None:
         json={
             "slug": "forbidden",
             "title": "No",
-            "doc_repo": "https://github.com/example/no",
+            "source_url": "https://github.com/example/no",
         },
         headers={"X-Auth-Request-User": "upload-user"},
     )

--- a/tests/handlers/authorization_test.py
+++ b/tests/handlers/authorization_test.py
@@ -29,7 +29,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "auth-proj",
             "title": "Auth Project",
-            "source_url": "https://github.com/example/auth",
+            "source_url": "https://example.com/example/auth",
         },
         headers={"X-Auth-Request-User": "admin-user"},
     )
@@ -101,7 +101,7 @@ async def test_create_project_as_reader(client: AsyncClient) -> None:
         json={
             "slug": "forbidden",
             "title": "No",
-            "source_url": "https://github.com/example/no",
+            "source_url": "https://example.com/example/no",
         },
         headers={"X-Auth-Request-User": "read-user"},
     )
@@ -116,7 +116,7 @@ async def test_create_project_as_uploader(client: AsyncClient) -> None:
         json={
             "slug": "forbidden",
             "title": "No",
-            "source_url": "https://github.com/example/no",
+            "source_url": "https://example.com/example/no",
         },
         headers={"X-Auth-Request-User": "upload-user"},
     )

--- a/tests/handlers/builds_test.py
+++ b/tests/handlers/builds_test.py
@@ -21,7 +21,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "build-proj",
             "title": "Build Project",
-            "source_url": "https://github.com/example/build",
+            "source_url": "https://example.com/example/build",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/builds_test.py
+++ b/tests/handlers/builds_test.py
@@ -21,7 +21,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "build-proj",
             "title": "Build Project",
-            "doc_repo": "https://github.com/example/build",
+            "source_url": "https://github.com/example/build",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/dashboard_enqueue_triggers_test.py
+++ b/tests/handlers/dashboard_enqueue_triggers_test.py
@@ -49,7 +49,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "dbt-proj",
             "title": "Dashboard Trigger Project",
-            "doc_repo": "https://github.com/example/dbt",
+            "source_url": "https://github.com/example/dbt",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/dashboard_enqueue_triggers_test.py
+++ b/tests/handlers/dashboard_enqueue_triggers_test.py
@@ -49,7 +49,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "dbt-proj",
             "title": "Dashboard Trigger Project",
-            "source_url": "https://github.com/example/dbt",
+            "source_url": "https://example.com/example/dbt",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/dashboard_template_test.py
+++ b/tests/handlers/dashboard_template_test.py
@@ -45,7 +45,7 @@ async def _setup_org_and_project(client: AsyncClient) -> None:
         json={
             "slug": _PROJECT,
             "title": "Tmpl Project",
-            "source_url": "https://github.com/example/tmpl",
+            "source_url": "https://example.com/example/tmpl",
         },
         headers={"X-Auth-Request-User": _ADMIN},
     )

--- a/tests/handlers/dashboard_template_test.py
+++ b/tests/handlers/dashboard_template_test.py
@@ -45,7 +45,7 @@ async def _setup_org_and_project(client: AsyncClient) -> None:
         json={
             "slug": _PROJECT,
             "title": "Tmpl Project",
-            "doc_repo": "https://github.com/example/tmpl",
+            "source_url": "https://github.com/example/tmpl",
         },
         headers={"X-Auth-Request-User": _ADMIN},
     )

--- a/tests/handlers/dashboard_test.py
+++ b/tests/handlers/dashboard_test.py
@@ -16,7 +16,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "dash-proj",
             "title": "Dash Project",
-            "source_url": "https://github.com/example/dash",
+            "source_url": "https://example.com/example/dash",
         },
         headers={"X-Auth-Request-User": "admin-user"},
     )
@@ -104,7 +104,7 @@ async def _create_project(
         json={
             "slug": slug,
             "title": f"Project {slug}",
-            "source_url": f"https://github.com/example/{slug}",
+            "source_url": f"https://example.com/example/{slug}",
         },
         headers={"X-Auth-Request-User": admin},
     )

--- a/tests/handlers/dashboard_test.py
+++ b/tests/handlers/dashboard_test.py
@@ -16,7 +16,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "dash-proj",
             "title": "Dash Project",
-            "doc_repo": "https://github.com/example/dash",
+            "source_url": "https://github.com/example/dash",
         },
         headers={"X-Auth-Request-User": "admin-user"},
     )
@@ -104,7 +104,7 @@ async def _create_project(
         json={
             "slug": slug,
             "title": f"Project {slug}",
-            "doc_repo": f"https://github.com/example/{slug}",
+            "source_url": f"https://github.com/example/{slug}",
         },
         headers={"X-Auth-Request-User": admin},
     )

--- a/tests/handlers/edition_patch_override_test.py
+++ b/tests/handlers/edition_patch_override_test.py
@@ -34,7 +34,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "pov-proj",
             "title": "Override Project",
-            "source_url": "https://github.com/example/pov",
+            "source_url": "https://example.com/example/pov",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/edition_patch_override_test.py
+++ b/tests/handlers/edition_patch_override_test.py
@@ -34,7 +34,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "pov-proj",
             "title": "Override Project",
-            "doc_repo": "https://github.com/example/pov",
+            "source_url": "https://github.com/example/pov",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/edition_rollback_test.py
+++ b/tests/handlers/edition_rollback_test.py
@@ -34,7 +34,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "rb-proj",
             "title": "Rollback Project",
-            "doc_repo": "https://github.com/example/rb",
+            "source_url": "https://github.com/example/rb",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/edition_rollback_test.py
+++ b/tests/handlers/edition_rollback_test.py
@@ -34,7 +34,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "rb-proj",
             "title": "Rollback Project",
-            "source_url": "https://github.com/example/rb",
+            "source_url": "https://example.com/example/rb",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -38,7 +38,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "ed-proj",
             "title": "Ed Project",
-            "source_url": "https://github.com/example/ed",
+            "source_url": "https://example.com/example/ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -38,7 +38,7 @@ async def _setup(client: AsyncClient) -> None:
         json={
             "slug": "ed-proj",
             "title": "Ed Project",
-            "doc_repo": "https://github.com/example/ed",
+            "source_url": "https://github.com/example/ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )

--- a/tests/handlers/group_authorization_test.py
+++ b/tests/handlers/group_authorization_test.py
@@ -66,7 +66,7 @@ async def test_group_uploader_can_create_build(
         json={
             "slug": "grp-proj",
             "title": "Group Project",
-            "source_url": "https://github.com/example/grp",
+            "source_url": "https://example.com/example/grp",
         },
         headers={"X-Auth-Request-User": "admin-user"},
     )
@@ -100,7 +100,7 @@ async def test_group_reader_cannot_create_build(
         json={
             "slug": "grp-ro-proj",
             "title": "Group RO Project",
-            "source_url": "https://github.com/example/grp-ro",
+            "source_url": "https://example.com/example/grp-ro",
         },
         headers={"X-Auth-Request-User": "admin-user"},
     )

--- a/tests/handlers/group_authorization_test.py
+++ b/tests/handlers/group_authorization_test.py
@@ -66,7 +66,7 @@ async def test_group_uploader_can_create_build(
         json={
             "slug": "grp-proj",
             "title": "Group Project",
-            "doc_repo": "https://github.com/example/grp",
+            "source_url": "https://github.com/example/grp",
         },
         headers={"X-Auth-Request-User": "admin-user"},
     )
@@ -100,7 +100,7 @@ async def test_group_reader_cannot_create_build(
         json={
             "slug": "grp-ro-proj",
             "title": "Group RO Project",
-            "doc_repo": "https://github.com/example/grp-ro",
+            "source_url": "https://github.com/example/grp-ro",
         },
         headers={"X-Auth-Request-User": "admin-user"},
     )

--- a/tests/handlers/keeper_sync_project_editions_test.py
+++ b/tests/handlers/keeper_sync_project_editions_test.py
@@ -68,7 +68,7 @@ async def _create_project(
         json={
             "slug": slug,
             "title": slug.title(),
-            "source_url": f"https://github.com/example/{slug}",
+            "source_url": f"https://example.com/example/{slug}",
         },
         headers={"X-Auth-Request-User": _ADMIN},
     )

--- a/tests/handlers/keeper_sync_project_editions_test.py
+++ b/tests/handlers/keeper_sync_project_editions_test.py
@@ -68,7 +68,7 @@ async def _create_project(
         json={
             "slug": slug,
             "title": slug.title(),
-            "doc_repo": f"https://github.com/example/{slug}",
+            "source_url": f"https://github.com/example/{slug}",
         },
         headers={"X-Auth-Request-User": _ADMIN},
     )

--- a/tests/handlers/keeper_sync_project_status_test.py
+++ b/tests/handlers/keeper_sync_project_status_test.py
@@ -77,7 +77,7 @@ async def _create_project(
         json={
             "slug": slug,
             "title": slug.title(),
-            "doc_repo": f"https://github.com/example/{slug}",
+            "source_url": f"https://github.com/example/{slug}",
         },
         headers={"X-Auth-Request-User": _ADMIN},
     )

--- a/tests/handlers/keeper_sync_project_status_test.py
+++ b/tests/handlers/keeper_sync_project_status_test.py
@@ -77,7 +77,7 @@ async def _create_project(
         json={
             "slug": slug,
             "title": slug.title(),
-            "source_url": f"https://github.com/example/{slug}",
+            "source_url": f"https://example.com/example/{slug}",
         },
         headers={"X-Auth-Request-User": _ADMIN},
     )

--- a/tests/handlers/keeper_sync_projects_list_test.py
+++ b/tests/handlers/keeper_sync_projects_list_test.py
@@ -60,7 +60,7 @@ async def _create_project(client: AsyncClient, *, slug: str) -> int:
         json={
             "slug": slug,
             "title": slug.title(),
-            "source_url": f"https://github.com/example/{slug}",
+            "source_url": f"https://example.com/example/{slug}",
         },
         headers={"X-Auth-Request-User": _ADMIN},
     )

--- a/tests/handlers/keeper_sync_projects_list_test.py
+++ b/tests/handlers/keeper_sync_projects_list_test.py
@@ -60,7 +60,7 @@ async def _create_project(client: AsyncClient, *, slug: str) -> int:
         json={
             "slug": slug,
             "title": slug.title(),
-            "doc_repo": f"https://github.com/example/{slug}",
+            "source_url": f"https://github.com/example/{slug}",
         },
         headers={"X-Auth-Request-User": _ADMIN},
     )

--- a/tests/handlers/pagination_test.py
+++ b/tests/handlers/pagination_test.py
@@ -31,7 +31,7 @@ async def _create_project(client: AsyncClient, slug: str) -> None:
         json={
             "slug": slug,
             "title": f"Project {slug}",
-            "doc_repo": f"https://github.com/example/{slug}",
+            "source_url": f"https://github.com/example/{slug}",
         },
         headers=AUTH,
     )

--- a/tests/handlers/pagination_test.py
+++ b/tests/handlers/pagination_test.py
@@ -31,7 +31,7 @@ async def _create_project(client: AsyncClient, slug: str) -> None:
         json={
             "slug": slug,
             "title": f"Project {slug}",
-            "source_url": f"https://github.com/example/{slug}",
+            "source_url": f"https://example.com/example/{slug}",
         },
         headers=AUTH,
     )

--- a/tests/handlers/project_github_resolve_enqueue_test.py
+++ b/tests/handlers/project_github_resolve_enqueue_test.py
@@ -77,36 +77,6 @@ async def test_post_project_with_github_enqueues_resolve(
 
 
 @pytest.mark.asyncio
-async def test_post_project_with_github_url_enqueues_resolve(
-    client: AsyncClient,
-) -> None:
-    """POST with a github.com ``source_url`` also enqueues a resolve.
-
-    The handler auto-populates ``github`` from a github.com URL when
-    the structured sub-object is omitted (existing behaviour from
-    #379); the resolution enqueue follows the populated binding rather
-    than the literal request body so this convenience path lands the
-    numeric ids too.
-    """
-    await _setup(client)
-    before = _resolve_count()
-
-    response = await client.post(
-        "/docverse/orgs/pgr-org/projects",
-        json={
-            "slug": "gh-from-url",
-            "title": "GitHub From URL",
-            "source_url": "https://github.com/lsst/from-url",
-        },
-        headers={"X-Auth-Request-User": "testuser"},
-    )
-    assert response.status_code == 201
-
-    after = _resolve_count()
-    assert after - before == 1
-
-
-@pytest.mark.asyncio
 async def test_post_non_github_project_does_not_enqueue_resolve(
     client: AsyncClient,
 ) -> None:

--- a/tests/handlers/project_github_resolve_enqueue_test.py
+++ b/tests/handlers/project_github_resolve_enqueue_test.py
@@ -1,0 +1,212 @@
+"""Integration tests for the project_github_resolve enqueue hooks.
+
+POST and PATCH on a project with a ``github`` sub-object must enqueue
+one ``project_github_resolve`` arq job (PRD #346 user story 12 /
+acceptance criterion 1). Projects without a GitHub binding must not
+generate a no-op enqueue: the worker would just skip them, and the
+queue noise would obscure real enqueues.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from safir.arq import MockArqQueue
+from safir.dependencies.arq import arq_dependency
+
+from tests.conftest import seed_org_with_admin
+from tests.support.arq_testing import count_jobs_by_name, get_jobs_by_name
+
+
+async def _setup(client: AsyncClient) -> None:
+    """Create an org and seed an admin membership."""
+    await seed_org_with_admin(client, "pgr-org", "testuser")
+
+
+def _resolve_count() -> int:
+    """Count enqueued ``project_github_resolve`` arq jobs."""
+    mock_arq = arq_dependency._arq_queue
+    assert isinstance(mock_arq, MockArqQueue)
+    return count_jobs_by_name(mock_arq, "project_github_resolve")
+
+
+def _resolve_payloads() -> list[dict[str, object]]:
+    """Return every ``project_github_resolve`` job's payload dict.
+
+    ``JobMetadata.kwargs`` carries the keyword arguments passed to
+    ``arq.enqueue_job``; ``ArqQueueBackend.enqueue`` wraps the worker's
+    payload under the ``payload`` key, so we unwrap one level here so
+    callers can assert on the ``project_id`` directly.
+    """
+    mock_arq = arq_dependency._arq_queue
+    assert isinstance(mock_arq, MockArqQueue)
+    return [
+        job.kwargs["payload"]
+        for job in get_jobs_by_name(mock_arq, "project_github_resolve")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_project_with_github_enqueues_resolve(
+    client: AsyncClient,
+) -> None:
+    """POST with ``github`` enqueues one ``project_github_resolve`` job.
+
+    Reproduces the post-create steady state of user story 12: an admin
+    creates a project with structured GitHub coordinates, and the
+    handler fires off the asynchronous installation-id resolution so
+    the operator does not have to know the installation id at create
+    time.
+    """
+    await _setup(client)
+    before = _resolve_count()
+
+    response = await client.post(
+        "/docverse/orgs/pgr-org/projects",
+        json={
+            "slug": "gh-bound",
+            "title": "GitHub Bound",
+            "github": {"owner": "lsst", "repo": "docverse"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+
+    after = _resolve_count()
+    assert after - before == 1
+
+
+@pytest.mark.asyncio
+async def test_post_project_with_github_url_enqueues_resolve(
+    client: AsyncClient,
+) -> None:
+    """POST with a github.com ``source_url`` also enqueues a resolve.
+
+    The handler auto-populates ``github`` from a github.com URL when
+    the structured sub-object is omitted (existing behaviour from
+    #379); the resolution enqueue follows the populated binding rather
+    than the literal request body so this convenience path lands the
+    numeric ids too.
+    """
+    await _setup(client)
+    before = _resolve_count()
+
+    response = await client.post(
+        "/docverse/orgs/pgr-org/projects",
+        json={
+            "slug": "gh-from-url",
+            "title": "GitHub From URL",
+            "source_url": "https://github.com/lsst/from-url",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+
+    after = _resolve_count()
+    assert after - before == 1
+
+
+@pytest.mark.asyncio
+async def test_post_non_github_project_does_not_enqueue_resolve(
+    client: AsyncClient,
+) -> None:
+    """POST with no github binding does not enqueue a resolve.
+
+    Non-GitHub projects (user story 14) can never benefit from the
+    GitHub-App-driven id resolution; enqueueing a job whose only
+    outcome is ``"skipped"`` would just clutter the queue and worker
+    logs.
+    """
+    await _setup(client)
+    before = _resolve_count()
+
+    response = await client.post(
+        "/docverse/orgs/pgr-org/projects",
+        json={
+            "slug": "non-gh",
+            "title": "Non-GitHub",
+            "source_url": "https://gitlab.com/lsst/non-github",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+
+    after = _resolve_count()
+    assert after - before == 0
+
+
+@pytest.mark.asyncio
+async def test_patch_project_with_github_enqueues_resolve(
+    client: AsyncClient,
+) -> None:
+    """PATCH that sets ``github`` enqueues a fresh resolve.
+
+    The numeric id columns were cleared by ``ProjectService._resolve_
+    github_for_update`` so the new binding's ids can be re-resolved
+    against the new repo (per the prior commit's PATCH-clears-ids
+    rule).
+    """
+    await _setup(client)
+    # Create a project without GitHub coordinates first so the PATCH
+    # is the only event that should fire a resolve.
+    create = await client.post(
+        "/docverse/orgs/pgr-org/projects",
+        json={
+            "slug": "to-gh",
+            "title": "To GitHub",
+            "source_url": "https://gitlab.com/lsst/to-gh",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert create.status_code == 201
+    before = _resolve_count()
+
+    patch = await client.patch(
+        "/docverse/orgs/pgr-org/projects/to-gh",
+        json={
+            "source_url": None,
+            "github": {"owner": "lsst", "repo": "to-gh"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert patch.status_code == 200
+
+    after = _resolve_count()
+    assert after - before == 1
+    payloads = _resolve_payloads()
+    project_id = payloads[-1]["project_id"]
+    assert isinstance(project_id, int)
+    assert project_id > 0
+
+
+@pytest.mark.asyncio
+async def test_patch_project_clearing_github_does_not_enqueue_resolve(
+    client: AsyncClient,
+) -> None:
+    """A PATCH that clears ``github`` (sets it to null) does not enqueue.
+
+    Clearing the binding leaves the project in the non-GitHub state
+    (story 14); a resolve would have nothing to resolve and the worker
+    would just skip.
+    """
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/pgr-org/projects",
+        json={
+            "slug": "gh-then-not",
+            "title": "GH Then Not",
+            "github": {"owner": "lsst", "repo": "gh-then-not"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    before = _resolve_count()
+
+    patch = await client.patch(
+        "/docverse/orgs/pgr-org/projects/gh-then-not",
+        json={"github": None},
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert patch.status_code == 200
+
+    after = _resolve_count()
+    assert after - before == 0

--- a/tests/handlers/projects_test.py
+++ b/tests/handlers/projects_test.py
@@ -23,7 +23,7 @@ async def test_create_project(client: AsyncClient) -> None:
         json={
             "slug": "my-docs",
             "title": "My Docs",
-            "doc_repo": "https://github.com/example/docs",
+            "source_url": "https://github.com/example/docs",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -50,7 +50,7 @@ async def test_create_project_with_lifecycle_rules(
         json={
             "slug": "lifecycle-create",
             "title": "Lifecycle Create",
-            "doc_repo": "https://github.com/example/lifecycle-create",
+            "source_url": "https://github.com/example/lifecycle-create",
             "lifecycle_rules": rules,
         },
         headers={"X-Auth-Request-User": "testuser"},
@@ -74,7 +74,7 @@ async def test_list_projects(client: AsyncClient) -> None:
         json={
             "slug": "proj-aa",
             "title": "A",
-            "doc_repo": "https://github.com/example/a",
+            "source_url": "https://github.com/example/a",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -103,7 +103,7 @@ async def test_get_project(client: AsyncClient) -> None:
         json={
             "slug": "get-proj",
             "title": "Get Proj",
-            "doc_repo": "https://github.com/example/get",
+            "source_url": "https://github.com/example/get",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -138,7 +138,7 @@ async def test_update_project(client: AsyncClient) -> None:
         json={
             "slug": "patch-proj",
             "title": "Original",
-            "doc_repo": "https://github.com/example/patch",
+            "source_url": "https://github.com/example/patch",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -162,7 +162,7 @@ async def test_patch_project_lifecycle_rules_valid(
         json={
             "slug": "lifecycle-proj",
             "title": "Lifecycle",
-            "doc_repo": "https://github.com/example/lifecycle",
+            "source_url": "https://github.com/example/lifecycle",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -201,7 +201,7 @@ async def test_patch_project_lifecycle_rules_unknown_type(
         json={
             "slug": "bad-lifecycle-proj",
             "title": "Bad",
-            "doc_repo": "https://github.com/example/bad",
+            "source_url": "https://github.com/example/bad",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -228,7 +228,7 @@ async def test_patch_project_lifecycle_rules_missing_field(
         json={
             "slug": "missing-field-proj",
             "title": "Missing",
-            "doc_repo": "https://github.com/example/missing",
+            "source_url": "https://github.com/example/missing",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -255,7 +255,7 @@ async def test_patch_project_lifecycle_rules_duplicate_types(
         json={
             "slug": "dup-lifecycle-proj",
             "title": "Dup",
-            "doc_repo": "https://github.com/example/dup",
+            "source_url": "https://github.com/example/dup",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -280,7 +280,7 @@ async def test_delete_project(client: AsyncClient) -> None:
         json={
             "slug": "del-proj",
             "title": "Delete Me",
-            "doc_repo": "https://github.com/example/del",
+            "source_url": "https://github.com/example/del",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -312,7 +312,7 @@ async def test_search_by_slug(client: AsyncClient) -> None:
             json={
                 "slug": slug,
                 "title": title,
-                "doc_repo": f"https://github.com/example/{slug}",
+                "source_url": f"https://github.com/example/{slug}",
             },
             headers=headers,
         )
@@ -345,7 +345,7 @@ async def test_search_by_title(client: AsyncClient) -> None:
             json={
                 "slug": slug,
                 "title": title,
-                "doc_repo": f"https://github.com/example/{slug}",
+                "source_url": f"https://github.com/example/{slug}",
             },
             headers=headers,
         )
@@ -387,7 +387,7 @@ async def test_search_pagination(client: AsyncClient) -> None:
             json={
                 "slug": f"pipeline-{i}",
                 "title": f"Pipeline Project {i}",
-                "doc_repo": f"https://github.com/example/pipeline-{i}",
+                "source_url": f"https://github.com/example/pipeline-{i}",
             },
             headers=headers,
         )
@@ -446,7 +446,7 @@ async def test_search_org_scoping(client: AsyncClient) -> None:
         json={
             "slug": "scoped-proj",
             "title": "Scoped Project",
-            "doc_repo": "https://github.com/example/scoped",
+            "source_url": "https://github.com/example/scoped",
         },
         headers=headers,
     )
@@ -457,7 +457,7 @@ async def test_search_org_scoping(client: AsyncClient) -> None:
         json={
             "slug": "scoped-proj",
             "title": "Scoped Project Other",
-            "doc_repo": "https://github.com/example/scoped-other",
+            "source_url": "https://github.com/example/scoped-other",
         },
         headers=headers,
     )
@@ -483,7 +483,7 @@ async def test_search_excludes_soft_deleted(client: AsyncClient) -> None:
         json={
             "slug": "deleted-proj",
             "title": "Deleted Project",
-            "doc_repo": "https://github.com/example/deleted",
+            "source_url": "https://github.com/example/deleted",
         },
         headers=headers,
     )
@@ -506,7 +506,7 @@ async def test_create_project_duplicate_slug(client: AsyncClient) -> None:
     payload = {
         "slug": "dup-proj",
         "title": "First",
-        "doc_repo": "https://github.com/example/dup",
+        "source_url": "https://github.com/example/dup",
     }
     response = await client.post(
         "/docverse/orgs/proj-org/projects",
@@ -533,7 +533,7 @@ async def test_create_project_has_default_edition(
         json={
             "slug": "default-ed",
             "title": "Default Ed",
-            "doc_repo": "https://github.com/example/default-ed",
+            "source_url": "https://github.com/example/default-ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -568,7 +568,7 @@ async def test_create_project_custom_default_edition(
         json={
             "slug": "custom-ed",
             "title": "Custom Ed",
-            "doc_repo": "https://github.com/example/custom-ed",
+            "source_url": "https://github.com/example/custom-ed",
             "default_edition": {
                 "tracking_mode": "lsst_doc",
                 "title": "Custom Main",
@@ -595,7 +595,7 @@ async def test_get_project_includes_default_edition(
         json={
             "slug": "get-ed-proj",
             "title": "Get Ed Proj",
-            "doc_repo": "https://github.com/example/get-ed",
+            "source_url": "https://github.com/example/get-ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -623,7 +623,7 @@ async def test_list_projects_no_default_edition(
         json={
             "slug": "list-ed-proj",
             "title": "List Ed Proj",
-            "doc_repo": "https://github.com/example/list-ed",
+            "source_url": "https://github.com/example/list-ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -647,7 +647,7 @@ async def test_patch_project_includes_default_edition(
         json={
             "slug": "patch-ed-proj",
             "title": "Patch Ed Proj",
-            "doc_repo": "https://github.com/example/patch-ed",
+            "source_url": "https://github.com/example/patch-ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -693,7 +693,7 @@ async def test_create_project_org_default_edition_config(
         json={
             "slug": "org-proj",
             "title": "Org Proj",
-            "doc_repo": "https://github.com/example/org-proj",
+            "source_url": "https://github.com/example/org-proj",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -734,7 +734,7 @@ async def test_create_project_request_overrides_org_config(
         json={
             "slug": "override-proj",
             "title": "Override Proj",
-            "doc_repo": "https://github.com/example/override",
+            "source_url": "https://github.com/example/override",
             "default_edition": {
                 "tracking_mode": "git_ref",
                 "tracking_params": {"git_ref": "master"},
@@ -756,3 +756,220 @@ async def test_permission_denied_no_auth(client: AsyncClient) -> None:
         "/docverse/orgs/proj-org/projects",
     )
     assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_project_with_github_binding_only(
+    client: AsyncClient,
+) -> None:
+    """POST with ``github`` and no source URL embeds the structured binding."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "gh-only",
+            "title": "GitHub Only",
+            "github": {"owner": "lsst", "repo": "docverse"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["github"] == {
+        "owner": "lsst",
+        "repo": "docverse",
+        "installation_id": None,
+    }
+    assert data["source_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_project_auto_populates_github_from_source_url(
+    client: AsyncClient,
+) -> None:
+    """POST with a github.com source URL populates ``github`` server-side."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "auto-gh",
+            "title": "Auto GH",
+            "source_url": "https://github.com/lsst/auto-gh.git",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["source_url"] == "https://github.com/lsst/auto-gh.git"
+    assert data["github"] == {
+        "owner": "lsst",
+        "repo": "auto-gh",
+        "installation_id": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_project_accepts_agreeing_github_and_source_url(
+    client: AsyncClient,
+) -> None:
+    """POST with agreeing ``source_url`` and ``github`` succeeds."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "agree-proj",
+            "title": "Agree",
+            "source_url": "https://github.com/lsst/agree-proj",
+            "github": {"owner": "lsst", "repo": "agree-proj"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["github"]["owner"] == "lsst"
+    assert data["github"]["repo"] == "agree-proj"
+
+
+@pytest.mark.asyncio
+async def test_create_project_rejects_disagreeing_github_and_source_url(
+    client: AsyncClient,
+) -> None:
+    """POST with disagreeing ``source_url`` and ``github`` fails with 422."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "mismatch-proj",
+            "title": "Mismatch",
+            "source_url": "https://github.com/lsst/one",
+            "github": {"owner": "other", "repo": "two"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_project_non_github_source_url_leaves_github_null(
+    client: AsyncClient,
+) -> None:
+    """POST with a non-GitHub source URL leaves ``github`` NULL."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "gitlab-proj",
+            "title": "GitLab",
+            "source_url": "https://gitlab.com/lsst/gitlab-proj",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["source_url"] == "https://gitlab.com/lsst/gitlab-proj"
+    assert data["github"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_project_without_source_or_github(
+    client: AsyncClient,
+) -> None:
+    """POST without source_url or github creates a project with both NULL."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "bare-proj",
+            "title": "Bare",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["source_url"] is None
+    assert data["github"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_project_rejects_disagreeing_github_and_source_url(
+    client: AsyncClient,
+) -> None:
+    """PATCH with disagreeing ``source_url`` and ``github`` fails with 422."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "patch-mismatch",
+            "title": "Patch Mismatch",
+            "github": {"owner": "lsst", "repo": "patch-mismatch"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    response = await client.patch(
+        "/docverse/orgs/proj-org/projects/patch-mismatch",
+        json={
+            "source_url": "https://github.com/lsst/one",
+            "github": {"owner": "other", "repo": "two"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_project_flips_github_to_non_github(
+    client: AsyncClient,
+) -> None:
+    """PATCH that clears ``github`` and sets a GitLab source URL succeeds."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "flip-proj",
+            "title": "Flip",
+            "github": {"owner": "lsst", "repo": "flip-proj"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    response = await client.patch(
+        "/docverse/orgs/proj-org/projects/flip-proj",
+        json={
+            "github": None,
+            "source_url": "https://gitlab.com/lsst/flip-proj",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["github"] is None
+    assert data["source_url"] == "https://gitlab.com/lsst/flip-proj"
+
+
+@pytest.mark.asyncio
+async def test_patch_project_sets_github_binding(
+    client: AsyncClient,
+) -> None:
+    """PATCH that adds a ``github`` sub-object writes structured columns."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "add-gh",
+            "title": "Add GH",
+            "source_url": "https://gitlab.com/lsst/add-gh",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    response = await client.patch(
+        "/docverse/orgs/proj-org/projects/add-gh",
+        json={"github": {"owner": "lsst", "repo": "add-gh"}},
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["github"] == {
+        "owner": "lsst",
+        "repo": "add-gh",
+        "installation_id": None,
+    }
+    assert data["source_url"] == "https://gitlab.com/lsst/add-gh"

--- a/tests/handlers/projects_test.py
+++ b/tests/handlers/projects_test.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+import structlog
 from httpx import AsyncClient
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import select
 
+from docverse.dbschema.project import SqlProject
+from docverse.dependencies.context import context_dependency
+from docverse.storage.project_store import ProjectStore
 from tests.conftest import seed_org_with_admin
 
 
@@ -779,6 +785,11 @@ async def test_create_project_with_github_binding_only(
         "owner": "lsst",
         "repo": "docverse",
         "installation_id": None,
+        # installation_id is NULL -> derived status is not_installed;
+        # the test app leaves the GitHub App feature unconfigured so
+        # app_url is absent.
+        "installation_status": "not_installed",
+        "app_url": None,
     }
     # source_url is derived from the binding, not stored separately.
     assert data["source_url"] == "https://github.com/lsst/docverse"
@@ -952,6 +963,8 @@ async def test_patch_project_sets_github_binding_drops_source_url(
         "owner": "lsst",
         "repo": "add-gh",
         "installation_id": None,
+        "installation_status": "not_installed",
+        "app_url": None,
     }
     # The GitLab URL is dropped; source_url is derived from the binding.
     assert data["source_url"] == "https://github.com/lsst/add-gh"
@@ -983,5 +996,67 @@ async def test_patch_project_source_url_null_leaves_github_intact(
         "owner": "lsst",
         "repo": "keep-gh",
         "installation_id": None,
+        "installation_status": "not_installed",
+        "app_url": None,
     }
     assert data["source_url"] == "https://github.com/lsst/keep-gh"
+
+
+@pytest.mark.asyncio
+async def test_project_github_installed_status_and_app_url(
+    client: AsyncClient,
+) -> None:
+    """``installation_status`` flips to installed once the id is set.
+
+    A NULL ``github_installation_id`` derives ``not_installed`` (covered
+    by the create/patch tests above). Here we persist an installation id
+    out-of-band — as the resolve worker or ``installation`` webhook would
+    — and stamp the captured GitHub App install-page URL on the shared
+    context, then assert both surface on the GET response.
+    """
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "gh-installed",
+            "title": "GH Installed",
+            "github": {"owner": "lsst", "repo": "gh-installed"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+
+    # Persist an installation id the way the resolve worker would.
+    logger = structlog.get_logger("docverse")
+    async for session in db_session_dependency():
+        async with session.begin():
+            result = await session.execute(
+                select(SqlProject.id).where(SqlProject.slug == "gh-installed")
+            )
+            project_id = result.scalar_one()
+            store = ProjectStore(session=session, logger=logger)
+            updated = await store.update_github_metadata(
+                project_id=project_id,
+                expected_owner="lsst",
+                expected_repo="gh-installed",
+                installation_id=42,
+                owner_id=111,
+                repo_id=222,
+            )
+            await session.commit()
+        assert updated
+        break
+
+    # Stand in for the startup ``GET /app`` html_url capture.
+    context_dependency.set_github_app_html_url(
+        "https://github.com/apps/docverse"
+    )
+
+    response = await client.get(
+        "/docverse/orgs/proj-org/projects/gh-installed",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 200
+    binding = response.json()["github"]
+    assert binding["installation_id"] == 42
+    assert binding["installation_status"] == "installed"
+    assert binding["app_url"] == "https://github.com/apps/docverse"

--- a/tests/handlers/projects_test.py
+++ b/tests/handlers/projects_test.py
@@ -23,7 +23,7 @@ async def test_create_project(client: AsyncClient) -> None:
         json={
             "slug": "my-docs",
             "title": "My Docs",
-            "source_url": "https://github.com/example/docs",
+            "source_url": "https://example.com/example/docs",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -50,7 +50,7 @@ async def test_create_project_with_lifecycle_rules(
         json={
             "slug": "lifecycle-create",
             "title": "Lifecycle Create",
-            "source_url": "https://github.com/example/lifecycle-create",
+            "source_url": "https://example.com/example/lifecycle-create",
             "lifecycle_rules": rules,
         },
         headers={"X-Auth-Request-User": "testuser"},
@@ -74,7 +74,7 @@ async def test_list_projects(client: AsyncClient) -> None:
         json={
             "slug": "proj-aa",
             "title": "A",
-            "source_url": "https://github.com/example/a",
+            "source_url": "https://example.com/example/a",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -103,7 +103,7 @@ async def test_get_project(client: AsyncClient) -> None:
         json={
             "slug": "get-proj",
             "title": "Get Proj",
-            "source_url": "https://github.com/example/get",
+            "source_url": "https://example.com/example/get",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -138,7 +138,7 @@ async def test_update_project(client: AsyncClient) -> None:
         json={
             "slug": "patch-proj",
             "title": "Original",
-            "source_url": "https://github.com/example/patch",
+            "source_url": "https://example.com/example/patch",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -162,7 +162,7 @@ async def test_patch_project_lifecycle_rules_valid(
         json={
             "slug": "lifecycle-proj",
             "title": "Lifecycle",
-            "source_url": "https://github.com/example/lifecycle",
+            "source_url": "https://example.com/example/lifecycle",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -201,7 +201,7 @@ async def test_patch_project_lifecycle_rules_unknown_type(
         json={
             "slug": "bad-lifecycle-proj",
             "title": "Bad",
-            "source_url": "https://github.com/example/bad",
+            "source_url": "https://example.com/example/bad",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -228,7 +228,7 @@ async def test_patch_project_lifecycle_rules_missing_field(
         json={
             "slug": "missing-field-proj",
             "title": "Missing",
-            "source_url": "https://github.com/example/missing",
+            "source_url": "https://example.com/example/missing",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -255,7 +255,7 @@ async def test_patch_project_lifecycle_rules_duplicate_types(
         json={
             "slug": "dup-lifecycle-proj",
             "title": "Dup",
-            "source_url": "https://github.com/example/dup",
+            "source_url": "https://example.com/example/dup",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -280,7 +280,7 @@ async def test_delete_project(client: AsyncClient) -> None:
         json={
             "slug": "del-proj",
             "title": "Delete Me",
-            "source_url": "https://github.com/example/del",
+            "source_url": "https://example.com/example/del",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -312,7 +312,7 @@ async def test_search_by_slug(client: AsyncClient) -> None:
             json={
                 "slug": slug,
                 "title": title,
-                "source_url": f"https://github.com/example/{slug}",
+                "source_url": f"https://example.com/example/{slug}",
             },
             headers=headers,
         )
@@ -345,7 +345,7 @@ async def test_search_by_title(client: AsyncClient) -> None:
             json={
                 "slug": slug,
                 "title": title,
-                "source_url": f"https://github.com/example/{slug}",
+                "source_url": f"https://example.com/example/{slug}",
             },
             headers=headers,
         )
@@ -387,7 +387,7 @@ async def test_search_pagination(client: AsyncClient) -> None:
             json={
                 "slug": f"pipeline-{i}",
                 "title": f"Pipeline Project {i}",
-                "source_url": f"https://github.com/example/pipeline-{i}",
+                "source_url": f"https://example.com/example/pipeline-{i}",
             },
             headers=headers,
         )
@@ -446,7 +446,7 @@ async def test_search_org_scoping(client: AsyncClient) -> None:
         json={
             "slug": "scoped-proj",
             "title": "Scoped Project",
-            "source_url": "https://github.com/example/scoped",
+            "source_url": "https://example.com/example/scoped",
         },
         headers=headers,
     )
@@ -457,7 +457,7 @@ async def test_search_org_scoping(client: AsyncClient) -> None:
         json={
             "slug": "scoped-proj",
             "title": "Scoped Project Other",
-            "source_url": "https://github.com/example/scoped-other",
+            "source_url": "https://example.com/example/scoped-other",
         },
         headers=headers,
     )
@@ -483,7 +483,7 @@ async def test_search_excludes_soft_deleted(client: AsyncClient) -> None:
         json={
             "slug": "deleted-proj",
             "title": "Deleted Project",
-            "source_url": "https://github.com/example/deleted",
+            "source_url": "https://example.com/example/deleted",
         },
         headers=headers,
     )
@@ -506,7 +506,7 @@ async def test_create_project_duplicate_slug(client: AsyncClient) -> None:
     payload = {
         "slug": "dup-proj",
         "title": "First",
-        "source_url": "https://github.com/example/dup",
+        "source_url": "https://example.com/example/dup",
     }
     response = await client.post(
         "/docverse/orgs/proj-org/projects",
@@ -533,7 +533,7 @@ async def test_create_project_has_default_edition(
         json={
             "slug": "default-ed",
             "title": "Default Ed",
-            "source_url": "https://github.com/example/default-ed",
+            "source_url": "https://example.com/example/default-ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -568,7 +568,7 @@ async def test_create_project_custom_default_edition(
         json={
             "slug": "custom-ed",
             "title": "Custom Ed",
-            "source_url": "https://github.com/example/custom-ed",
+            "source_url": "https://example.com/example/custom-ed",
             "default_edition": {
                 "tracking_mode": "lsst_doc",
                 "title": "Custom Main",
@@ -595,7 +595,7 @@ async def test_get_project_includes_default_edition(
         json={
             "slug": "get-ed-proj",
             "title": "Get Ed Proj",
-            "source_url": "https://github.com/example/get-ed",
+            "source_url": "https://example.com/example/get-ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -623,7 +623,7 @@ async def test_list_projects_no_default_edition(
         json={
             "slug": "list-ed-proj",
             "title": "List Ed Proj",
-            "source_url": "https://github.com/example/list-ed",
+            "source_url": "https://example.com/example/list-ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -647,7 +647,7 @@ async def test_patch_project_includes_default_edition(
         json={
             "slug": "patch-ed-proj",
             "title": "Patch Ed Proj",
-            "source_url": "https://github.com/example/patch-ed",
+            "source_url": "https://example.com/example/patch-ed",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -693,7 +693,7 @@ async def test_create_project_org_default_edition_config(
         json={
             "slug": "org-proj",
             "title": "Org Proj",
-            "source_url": "https://github.com/example/org-proj",
+            "source_url": "https://example.com/example/org-proj",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -734,7 +734,7 @@ async def test_create_project_request_overrides_org_config(
         json={
             "slug": "override-proj",
             "title": "Override Proj",
-            "source_url": "https://github.com/example/override",
+            "source_url": "https://example.com/example/override",
             "default_edition": {
                 "tracking_mode": "git_ref",
                 "tracking_params": {"git_ref": "master"},
@@ -762,7 +762,7 @@ async def test_permission_denied_no_auth(client: AsyncClient) -> None:
 async def test_create_project_with_github_binding_only(
     client: AsyncClient,
 ) -> None:
-    """POST with ``github`` and no source URL embeds the structured binding."""
+    """POST with ``github`` derives the source_url from the binding."""
     await _setup(client)
     response = await client.post(
         "/docverse/orgs/proj-org/projects",
@@ -780,69 +780,45 @@ async def test_create_project_with_github_binding_only(
         "repo": "docverse",
         "installation_id": None,
     }
-    assert data["source_url"] is None
+    # source_url is derived from the binding, not stored separately.
+    assert data["source_url"] == "https://github.com/lsst/docverse"
 
 
 @pytest.mark.asyncio
-async def test_create_project_auto_populates_github_from_source_url(
+async def test_create_project_rejects_github_source_url(
     client: AsyncClient,
 ) -> None:
-    """POST with a github.com source URL populates ``github`` server-side."""
+    """POST with a github.com ``source_url`` fails with 422 (Rule A).
+
+    The breaking change from PRD #346: a github.com URL must be supplied
+    through the structured ``github`` field, not ``source_url``.
+    """
     await _setup(client)
     response = await client.post(
         "/docverse/orgs/proj-org/projects",
         json={
-            "slug": "auto-gh",
-            "title": "Auto GH",
-            "source_url": "https://github.com/lsst/auto-gh.git",
+            "slug": "gh-url",
+            "title": "GH URL",
+            "source_url": "https://github.com/lsst/gh-url",
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
-    assert response.status_code == 201
-    data = response.json()
-    assert data["source_url"] == "https://github.com/lsst/auto-gh.git"
-    assert data["github"] == {
-        "owner": "lsst",
-        "repo": "auto-gh",
-        "installation_id": None,
-    }
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio
-async def test_create_project_accepts_agreeing_github_and_source_url(
+async def test_create_project_rejects_source_url_and_github_together(
     client: AsyncClient,
 ) -> None:
-    """POST with agreeing ``source_url`` and ``github`` succeeds."""
+    """POST with both ``source_url`` and ``github`` fails with 422 (Rule B)."""
     await _setup(client)
     response = await client.post(
         "/docverse/orgs/proj-org/projects",
         json={
-            "slug": "agree-proj",
-            "title": "Agree",
-            "source_url": "https://github.com/lsst/agree-proj",
-            "github": {"owner": "lsst", "repo": "agree-proj"},
-        },
-        headers={"X-Auth-Request-User": "testuser"},
-    )
-    assert response.status_code == 201
-    data = response.json()
-    assert data["github"]["owner"] == "lsst"
-    assert data["github"]["repo"] == "agree-proj"
-
-
-@pytest.mark.asyncio
-async def test_create_project_rejects_disagreeing_github_and_source_url(
-    client: AsyncClient,
-) -> None:
-    """POST with disagreeing ``source_url`` and ``github`` fails with 422."""
-    await _setup(client)
-    response = await client.post(
-        "/docverse/orgs/proj-org/projects",
-        json={
-            "slug": "mismatch-proj",
-            "title": "Mismatch",
-            "source_url": "https://github.com/lsst/one",
-            "github": {"owner": "other", "repo": "two"},
+            "slug": "both-proj",
+            "title": "Both",
+            "source_url": "https://gitlab.com/lsst/both",
+            "github": {"owner": "lsst", "repo": "both"},
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
@@ -891,24 +867,24 @@ async def test_create_project_without_source_or_github(
 
 
 @pytest.mark.asyncio
-async def test_patch_project_rejects_disagreeing_github_and_source_url(
+async def test_patch_project_rejects_source_url_and_github_together(
     client: AsyncClient,
 ) -> None:
-    """PATCH with disagreeing ``source_url`` and ``github`` fails with 422."""
+    """PATCH with both source_url and github fails with 422 (Rule B)."""
     await _setup(client)
     await client.post(
         "/docverse/orgs/proj-org/projects",
         json={
-            "slug": "patch-mismatch",
-            "title": "Patch Mismatch",
-            "github": {"owner": "lsst", "repo": "patch-mismatch"},
+            "slug": "patch-both",
+            "title": "Patch Both",
+            "github": {"owner": "lsst", "repo": "patch-both"},
         },
         headers={"X-Auth-Request-User": "testuser"},
     )
     response = await client.patch(
-        "/docverse/orgs/proj-org/projects/patch-mismatch",
+        "/docverse/orgs/proj-org/projects/patch-both",
         json={
-            "source_url": "https://github.com/lsst/one",
+            "source_url": "https://gitlab.com/lsst/patch-both",
             "github": {"owner": "other", "repo": "two"},
         },
         headers={"X-Auth-Request-User": "testuser"},
@@ -946,10 +922,15 @@ async def test_patch_project_flips_github_to_non_github(
 
 
 @pytest.mark.asyncio
-async def test_patch_project_sets_github_binding(
+async def test_patch_project_sets_github_binding_drops_source_url(
     client: AsyncClient,
 ) -> None:
-    """PATCH that adds a ``github`` sub-object writes structured columns."""
+    """PATCH adding ``github`` writes the binding and drops the stored URL.
+
+    The project starts non-GitHub (a GitLab ``source_url``); adding the
+    binding nulls that column, so the response source_url is now derived
+    from the binding rather than echoing the dropped GitLab URL.
+    """
     await _setup(client)
     await client.post(
         "/docverse/orgs/proj-org/projects",
@@ -972,4 +953,35 @@ async def test_patch_project_sets_github_binding(
         "repo": "add-gh",
         "installation_id": None,
     }
-    assert data["source_url"] == "https://gitlab.com/lsst/add-gh"
+    # The GitLab URL is dropped; source_url is derived from the binding.
+    assert data["source_url"] == "https://github.com/lsst/add-gh"
+
+
+@pytest.mark.asyncio
+async def test_patch_project_source_url_null_leaves_github_intact(
+    client: AsyncClient,
+) -> None:
+    """PATCH ``source_url: null`` is a no-op for a GitHub-bound project."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "keep-gh",
+            "title": "Keep GH",
+            "github": {"owner": "lsst", "repo": "keep-gh"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    response = await client.patch(
+        "/docverse/orgs/proj-org/projects/keep-gh",
+        json={"source_url": None},
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["github"] == {
+        "owner": "lsst",
+        "repo": "keep-gh",
+        "installation_id": None,
+    }
+    assert data["source_url"] == "https://github.com/lsst/keep-gh"

--- a/tests/handlers/superadmin_test.py
+++ b/tests/handlers/superadmin_test.py
@@ -51,7 +51,7 @@ async def test_superadmin_can_create_project(
         json={
             "slug": "my-proj",
             "title": "My Project",
-            "doc_repo": "https://github.com/example/proj",
+            "source_url": "https://github.com/example/proj",
         },
         headers=SUPERADMIN_HEADERS,
     )
@@ -80,7 +80,7 @@ async def test_superadmin_overrides_reader_membership(
         json={
             "slug": "sa-override-proj",
             "title": "Override Project",
-            "doc_repo": "https://github.com/example/override",
+            "source_url": "https://github.com/example/override",
         },
         headers=SUPERADMIN_HEADERS,
     )

--- a/tests/handlers/superadmin_test.py
+++ b/tests/handlers/superadmin_test.py
@@ -51,7 +51,7 @@ async def test_superadmin_can_create_project(
         json={
             "slug": "my-proj",
             "title": "My Project",
-            "source_url": "https://github.com/example/proj",
+            "source_url": "https://example.com/example/proj",
         },
         headers=SUPERADMIN_HEADERS,
     )
@@ -80,7 +80,7 @@ async def test_superadmin_overrides_reader_membership(
         json={
             "slug": "sa-override-proj",
             "title": "Override Project",
-            "source_url": "https://github.com/example/override",
+            "source_url": "https://example.com/example/override",
         },
         headers=SUPERADMIN_HEADERS,
     )

--- a/tests/services/dashboard/context_test.py
+++ b/tests/services/dashboard/context_test.py
@@ -73,7 +73,7 @@ async def _seed_org_and_project(
         data=ProjectCreate(
             slug=project_slug,
             title="Context Project",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     return org, project

--- a/tests/services/dashboard/context_test.py
+++ b/tests/services/dashboard/context_test.py
@@ -73,7 +73,7 @@ async def _seed_org_and_project(
         data=ProjectCreate(
             slug=project_slug,
             title="Context Project",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     return org, project

--- a/tests/services/dashboard/context_test.py
+++ b/tests/services/dashboard/context_test.py
@@ -541,7 +541,7 @@ def _make_project() -> Project:
         slug="proj",
         title="Project",
         org_id=1,
-        doc_repo="https://example.com/repo",
+        source_url="https://example.com/repo",
         slug_rewrite_rules=None,
         lifecycle_rules=None,
         date_created=now,

--- a/tests/services/dashboard/enqueue_test.py
+++ b/tests/services/dashboard/enqueue_test.py
@@ -56,7 +56,7 @@ async def _seed_org_with_project(
         data=ProjectCreate(
             slug=project_slug,
             title=f"Project {project_slug}",
-            source_url=f"https://github.com/example/{project_slug}",
+            source_url=f"https://example.com/example/{project_slug}",
         ),
     )
     return org.id, project.id
@@ -263,7 +263,7 @@ async def test_enqueue_for_org_filters_skipped_projects(
             data=ProjectCreate(
                 slug="keeper",
                 title="Keeper",
-                source_url="https://github.com/example/keeper",
+                source_url="https://example.com/example/keeper",
             ),
         )
         already_active = await proj_store.create(
@@ -271,7 +271,7 @@ async def test_enqueue_for_org_filters_skipped_projects(
             data=ProjectCreate(
                 slug="already",
                 title="Already",
-                source_url="https://github.com/example/already",
+                source_url="https://example.com/example/already",
             ),
         )
         await db_session.commit()

--- a/tests/services/dashboard/enqueue_test.py
+++ b/tests/services/dashboard/enqueue_test.py
@@ -56,7 +56,7 @@ async def _seed_org_with_project(
         data=ProjectCreate(
             slug=project_slug,
             title=f"Project {project_slug}",
-            doc_repo=f"https://github.com/example/{project_slug}",
+            source_url=f"https://github.com/example/{project_slug}",
         ),
     )
     return org.id, project.id
@@ -263,7 +263,7 @@ async def test_enqueue_for_org_filters_skipped_projects(
             data=ProjectCreate(
                 slug="keeper",
                 title="Keeper",
-                doc_repo="https://github.com/example/keeper",
+                source_url="https://github.com/example/keeper",
             ),
         )
         already_active = await proj_store.create(
@@ -271,7 +271,7 @@ async def test_enqueue_for_org_filters_skipped_projects(
             data=ProjectCreate(
                 slug="already",
                 title="Already",
-                doc_repo="https://github.com/example/already",
+                source_url="https://github.com/example/already",
             ),
         )
         await db_session.commit()

--- a/tests/services/dashboard/publisher_test.py
+++ b/tests/services/dashboard/publisher_test.py
@@ -91,7 +91,7 @@ async def test_publisher_uploads_dashboard_and_switcher(
             data=ProjectCreate(
                 slug="pub-proj",
                 title="Pub Project",
-                source_url="https://github.com/example/pub",
+                source_url="https://example.com/example/pub",
             ),
         )
         await edition_store.create_internal(
@@ -194,7 +194,7 @@ async def test_publisher_writes_per_edition_json_files(
             data=ProjectCreate(
                 slug="per-ed-proj",
                 title="Per Ed Project",
-                source_url="https://github.com/example/per-ed",
+                source_url="https://example.com/example/per-ed",
             ),
         )
         await edition_store.create_internal(
@@ -266,7 +266,7 @@ async def test_publisher_handles_empty_project(
             data=ProjectCreate(
                 slug="empty-pub-proj",
                 title="Empty Project",
-                source_url="https://github.com/example/empty",
+                source_url="https://example.com/example/empty",
             ),
         )
         await db_session.commit()
@@ -350,7 +350,7 @@ async def test_publisher_resolve_template_returns_builtin_when_unbound(
             data=ProjectCreate(
                 slug="resolve-builtin-proj",
                 title="Resolve Builtin Project",
-                source_url="https://github.com/example/resolve-builtin",
+                source_url="https://example.com/example/resolve-builtin",
             ),
         )
         await db_session.commit()
@@ -401,7 +401,7 @@ async def test_publisher_render_and_upload_uses_provided_resolved_template(
             data=ProjectCreate(
                 slug="render-provided-proj",
                 title="Render Provided Project",
-                source_url="https://github.com/example/render-provided",
+                source_url="https://example.com/example/render-provided",
             ),
         )
         template_result = await template_store.upsert(
@@ -488,7 +488,7 @@ async def test_publisher_logs_builtin_template_origin(
             data=ProjectCreate(
                 slug="origin-builtin-proj",
                 title="Origin Builtin Project",
-                source_url="https://github.com/example/origin-builtin",
+                source_url="https://example.com/example/origin-builtin",
             ),
         )
         await db_session.commit()
@@ -545,7 +545,7 @@ async def test_publisher_logs_github_template_origin(
             data=ProjectCreate(
                 slug="origin-github-proj",
                 title="Origin GitHub Project",
-                source_url="https://github.com/example/origin-github",
+                source_url="https://example.com/example/origin-github",
             ),
         )
         template_result = await template_store.upsert(

--- a/tests/services/dashboard/publisher_test.py
+++ b/tests/services/dashboard/publisher_test.py
@@ -91,7 +91,7 @@ async def test_publisher_uploads_dashboard_and_switcher(
             data=ProjectCreate(
                 slug="pub-proj",
                 title="Pub Project",
-                doc_repo="https://github.com/example/pub",
+                source_url="https://github.com/example/pub",
             ),
         )
         await edition_store.create_internal(
@@ -194,7 +194,7 @@ async def test_publisher_writes_per_edition_json_files(
             data=ProjectCreate(
                 slug="per-ed-proj",
                 title="Per Ed Project",
-                doc_repo="https://github.com/example/per-ed",
+                source_url="https://github.com/example/per-ed",
             ),
         )
         await edition_store.create_internal(
@@ -266,7 +266,7 @@ async def test_publisher_handles_empty_project(
             data=ProjectCreate(
                 slug="empty-pub-proj",
                 title="Empty Project",
-                doc_repo="https://github.com/example/empty",
+                source_url="https://github.com/example/empty",
             ),
         )
         await db_session.commit()
@@ -350,7 +350,7 @@ async def test_publisher_resolve_template_returns_builtin_when_unbound(
             data=ProjectCreate(
                 slug="resolve-builtin-proj",
                 title="Resolve Builtin Project",
-                doc_repo="https://github.com/example/resolve-builtin",
+                source_url="https://github.com/example/resolve-builtin",
             ),
         )
         await db_session.commit()
@@ -401,7 +401,7 @@ async def test_publisher_render_and_upload_uses_provided_resolved_template(
             data=ProjectCreate(
                 slug="render-provided-proj",
                 title="Render Provided Project",
-                doc_repo="https://github.com/example/render-provided",
+                source_url="https://github.com/example/render-provided",
             ),
         )
         template_result = await template_store.upsert(
@@ -488,7 +488,7 @@ async def test_publisher_logs_builtin_template_origin(
             data=ProjectCreate(
                 slug="origin-builtin-proj",
                 title="Origin Builtin Project",
-                doc_repo="https://github.com/example/origin-builtin",
+                source_url="https://github.com/example/origin-builtin",
             ),
         )
         await db_session.commit()
@@ -545,7 +545,7 @@ async def test_publisher_logs_github_template_origin(
             data=ProjectCreate(
                 slug="origin-github-proj",
                 title="Origin GitHub Project",
-                doc_repo="https://github.com/example/origin-github",
+                source_url="https://github.com/example/origin-github",
             ),
         )
         template_result = await template_store.upsert(

--- a/tests/services/dashboard/renderers_test.py
+++ b/tests/services/dashboard/renderers_test.py
@@ -95,7 +95,7 @@ def _make_context(
         project=ProjectContext(
             slug="proj",
             title="A Project",
-            source_repo_url="https://github.com/example/proj",
+            source_repo_url="https://example.com/example/proj",
             published_url="https://proj.example.com/",
         ),
         editions=EditionsContext(

--- a/tests/services/dashboard_templates/fanout_test.py
+++ b/tests/services/dashboard_templates/fanout_test.py
@@ -77,7 +77,7 @@ async def _seed_org_with_projects(
             data=ProjectCreate(
                 slug=slug,
                 title=f"Project {slug}",
-                doc_repo=f"https://github.com/example/{slug}",
+                source_url=f"https://github.com/example/{slug}",
             ),
         )
         project_ids.append(project.id)

--- a/tests/services/dashboard_templates/fanout_test.py
+++ b/tests/services/dashboard_templates/fanout_test.py
@@ -77,7 +77,7 @@ async def _seed_org_with_projects(
             data=ProjectCreate(
                 slug=slug,
                 title=f"Project {slug}",
-                source_url=f"https://github.com/example/{slug}",
+                source_url=f"https://example.com/example/{slug}",
             ),
         )
         project_ids.append(project.id)

--- a/tests/services/dashboard_templates/installation_processor_test.py
+++ b/tests/services/dashboard_templates/installation_processor_test.py
@@ -8,7 +8,8 @@ import pytest
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from docverse.client.models import OrganizationCreate
+from docverse.client.models import OrganizationCreate, ProjectCreate
+from docverse.client.models.projects import ProjectGitHubBindingCreate
 from docverse.services.dashboard_templates.installation_processor import (
     INSTALLATION_DELETED_REASON,
     INSTALLATION_SUSPENDED_REASON,
@@ -19,6 +20,7 @@ from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
 )
 from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
 
 
 def _logger() -> structlog.stdlib.BoundLogger:
@@ -30,6 +32,7 @@ def _make_processor(session: AsyncSession) -> InstallationEventProcessor:
         binding_store=DashboardGitHubTemplateBindingStore(
             session=session, logger=_logger()
         ),
+        project_store=ProjectStore(session=session, logger=_logger()),
         logger=_logger(),
     )
 
@@ -83,6 +86,34 @@ def _installation_payload(
         },
         "repositories": [],
     }
+
+
+async def _seed_project(
+    session: AsyncSession,
+    *,
+    org_id: int,
+    slug: str,
+    github_owner: str | None,
+    github_repo: str | None,
+) -> int:
+    """Seed a project with optional structured GitHub coordinates."""
+    store = ProjectStore(session=session, logger=_logger())
+    binding = (
+        ProjectGitHubBindingCreate(owner=github_owner, repo=github_repo)
+        if github_owner is not None and github_repo is not None
+        else None
+    )
+    project = await store.create(
+        org_id=org_id,
+        data=ProjectCreate(
+            slug=slug,
+            title=f"Project {slug}",
+            github=binding,
+        ),
+        github_owner=github_owner,
+        github_repo=github_repo,
+    )
+    return project.id
 
 
 @pytest.mark.asyncio
@@ -283,3 +314,260 @@ async def test_installation_event_does_not_touch_other_installations(
     assert binding is not None
     assert binding.last_sync_status == "pending"
     assert binding.last_sync_error is None
+
+
+def _installation_created_payload(
+    *,
+    installation_id: int = 99,
+    owner: str = "acme",
+    owner_id: int = 999,
+    repos: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build an ``installation.created`` payload with seeded repositories."""
+    return {
+        "action": "created",
+        "installation": {
+            "id": installation_id,
+            "account": {"login": owner, "id": owner_id},
+        },
+        "repositories": repos or [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_installation_created_backfills_project_installation_id(
+    db_session: AsyncSession,
+) -> None:
+    """``installation.created`` writes the three github_*_id columns.
+
+    Reproduces the post-install steady state of PRD #346 user story 12:
+    an admin installed the Docverse App on a repo that already has a
+    Docverse project bound to it. The project row's three opportunistic
+    id columns are populated from the webhook payload alone, without a
+    follow-up GitHub API round-trip.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-create-backfill")
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner="acme",
+            github_repo="templates",
+        )
+        await db_session.commit()
+
+    payload = _installation_created_payload(
+        installation_id=42,
+        owner="acme",
+        owner_id=999,
+        repos=[
+            {
+                "id": 12345,
+                "name": "templates",
+                "full_name": "acme/templates",
+            }
+        ],
+    )
+
+    async with db_session.begin():
+        await _make_processor(db_session).process(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert project is not None
+    assert project.github_installation_id == 42
+    assert project.github_owner_id == 999
+    assert project.github_repo_id == 12345
+
+
+@pytest.mark.asyncio
+async def test_installation_created_ignores_non_matching_repo(
+    db_session: AsyncSession,
+) -> None:
+    """Projects whose owner/repo do not match the payload are untouched.
+
+    The webhook fires once for every Docverse-App installation, not
+    once per project; a payload covering ``acme/other`` must not flip
+    the columns on a project bound to ``acme/templates``.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-create-no-match")
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner="acme",
+            github_repo="templates",
+        )
+        await db_session.commit()
+
+    payload = _installation_created_payload(
+        installation_id=42,
+        owner="acme",
+        owner_id=999,
+        repos=[
+            {
+                "id": 88888,
+                "name": "other",
+                "full_name": "acme/other",
+            }
+        ],
+    )
+
+    async with db_session.begin():
+        await _make_processor(db_session).process(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert project is not None
+    assert project.github_installation_id is None
+    assert project.github_owner_id is None
+    assert project.github_repo_id is None
+
+
+@pytest.mark.asyncio
+async def test_installation_created_matches_case_insensitive(
+    db_session: AsyncSession,
+) -> None:
+    """Owner/repo matching is case-insensitive (GitHub canonicalisation).
+
+    The seeded project may have been registered against ``Acme/Docs``
+    while GitHub delivers ``acme/docs`` in the payload. The case-
+    insensitive index on ``(lower(github_owner), lower(github_repo))``
+    is what makes the webhook lookup robust.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-create-case")
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner="Acme",
+            github_repo="Templates",
+        )
+        await db_session.commit()
+
+    payload = _installation_created_payload(
+        repos=[
+            {
+                "id": 12345,
+                "name": "templates",
+                "full_name": "acme/templates",
+            }
+        ],
+    )
+
+    async with db_session.begin():
+        await _make_processor(db_session).process(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert project is not None
+    assert project.github_installation_id == 99
+    assert project.github_repo_id == 12345
+
+
+@pytest.mark.asyncio
+async def test_installation_repositories_added_backfills_projects(
+    db_session: AsyncSession,
+) -> None:
+    """``installation_repositories.added`` backfills like ``installation``.
+
+    An operator can scope an existing app installation to new repos
+    after the fact; that path lands as ``installation_repositories
+    .added`` rather than a fresh ``installation.created``. Both event
+    shapes must end up in the same column-write contract.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-repos-added")
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner="acme",
+            github_repo="templates",
+        )
+        await db_session.commit()
+
+    payload = {
+        "action": "added",
+        "installation": {
+            "id": 42,
+            "account": {"login": "acme", "id": 999},
+        },
+        "repositories_added": [
+            {
+                "id": 12345,
+                "name": "templates",
+                "full_name": "acme/templates",
+            }
+        ],
+    }
+
+    async with db_session.begin():
+        await _make_processor(db_session).process_installation_repositories(
+            payload
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert project is not None
+    assert project.github_installation_id == 42
+    assert project.github_owner_id == 999
+    assert project.github_repo_id == 12345
+
+
+@pytest.mark.asyncio
+async def test_installation_created_does_not_touch_non_github_project(
+    db_session: AsyncSession,
+) -> None:
+    """A project without ``github_owner``/``github_repo`` stays NULL.
+
+    Non-GitHub projects (story 14) have NULL in the structured columns;
+    the case-insensitive comparison never matches them, so no row is
+    accidentally bound to an installation that has no claim on it.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "install-non-github")
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner=None,
+            github_repo=None,
+        )
+        await db_session.commit()
+
+    payload = _installation_created_payload(
+        repos=[
+            {
+                "id": 12345,
+                "name": "templates",
+                "full_name": "acme/templates",
+            }
+        ],
+    )
+
+    async with db_session.begin():
+        await _make_processor(db_session).process(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert project is not None
+    assert project.github_installation_id is None

--- a/tests/services/dashboard_templates/rename_processor_test.py
+++ b/tests/services/dashboard_templates/rename_processor_test.py
@@ -53,7 +53,6 @@ async def _seed_project(
     github_repo: str,
     github_owner_id: int | None = None,
     github_repo_id: int | None = None,
-    source_url: str | None = None,
 ) -> int:
     """Seed a project carrying structured GitHub coordinates."""
     store = ProjectStore(session=session, logger=_logger())
@@ -63,7 +62,6 @@ async def _seed_project(
         data=ProjectCreate(
             slug=slug,
             title=f"Project {slug}",
-            source_url=source_url,
             github=binding,
         ),
         github_owner=github_owner,
@@ -673,13 +671,13 @@ async def test_repository_renamed_no_id_match_no_writes(
 async def test_repository_renamed_updates_project_keyed_by_repo_id(
     db_session: AsyncSession,
 ) -> None:
-    """A repo rename rewrites ``github_repo`` + ``source_url`` on projects.
+    """A repo rename flips ``github_repo`` on the project keyed by repo id.
 
     User story 17: renaming the GitHub repository updates both the
-    dashboard-template binding and the project row. The project
-    structured columns are the source of truth; ``source_url`` is the
-    cosmetic URL that surfaces in admin tooling and must follow the
-    canonical owner/repo so the rendered link still resolves on GitHub.
+    dashboard-template binding and the project row. The structured
+    columns are the single source of truth; the operator-visible source
+    URL is derived from them on read, so there is no stored URL to keep
+    in sync.
     """
     async with db_session.begin():
         org_id = await _seed_org(db_session, "rename-project-by-id")
@@ -691,7 +689,6 @@ async def test_repository_renamed_updates_project_keyed_by_repo_id(
             github_repo="old-name",
             github_owner_id=999,
             github_repo_id=12345,
-            source_url="https://github.com/acme/old-name",
         )
         await db_session.commit()
 
@@ -716,119 +713,21 @@ async def test_repository_renamed_updates_project_keyed_by_repo_id(
     assert project.github_repo == "new-name"
     assert project.github_owner == "acme"
     assert project.github_repo_id == 12345
-    assert project.source_url == "https://github.com/acme/new-name"
-
-
-@pytest.mark.asyncio
-async def test_repository_renamed_preserves_source_url_path_tail(
-    db_session: AsyncSession,
-) -> None:
-    """Source URL deep paths survive the owner/repo rewrite.
-
-    ``source_url`` may carry a path tail like ``/tree/main/docs`` for
-    operators whose docs live in a subdirectory of the repo (PRD #346
-    in the dashboard-template world reuses this shape, and #381's
-    Project response already documents the deep-path case). The
-    rename rewrites only the first two path segments so the
-    operator-visible link still points at the same subtree under the
-    new repo name.
-    """
-    async with db_session.begin():
-        org_id = await _seed_org(db_session, "rename-project-path")
-        project_id = await _seed_project(
-            db_session,
-            org_id=org_id,
-            slug="docs",
-            github_owner="acme",
-            github_repo="old-name",
-            github_owner_id=999,
-            github_repo_id=12345,
-            source_url="https://github.com/acme/old-name/tree/main/docs",
-        )
-        await db_session.commit()
-
-    payload = _repository_renamed_payload(
-        repo_id=12345,
-        owner="acme",
-        owner_id=999,
-        new_name="new-name",
-        old_name="old-name",
-    )
-
-    async with db_session.begin():
-        processor = _make_processor(db_session)
-        await processor.process_repository_renamed(payload)
-        await db_session.commit()
-
-    async with db_session.begin():
-        project = await ProjectStore(
-            session=db_session, logger=_logger()
-        ).get_by_id(project_id)
-    assert project is not None
-    assert (
-        project.source_url == "https://github.com/acme/new-name/tree/main/docs"
-    )
-
-
-@pytest.mark.asyncio
-async def test_repository_renamed_leaves_non_github_source_url(
-    db_session: AsyncSession,
-) -> None:
-    """A non-github.com ``source_url`` survives a rename untouched.
-
-    Projects bound to a GitLab repo whose docs were once also mirrored
-    to GitHub may carry both a structured GitHub binding (because
-    something else lives there) and a non-GitHub ``source_url``. A
-    rename of the GitHub side must not rewrite the GitLab URL.
-    """
-    async with db_session.begin():
-        org_id = await _seed_org(db_session, "rename-non-github-url")
-        project_id = await _seed_project(
-            db_session,
-            org_id=org_id,
-            slug="docs",
-            github_owner="acme",
-            github_repo="old-name",
-            github_owner_id=999,
-            github_repo_id=12345,
-            source_url="https://gitlab.com/acme/old-name",
-        )
-        await db_session.commit()
-
-    payload = _repository_renamed_payload(
-        repo_id=12345,
-        owner="acme",
-        owner_id=999,
-        new_name="new-name",
-        old_name="old-name",
-    )
-
-    async with db_session.begin():
-        processor = _make_processor(db_session)
-        await processor.process_repository_renamed(payload)
-        await db_session.commit()
-
-    async with db_session.begin():
-        project = await ProjectStore(
-            session=db_session, logger=_logger()
-        ).get_by_id(project_id)
-    assert project is not None
-    assert project.github_repo == "new-name"
-    # GitLab URL is untouched.
-    assert project.source_url == "https://gitlab.com/acme/old-name"
+    # The derived effective URL follows the binding.
+    assert project.effective_source_url == "https://github.com/acme/new-name"
 
 
 @pytest.mark.asyncio
 async def test_repository_transferred_rewrites_project_owner(
     db_session: AsyncSession,
 ) -> None:
-    """A repo transfer updates ``github_owner``, owner_id, and source_url.
+    """A repo transfer flips ``github_owner``, owner_id, and repo strings.
 
     User story 18: transferring the repo to a new owner shifts every
-    operator-visible field for the project. ``github_repo_id`` is the
-    stable handle that survives the transfer; the strings on either
-    side of the slash and the cached numeric ``github_owner_id`` all
-    flip together.
+    structured field for the project. ``github_repo_id`` is the stable
+    handle that survives the transfer; the strings on either side of the
+    slash and the cached numeric ``github_owner_id`` all flip together,
+    and the derived source URL follows.
     """
     async with db_session.begin():
         org_id = await _seed_org(db_session, "transfer-project")
@@ -840,7 +739,6 @@ async def test_repository_transferred_rewrites_project_owner(
             github_repo="docs",
             github_owner_id=111,
             github_repo_id=12345,
-            source_url="https://github.com/old-owner/docs",
         )
         await db_session.commit()
 
@@ -867,7 +765,8 @@ async def test_repository_transferred_rewrites_project_owner(
     assert project.github_owner_id == 222
     assert project.github_repo == "docs"
     assert project.github_repo_id == 12345
-    assert project.source_url == "https://github.com/new-owner/docs"
+    # The derived effective URL follows the new owner namespace.
+    assert project.effective_source_url == "https://github.com/new-owner/docs"
 
 
 @pytest.mark.asyncio
@@ -899,7 +798,6 @@ async def test_repository_renamed_updates_binding_and_project_together(
             github_repo="old-name",
             github_owner_id=999,
             github_repo_id=12345,
-            source_url="https://github.com/acme/old-name",
         )
         await db_session.commit()
 
@@ -927,4 +825,4 @@ async def test_repository_renamed_updates_binding_and_project_together(
     assert binding.github_repo == "new-name"
     assert project is not None
     assert project.github_repo == "new-name"
-    assert project.source_url == "https://github.com/acme/new-name"
+    assert project.effective_source_url == "https://github.com/acme/new-name"

--- a/tests/services/dashboard_templates/rename_processor_test.py
+++ b/tests/services/dashboard_templates/rename_processor_test.py
@@ -6,9 +6,12 @@ from typing import Any
 
 import pytest
 import structlog
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from docverse.client.models import OrganizationCreate
+from docverse.client.models import OrganizationCreate, ProjectCreate
+from docverse.client.models.projects import ProjectGitHubBindingCreate
+from docverse.dbschema.project import SqlProject
 from docverse.services.dashboard_templates.rename_processor import (
     RenameEventProcessor,
 )
@@ -20,6 +23,7 @@ from docverse.storage.dashboard_templates.github import (
     GitHubTemplateKey,
 )
 from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
 
 
 def _logger() -> structlog.stdlib.BoundLogger:
@@ -35,8 +39,47 @@ def _make_processor(session: AsyncSession) -> RenameEventProcessor:
         template_store=DashboardGitHubTemplateStore(
             session=session, logger=logger
         ),
+        project_store=ProjectStore(session=session, logger=logger),
         logger=logger,
     )
+
+
+async def _seed_project(
+    session: AsyncSession,
+    *,
+    org_id: int,
+    slug: str,
+    github_owner: str,
+    github_repo: str,
+    github_owner_id: int | None = None,
+    github_repo_id: int | None = None,
+    source_url: str | None = None,
+) -> int:
+    """Seed a project carrying structured GitHub coordinates."""
+    store = ProjectStore(session=session, logger=_logger())
+    binding = ProjectGitHubBindingCreate(owner=github_owner, repo=github_repo)
+    project = await store.create(
+        org_id=org_id,
+        data=ProjectCreate(
+            slug=slug,
+            title=f"Project {slug}",
+            source_url=source_url,
+            github=binding,
+        ),
+        github_owner=github_owner,
+        github_repo=github_repo,
+    )
+    if github_owner_id is not None or github_repo_id is not None:
+        await session.execute(
+            sa_update(SqlProject)
+            .where(SqlProject.id == project.id)
+            .values(
+                github_owner_id=github_owner_id,
+                github_repo_id=github_repo_id,
+            )
+        )
+        await session.flush()
+    return project.id
 
 
 async def _seed_org(session: AsyncSession, slug: str) -> int:
@@ -624,3 +667,264 @@ async def test_repository_renamed_no_id_match_no_writes(
         binding = await store.get_by_id(keep_id)
     assert binding is not None
     assert binding.github_repo == "other"
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_updates_project_keyed_by_repo_id(
+    db_session: AsyncSession,
+) -> None:
+    """A repo rename rewrites ``github_repo`` + ``source_url`` on projects.
+
+    User story 17: renaming the GitHub repository updates both the
+    dashboard-template binding and the project row. The project
+    structured columns are the source of truth; ``source_url`` is the
+    cosmetic URL that surfaces in admin tooling and must follow the
+    canonical owner/repo so the rendered link still resolves on GitHub.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "rename-project-by-id")
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner="acme",
+            github_repo="old-name",
+            github_owner_id=999,
+            github_repo_id=12345,
+            source_url="https://github.com/acme/old-name",
+        )
+        await db_session.commit()
+
+    payload = _repository_renamed_payload(
+        repo_id=12345,
+        owner="acme",
+        owner_id=999,
+        new_name="new-name",
+        old_name="old-name",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert project is not None
+    assert project.github_repo == "new-name"
+    assert project.github_owner == "acme"
+    assert project.github_repo_id == 12345
+    assert project.source_url == "https://github.com/acme/new-name"
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_preserves_source_url_path_tail(
+    db_session: AsyncSession,
+) -> None:
+    """Source URL deep paths survive the owner/repo rewrite.
+
+    ``source_url`` may carry a path tail like ``/tree/main/docs`` for
+    operators whose docs live in a subdirectory of the repo (PRD #346
+    in the dashboard-template world reuses this shape, and #381's
+    Project response already documents the deep-path case). The
+    rename rewrites only the first two path segments so the
+    operator-visible link still points at the same subtree under the
+    new repo name.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "rename-project-path")
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner="acme",
+            github_repo="old-name",
+            github_owner_id=999,
+            github_repo_id=12345,
+            source_url="https://github.com/acme/old-name/tree/main/docs",
+        )
+        await db_session.commit()
+
+    payload = _repository_renamed_payload(
+        repo_id=12345,
+        owner="acme",
+        owner_id=999,
+        new_name="new-name",
+        old_name="old-name",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert project is not None
+    assert (
+        project.source_url == "https://github.com/acme/new-name/tree/main/docs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_leaves_non_github_source_url(
+    db_session: AsyncSession,
+) -> None:
+    """A non-github.com ``source_url`` survives a rename untouched.
+
+    Projects bound to a GitLab repo whose docs were once also mirrored
+    to GitHub may carry both a structured GitHub binding (because
+    something else lives there) and a non-GitHub ``source_url``. A
+    rename of the GitHub side must not rewrite the GitLab URL.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "rename-non-github-url")
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner="acme",
+            github_repo="old-name",
+            github_owner_id=999,
+            github_repo_id=12345,
+            source_url="https://gitlab.com/acme/old-name",
+        )
+        await db_session.commit()
+
+    payload = _repository_renamed_payload(
+        repo_id=12345,
+        owner="acme",
+        owner_id=999,
+        new_name="new-name",
+        old_name="old-name",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert project is not None
+    assert project.github_repo == "new-name"
+    # GitLab URL is untouched.
+    assert project.source_url == "https://gitlab.com/acme/old-name"
+
+
+@pytest.mark.asyncio
+async def test_repository_transferred_rewrites_project_owner(
+    db_session: AsyncSession,
+) -> None:
+    """A repo transfer updates ``github_owner``, owner_id, and source_url.
+
+    User story 18: transferring the repo to a new owner shifts every
+    operator-visible field for the project. ``github_repo_id`` is the
+    stable handle that survives the transfer; the strings on either
+    side of the slash and the cached numeric ``github_owner_id`` all
+    flip together.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "transfer-project")
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner="old-owner",
+            github_repo="docs",
+            github_owner_id=111,
+            github_repo_id=12345,
+            source_url="https://github.com/old-owner/docs",
+        )
+        await db_session.commit()
+
+    payload = _repository_transferred_payload(
+        repo_id=12345,
+        new_owner="new-owner",
+        new_owner_id=222,
+        new_name="docs",
+        old_owner="old-owner",
+        old_owner_id=111,
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_transferred(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert project is not None
+    assert project.github_owner == "new-owner"
+    assert project.github_owner_id == 222
+    assert project.github_repo == "docs"
+    assert project.github_repo_id == 12345
+    assert project.source_url == "https://github.com/new-owner/docs"
+
+
+@pytest.mark.asyncio
+async def test_repository_renamed_updates_binding_and_project_together(
+    db_session: AsyncSession,
+) -> None:
+    """A single rename payload rewrites both rows when both back the repo.
+
+    User story 17 specifically pins this end-to-end shape: an admin
+    creates a dashboard-template binding *and* a project against the
+    same repo; a single ``repository.renamed`` payload must land on
+    both rows so the two cannot disagree about where the repo lives.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "rename-both-rows")
+        binding_id = await _seed_binding(
+            db_session,
+            org_id=org_id,
+            github_owner="acme",
+            github_repo="old-name",
+            github_repo_id=12345,
+            github_owner_id=999,
+        )
+        project_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="docs",
+            github_owner="acme",
+            github_repo="old-name",
+            github_owner_id=999,
+            github_repo_id=12345,
+            source_url="https://github.com/acme/old-name",
+        )
+        await db_session.commit()
+
+    payload = _repository_renamed_payload(
+        repo_id=12345,
+        owner="acme",
+        owner_id=999,
+        new_name="new-name",
+        old_name="old-name",
+    )
+
+    async with db_session.begin():
+        processor = _make_processor(db_session)
+        await processor.process_repository_renamed(payload)
+        await db_session.commit()
+
+    async with db_session.begin():
+        binding = await DashboardGitHubTemplateBindingStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(binding_id)
+        project = await ProjectStore(
+            session=db_session, logger=_logger()
+        ).get_by_id(project_id)
+    assert binding is not None
+    assert binding.github_repo == "new-name"
+    assert project is not None
+    assert project.github_repo == "new-name"
+    assert project.source_url == "https://github.com/acme/new-name"

--- a/tests/services/dashboard_templates/resolver_test.py
+++ b/tests/services/dashboard_templates/resolver_test.py
@@ -55,7 +55,7 @@ async def _seed_org_and_project(
         data=ProjectCreate(
             slug=project_slug,
             title="Resolver Project",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     return org.id, project

--- a/tests/services/dashboard_templates/resolver_test.py
+++ b/tests/services/dashboard_templates/resolver_test.py
@@ -55,7 +55,7 @@ async def _seed_org_and_project(
         data=ProjectCreate(
             slug=project_slug,
             title="Resolver Project",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     return org.id, project

--- a/tests/services/edition_publishing_test.py
+++ b/tests/services/edition_publishing_test.py
@@ -142,7 +142,7 @@ async def _setup(
         data=ProjectCreate(
             slug=_PROJECT_SLUG,
             title="Publish Project",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     edition = await edition_store.create(

--- a/tests/services/edition_publishing_test.py
+++ b/tests/services/edition_publishing_test.py
@@ -142,7 +142,7 @@ async def _setup(
         data=ProjectCreate(
             slug=_PROJECT_SLUG,
             title="Publish Project",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     edition = await edition_store.create(

--- a/tests/services/edition_tracking_test.py
+++ b/tests/services/edition_tracking_test.py
@@ -90,7 +90,7 @@ async def _setup(
         data=ProjectCreate(
             slug="track-proj",
             title="Track Project",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     return org, project

--- a/tests/services/edition_tracking_test.py
+++ b/tests/services/edition_tracking_test.py
@@ -90,7 +90,7 @@ async def _setup(
         data=ProjectCreate(
             slug="track-proj",
             title="Track Project",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     return org, project

--- a/tests/services/publish_enqueue_test.py
+++ b/tests/services/publish_enqueue_test.py
@@ -76,7 +76,7 @@ async def _seed_org_project_edition_build(
         data=ProjectCreate(
             slug="pe-proj",
             title="PE Project",
-            doc_repo="https://github.com/example/pe",
+            source_url="https://github.com/example/pe",
         ),
     )
     edition = await edition_store.create(

--- a/tests/services/publish_enqueue_test.py
+++ b/tests/services/publish_enqueue_test.py
@@ -76,7 +76,7 @@ async def _seed_org_project_edition_build(
         data=ProjectCreate(
             slug="pe-proj",
             title="PE Project",
-            source_url="https://github.com/example/pe",
+            source_url="https://example.com/example/pe",
         ),
     )
     edition = await edition_store.create(

--- a/tests/storage/build_store_test.py
+++ b/tests/storage/build_store_test.py
@@ -45,7 +45,7 @@ async def _create_org_and_project(
         data=ProjectCreate(
             slug="build-proj",
             title="Build Project",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     return org.id, project.id

--- a/tests/storage/build_store_test.py
+++ b/tests/storage/build_store_test.py
@@ -45,7 +45,7 @@ async def _create_org_and_project(
         data=ProjectCreate(
             slug="build-proj",
             title="Build Project",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     return org.id, project.id

--- a/tests/storage/dashboard_templates/github/binding_store_test.py
+++ b/tests/storage/dashboard_templates/github/binding_store_test.py
@@ -47,7 +47,7 @@ async def _seed_org_and_project(
         data=ProjectCreate(
             slug=project_slug,
             title="Tmpl Project",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     return org.id, project.id

--- a/tests/storage/dashboard_templates/github/binding_store_test.py
+++ b/tests/storage/dashboard_templates/github/binding_store_test.py
@@ -47,7 +47,7 @@ async def _seed_org_and_project(
         data=ProjectCreate(
             slug=project_slug,
             title="Tmpl Project",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     return org.id, project.id

--- a/tests/storage/edition_build_history_store_test.py
+++ b/tests/storage/edition_build_history_store_test.py
@@ -64,7 +64,7 @@ async def _create_edition_and_builds(
         data=ProjectCreate(
             slug=project_slug,
             title=f"Project {project_slug}",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     edition = await edition_store.create(
@@ -303,7 +303,7 @@ async def test_list_with_build_info_includes_annotations(
             data=ProjectCreate(
                 slug="ann-proj",
                 title="Ann Project",
-                source_url="https://github.com/example/ann",
+                source_url="https://example.com/example/ann",
             ),
         )
         edition = await edition_store.create(

--- a/tests/storage/edition_build_history_store_test.py
+++ b/tests/storage/edition_build_history_store_test.py
@@ -64,7 +64,7 @@ async def _create_edition_and_builds(
         data=ProjectCreate(
             slug=project_slug,
             title=f"Project {project_slug}",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     edition = await edition_store.create(
@@ -303,7 +303,7 @@ async def test_list_with_build_info_includes_annotations(
             data=ProjectCreate(
                 slug="ann-proj",
                 title="Ann Project",
-                doc_repo="https://github.com/example/ann",
+                source_url="https://github.com/example/ann",
             ),
         )
         edition = await edition_store.create(

--- a/tests/storage/edition_store_test.py
+++ b/tests/storage/edition_store_test.py
@@ -62,7 +62,7 @@ async def _create_project(
         data=ProjectCreate(
             slug="ed-proj",
             title="Ed Project",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     return project.id

--- a/tests/storage/edition_store_test.py
+++ b/tests/storage/edition_store_test.py
@@ -62,7 +62,7 @@ async def _create_project(
         data=ProjectCreate(
             slug="ed-proj",
             title="Ed Project",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     return project.id

--- a/tests/storage/github/app_client_test.py
+++ b/tests/storage/github/app_client_test.py
@@ -20,6 +20,7 @@ from docverse.storage.github import (
     GitHubAppClient,
     GitHubAppNotConfiguredError,
     InstallationAuth,
+    RepositoryMetadata,
 )
 from tests.support.github_mock import DEFAULT_APP_NAME, GitHubMock
 
@@ -105,6 +106,43 @@ async def test_get_installation_auth_returns_token_record(
     assert auth.token == "ghs_installtok"  # noqa: S105
     assert auth.base_url == GITHUB_API_BASE_URL
     assert auth.installation_id == 42
+
+
+@pytest.mark.asyncio
+async def test_resolve_repository_metadata_returns_all_three_ids(
+    mock_github: GitHubMock,
+) -> None:
+    """``resolve_repository_metadata`` returns installation, owner, repo IDs.
+
+    Combines the existing ``/repos/{owner}/{repo}/installation`` and
+    ``/repos/{owner}/{repo}`` lookups into one call so the ``project_
+    github_resolve`` worker has a single deep entry point. Asserts the
+    return record carries all three IDs without depending on which
+    endpoint surfaced each — the caller just needs the bundle.
+    """
+    mock_github.seed_installation(
+        "acme", "templates", installation_id=42, owner_id=111
+    )
+    mock_github.seed_repo("acme", "templates", repo_id=12345, owner_id=111)
+
+    async with httpx.AsyncClient() as http_client:
+        factory = GitHubAppClientFactory(
+            id=mock_github.app_id,
+            key=mock_github.private_key_pem,
+            name=DEFAULT_APP_NAME,
+            http_client=http_client,
+        )
+        client = GitHubAppClient(
+            factory=factory, http_client=http_client, logger=_logger()
+        )
+        metadata = await client.resolve_repository_metadata(
+            owner="acme", repo="templates"
+        )
+
+    assert isinstance(metadata, RepositoryMetadata)
+    assert metadata.installation_id == 42
+    assert metadata.owner_id == 111
+    assert metadata.repo_id == 12345
 
 
 @pytest.mark.asyncio

--- a/tests/storage/github/app_client_test.py
+++ b/tests/storage/github/app_client_test.py
@@ -19,6 +19,7 @@ from docverse.storage.github import (
     GITHUB_API_BASE_URL,
     GitHubAppClient,
     GitHubAppNotConfiguredError,
+    GitHubAppNotInstalledError,
     InstallationAuth,
     RepositoryMetadata,
 )
@@ -49,6 +50,69 @@ async def test_get_installation_id_uses_app_jwt(
         installation_id = await client.get_installation_id("acme", "templates")
 
     assert installation_id == 42
+
+
+@pytest.mark.asyncio
+async def test_get_installation_id_raises_not_installed_on_404(
+    mock_github: GitHubMock,
+) -> None:
+    """A 404 maps to ``GitHubAppNotInstalledError`` carrying owner/repo.
+
+    A 404 from ``/repos/{owner}/{repo}/installation`` means no
+    installation grants the App access to this repo — an expected,
+    operator-recoverable state, not a credential bug. The wrapper
+    translates it to a dedicated non-Slack exception so the worker can
+    leave the ids NULL without paging Sentry.
+    """
+    mock_github.router.get(
+        "https://api.github.com/repos/acme/templates/installation"
+    ).mock(return_value=httpx.Response(404, json={"message": "Not Found"}))
+
+    async with httpx.AsyncClient() as http_client:
+        factory = GitHubAppClientFactory(
+            id=mock_github.app_id,
+            key=mock_github.private_key_pem,
+            name=DEFAULT_APP_NAME,
+            http_client=http_client,
+        )
+        client = GitHubAppClient(
+            factory=factory, http_client=http_client, logger=_logger()
+        )
+        with pytest.raises(GitHubAppNotInstalledError) as excinfo:
+            await client.get_installation_id("acme", "templates")
+
+    assert excinfo.value.owner == "acme"
+    assert excinfo.value.repo == "templates"
+    assert not isinstance(excinfo.value, DocverseSlackException)
+
+
+@pytest.mark.asyncio
+async def test_get_installation_id_reraises_non_404_bad_request(
+    mock_github: GitHubMock,
+) -> None:
+    """A non-404 ``BadRequest`` (e.g. 403) propagates unchanged.
+
+    Only 404 means "App not connected to this repo". Other 4xx — a 403
+    forbidden, say — is a genuine error the worker must still capture to
+    Sentry, so the wrapper re-raises the original ``gidgethub`` error
+    rather than masking it as not-installed.
+    """
+    mock_github.router.get(
+        "https://api.github.com/repos/acme/templates/installation"
+    ).mock(return_value=httpx.Response(403, json={"message": "Forbidden"}))
+
+    async with httpx.AsyncClient() as http_client:
+        factory = GitHubAppClientFactory(
+            id=mock_github.app_id,
+            key=mock_github.private_key_pem,
+            name=DEFAULT_APP_NAME,
+            http_client=http_client,
+        )
+        client = GitHubAppClient(
+            factory=factory, http_client=http_client, logger=_logger()
+        )
+        with pytest.raises(gidgethub.BadRequest):
+            await client.get_installation_id("acme", "templates")
 
 
 @pytest.mark.asyncio
@@ -149,7 +213,11 @@ async def test_resolve_repository_metadata_returns_all_three_ids(
 async def test_validate_succeeds_on_2xx_app_response(
     mock_github: GitHubMock,
 ) -> None:
-    """``validate`` returns cleanly when ``GET /app`` returns 200."""
+    """``validate`` returns the App ``html_url`` when ``GET /app`` is 200.
+
+    The captured ``html_url`` is the App's public install page, threaded
+    through startup so the API can surface it as ``github.app_url``.
+    """
     mock_github.seed_app()
 
     async with httpx.AsyncClient() as http_client:
@@ -162,7 +230,9 @@ async def test_validate_succeeds_on_2xx_app_response(
         client = GitHubAppClient(
             factory=factory, http_client=http_client, logger=_logger()
         )
-        await client.validate()
+        html_url = await client.validate()
+
+    assert html_url == "https://github.com/apps/docverse"
 
 
 @pytest.mark.asyncio

--- a/tests/storage/project_store_test.py
+++ b/tests/storage/project_store_test.py
@@ -57,7 +57,7 @@ async def test_create_project(
             data=ProjectCreate(
                 slug="my-project",
                 title="My Project",
-                doc_repo="https://github.com/example/repo",
+                source_url="https://github.com/example/repo",
             ),
         )
         await db_session.commit()
@@ -81,7 +81,7 @@ async def test_get_by_slug(
             data=ProjectCreate(
                 slug="find-me",
                 title="Find Me",
-                doc_repo="https://github.com/example/repo",
+                source_url="https://github.com/example/repo",
             ),
         )
         found = await store.get_by_slug(org_id=org_id, slug="find-me")
@@ -116,7 +116,7 @@ async def test_list_by_org(
             data=ProjectCreate(
                 slug="proj-aa",
                 title="A",
-                doc_repo="https://github.com/example/a",
+                source_url="https://github.com/example/a",
             ),
         )
         await store.create(
@@ -124,7 +124,7 @@ async def test_list_by_org(
             data=ProjectCreate(
                 slug="proj-bb",
                 title="B",
-                doc_repo="https://github.com/example/b",
+                source_url="https://github.com/example/b",
             ),
         )
         result = await store.list_by_org(
@@ -151,7 +151,7 @@ async def test_update_project(
             data=ProjectCreate(
                 slug="upd-proj",
                 title="Original",
-                doc_repo="https://github.com/example/repo",
+                source_url="https://github.com/example/repo",
             ),
         )
         updated = await store.update(
@@ -178,7 +178,7 @@ async def test_soft_delete(
             data=ProjectCreate(
                 slug="del-proj",
                 title="Delete Me",
-                doc_repo="https://github.com/example/repo",
+                source_url="https://github.com/example/repo",
             ),
         )
         deleted = await store.soft_delete(org_id=org_id, slug="del-proj")

--- a/tests/storage/project_store_test.py
+++ b/tests/storage/project_store_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -163,6 +165,221 @@ async def test_update_project(
     assert updated is not None
     assert updated.title == "Updated"
     assert updated.slug == "upd-proj"
+
+
+@pytest.mark.asyncio
+async def test_rename_repo_by_repo_id_preserves_date_updated(
+    db_session: AsyncSession,
+    store: ProjectStore,
+    org_store: OrganizationStore,
+) -> None:
+    """A GitHub-side repo rename must not bump ``date_updated``.
+
+    ``date_updated`` is the operator-visible "last source-coordinate
+    edit" signal; those edits arrive through PUT/PATCH, not through a
+    GitHub-side metadata sync. The rename still rewrites ``github_repo``
+    and the matching ``source_url``.
+    """
+    async with db_session.begin():
+        org_id = await _create_org(org_store)
+        created = await store.create(
+            org_id=org_id,
+            data=ProjectCreate(
+                slug="rename-me",
+                title="Rename Me",
+                source_url="https://github.com/acme/old-repo",
+            ),
+            github_owner="acme",
+            github_repo="old-repo",
+        )
+        # Set github_repo_id without bumping date_updated so the baseline
+        # below is the create timestamp.
+        await store.apply_installation_scope(
+            installation_id=111,
+            owner="acme",
+            owner_id=222,
+            repo="old-repo",
+            repo_id=333,
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        before = await store.get_by_id(created.id)
+    assert before is not None
+    baseline = before.date_updated
+
+    # Run the rename in a later transaction so a re-fired
+    # ``onupdate=func.now()`` would yield a strictly greater timestamp
+    # than the create transaction's ``now()``.
+    await asyncio.sleep(0.05)
+    async with db_session.begin():
+        updated_ids = await store.rename_repo_by_repo_id(
+            github_repo_id=333,
+            new_repo="new-repo",
+        )
+        await db_session.commit()
+    assert updated_ids == [created.id]
+
+    async with db_session.begin():
+        after = await store.get_by_id(created.id)
+    assert after is not None
+    assert after.github_repo == "new-repo"
+    assert after.source_url == "https://github.com/acme/new-repo"
+    assert after.date_updated == baseline
+
+
+@pytest.mark.asyncio
+async def test_transfer_repo_by_repo_id_preserves_date_updated(
+    db_session: AsyncSession,
+    store: ProjectStore,
+    org_store: OrganizationStore,
+) -> None:
+    """A GitHub-side repo transfer must not bump ``date_updated``.
+
+    The transfer still flips ``github_owner`` / ``github_owner_id`` /
+    ``github_repo`` and rewrites the matching ``source_url``.
+    """
+    async with db_session.begin():
+        org_id = await _create_org(org_store)
+        created = await store.create(
+            org_id=org_id,
+            data=ProjectCreate(
+                slug="transfer-me",
+                title="Transfer Me",
+                source_url="https://github.com/acme/repo",
+            ),
+            github_owner="acme",
+            github_repo="repo",
+        )
+        await store.apply_installation_scope(
+            installation_id=111,
+            owner="acme",
+            owner_id=222,
+            repo="repo",
+            repo_id=333,
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        before = await store.get_by_id(created.id)
+    assert before is not None
+    baseline = before.date_updated
+
+    await asyncio.sleep(0.05)
+    async with db_session.begin():
+        updated_ids = await store.transfer_repo_by_repo_id(
+            github_repo_id=333,
+            new_owner="beta",
+            new_owner_id=444,
+            new_repo="repo",
+        )
+        await db_session.commit()
+    assert updated_ids == [created.id]
+
+    async with db_session.begin():
+        after = await store.get_by_id(created.id)
+    assert after is not None
+    assert after.github_owner == "beta"
+    assert after.github_owner_id == 444
+    assert after.source_url == "https://github.com/beta/repo"
+    assert after.date_updated == baseline
+
+
+@pytest.mark.asyncio
+async def test_update_github_metadata_preserves_date_updated(
+    db_session: AsyncSession,
+    store: ProjectStore,
+    org_store: OrganizationStore,
+) -> None:
+    """Capturing the github_*_id columns preserves ``date_updated``.
+
+    The three numeric ids are sync-bookkeeping, not an operator-visible
+    source-coordinate edit.
+    """
+    async with db_session.begin():
+        org_id = await _create_org(org_store)
+        created = await store.create(
+            org_id=org_id,
+            data=ProjectCreate(
+                slug="meta-me",
+                title="Meta Me",
+                source_url="https://github.com/acme/repo",
+            ),
+            github_owner="acme",
+            github_repo="repo",
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        before = await store.get_by_id(created.id)
+    assert before is not None
+    baseline = before.date_updated
+
+    await asyncio.sleep(0.05)
+    async with db_session.begin():
+        updated = await store.update_github_metadata(
+            project_id=created.id,
+            expected_owner="acme",
+            expected_repo="repo",
+            installation_id=10,
+            owner_id=20,
+            repo_id=30,
+        )
+        await db_session.commit()
+    assert updated is True
+
+    async with db_session.begin():
+        after = await store.get_by_id(created.id)
+    assert after is not None
+    assert after.github_installation_id == 10
+    assert after.github_owner_id == 20
+    assert after.github_repo_id == 30
+    assert after.date_updated == baseline
+
+
+@pytest.mark.asyncio
+async def test_update_github_metadata_skips_on_binding_change(
+    db_session: AsyncSession,
+    store: ProjectStore,
+    org_store: OrganizationStore,
+) -> None:
+    """Returns ``False`` and writes nothing when the binding flipped.
+
+    The ``expected_owner``/``expected_repo`` guard protects against a
+    PATCH that rewrote ``github`` between enqueue and the worker run.
+    """
+    async with db_session.begin():
+        org_id = await _create_org(org_store)
+        created = await store.create(
+            org_id=org_id,
+            data=ProjectCreate(
+                slug="stale-me",
+                title="Stale Me",
+                source_url="https://github.com/acme/repo",
+            ),
+            github_owner="acme",
+            github_repo="repo",
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        updated = await store.update_github_metadata(
+            project_id=created.id,
+            expected_owner="acme",
+            expected_repo="different-repo",
+            installation_id=10,
+            owner_id=20,
+            repo_id=30,
+        )
+        await db_session.commit()
+    assert updated is False
+
+    async with db_session.begin():
+        after = await store.get_by_id(created.id)
+    assert after is not None
+    assert after.github_repo_id is None
+    assert after.github_owner_id is None
+    assert after.github_installation_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/storage/project_store_test.py
+++ b/tests/storage/project_store_test.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.client.models import (
     OrganizationCreate,
     ProjectCreate,
+    ProjectGitHubBindingCreate,
     ProjectUpdate,
 )
 from docverse.storage.organization_store import OrganizationStore
@@ -59,7 +60,7 @@ async def test_create_project(
             data=ProjectCreate(
                 slug="my-project",
                 title="My Project",
-                source_url="https://github.com/example/repo",
+                source_url="https://example.com/example/repo",
             ),
         )
         await db_session.commit()
@@ -83,7 +84,7 @@ async def test_get_by_slug(
             data=ProjectCreate(
                 slug="find-me",
                 title="Find Me",
-                source_url="https://github.com/example/repo",
+                source_url="https://example.com/example/repo",
             ),
         )
         found = await store.get_by_slug(org_id=org_id, slug="find-me")
@@ -118,7 +119,7 @@ async def test_list_by_org(
             data=ProjectCreate(
                 slug="proj-aa",
                 title="A",
-                source_url="https://github.com/example/a",
+                source_url="https://example.com/example/a",
             ),
         )
         await store.create(
@@ -126,7 +127,7 @@ async def test_list_by_org(
             data=ProjectCreate(
                 slug="proj-bb",
                 title="B",
-                source_url="https://github.com/example/b",
+                source_url="https://example.com/example/b",
             ),
         )
         result = await store.list_by_org(
@@ -153,7 +154,7 @@ async def test_update_project(
             data=ProjectCreate(
                 slug="upd-proj",
                 title="Original",
-                source_url="https://github.com/example/repo",
+                source_url="https://example.com/example/repo",
             ),
         )
         updated = await store.update(
@@ -177,8 +178,8 @@ async def test_rename_repo_by_repo_id_preserves_date_updated(
 
     ``date_updated`` is the operator-visible "last source-coordinate
     edit" signal; those edits arrive through PUT/PATCH, not through a
-    GitHub-side metadata sync. The rename still rewrites ``github_repo``
-    and the matching ``source_url``.
+    GitHub-side metadata sync. The rename still flips ``github_repo``;
+    the effective source URL is derived from the binding.
     """
     async with db_session.begin():
         org_id = await _create_org(org_store)
@@ -187,7 +188,9 @@ async def test_rename_repo_by_repo_id_preserves_date_updated(
             data=ProjectCreate(
                 slug="rename-me",
                 title="Rename Me",
-                source_url="https://github.com/acme/old-repo",
+                github=ProjectGitHubBindingCreate(
+                    owner="acme", repo="old-repo"
+                ),
             ),
             github_owner="acme",
             github_repo="old-repo",
@@ -224,7 +227,8 @@ async def test_rename_repo_by_repo_id_preserves_date_updated(
         after = await store.get_by_id(created.id)
     assert after is not None
     assert after.github_repo == "new-repo"
-    assert after.source_url == "https://github.com/acme/new-repo"
+    assert after.source_url is None
+    assert after.effective_source_url == "https://github.com/acme/new-repo"
     assert after.date_updated == baseline
 
 
@@ -237,7 +241,8 @@ async def test_transfer_repo_by_repo_id_preserves_date_updated(
     """A GitHub-side repo transfer must not bump ``date_updated``.
 
     The transfer still flips ``github_owner`` / ``github_owner_id`` /
-    ``github_repo`` and rewrites the matching ``source_url``.
+    ``github_repo``; the effective source URL is derived from the
+    binding.
     """
     async with db_session.begin():
         org_id = await _create_org(org_store)
@@ -246,7 +251,7 @@ async def test_transfer_repo_by_repo_id_preserves_date_updated(
             data=ProjectCreate(
                 slug="transfer-me",
                 title="Transfer Me",
-                source_url="https://github.com/acme/repo",
+                github=ProjectGitHubBindingCreate(owner="acme", repo="repo"),
             ),
             github_owner="acme",
             github_repo="repo",
@@ -281,7 +286,8 @@ async def test_transfer_repo_by_repo_id_preserves_date_updated(
     assert after is not None
     assert after.github_owner == "beta"
     assert after.github_owner_id == 444
-    assert after.source_url == "https://github.com/beta/repo"
+    assert after.source_url is None
+    assert after.effective_source_url == "https://github.com/beta/repo"
     assert after.date_updated == baseline
 
 
@@ -303,7 +309,7 @@ async def test_update_github_metadata_preserves_date_updated(
             data=ProjectCreate(
                 slug="meta-me",
                 title="Meta Me",
-                source_url="https://github.com/acme/repo",
+                github=ProjectGitHubBindingCreate(owner="acme", repo="repo"),
             ),
             github_owner="acme",
             github_repo="repo",
@@ -355,7 +361,7 @@ async def test_update_github_metadata_skips_on_binding_change(
             data=ProjectCreate(
                 slug="stale-me",
                 title="Stale Me",
-                source_url="https://github.com/acme/repo",
+                github=ProjectGitHubBindingCreate(owner="acme", repo="repo"),
             ),
             github_owner="acme",
             github_repo="repo",
@@ -395,7 +401,7 @@ async def test_soft_delete(
             data=ProjectCreate(
                 slug="del-proj",
                 title="Delete Me",
-                source_url="https://github.com/example/repo",
+                source_url="https://example.com/example/repo",
             ),
         )
         deleted = await store.soft_delete(org_id=org_id, slug="del-proj")

--- a/tests/storage/queue_job_store_test.py
+++ b/tests/storage/queue_job_store_test.py
@@ -75,7 +75,7 @@ async def test_publish_edition_job_with_edition_id(
             data=ProjectCreate(
                 slug="qj-proj",
                 title="QJ Project",
-                doc_repo="https://github.com/example/repo",
+                source_url="https://github.com/example/repo",
             ),
         )
         edition = await edition_store.create(

--- a/tests/storage/queue_job_store_test.py
+++ b/tests/storage/queue_job_store_test.py
@@ -75,7 +75,7 @@ async def test_publish_edition_job_with_edition_id(
             data=ProjectCreate(
                 slug="qj-proj",
                 title="QJ Project",
-                source_url="https://github.com/example/repo",
+                source_url="https://example.com/example/repo",
             ),
         )
         edition = await edition_store.create(

--- a/tests/support/github_mock.py
+++ b/tests/support/github_mock.py
@@ -101,10 +101,12 @@ class GitHubMock:
         failure branch of the validator.
         """
         if body is None:
+            slug = self.app_name.split("/", 1)[-1]
             body = {
                 "id": self.app_id,
-                "slug": self.app_name.split("/", 1)[-1],
+                "slug": slug,
                 "name": self.app_name,
+                "html_url": f"https://github.com/apps/{slug}",
             }
         self.router.get(f"{_GITHUB_API}/app").mock(
             return_value=httpx.Response(status_code, json=body)

--- a/tests/worker/build_processing_test.py
+++ b/tests/worker/build_processing_test.py
@@ -99,7 +99,7 @@ async def _setup_org_and_project(
         data=ProjectCreate(
             slug="worker-test-proj",
             title="Worker Test Project",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     return org, project

--- a/tests/worker/build_processing_test.py
+++ b/tests/worker/build_processing_test.py
@@ -99,7 +99,7 @@ async def _setup_org_and_project(
         data=ProjectCreate(
             slug="worker-test-proj",
             title="Worker Test Project",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     return org, project

--- a/tests/worker/dashboard_build_test.py
+++ b/tests/worker/dashboard_build_test.py
@@ -71,7 +71,7 @@ async def _setup_org_and_project(
         data=ProjectCreate(
             slug="dash-proj",
             title="Dash Project",
-            source_url="https://github.com/example/dash",
+            source_url="https://example.com/example/dash",
         ),
     )
     await edition_store.create_internal(

--- a/tests/worker/dashboard_build_test.py
+++ b/tests/worker/dashboard_build_test.py
@@ -71,7 +71,7 @@ async def _setup_org_and_project(
         data=ProjectCreate(
             slug="dash-proj",
             title="Dash Project",
-            doc_repo="https://github.com/example/dash",
+            source_url="https://github.com/example/dash",
         ),
     )
     await edition_store.create_internal(

--- a/tests/worker/dashboard_sync_test.py
+++ b/tests/worker/dashboard_sync_test.py
@@ -72,7 +72,7 @@ async def _setup_org_and_projects(
             data=ProjectCreate(
                 slug=slug,
                 title=f"Project {slug}",
-                source_url=f"https://github.com/example/{slug}",
+                source_url=f"https://example.com/example/{slug}",
             ),
         )
         project_ids.append(project.id)

--- a/tests/worker/dashboard_sync_test.py
+++ b/tests/worker/dashboard_sync_test.py
@@ -72,7 +72,7 @@ async def _setup_org_and_projects(
             data=ProjectCreate(
                 slug=slug,
                 title=f"Project {slug}",
-                doc_repo=f"https://github.com/example/{slug}",
+                source_url=f"https://github.com/example/{slug}",
             ),
         )
         project_ids.append(project.id)

--- a/tests/worker/lifecycle_eval_dispatcher_test.py
+++ b/tests/worker/lifecycle_eval_dispatcher_test.py
@@ -80,7 +80,7 @@ async def _seed_project(
         data=ProjectCreate(
             slug=slug,
             title=f"Project {slug}",
-            doc_repo=f"https://example.com/{slug}",
+            source_url=f"https://example.com/{slug}",
             lifecycle_rules=lifecycle_rules,
         ),
     )

--- a/tests/worker/lifecycle_eval_test.py
+++ b/tests/worker/lifecycle_eval_test.py
@@ -93,7 +93,7 @@ async def _seed_project(
         data=ProjectCreate(
             slug=slug,
             title=f"Project {slug}",
-            doc_repo=f"https://example.com/{slug}",
+            source_url=f"https://example.com/{slug}",
             lifecycle_rules=lifecycle_rules,
         ),
     )

--- a/tests/worker/project_github_resolve_test.py
+++ b/tests/worker/project_github_resolve_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import httpx
 import pytest
+import sentry_sdk
 import structlog
 from pydantic import SecretStr
 from safir.dependencies.db_session import db_session_dependency
@@ -184,14 +185,18 @@ async def test_project_github_resolve_leaves_ids_null_on_github_404(
     app: None,
     db_session: AsyncSession,
     mock_github: GitHubMock,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A 404 from GitHub leaves the columns NULL and is logged.
+    """A 404 is the expected "App not installed" state, not a failure.
 
-    Acceptance criteria from the issue: ``on failure they stay NULL and
-    the failure is logged``. The 404 path is the canonical case
-    (GitHub App not installed for the repo) so it must not raise out of
-    the worker — that would surface as an arq-level error rather than
-    a per-row data-gap log line.
+    The GitHub App installation id is per-account, found via a repo the
+    App can access — so a 404 from ``/repos/{owner}/{repo}/installation``
+    means no installation grants the App access to this repo. That is an
+    operator-recoverable state the ``installation`` webhook backfills, so
+    the worker returns ``"not_installed"``, leaves the ids NULL, and must
+    **not** page Sentry (which it did before this change). It also must
+    not raise out of the worker — that would surface as an arq-level
+    error rather than a per-row data-gap log line.
     """
     async with db_session.begin():
         _org_id, project_id = await _seed_org_and_project(db_session)
@@ -201,11 +206,18 @@ async def test_project_github_resolve_leaves_ids_null_on_github_404(
         "https://api.github.com/repos/acme/templates/installation"
     ).mock(return_value=httpx.Response(404, json={"message": "Not Found"}))
 
+    captured: list[BaseException] = []
+    # The worker calls ``sentry_sdk.capture_exception``; patch the
+    # module attribute (the string-path form fails because
+    # ``project_github_resolve`` is a module, not a package).
+    monkeypatch.setattr(sentry_sdk, "capture_exception", captured.append)
+
     async with httpx.AsyncClient() as http_client:
         ctx = _make_ctx(http_client=http_client, mock_github=mock_github)
         result = await project_github_resolve(ctx, {"project_id": project_id})
 
-    assert result == "failed"
+    assert result == "not_installed"
+    assert captured == []
     (
         owner,
         repo,
@@ -215,6 +227,52 @@ async def test_project_github_resolve_leaves_ids_null_on_github_404(
     ) = await _fetch_project_github_ids(project_id)
     assert owner == "acme"
     assert repo == "templates"
+    assert owner_id is None
+    assert repo_id is None
+    assert installation_id is None
+
+
+@pytest.mark.asyncio
+async def test_project_github_resolve_captures_genuine_github_error(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-404 GitHub error fails the resolve and is paged to Sentry.
+
+    Only a 404 is the expected "App not installed" state. Any other
+    GitHub error (here a 500) is a genuine failure: the worker leaves
+    the ids NULL, returns ``"failed"``, and still calls
+    ``sentry_sdk.capture_exception`` so an operator is paged.
+    """
+    async with db_session.begin():
+        _org_id, project_id = await _seed_org_and_project(db_session)
+        await db_session.commit()
+
+    mock_github.router.get(
+        "https://api.github.com/repos/acme/templates/installation"
+    ).mock(return_value=httpx.Response(500, json={"message": "Server Error"}))
+
+    captured: list[BaseException] = []
+    # The worker calls ``sentry_sdk.capture_exception``; patch the
+    # module attribute (the string-path form fails because
+    # ``project_github_resolve`` is a module, not a package).
+    monkeypatch.setattr(sentry_sdk, "capture_exception", captured.append)
+
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(http_client=http_client, mock_github=mock_github)
+        result = await project_github_resolve(ctx, {"project_id": project_id})
+
+    assert result == "failed"
+    assert len(captured) == 1
+    (
+        _owner,
+        _repo,
+        owner_id,
+        repo_id,
+        installation_id,
+    ) = await _fetch_project_github_ids(project_id)
     assert owner_id is None
     assert repo_id is None
     assert installation_id is None

--- a/tests/worker/project_github_resolve_test.py
+++ b/tests/worker/project_github_resolve_test.py
@@ -1,0 +1,240 @@
+"""Integration tests for the ``project_github_resolve`` worker function."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import structlog
+from pydantic import SecretStr
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import OrganizationCreate, ProjectCreate
+from docverse.client.models.projects import ProjectGitHubBindingCreate
+from docverse.dbschema.project import SqlProject
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+from docverse.worker.functions.project_github_resolve import (
+    project_github_resolve,
+)
+from tests.support.github_mock import GitHubMock
+from tests.worker.conftest import make_worker_ctx
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _seed_org_and_project(
+    db_session: AsyncSession,
+    *,
+    org_slug: str = "pgr-org",
+    project_slug: str = "pgr-proj",
+    github_owner: str | None = "acme",
+    github_repo: str | None = "templates",
+) -> tuple[int, int]:
+    """Seed an org plus one project with optional GitHub coordinates."""
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+    org = await org_store.create(
+        OrganizationCreate(
+            slug=org_slug,
+            title=f"Org {org_slug}",
+            base_domain=f"{org_slug}.example.com",
+        )
+    )
+    binding = (
+        ProjectGitHubBindingCreate(owner=github_owner, repo=github_repo)
+        if github_owner is not None and github_repo is not None
+        else None
+    )
+    project = await proj_store.create(
+        org_id=org.id,
+        data=ProjectCreate(
+            slug=project_slug,
+            title=f"Project {project_slug}",
+            github=binding,
+        ),
+        github_owner=github_owner,
+        github_repo=github_repo,
+    )
+    return org.id, project.id
+
+
+async def _fetch_project_github_ids(
+    project_id: int,
+) -> tuple[str | None, str | None, int | None, int | None, int | None]:
+    """Return ``(owner, repo, owner_id, repo_id, installation_id)``."""
+    async for session in db_session_dependency():
+        result = await session.execute(
+            select(
+                SqlProject.github_owner,
+                SqlProject.github_repo,
+                SqlProject.github_owner_id,
+                SqlProject.github_repo_id,
+                SqlProject.github_installation_id,
+            ).where(SqlProject.id == project_id)
+        )
+        row = result.one()
+        return (row[0], row[1], row[2], row[3], row[4])
+    msg = "No database session available"
+    raise RuntimeError(msg)
+
+
+def _make_ctx(
+    *,
+    http_client: httpx.AsyncClient,
+    mock_github: GitHubMock,
+) -> dict[str, object]:
+    return make_worker_ctx(
+        http_client=http_client,
+        github_app_id=mock_github.app_id,
+        github_app_private_key=SecretStr(mock_github.private_key_pem),
+        github_webhook_secret=SecretStr("webhook-secret"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_project_github_resolve_persists_three_ids(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A successful resolve writes the three opportunistic id columns.
+
+    Reproduces the post-create steady state from PRD #346 user story 12:
+    a project has been created with ``github={owner, repo}`` but the
+    three ``github_*_id`` columns are still NULL. The worker fetches
+    them from GitHub and persists them so future webhook lookups can
+    use the stable numeric keys.
+    """
+    async with db_session.begin():
+        _org_id, project_id = await _seed_org_and_project(db_session)
+        await db_session.commit()
+
+    mock_github.seed_installation(
+        "acme", "templates", installation_id=42, owner_id=111
+    )
+    mock_github.seed_repo("acme", "templates", repo_id=12345, owner_id=111)
+
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(http_client=http_client, mock_github=mock_github)
+        result = await project_github_resolve(ctx, {"project_id": project_id})
+
+    assert result == "completed"
+    (
+        owner,
+        repo,
+        owner_id,
+        repo_id,
+        installation_id,
+    ) = await _fetch_project_github_ids(project_id)
+    assert owner == "acme"
+    assert repo == "templates"
+    assert owner_id == 111
+    assert repo_id == 12345
+    assert installation_id == 42
+
+
+@pytest.mark.asyncio
+async def test_project_github_resolve_skips_non_github_project(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A project with no GitHub binding short-circuits without API calls.
+
+    Pins user story 14: projects whose source_url is non-GitHub never
+    populate the structured columns, so a stray enqueue for one must
+    not touch the row or open the network. ``mock_github.router``
+    captures every HTTP call so the absence is asserted as a count.
+    """
+    async with db_session.begin():
+        _org_id, project_id = await _seed_org_and_project(
+            db_session,
+            github_owner=None,
+            github_repo=None,
+        )
+        await db_session.commit()
+
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(http_client=http_client, mock_github=mock_github)
+        result = await project_github_resolve(ctx, {"project_id": project_id})
+
+    assert result == "skipped"
+    assert mock_github.router.calls.call_count == 0
+    (
+        owner,
+        repo,
+        owner_id,
+        repo_id,
+        installation_id,
+    ) = await _fetch_project_github_ids(project_id)
+    assert owner is None
+    assert repo is None
+    assert owner_id is None
+    assert repo_id is None
+    assert installation_id is None
+
+
+@pytest.mark.asyncio
+async def test_project_github_resolve_leaves_ids_null_on_github_404(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A 404 from GitHub leaves the columns NULL and is logged.
+
+    Acceptance criteria from the issue: ``on failure they stay NULL and
+    the failure is logged``. The 404 path is the canonical case
+    (GitHub App not installed for the repo) so it must not raise out of
+    the worker — that would surface as an arq-level error rather than
+    a per-row data-gap log line.
+    """
+    async with db_session.begin():
+        _org_id, project_id = await _seed_org_and_project(db_session)
+        await db_session.commit()
+
+    mock_github.router.get(
+        "https://api.github.com/repos/acme/templates/installation"
+    ).mock(return_value=httpx.Response(404, json={"message": "Not Found"}))
+
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(http_client=http_client, mock_github=mock_github)
+        result = await project_github_resolve(ctx, {"project_id": project_id})
+
+    assert result == "failed"
+    (
+        owner,
+        repo,
+        owner_id,
+        repo_id,
+        installation_id,
+    ) = await _fetch_project_github_ids(project_id)
+    assert owner == "acme"
+    assert repo == "templates"
+    assert owner_id is None
+    assert repo_id is None
+    assert installation_id is None
+
+
+@pytest.mark.asyncio
+async def test_project_github_resolve_skips_missing_project(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """A payload for a non-existent project id is a clean skip.
+
+    A project can be soft-deleted between enqueue and dequeue. The
+    worker must not raise (so arq does not retry the job five times)
+    and must not write to a row that does not exist.
+    """
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(http_client=http_client, mock_github=mock_github)
+        result = await project_github_resolve(ctx, {"project_id": 999999})
+
+    assert result == "skipped"
+    assert mock_github.router.calls.call_count == 0

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -160,7 +160,7 @@ async def _setup_publish_scenario(
         data=ProjectCreate(
             slug="pub-proj",
             title="Publish Project",
-            source_url="https://github.com/example/repo",
+            source_url="https://example.com/example/repo",
         ),
     )
     edition = await edition_store.create(

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -160,7 +160,7 @@ async def _setup_publish_scenario(
         data=ProjectCreate(
             slug="pub-proj",
             title="Publish Project",
-            doc_repo="https://github.com/example/repo",
+            source_url="https://github.com/example/repo",
         ),
     )
     edition = await edition_store.create(


### PR DESCRIPTION
## Summary

- Land the structured GitHub binding on the `projects` table: five new nullable columns (`github_owner`, `github_repo`, `github_owner_id`, `github_repo_id`, `github_installation_id`), a both-or-neither check constraint on the owner/repo pair, and two webhook-lookup indexes (`idx_projects_github_owner_repo` keyed on the `lower(...)` pair, `idx_projects_github_repo_id`). Rename `doc_repo String(512) NOT NULL` → `source_url String(512) NULL`; existing values flow through unchanged. The Alembic migration parses every existing `doc_repo` value into the structured pair and aborts loudly listing offending project ids when any URL's host is not `github.com`.
- Expose the structured binding through the Project API: add `ProjectGitHubBindingCreate` (input, `{owner, repo}`) and `ProjectGitHubBinding` (response, `{owner, repo, installation_id}`) to `docverse-client` reusing the dashboard-binding owner/repo regexes; swap the client field `doc_repo` to nullable `source_url` on `ProjectCreate` / `Project` / `ProjectUpdate`.

## Revised behaviour: GitHub binding is the source of truth, `source_url` is derived

A later review flagged that PATCH validation could not see the *stored* `source_url`, so a PATCH that changed `github` (or sent a non-github `source_url`) without touching the other field could leave a row whose stored `source_url` disagreed with its `(github_owner, github_repo)` binding. Since `source_url` is purely cosmetic (read only for display, parsed once at create for owner/repo — nothing consumes the path tail or clones from it), the structured `github` binding is now the **single source of truth** and we stop storing `source_url` for GitHub-bound projects. This makes the disagreement structurally impossible.

- **Storage invariant:** the `source_url` column stores only non-github URLs, or NULL — never a github.com URL. A project is exactly one of: GitHub-bound (binding set, column NULL) · non-github (column = URL, binding NULL) · neither.
- **Derived on read:** the Project response and the dashboard derive the effective URL once, via `Project.effective_source_url` (binding → `https://github.com/{owner}/{repo}`; else the stored column; else `null`). A new `build_github_url(owner, repo)` helper is the inverse of `parse_github_url`.
- **Input validation (422 on both `ProjectCreate` and `ProjectUpdate`):**
  - Rule A — a github.com `source_url` is rejected: *"use the `github` field for GitHub repositories"*.
  - Rule B — `source_url` (non-null) and `github` (non-null) are mutually exclusive.
- **PATCH semantics:** `github: {owner, repo}` sets the binding, clears the numeric ids, **and nulls the `source_url` column**; `github: null` clears all five github columns; a non-github `source_url` clears the binding and stores the URL; `source_url: null` clears only the free-form column (no-op for bound projects).
- **Cleanup:** removed all `source_url`-rewriting from `rename_repo_by_repo_id` / `transfer_repo_by_repo_id` (renames now only flip the binding columns; the derived URL follows). Keeper-sync now routes a github.com LTD `doc_repo` into the `github` binding instead of `source_url`. A second Alembic migration (`y3z4a5b6c7d8`) nulls any redundant github.com `source_url` values left by the first migration.

### ⚠️ Breaking change

Clients that POST/PATCH a `source_url` pointing at github.com now receive **422** and must switch to the `github: {owner, repo}` object. Sending both `source_url` and `github` is also **422** (mutually exclusive). For GitHub-bound projects the response `source_url` is **derived** from the binding rather than echoing a stored value.

## Validation steps

- [ ] On a staging snapshot, run `alembic upgrade head` and confirm every previously-GitHub `projects` row has `(github_owner, github_repo)` populated and its `source_url` column nulled, while non-github rows keep their `source_url` verbatim.
- [ ] In a scratch DB, seed a row with a non-`github.com` `doc_repo` (e.g. `https://gitlab.com/example/repo`), run the first migration, and confirm it aborts with a `RuntimeError` listing the offending project id(s) — and that no partial schema state is left behind.
- [ ] In `psql`, attempt `INSERT INTO projects (..., github_owner, github_repo, ...) VALUES (..., 'owner', NULL, ...)` and confirm the `ck_projects_github_owner_repo_both_or_neither` check constraint rejects it.
- [ ] Confirm both new indexes exist via `\d projects` and that `idx_projects_github_owner_repo` uses the functional `lower(...)` form.
- [ ] POST `/orgs/{org}/projects` with `{"github": {"owner": "lsst", "repo": "docverse"}}` (no `source_url`) on a dev instance and confirm the response embeds the structured `github` sub-object with `installation_id: null` and a **derived** `source_url: "https://github.com/lsst/docverse"`.
- [ ] POST with `{"source_url": "https://github.com/lsst/foo"}` (Rule A) and confirm the response is HTTP **422** instructing the caller to use the `github` field.
- [ ] POST with both `source_url` (any host) and `github` set (Rule B) and confirm the response is HTTP **422** (mutually exclusive).
- [ ] POST with `{"source_url": "https://gitlab.com/lsst/mirror"}` (no `github`) and confirm the project is created with `github: null` and the `source_url` echoed.
- [ ] PATCH an existing non-github project with `{"github": {"owner": "lsst", "repo": "foo"}}` and confirm the stored `source_url` is dropped and the response derives `https://github.com/lsst/foo`; PATCH `{"github": null, "source_url": "https://gitlab.com/lsst/mirror"}` and confirm `github: null`, the new `source_url`, and that the `github_*_id` / `github_installation_id` columns are cleared.

## References

- Closes #378
- Closes #379
- PRD: #346
- Jira: https://rubinobs.atlassian.net/browse/DM-54913
