### PR TITLE
DM-54914: Tombstone data layer (schema + service core)

### DIFF
--- a/alembic/versions/20260527_0000_a5b6c7d8e9f0_keeper_sync_state_tombstone_columns.py
+++ b/alembic/versions/20260527_0000_a5b6c7d8e9f0_keeper_sync_state_tombstone_columns.py
@@ -1,0 +1,68 @@
+"""Add tombstone columns to ``keeper_sync_state``.
+
+Foundational data layer for sync tombstones (PRD #332 / DM-54914).
+A sync tombstone is a permanent veto recorded on the existing
+``keeper_sync_state`` table that tells keeper-sync "this LTD resource
+has been deleted on the Docverse side; do not re-migrate it." Three
+new nullable columns capture the veto:
+
+- ``date_tombstoned`` — when the tombstone was recorded. ``NULL`` means
+  the row is not tombstoned.
+- ``tombstone_reason`` — short string enum. Constrained via a
+  ``CheckConstraint`` matching the existing ``resource_type`` pattern
+  (``NULL`` or one of ``manual_delete`` / ``lifecycle_delete`` /
+  ``lifecycle_preemptive``).
+- ``tombstone_note`` — short free-text the writer can attach for the
+  admin UI.
+
+All three columns are nullable so every existing row is NULL-backfilled
+to "not tombstoned"; no operator intervention is required to deploy.
+
+Revision ID: a5b6c7d8e9f0
+Revises: z4a5b6c7d8e9
+Create Date: 2026-05-27 00:00:00.000000+00:00
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a5b6c7d8e9f0"
+down_revision: str | None = "z4a5b6c7d8e9"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "keeper_sync_state",
+        sa.Column(
+            "date_tombstoned", sa.DateTime(timezone=True), nullable=True
+        ),
+    )
+    op.add_column(
+        "keeper_sync_state",
+        sa.Column("tombstone_reason", sa.String(32), nullable=True),
+    )
+    op.add_column(
+        "keeper_sync_state",
+        sa.Column("tombstone_note", sa.String(512), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_keeper_sync_state_tombstone_reason",
+        "keeper_sync_state",
+        "tombstone_reason IS NULL OR tombstone_reason IN "
+        "('manual_delete', 'lifecycle_delete', 'lifecycle_preemptive')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_keeper_sync_state_tombstone_reason",
+        "keeper_sync_state",
+        type_="check",
+    )
+    op.drop_column("keeper_sync_state", "tombstone_note")
+    op.drop_column("keeper_sync_state", "tombstone_reason")
+    op.drop_column("keeper_sync_state", "date_tombstoned")

--- a/alembic/versions/20260527_0001_b6c7d8e9f0a1_keeper_sync_state_tombstone_index.py
+++ b/alembic/versions/20260527_0001_b6c7d8e9f0a1_keeper_sync_state_tombstone_index.py
@@ -1,0 +1,47 @@
+"""Add partial index backing the keeper-sync tombstones listing.
+
+The admin ``GET /orgs/{org}/keeper-sync/tombstones`` endpoint pages one
+org's tombstoned ``keeper_sync_state`` rows ordered by
+``date_tombstoned DESC, id DESC`` (see
+``KeeperSyncStateDateTombstonedCursor``). Without a supporting index that
+query filters ``org_id`` off ``idx_keeper_sync_state_org_id`` and then
+sorts the org's matching rows in memory.
+
+The partial index ``(org_id, date_tombstoned) WHERE date_tombstoned IS
+NOT NULL`` serves both the filter and the ordering directly. The partial
+predicate keeps the index small — only tombstoned rows, the rare case,
+are indexed — and PostgreSQL scans the ``date_tombstoned`` key backward
+to satisfy the ``DESC`` ordering, so no explicit ``DESC`` modifier is
+needed. The optional ``resource_type`` / ``tombstone_reason`` filters
+are applied as cheap residual predicates on the rows the index returns.
+
+Revision ID: b6c7d8e9f0a1
+Revises: a5b6c7d8e9f0
+Create Date: 2026-05-27 00:01:00.000000+00:00
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b6c7d8e9f0a1"
+down_revision: str | None = "a5b6c7d8e9f0"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_keeper_sync_state_org_date_tombstoned",
+        "keeper_sync_state",
+        ["org_id", "date_tombstoned"],
+        postgresql_where=sa.text("date_tombstoned IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_keeper_sync_state_org_date_tombstoned",
+        table_name="keeper_sync_state",
+    )

--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -44,6 +44,7 @@ from .keeper_sync import (
     KeeperSyncProjectRefreshAccepted,
     KeeperSyncProjectStateSummary,
     KeeperSyncProjectStatus,
+    KeeperSyncResourceType,
     KeeperSyncRun,
     KeeperSyncRunCreated,
     KeeperSyncRunKind,
@@ -51,6 +52,8 @@ from .keeper_sync import (
     KeeperSyncTierCohort,
     KeeperSyncTierName,
     KeeperSyncTierStatus,
+    KeeperSyncTombstone,
+    KeeperSyncTombstoneReason,
 )
 from .lifecycle import (
     BuildHistoryOrphanRule,
@@ -125,6 +128,7 @@ __all__ = [
     "KeeperSyncProjectRefreshAccepted",
     "KeeperSyncProjectStateSummary",
     "KeeperSyncProjectStatus",
+    "KeeperSyncResourceType",
     "KeeperSyncRun",
     "KeeperSyncRunCreated",
     "KeeperSyncRunKind",
@@ -132,6 +136,8 @@ __all__ = [
     "KeeperSyncTierCohort",
     "KeeperSyncTierName",
     "KeeperSyncTierStatus",
+    "KeeperSyncTombstone",
+    "KeeperSyncTombstoneReason",
     "LifecycleEvalRunStatus",
     "LifecycleRule",
     "LifecycleRuleSet",

--- a/client/src/docverse/client/models/keeper_sync.py
+++ b/client/src/docverse/client/models/keeper_sync.py
@@ -17,6 +17,7 @@ __all__ = [
     "KeeperSyncProjectRefreshAccepted",
     "KeeperSyncProjectStateSummary",
     "KeeperSyncProjectStatus",
+    "KeeperSyncResourceType",
     "KeeperSyncRun",
     "KeeperSyncRunCreated",
     "KeeperSyncRunKind",
@@ -24,6 +25,8 @@ __all__ = [
     "KeeperSyncTierCohort",
     "KeeperSyncTierName",
     "KeeperSyncTierStatus",
+    "KeeperSyncTombstone",
+    "KeeperSyncTombstoneReason",
 ]
 
 
@@ -467,4 +470,135 @@ class KeeperSyncProjectRefreshAccepted(BaseModel):
 
     queue_job_url: HttpUrl = Field(
         description="URL of the enqueued queue job resource."
+    )
+
+
+class KeeperSyncResourceType(StrEnum):
+    """LTD resource types tracked by keeper-sync.
+
+    Mirrors :class:`docverse.storage.keeper_sync.ResourceType` as a
+    public wire value so the admin tombstone API can filter requests
+    and shape responses without leaking the server-side enum's import
+    path. Builds are not tombstoned today, but the value is kept so
+    operator-facing filters do not silently reject a valid resource
+    type the schema otherwise carries.
+    """
+
+    project = "project"
+    edition = "edition"
+    build = "build"
+
+
+class KeeperSyncTombstoneReason(StrEnum):
+    """Why a ``keeper_sync_state`` row was tombstoned.
+
+    Wire-stable enum surfaced by the admin tombstone API. Mirrors
+    :class:`docverse.storage.keeper_sync.TombstoneReason`.
+    """
+
+    manual_delete = "manual_delete"
+    """Operator-driven soft-delete of the Docverse-side resource."""
+
+    lifecycle_delete = "lifecycle_delete"
+    """Automated soft-delete by ``lifecycle_eval`` / ``git_ref_audit`` /
+    the ``ref_deleted`` webhook."""
+
+    lifecycle_preemptive = "lifecycle_preemptive"
+    """Sync itself short-circuited an LTD edition that the lifecycle
+    rules would immediately delete, before the build content was
+    copied. No matching Docverse row exists in this case."""
+
+
+class KeeperSyncTombstone(BaseModel):
+    """One tombstoned ``keeper_sync_state`` row.
+
+    Returned by ``GET /orgs/{org}/keeper-sync/tombstones`` and
+    ``DELETE /orgs/{org}/keeper-sync/tombstones/{state_id}`` (the
+    DELETE returns 204 with no body, so this model only appears on
+    list responses today; keeping it as a sibling of the list-entry
+    shape lets a future "get one tombstone" endpoint reuse it).
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    self_url: HttpUrl = Field(
+        description=(
+            "Canonical URL of the DELETE endpoint that would clear this"
+            " tombstone (``delete_org_keeper_sync_tombstone``). The"
+            " endpoint accepts only ``DELETE``; GET-on-self is not"
+            " modelled because the list response already carries every"
+            " field a single-tombstone fetch would return."
+        )
+    )
+
+    state_id: int = Field(
+        description=(
+            "Primary key of the underlying ``keeper_sync_state`` row."
+            " Use this id with the DELETE endpoint to clear the"
+            " tombstone."
+        )
+    )
+
+    resource_type: KeeperSyncResourceType = Field(
+        description=(
+            "LTD resource type the tombstone applies to. ``project``"
+            " vetoes re-import of the LTD product entirely; ``edition``"
+            " vetoes one specific LTD edition; ``build`` is reserved"
+            " (no caller writes build-level tombstones today)."
+        )
+    )
+
+    ltd_slug: str = Field(
+        description=(
+            "LTD-side slug for the tombstoned resource. For ``project``"
+            " rows this is the LTD product slug; for ``edition`` rows"
+            " it is the LTD edition slug (e.g. ``main`` or ``v1.0``)."
+        )
+    )
+
+    ltd_id: int | None = Field(
+        default=None,
+        description=(
+            "LTD-side numeric id for the tombstoned resource."
+            " Populated for ``edition`` and ``build`` rows; ``null``"
+            " for ``project`` rows (LTD products are slug-only)."
+        ),
+    )
+
+    docverse_id: int | None = Field(
+        default=None,
+        description=(
+            "Docverse-side row id the tombstone is paired to."
+            " ``null`` for ``lifecycle_preemptive`` rows that veto an"
+            " LTD edition that was never imported (so no Docverse row"
+            " exists)."
+        ),
+    )
+
+    date_tombstoned: datetime = Field(
+        description="Wall-clock time the tombstone was recorded."
+    )
+
+    tombstone_reason: KeeperSyncTombstoneReason = Field(
+        description="Why this row was tombstoned."
+    )
+
+    tombstone_note: str | None = Field(
+        default=None,
+        description=(
+            "Optional operator-facing note the writer attached to this"
+            " tombstone. ``null`` for automated writes (lifecycle and"
+            " preemptive paths attach no note today)."
+        ),
+    )
+
+    display_path: str = Field(
+        description=(
+            "Docverse-side display path for the tombstoned resource."
+            " For ``project`` rows: the Docverse project slug. For"
+            " ``edition`` rows: ``<project_slug>/<edition_slug>``."
+            " Falls back to the LTD slug when no Docverse row is"
+            " linked (``lifecycle_preemptive`` rows) or the linked"
+            " row has been hard-deleted out from under the tombstone."
+        )
     )

--- a/src/docverse/dbschema/keeper_sync_state.py
+++ b/src/docverse/dbschema/keeper_sync_state.py
@@ -110,4 +110,17 @@ class SqlKeeperSyncState(Base):
             name="ck_keeper_sync_state_tombstone_reason",
         ),
         Index("idx_keeper_sync_state_org_id", "org_id"),
+        # Backs the admin tombstones listing
+        # (``GET /orgs/{org}/keeper-sync/tombstones``), which filters to
+        # one org's tombstoned rows and orders by ``date_tombstoned DESC,
+        # id DESC``. The ``WHERE date_tombstoned IS NOT NULL`` predicate
+        # keeps the index to just tombstoned rows — the rare case — and
+        # PostgreSQL scans the ``date_tombstoned`` key backward to serve
+        # the DESC ordering, so no explicit DESC modifier is needed.
+        Index(
+            "idx_keeper_sync_state_org_date_tombstoned",
+            "org_id",
+            "date_tombstoned",
+            postgresql_where=text("date_tombstoned IS NOT NULL"),
+        ),
     )

--- a/src/docverse/dbschema/keeper_sync_state.py
+++ b/src/docverse/dbschema/keeper_sync_state.py
@@ -72,6 +72,18 @@ class SqlKeeperSyncState(Base):
         JSONB, nullable=True
     )
 
+    date_tombstoned: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    tombstone_reason: Mapped[str | None] = mapped_column(
+        String(32), nullable=True
+    )
+
+    tombstone_note: Mapped[str | None] = mapped_column(
+        String(512), nullable=True
+    )
+
     __table_args__ = (
         Index(
             "uq_keeper_sync_state_project_org_slug",
@@ -91,6 +103,11 @@ class SqlKeeperSyncState(Base):
         CheckConstraint(
             "resource_type IN ('project', 'edition', 'build')",
             name="ck_keeper_sync_state_resource_type",
+        ),
+        CheckConstraint(
+            "tombstone_reason IS NULL OR tombstone_reason IN "
+            "('manual_delete', 'lifecycle_delete', 'lifecycle_preemptive')",
+            name="ck_keeper_sync_state_tombstone_reason",
         ),
         Index("idx_keeper_sync_state_org_id", "org_id"),
     )

--- a/src/docverse/exceptions.py
+++ b/src/docverse/exceptions.py
@@ -17,6 +17,7 @@ __all__ = [
     "InvalidBuildStateError",
     "InvalidJobStateError",
     "JobNotFoundError",
+    "KeeperSyncInvariantError",
     "MissingConfigurationError",
     "NotFoundError",
     "PermissionDeniedError",
@@ -299,3 +300,20 @@ class JobNotFoundError(DocverseSlackException):
         if job_public_id is not None:
             return f"Queue job {job_public_id} not found"
         return "Queue job not found"
+
+
+class KeeperSyncInvariantError(DocverseSlackException):
+    """An internal keeper-sync invariant was violated.
+
+    Raised by "should never happen" guards on the keeper-sync sync and
+    tombstone paths (composing a tombstone response from a row that is
+    not tombstoned, a state row vanishing mid-transaction, or
+    ``_fetch_live_refs`` invoked without its GitHub collaborators
+    configured). Replaces bare ``assert`` statements so the invariant
+    still fails loudly under ``python -O``.
+
+    No ``to_sentry`` override: the stack trace plus the free-form
+    ``message`` is enough to triage, and the only identifiers in scope
+    (``state_id``, ``org_id``) are internal row ids that must not be
+    surfaced as Sentry tags. Mirrors :class:`InvalidSlugError`.
+    """

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -893,6 +893,23 @@ class Factory:
             build_store=self.create_build_store(),
             state_store=self.create_keeper_sync_state_store(),
         )
+        # The proactive lifecycle evaluator needs all three GitHub-aware
+        # deps. Missing GitHub-App secrets or an unconfigured HTTP client
+        # disables the proactive pass — sync_project then falls through
+        # to the existing per-edition path; the regular lifecycle_eval
+        # / git_ref_audit crons still catch any deletable editions on
+        # their own schedule.
+        tombstone_service = self.create_keeper_sync_tombstone_service()
+        binding_resolver: ProjectGitHubBindingResolver | None
+        ref_set_fetcher: GitHubRefSetFetcher | None
+        try:
+            binding_resolver = self.create_project_github_binding_resolver()
+        except (GitHubAppNotConfiguredError, RuntimeError):
+            binding_resolver = None
+        try:
+            ref_set_fetcher = self.create_github_ref_set_fetcher()
+        except RuntimeError:
+            ref_set_fetcher = None
         return KeeperSyncService(
             session=self._session,
             context=context,
@@ -900,6 +917,9 @@ class Factory:
             copy_callable=copy_callable,
             manifest_callable=manifest_callable,
             logger=self._logger,
+            tombstone_service=tombstone_service,
+            binding_resolver=binding_resolver,
+            ref_set_fetcher=ref_set_fetcher,
         )
 
 

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -662,6 +662,7 @@ class Factory:
         ref_deleted = RefDeletedWebhookProcessor(
             project_store=self.create_project_store(),
             edition_store=self.create_edition_store(),
+            edition_service=self.create_edition_service(),
             org_store=self.create_org_store(),
             publishing_service=self.create_edition_publishing_service(),
             logger=self._logger,

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -46,6 +46,7 @@ from .services.keeper_sync import (
 from .services.keeper_sync_config import KeeperSyncConfigService
 from .services.keeper_sync_project import KeeperSyncProjectService
 from .services.keeper_sync_run import KeeperSyncRunService
+from .services.keeper_sync_tombstone import KeeperSyncTombstoneService
 from .services.lock_service import LockService
 from .services.organization import OrganizationService
 from .services.project import ProjectService
@@ -844,6 +845,16 @@ class Factory:
     def create_keeper_sync_state_store(self) -> KeeperSyncStateStore:
         """Create a :class:`KeeperSyncStateStore`."""
         return KeeperSyncStateStore(session=self._session, logger=self._logger)
+
+    def create_keeper_sync_tombstone_service(
+        self,
+    ) -> KeeperSyncTombstoneService:
+        """Create a :class:`KeeperSyncTombstoneService`."""
+        return KeeperSyncTombstoneService(
+            session=self._session,
+            state_store=self.create_keeper_sync_state_store(),
+            logger=self._logger,
+        )
 
     def create_keeper_sync_service(
         self,

--- a/src/docverse/handlers/orgs/editions.py
+++ b/src/docverse/handlers/orgs/editions.py
@@ -22,7 +22,7 @@ from docverse.domain.published_url import (
     edition_published_url,
     project_published_url,
 )
-from docverse.exceptions import PermissionDeniedError
+from docverse.exceptions import NotFoundError, PermissionDeniedError
 from docverse.handlers.params import (
     EditionSlugParam,
     OrgSlugParam,
@@ -31,6 +31,7 @@ from docverse.handlers.params import (
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_slug,
 )
+from docverse.storage.keeper_sync import TombstoneReason
 from docverse.storage.pagination import (
     DEFAULT_PAGE_LIMIT,
     EDITION_CURSOR_TYPES,
@@ -341,12 +342,36 @@ async def delete_edition(
         msg = "The default edition '__main' cannot be deleted"
         raise PermissionDeniedError(msg)
     async with context.session.begin():
-        service = context.factory.create_edition_service()
-        org = await service.soft_delete(
-            org_slug=org_slug,
-            project_slug=project_slug,
-            slug=edition_slug,
+        org_store = context.factory.create_org_store()
+        project_store = context.factory.create_project_store()
+        edition_store = context.factory.create_edition_store()
+        org = await org_store.get_by_slug(org_slug)
+        if org is None:
+            msg = f"Organization {org_slug!r} not found"
+            raise NotFoundError(msg)
+        project = await project_store.get_by_slug(
+            org_id=org.id, slug=project_slug
         )
+        if project is None:
+            msg = f"Project {project_slug!r} not found"
+            raise NotFoundError(msg)
+        edition = await edition_store.get_by_slug(
+            project_id=project.id, slug=edition_slug
+        )
+        if edition is None:
+            msg = f"Edition {edition_slug!r} not found"
+            raise NotFoundError(msg)
+        service = context.factory.create_edition_service()
+        deleted = await service.soft_delete(
+            org_id=org.id,
+            project_id=project.id,
+            edition_id=edition.id,
+            edition_slug=edition.slug,
+            reason=TombstoneReason.manual_delete,
+        )
+        if not deleted:
+            msg = f"Edition {edition_slug!r} not found"
+            raise NotFoundError(msg)
         await context.session.commit()
     # Remove the CDN pointer after the soft-delete commit so the public
     # URL stops resolving once the row is gone. ``unpublish`` is

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -23,6 +23,7 @@ from docverse.storage.pagination import (
     KEEPER_SYNC_EDITION_CURSOR_TYPE,
     KEEPER_SYNC_PROJECT_STATE_CURSOR_TYPE,
     KEEPER_SYNC_RUN_CURSOR_TYPE,
+    KEEPER_SYNC_TOMBSTONE_CURSOR_TYPE,
     MAX_PAGE_LIMIT,
     QUEUE_JOB_CURSOR_TYPE,
 )
@@ -446,7 +447,7 @@ async def get_org_keeper_sync_tombstones(  # noqa: PLR0913
     ] = None,
 ) -> list[KeeperSyncTombstone]:
     parsed_cursor = (
-        KEEPER_SYNC_PROJECT_STATE_CURSOR_TYPE.from_str(cursor)
+        KEEPER_SYNC_TOMBSTONE_CURSOR_TYPE.from_str(cursor)
         if cursor is not None
         else None
     )

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -4,17 +4,20 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, Query, status
+from fastapi import APIRouter, Depends, Path, Query, Response, status
 
 from docverse.client.models import (
     JobStatus,
     KeeperSyncConfig,
+    KeeperSyncResourceType,
     KeeperSyncRunStatus,
+    KeeperSyncTombstoneReason,
 )
 from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.handlers.params import OrgSlugParam
 from docverse.handlers.queue.models import QueueJob
+from docverse.storage.keeper_sync import ResourceType, TombstoneReason
 from docverse.storage.pagination import (
     DEFAULT_PAGE_LIMIT,
     KEEPER_SYNC_EDITION_CURSOR_TYPE,
@@ -30,6 +33,7 @@ from .keeper_sync_models import (
     KeeperSyncProjectStatus,
     KeeperSyncRun,
     KeeperSyncRunCreated,
+    KeeperSyncTombstone,
 )
 
 router = APIRouter()
@@ -403,3 +407,123 @@ async def get_org_keeper_sync_run_jobs(  # noqa: PLR0913
     return [
         QueueJob.from_domain(job, context.request) for job in result.entries
     ]
+
+
+@router.get(
+    "/orgs/{org}/keeper-sync/tombstones",
+    response_model=list[KeeperSyncTombstone],
+    summary="List sync tombstones for an organization",
+    name="get_org_keeper_sync_tombstones",
+)
+async def get_org_keeper_sync_tombstones(  # noqa: PLR0913
+    org_slug: OrgSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],
+    cursor: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Opaque pagination cursor from a previous response's"
+                " ``Link`` header."
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            ge=1,
+            le=MAX_PAGE_LIMIT,
+            description="Maximum number of results per page.",
+        ),
+    ] = DEFAULT_PAGE_LIMIT,
+    resource_type: Annotated[
+        KeeperSyncResourceType | None,
+        Query(description="Filter tombstones by resource type."),
+    ] = None,
+    tombstone_reason: Annotated[
+        KeeperSyncTombstoneReason | None,
+        Query(description="Filter tombstones by reason."),
+    ] = None,
+) -> list[KeeperSyncTombstone]:
+    parsed_cursor = (
+        KEEPER_SYNC_PROJECT_STATE_CURSOR_TYPE.from_str(cursor)
+        if cursor is not None
+        else None
+    )
+    storage_resource_type = (
+        ResourceType(resource_type.value)
+        if resource_type is not None
+        else None
+    )
+    storage_tombstone_reason = (
+        TombstoneReason(tombstone_reason.value)
+        if tombstone_reason is not None
+        else None
+    )
+    context.rebind_logger(actor=user.username)
+    async with context.session.begin():
+        service = context.factory.create_keeper_sync_tombstone_service()
+        result = await service.list_for_org(
+            org_id=user.org.id,
+            cursor=parsed_cursor,
+            limit=limit,
+            resource_type=storage_resource_type,
+            tombstone_reason=storage_tombstone_reason,
+        )
+    context.response.headers["Link"] = result.page.link_header(
+        context.request.url
+    )
+    context.response.headers["X-Total-Count"] = str(result.page.count)
+    context.logger.info(
+        "Listed sync tombstones",
+        org=org_slug,
+        resource_type=(
+            resource_type.value if resource_type is not None else None
+        ),
+        tombstone_reason=(
+            tombstone_reason.value if tombstone_reason is not None else None
+        ),
+        count=len(result.page.entries),
+    )
+    return [
+        KeeperSyncTombstone.from_domain(
+            entry,
+            result.display_path_by_state_id[entry.id],
+            context.request,
+            org_slug,
+        )
+        for entry in result.page.entries
+    ]
+
+
+@router.delete(
+    "/orgs/{org}/keeper-sync/tombstones/{state_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    summary="Clear a sync tombstone",
+    name="delete_org_keeper_sync_tombstone",
+)
+async def delete_org_keeper_sync_tombstone(
+    org_slug: OrgSlugParam,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],
+    state_id: Annotated[
+        int,
+        Path(description="Primary key of the keeper_sync_state row."),
+    ],
+) -> Response:
+    context.rebind_logger(actor=user.username)
+    async with context.session.begin():
+        service = context.factory.create_keeper_sync_tombstone_service()
+        cleared = await service.clear(state_id=state_id, org_id=user.org.id)
+        await context.session.commit()
+    context.logger.info(
+        "Cleared sync tombstone",
+        org=org_slug,
+        state_id=state_id,
+        resource_type=cleared.state.resource_type,
+        ltd_id=cleared.state.ltd_id,
+        ltd_slug=cleared.state.ltd_slug,
+        revived_docverse_row=cleared.revived_docverse_row,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/docverse/handlers/orgs/keeper_sync_models.py
+++ b/src/docverse/handlers/orgs/keeper_sync_models.py
@@ -38,6 +38,7 @@ from docverse.domain.keeper_sync_run import (
     KeeperSyncRunActivity as KeeperSyncRunActivityDomain,
 )
 from docverse.domain.queue import QueueJob as QueueJobDomain
+from docverse.exceptions import KeeperSyncInvariantError
 from docverse.services.keeper_sync_project import KeeperSyncProjectStatusResult
 from docverse.storage.keeper_sync import KeeperSyncState
 
@@ -265,11 +266,16 @@ class KeeperSyncTombstone(_KeeperSyncTombstoneBase):
 
         ``state.date_tombstoned`` and ``state.tombstone_reason`` must
         be non-null — the caller (admin list endpoint) only invokes
-        this for tombstoned rows. The assertions documents that
-        invariant for static analysis.
+        this for tombstoned rows. The guard below enforces that
+        invariant at runtime and narrows both fields for static
+        analysis.
         """
-        assert state.date_tombstoned is not None
-        assert state.tombstone_reason is not None
+        if state.date_tombstoned is None or state.tombstone_reason is None:
+            msg = (
+                "KeeperSyncTombstone.from_domain requires a tombstoned "
+                f"state row; state_id={state.id} has no tombstone"
+            )
+            raise KeeperSyncInvariantError(msg)
         return cls(
             self_url=HttpUrl(
                 str(

--- a/src/docverse/handlers/orgs/keeper_sync_models.py
+++ b/src/docverse/handlers/orgs/keeper_sync_models.py
@@ -16,11 +16,19 @@ from docverse.client.models import (
 from docverse.client.models import (
     KeeperSyncProjectStatus as _KeeperSyncProjectStatusBase,
 )
+from docverse.client.models import (
+    KeeperSyncResourceType,
+    KeeperSyncRunKind,
+    KeeperSyncRunStatus,
+    KeeperSyncTombstoneReason,
+)
 from docverse.client.models import KeeperSyncRun as _KeeperSyncRunBase
 from docverse.client.models import (
     KeeperSyncRunCreated as _KeeperSyncRunCreatedBase,
 )
-from docverse.client.models import KeeperSyncRunKind, KeeperSyncRunStatus
+from docverse.client.models import (
+    KeeperSyncTombstone as _KeeperSyncTombstoneBase,
+)
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.edition import Edition as EditionDomain
 from docverse.domain.keeper_sync_run import (
@@ -39,6 +47,7 @@ __all__ = [
     "KeeperSyncProjectStatus",
     "KeeperSyncRun",
     "KeeperSyncRunCreated",
+    "KeeperSyncTombstone",
 ]
 
 
@@ -238,4 +247,46 @@ class KeeperSyncProjectStatus(_KeeperSyncProjectStatusBase):
             tier_status=result.tier_status,
             main_edition=main_edition,
             edition_diff=result.edition_diff,
+        )
+
+
+class KeeperSyncTombstone(_KeeperSyncTombstoneBase):
+    """Tombstone entry wrapper minting the HATEOAS DELETE URL."""
+
+    @classmethod
+    def from_domain(
+        cls,
+        state: KeeperSyncState,
+        display_path: str,
+        request: Request,
+        org_slug: str,
+    ) -> Self:
+        """Compose the entry from a state row + derived display path.
+
+        ``state.date_tombstoned`` and ``state.tombstone_reason`` must
+        be non-null — the caller (admin list endpoint) only invokes
+        this for tombstoned rows. The assertions documents that
+        invariant for static analysis.
+        """
+        assert state.date_tombstoned is not None
+        assert state.tombstone_reason is not None
+        return cls(
+            self_url=HttpUrl(
+                str(
+                    request.url_for(
+                        "delete_org_keeper_sync_tombstone",
+                        org=org_slug,
+                        state_id=state.id,
+                    )
+                )
+            ),
+            state_id=state.id,
+            resource_type=KeeperSyncResourceType(state.resource_type),
+            ltd_slug=state.ltd_slug,
+            ltd_id=state.ltd_id,
+            docverse_id=state.docverse_id,
+            date_tombstoned=state.date_tombstoned,
+            tombstone_reason=KeeperSyncTombstoneReason(state.tombstone_reason),
+            tombstone_note=state.tombstone_note,
+            display_path=display_path,
         )

--- a/src/docverse/services/edition.py
+++ b/src/docverse/services/edition.py
@@ -18,6 +18,7 @@ from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
 )
 from docverse.storage.edition_store import EditionStore
+from docverse.storage.keeper_sync import TombstoneReason
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.pagination import EditionBuildHistoryPositionCursor
 from docverse.storage.project_store import ProjectStore
@@ -431,30 +432,42 @@ class EditionService:
         return org, project, updated_edition
 
     async def soft_delete(
-        self, *, org_slug: str, project_slug: str, slug: str
-    ) -> Organization:
-        """Soft-delete an edition.
+        self,
+        *,
+        org_id: int,
+        project_id: int,
+        edition_id: int,
+        edition_slug: str,
+        reason: TombstoneReason,
+    ) -> bool:
+        """Soft-delete one edition and stamp the keeper-sync tombstone.
 
-        Returns the resolved :class:`Organization` so the caller can
-        invoke downstream side-effects (e.g. CDN unpublish) keyed on
-        ``org_id`` without re-resolving the slug.
+        The single, id-based entrypoint shared by every Docverse-side
+        deletion path (PRD #332): the API DELETE handler, the
+        ``lifecycle_eval`` and ``git_ref_audit`` workers, and the
+        ``ref_deleted`` webhook processor. The ``reason`` is threaded
+        through to :meth:`EditionStore.soft_delete`, which records it
+        on the matching ``keeper_sync_state`` row in the same flush as
+        ``date_deleted`` (no-op when no state row exists).
 
-        Raises
-        ------
-        NotFoundError
-            If the edition is not found.
+        Returns ``False`` when the edition was not found / already
+        soft-deleted so bulk callers iterating a candidate set can
+        treat it as a no-op and continue; the handler raises
+        :class:`NotFoundError` on ``False``.
         """
-        org, project = await self._resolve_org_project(org_slug, project_slug)
         deleted = await self._store.soft_delete(
-            project_id=project.id, slug=slug
+            org_id=org_id,
+            project_id=project_id,
+            slug=edition_slug,
+            reason=reason,
         )
-        if not deleted:
-            msg = f"Edition {slug!r} not found"
-            raise NotFoundError(msg)
-        self._logger.info(
-            "Soft-deleted edition",
-            slug=slug,
-            org=org_slug,
-            project=project_slug,
-        )
-        return org
+        if deleted:
+            self._logger.info(
+                "Soft-deleted edition",
+                org_id=org_id,
+                project_id=project_id,
+                edition_id=edition_id,
+                edition_slug=edition_slug,
+                reason=reason.value,
+            )
+        return deleted

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -132,9 +132,14 @@ class EditionSyncOutcome:
     ``on_edition_synced`` publish-enqueue callback) have the project
     context the publish helper needs without re-querying the project
     store from the closure.
+
+    ``docverse_edition_id`` is ``None`` when the call short-circuited
+    on a tombstoned ``keeper_sync_state`` row whose ``docverse_id`` is
+    also ``None`` (the ``lifecycle_preemptive`` case writes such rows
+    for LTD editions that were never imported).
     """
 
-    docverse_edition_id: int
+    docverse_edition_id: int | None
     docverse_slug: str
     docverse_project_id: int
     docverse_project_slug: str
@@ -143,9 +148,17 @@ class EditionSyncOutcome:
 
 @dataclass(frozen=True)
 class ProjectSyncResult:
-    """What ``sync_project`` did with one LTD product."""
+    """What ``sync_project`` did with one LTD product.
 
-    docverse_project_id: int
+    ``docverse_project_id`` is ``None`` only when the call
+    short-circuited on a tombstoned ``keeper_sync_state`` project row
+    whose ``docverse_id`` was never populated — practically a
+    defensive shape; the only production path that writes a project
+    tombstone is the manual-delete chokepoint, which always carries a
+    Docverse project id.
+    """
+
+    docverse_project_id: int | None
     docverse_project_slug: str
     edition_outcomes: list[EditionSyncOutcome]
 
@@ -213,7 +226,33 @@ class KeeperSyncService:
         stop the rest of the project sync; the tail-end self-heal pass
         in the worker picks up any edition the callback failed to act
         on. The default ``None`` preserves all non-worker call sites.
+
+        Short-circuits before the LTD product fetch when the project's
+        ``keeper_sync_state`` row is tombstoned: the operator has
+        deleted the project on the Docverse side and the migration
+        must not re-import it. Returns a result with empty
+        ``edition_outcomes`` so worker post-sync passes (e.g. the
+        self-heal pass) iterate nothing.
         """
+        async with self._session.begin():
+            project_state = await self._state_store.get(
+                org_id=org_id,
+                resource_type=ResourceType.project,
+                ltd_slug=ltd_slug,
+                include_tombstoned=True,
+            )
+        if project_state is not None and project_state.date_tombstoned:
+            self._logger.info(
+                "Sync short-circuited: project tombstoned",
+                ltd_slug=ltd_slug,
+                tombstone_reason=project_state.tombstone_reason,
+            )
+            return ProjectSyncResult(
+                docverse_project_id=project_state.docverse_id,
+                docverse_project_slug=ltd_slug,
+                edition_outcomes=[],
+            )
+
         ltd_product = await self._ltd_client.get_product(ltd_slug)
         async with self._session.begin():
             org, project = await self._ensure_project(
@@ -305,7 +344,39 @@ class KeeperSyncService:
         ltd_edition: LtdEdition,
         org_slug: str | None = None,
     ) -> EditionSyncOutcome:
-        """Sync one LTD edition (and its current build) into Docverse."""
+        """Sync one LTD edition (and its current build) into Docverse.
+
+        Short-circuits *before* ``_ensure_edition`` runs when the
+        edition's ``keeper_sync_state`` row is tombstoned. The check
+        sits ahead of ``_ensure_edition`` so a tombstoned-but-still-
+        soft-deleted edition row cannot trip the ``create_internal``
+        slug clash that previously raised "lost ON CONFLICT race"
+        (the canonical Docverse uniqueness index ignores
+        ``date_deleted``, so a soft-deleted row keeps its slug
+        reserved against re-import).
+        """
+        async with self._session.begin():
+            edition_state = await self._state_store.get(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=ltd_edition.ltd_id,
+                include_tombstoned=True,
+            )
+        if edition_state is not None and edition_state.date_tombstoned:
+            self._logger.info(
+                "Sync short-circuited: edition tombstoned",
+                ltd_edition_id=ltd_edition.ltd_id,
+                ltd_edition_slug=ltd_edition.slug,
+                tombstone_reason=edition_state.tombstone_reason,
+            )
+            return EditionSyncOutcome(
+                docverse_edition_id=edition_state.docverse_id,
+                docverse_slug=derive_edition_slug(ltd_edition.slug),
+                docverse_project_id=project.id,
+                docverse_project_slug=project.slug,
+                build_outcome=None,
+            )
+
         # ``manual`` editions need the published build's git_refs to
         # synthesize a Docverse ``git_ref`` tracking pair. Other modes
         # ignore the build for mapping; we skip the extra fetch when we

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -42,7 +42,7 @@ from docverse.domain.edition import Edition
 from docverse.domain.lifecycle import DraftInactivityRule, RefDeletedRule
 from docverse.domain.organization import Organization
 from docverse.domain.project import Project
-from docverse.exceptions import NotFoundError
+from docverse.exceptions import KeeperSyncInvariantError, NotFoundError
 from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
 from docverse.services.lifecycle.evaluator import (
     LifecycleEvaluationContext,
@@ -457,8 +457,13 @@ class KeeperSyncService:
         **not** wrap this method in ``session.begin()``. Mirrors
         :func:`git_ref_audit._fetch_refs_per_project`.
         """
-        assert self._binding_resolver is not None  # checked by caller
-        assert self._ref_set_fetcher is not None  # checked by caller
+        if self._binding_resolver is None or self._ref_set_fetcher is None:
+            msg = (
+                "_fetch_live_refs requires binding_resolver and "
+                "ref_set_fetcher to be configured; caller must "
+                "short-circuit when they are None"
+            )
+            raise KeeperSyncInvariantError(msg)
         binding = await self._binding_resolver.resolve(project.id)
         if binding is None:
             return None

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -39,13 +39,33 @@ from docverse.client.models.projects import parse_github_url
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
+from docverse.domain.lifecycle import DraftInactivityRule, RefDeletedRule
 from docverse.domain.organization import Organization
 from docverse.domain.project import Project
 from docverse.exceptions import NotFoundError
+from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
+from docverse.services.lifecycle.evaluator import (
+    LifecycleEvaluationContext,
+    evaluate_lifecycle,
+    filter_rule_set,
+    resolve_rule_set,
+)
 from docverse.services.project import DEFAULT_EDITION_SLUG, ProjectService
+from docverse.services.project_github_binding import (
+    ProjectGitHubBindingResolver,
+)
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_store import EditionStore
-from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
+from docverse.storage.github import (
+    GitHubRefSetFetcher,
+    RepositoryNotAccessibleError,
+    RepositoryRefFetchError,
+)
+from docverse.storage.keeper_sync import (
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
 from docverse.storage.ltd import (
     LtdBuild,
     LtdClient,
@@ -193,6 +213,9 @@ class KeeperSyncService:
         manifest_callable: ManifestCallable,
         logger: structlog.stdlib.BoundLogger,
         orphan_reclaim_max_age: timedelta = DEFAULT_ORPHAN_RECLAIM_MAX_AGE,
+        tombstone_service: KeeperSyncTombstoneService | None = None,
+        binding_resolver: ProjectGitHubBindingResolver | None = None,
+        ref_set_fetcher: GitHubRefSetFetcher | None = None,
     ) -> None:
         self._session = session
         self._org_store = context.org_store
@@ -206,6 +229,9 @@ class KeeperSyncService:
         self._manifest_callable = manifest_callable
         self._logger = logger
         self._orphan_reclaim_max_age = orphan_reclaim_max_age
+        self._tombstone_service = tombstone_service
+        self._binding_resolver = binding_resolver
+        self._ref_set_fetcher = ref_set_fetcher
 
     async def sync_project(
         self,
@@ -261,8 +287,15 @@ class KeeperSyncService:
         ltd_editions = await self._ltd_client.list_editions_for_product(
             ltd_slug
         )
+        skip_ltd_ids = await self._proactive_lifecycle_pass(
+            org=org,
+            project=project,
+            ltd_editions=ltd_editions,
+        )
         outcomes: list[EditionSyncOutcome] = []
         for ltd_edition in ltd_editions:
+            if ltd_edition.ltd_id in skip_ltd_ids:
+                continue
             outcome = await self.sync_edition(
                 org_id=org.id,
                 org_slug=org.slug,
@@ -284,6 +317,182 @@ class KeeperSyncService:
             docverse_project_slug=project.slug,
             edition_outcomes=outcomes,
         )
+
+    async def _proactive_lifecycle_pass(
+        self,
+        *,
+        org: Organization,
+        project: Project,
+        ltd_editions: list[LtdEdition],
+    ) -> set[int]:
+        """Tombstone LTD editions a lifecycle rule would delete on import.
+
+        Runs once per :meth:`sync_project` invocation, between the LTD
+        editions list and the per-edition fan-out. For every LTD edition
+        that has no Docverse row and no existing tombstone, builds a
+        transient domain :class:`Edition` and runs
+        :func:`evaluate_lifecycle` filtered to ``draft_inactivity`` and
+        ``ref_deleted``; ``build_history_orphan`` is excluded because it
+        matches against the Docverse build-history chain that only
+        exists post-import (the post-import ``lifecycle_eval`` pass owns
+        it).
+
+        Returns the set of LTD edition ids the caller must skip — those
+        are tombstoned ``lifecycle_preemptive`` and never reach
+        ``sync_edition``. An empty set means "nothing tombstoned
+        proactively; iterate every LTD edition normally."
+
+        The proactive pass is a no-op when any of ``tombstone_service``,
+        ``binding_resolver``, or ``ref_set_fetcher`` is unconfigured —
+        the production factory wires all three; tests that exercise
+        only the non-proactive paths can omit them.
+
+        The per-project GitHub ref pre-fetch happens here (once,
+        outside any open write transaction) and is shared across every
+        edition. A ``RepositoryNotAccessibleError`` or
+        ``RepositoryRefFetchError`` is caught, logged, and downgrades
+        the pass — ``ref_deleted`` cannot match without ``live_refs``,
+        so those projects fall through to KEEP and the regular
+        ``git_ref_audit`` cron catches up on its own schedule.
+        """
+        if (
+            self._tombstone_service is None
+            or self._binding_resolver is None
+            or self._ref_set_fetcher is None
+        ):
+            return set()
+        if not ltd_editions:
+            return set()
+        rule_set = filter_rule_set(
+            resolve_rule_set(
+                org_rules=org.lifecycle_rules,
+                project_rules=project.lifecycle_rules,
+            ),
+            include=(DraftInactivityRule, RefDeletedRule),
+        )
+        if not rule_set.root:
+            return set()
+
+        # Pre-load state rows for this project's LTD editions in one
+        # round-trip. We need both ``date_tombstoned`` (skip already-
+        # vetoed editions so we do not overwrite the recorded reason)
+        # and ``docverse_id`` (skip already-imported editions — the
+        # regular ``lifecycle_eval`` pass owns those, and the transient
+        # built from LTD metadata could not see ``lifecycle_exempt`` or
+        # other Docverse-side state).
+        ltd_ids = [e.ltd_id for e in ltd_editions]
+        async with self._session.begin():
+            state_rows = await self._state_store.list_for_org(
+                org_id=org.id,
+                resource_type=ResourceType.edition,
+                ltd_ids=ltd_ids,
+                include_tombstoned=True,
+            )
+        state_by_ltd_id = {
+            row.ltd_id: row for row in state_rows if row.ltd_id is not None
+        }
+
+        live_refs = await self._fetch_live_refs(project=project)
+        now = _now()
+        skip_ltd_ids: set[int] = set()
+        for ltd_edition in ltd_editions:
+            state = state_by_ltd_id.get(ltd_edition.ltd_id)
+            if state is not None and (
+                state.date_tombstoned is not None
+                or state.docverse_id is not None
+            ):
+                continue
+            transient = _transient_edition_from_ltd(
+                ltd_edition=ltd_edition, project_id=project.id
+            )
+            if transient is None:
+                continue
+            decision = evaluate_lifecycle(
+                rule_set=rule_set,
+                context=LifecycleEvaluationContext(
+                    editions=[transient],
+                    builds=[],
+                    edition_build_history=[],
+                    now=now,
+                    live_refs=live_refs,
+                ),
+            )
+            matched_rule = decision.edition_matches.get(transient.id)
+            if matched_rule is None:
+                continue
+            async with self._session.begin():
+                await self._tombstone_service.record(
+                    org_id=org.id,
+                    resource_type=ResourceType.edition,
+                    ltd_id=ltd_edition.ltd_id,
+                    ltd_slug=ltd_edition.slug,
+                    reason=TombstoneReason.lifecycle_preemptive,
+                )
+            self._logger.info(
+                "Proactive lifecycle delete: tombstoning LTD edition",
+                ltd_edition_id=ltd_edition.ltd_id,
+                ltd_edition_slug=ltd_edition.slug,
+                rule_type=matched_rule,
+                org_id=org.id,
+                project_id=project.id,
+                project=project.slug,
+            )
+            skip_ltd_ids.add(ltd_edition.ltd_id)
+        return skip_ltd_ids
+
+    async def _fetch_live_refs(
+        self, *, project: Project
+    ) -> frozenset[str] | None:
+        """Resolve binding + fetch the project's live ref set, once.
+
+        Returns ``None`` when the project has no GitHub binding (the
+        ``ref_deleted`` rule simply does not fire) or when the GitHub
+        round-trip fails — both are accepted "rule disabled, KEEP wins"
+        outcomes. ``draft_inactivity`` is unaffected because it does
+        not read ``live_refs``.
+
+        ``ProjectGitHubBindingResolver.resolve`` owns its own short
+        read transaction and mints the GitHub installation token
+        *after* that transaction has closed; the caller must therefore
+        **not** wrap this method in ``session.begin()``. Mirrors
+        :func:`git_ref_audit._fetch_refs_per_project`.
+        """
+        assert self._binding_resolver is not None  # checked by caller
+        assert self._ref_set_fetcher is not None  # checked by caller
+        binding = await self._binding_resolver.resolve(project.id)
+        if binding is None:
+            return None
+        try:
+            ref_set = await self._ref_set_fetcher.fetch(
+                owner=binding.owner,
+                repo=binding.repo,
+                auth=binding.auth,
+                logger=self._logger,
+            )
+        except RepositoryNotAccessibleError as exc:
+            self._logger.info(
+                "Proactive lifecycle: GitHub repository not accessible,"
+                " ref_deleted disabled for this pass",
+                owner=exc.owner,
+                repo=exc.repo,
+                installation_id=binding.installation_id,
+                project_id=project.id,
+                project=project.slug,
+            )
+            return None
+        except RepositoryRefFetchError as exc:
+            self._logger.warning(
+                "Proactive lifecycle: GitHub ref fetch failed,"
+                " ref_deleted disabled for this pass",
+                owner=exc.owner,
+                repo=exc.repo,
+                installation_id=binding.installation_id,
+                project_id=project.id,
+                project=project.slug,
+                error=str(exc),
+            )
+            return None
+        return ref_set.all
 
     async def _ensure_project(
         self, *, org_id: int, ltd_product: LtdProduct
@@ -792,3 +1001,47 @@ def _now() -> datetime:
 
 def _ensure_trailing_slash(prefix: str) -> str:
     return prefix if prefix.endswith("/") else f"{prefix}/"
+
+
+def _transient_edition_from_ltd(
+    *, ltd_edition: LtdEdition, project_id: int
+) -> Edition | None:
+    """Build a transient ``Edition`` from an LTD edition for proactive eval.
+
+    The proactive lifecycle pass evaluates :func:`evaluate_lifecycle`
+    against editions that may not have a Docverse row yet, so we
+    synthesise a domain :class:`Edition` from the LTD edition's
+    metadata. Only ``draft_inactivity`` and ``ref_deleted`` participate
+    in the proactive pass, so the transient only needs the fields
+    those two predicates read: ``kind``, ``tracking_mode``,
+    ``tracking_params``, ``lifecycle_exempt``, ``date_deleted``, and
+    ``date_updated``.
+
+    Returns ``None`` when the LTD edition's mode requires the
+    currently-published build to map (``manual``) — the proactive
+    evaluator deliberately does not fetch builds (defeats the
+    bandwidth-saving point). Those editions fall through to
+    ``sync_edition`` and the regular ``lifecycle_eval`` pass handles
+    them post-import. ``date_updated`` mirrors LTD's ``date_rebuilt``
+    when set (LTD's analogue of Docverse's edition-touch timestamp)
+    and falls back to ``date_created`` otherwise.
+    """
+    try:
+        tracking_mode, tracking_params = map_edition_tracking(
+            ltd_edition, build=None
+        )
+    except ValueError:
+        return None
+    return Edition(
+        id=ltd_edition.ltd_id,
+        slug=derive_edition_slug(ltd_edition.slug),
+        title=ltd_edition.title,
+        project_id=project_id,
+        kind=derive_edition_kind(ltd_edition.slug),
+        tracking_mode=tracking_mode,
+        tracking_params=tracking_params or None,
+        lifecycle_exempt=False,
+        date_created=ltd_edition.date_created,
+        date_updated=ltd_edition.date_rebuilt or ltd_edition.date_created,
+        date_deleted=None,
+    )

--- a/src/docverse/services/keeper_sync_tombstone.py
+++ b/src/docverse/services/keeper_sync_tombstone.py
@@ -6,21 +6,25 @@ LTD resource has been deleted on the Docverse side; do not re-migrate
 it." See PRD #332 / DM-54914 for the full design.
 
 This service is the single, well-tested entrypoint every deletion path
-goes through to write or check a tombstone. Subsequent slices of the
-PRD wire individual call sites (manual delete, lifecycle delete, the
-lifecycle-preemptive short-circuit, the admin API) through this
-service; this slice ships only the storage primitives.
+goes through to write, check, list, or clear a tombstone. Manual
+deletes, lifecycle-driven deletes, and the lifecycle-preemptive
+short-circuit all write via :meth:`record`; the admin API reads via
+:meth:`list_for_org` and recovers via :meth:`clear`.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 import structlog
-from sqlalchemy import select
+from safir.database import CountedPaginatedList
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
+from docverse.dbschema.project import SqlProject
 from docverse.storage.keeper_sync import (
     KeeperSyncState,
     KeeperSyncStateStore,
@@ -28,8 +32,49 @@ from docverse.storage.keeper_sync import (
     TombstoneReason,
 )
 from docverse.storage.keeper_sync.state_store import _key_clauses
+from docverse.storage.pagination import KeeperSyncProjectStateIdCursor
 
-__all__ = ["KeeperSyncTombstoneService"]
+__all__ = [
+    "ClearedTombstone",
+    "KeeperSyncTombstoneListResult",
+    "KeeperSyncTombstoneService",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class KeeperSyncTombstoneListResult:
+    """Handler-agnostic result of :meth:`list_for_org`.
+
+    Carries the paginated state-row page plus per-entry derived display
+    paths so the handler can compose the API response without
+    re-issuing project / edition lookups. ``display_path_by_state_id``
+    maps each entry's ``state.id`` to a human-readable
+    Docverse-side path (``project_slug`` for project rows;
+    ``project_slug/edition_slug`` for edition rows when the related
+    Docverse rows still exist) and falls back to the LTD slug when no
+    Docverse row exists — i.e. for ``lifecycle_preemptive`` rows or
+    rows whose docverse row has been hard-deleted out from under the
+    tombstone.
+    """
+
+    page: CountedPaginatedList[KeeperSyncState, KeeperSyncProjectStateIdCursor]
+    display_path_by_state_id: dict[int, str]
+
+
+@dataclass(frozen=True, slots=True)
+class ClearedTombstone:
+    """Result of :meth:`clear` — the cleared row plus revive outcome.
+
+    ``revived_docverse_row`` is ``True`` when the matching Docverse row
+    (edition or project) was still soft-deleted at clear time and its
+    ``date_deleted`` was cleared in the same transaction. This is the
+    revive-on-clear behavior PRD #332 calls out — without it the next
+    sync iteration would crash on the slug clash because the
+    soft-deleted row still occupies the unique index slot.
+    """
+
+    state: KeeperSyncState
+    revived_docverse_row: bool
 
 
 class KeeperSyncTombstoneService:
@@ -132,3 +177,204 @@ class KeeperSyncTombstoneService:
             include_tombstoned=True,
         )
         return row is not None and row.date_tombstoned is not None
+
+    async def list_for_org(
+        self,
+        *,
+        org_id: int,
+        cursor: KeeperSyncProjectStateIdCursor | None,
+        limit: int,
+        resource_type: ResourceType | None = None,
+        tombstone_reason: TombstoneReason | None = None,
+    ) -> KeeperSyncTombstoneListResult:
+        """Return a paginated page of tombstoned rows for an org.
+
+        Backs the admin ``GET /orgs/{org}/keeper-sync/tombstones``
+        endpoint. Filters by ``resource_type`` and ``tombstone_reason``
+        stack and may both be ``None`` (no filter). Each entry's
+        ``display_path`` is computed in one extra round-trip per table:
+        editions in the page are bulk-fetched (including soft-deleted)
+        and their parent projects (including soft-deleted) are
+        bulk-fetched once, so the response is composed without N+1
+        per-row lookups.
+        """
+        page = await self._state_store.list_tombstones_for_org(
+            org_id=org_id,
+            cursor=cursor,
+            limit=limit,
+            resource_type=resource_type,
+            tombstone_reason=(
+                tombstone_reason.value
+                if tombstone_reason is not None
+                else None
+            ),
+        )
+
+        edition_ids: set[int] = set()
+        project_ids: set[int] = set()
+        for entry in page.entries:
+            if entry.docverse_id is None:
+                continue
+            if entry.resource_type == ResourceType.edition.value:
+                edition_ids.add(entry.docverse_id)
+            elif entry.resource_type == ResourceType.project.value:
+                project_ids.add(entry.docverse_id)
+
+        editions_by_id: dict[int, SqlEdition] = {}
+        if edition_ids:
+            edition_result = await self._session.execute(
+                select(SqlEdition).where(SqlEdition.id.in_(edition_ids))
+            )
+            editions_by_id = {
+                row.id: row for row in edition_result.scalars().all()
+            }
+            project_ids.update(
+                row.project_id for row in editions_by_id.values()
+            )
+
+        projects_by_id: dict[int, SqlProject] = {}
+        if project_ids:
+            project_result = await self._session.execute(
+                select(SqlProject).where(SqlProject.id.in_(project_ids))
+            )
+            projects_by_id = {
+                row.id: row for row in project_result.scalars().all()
+            }
+
+        display_path_by_state_id: dict[int, str] = {
+            entry.id: _derive_display_path(
+                entry,
+                editions_by_id=editions_by_id,
+                projects_by_id=projects_by_id,
+            )
+            for entry in page.entries
+        }
+        return KeeperSyncTombstoneListResult(
+            page=page,
+            display_path_by_state_id=display_path_by_state_id,
+        )
+
+    async def clear(
+        self,
+        *,
+        state_id: int,
+        org_id: int,
+    ) -> ClearedTombstone:
+        """Clear the tombstone on a state row, reviving its Docverse row.
+
+        Backs ``DELETE /orgs/{org}/keeper-sync/tombstones/{state_id}``.
+        Looks up the state row by ``(state_id, org_id)`` so a guessed
+        id from another org is invisible. The state row's
+        ``date_tombstoned`` / ``tombstone_reason`` / ``tombstone_note``
+        are cleared in-place. When the row carries a non-null
+        ``docverse_id`` and the matching ``editions`` / ``projects``
+        row is still soft-deleted, that row's ``date_deleted`` is
+        cleared in the *same* transaction — otherwise the next sync
+        iteration would crash on the slug clash because the
+        soft-deleted row still occupies the
+        ``uq_editions_project_lower_slug`` index slot. Soft-delete on
+        builds is not modelled in this codebase, so the build branch
+        only clears the tombstone fields.
+
+        Raises
+        ------
+        NotFoundError
+            When no row matches ``(state_id, org_id)`` *or* the
+            matched row is not tombstoned. (Clearing an already-clear
+            row is treated as "no such tombstone" — the admin URL is
+            meaningful only on a tombstoned row.)
+        """
+        from docverse.exceptions import NotFoundError  # noqa: PLC0415
+
+        state = await self._state_store.get_by_id_for_org(
+            state_id=state_id, org_id=org_id
+        )
+        if state is None or state.date_tombstoned is None:
+            msg = f"No tombstone found for state_id={state_id}"
+            raise NotFoundError(msg)
+
+        await self._session.execute(
+            update(SqlKeeperSyncState)
+            .where(SqlKeeperSyncState.id == state_id)
+            .values(
+                date_tombstoned=None,
+                tombstone_reason=None,
+                tombstone_note=None,
+            )
+        )
+
+        revived = False
+        if state.docverse_id is not None:
+            if state.resource_type == ResourceType.edition.value:
+                edition_revive = await self._session.execute(
+                    update(SqlEdition)
+                    .where(
+                        SqlEdition.id == state.docverse_id,
+                        SqlEdition.date_deleted.is_not(None),
+                    )
+                    .values(date_deleted=None)
+                    .returning(SqlEdition.id)
+                )
+                revived = edition_revive.scalar_one_or_none() is not None
+            elif state.resource_type == ResourceType.project.value:
+                project_revive = await self._session.execute(
+                    update(SqlProject)
+                    .where(
+                        SqlProject.id == state.docverse_id,
+                        SqlProject.date_deleted.is_not(None),
+                    )
+                    .values(date_deleted=None)
+                    .returning(SqlProject.id)
+                )
+                revived = project_revive.scalar_one_or_none() is not None
+
+        await self._session.flush()
+
+        cleared = await self._state_store.get_by_id_for_org(
+            state_id=state_id, org_id=org_id
+        )
+        assert cleared is not None  # we just cleared it; row still exists
+        self._logger.info(
+            "Sync tombstone cleared",
+            org_id=org_id,
+            state_id=state_id,
+            resource_type=state.resource_type,
+            ltd_id=state.ltd_id,
+            ltd_slug=state.ltd_slug,
+            previous_reason=state.tombstone_reason,
+            revived_docverse_row=revived,
+        )
+        return ClearedTombstone(state=cleared, revived_docverse_row=revived)
+
+
+def _derive_display_path(
+    state: KeeperSyncState,
+    *,
+    editions_by_id: dict[int, SqlEdition],
+    projects_by_id: dict[int, SqlProject],
+) -> str:
+    """Compose a Docverse-side display path for a tombstoned state row.
+
+    For project rows this is the Docverse project slug; for edition
+    rows it is ``<project_slug>/<edition_slug>``. Falls back to the
+    LTD-side slug when no Docverse row is linked — i.e. for
+    ``lifecycle_preemptive`` rows that veto an LTD edition that was
+    never imported.
+    """
+    if state.resource_type == ResourceType.edition.value:
+        if state.docverse_id is not None:
+            edition = editions_by_id.get(state.docverse_id)
+            if edition is not None:
+                project = projects_by_id.get(edition.project_id)
+                if project is not None:
+                    return f"{project.slug}/{edition.slug}"
+                return edition.slug
+        return state.ltd_slug
+    if state.resource_type == ResourceType.project.value:
+        if state.docverse_id is not None:
+            project = projects_by_id.get(state.docverse_id)
+            if project is not None:
+                return project.slug
+        return state.ltd_slug
+    # builds (not used by the admin UI today but kept defensive)
+    return state.ltd_slug

--- a/src/docverse/services/keeper_sync_tombstone.py
+++ b/src/docverse/services/keeper_sync_tombstone.py
@@ -32,7 +32,7 @@ from docverse.storage.keeper_sync import (
     TombstoneReason,
 )
 from docverse.storage.keeper_sync.state_store import _key_clauses
-from docverse.storage.pagination import KeeperSyncProjectStateIdCursor
+from docverse.storage.pagination import KeeperSyncStateDateTombstonedCursor
 
 __all__ = [
     "ClearedTombstone",
@@ -57,7 +57,9 @@ class KeeperSyncTombstoneListResult:
     tombstone.
     """
 
-    page: CountedPaginatedList[KeeperSyncState, KeeperSyncProjectStateIdCursor]
+    page: CountedPaginatedList[
+        KeeperSyncState, KeeperSyncStateDateTombstonedCursor
+    ]
     display_path_by_state_id: dict[int, str]
 
 
@@ -182,7 +184,7 @@ class KeeperSyncTombstoneService:
         self,
         *,
         org_id: int,
-        cursor: KeeperSyncProjectStateIdCursor | None,
+        cursor: KeeperSyncStateDateTombstonedCursor | None,
         limit: int,
         resource_type: ResourceType | None = None,
         tombstone_reason: TombstoneReason | None = None,

--- a/src/docverse/services/keeper_sync_tombstone.py
+++ b/src/docverse/services/keeper_sync_tombstone.py
@@ -1,0 +1,134 @@
+"""Service for writing and reading keeper-sync tombstones.
+
+A *sync tombstone* is a permanent veto recorded on the existing
+``keeper_sync_state`` table that tells the keeper-sync engine "this
+LTD resource has been deleted on the Docverse side; do not re-migrate
+it." See PRD #332 / DM-54914 for the full design.
+
+This service is the single, well-tested entrypoint every deletion path
+goes through to write or check a tombstone. Subsequent slices of the
+PRD wire individual call sites (manual delete, lifecycle delete, the
+lifecycle-preemptive short-circuit, the admin API) through this
+service; this slice ships only the storage primitives.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
+from docverse.storage.keeper_sync import (
+    KeeperSyncState,
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
+from docverse.storage.keeper_sync.state_store import _key_clauses
+
+__all__ = ["KeeperSyncTombstoneService"]
+
+
+class KeeperSyncTombstoneService:
+    """Write and read sync tombstones on ``keeper_sync_state`` rows."""
+
+    def __init__(
+        self,
+        *,
+        session: AsyncSession,
+        state_store: KeeperSyncStateStore,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._session = session
+        self._state_store = state_store
+        self._logger = logger
+
+    async def record(  # noqa: PLR0913
+        self,
+        *,
+        org_id: int,
+        resource_type: ResourceType,
+        reason: TombstoneReason,
+        ltd_id: int | None = None,
+        ltd_slug: str | None = None,
+        note: str | None = None,
+    ) -> KeeperSyncState:
+        """Tombstone the matching ``keeper_sync_state`` row.
+
+        The veto is written by stamping ``date_tombstoned``,
+        ``tombstone_reason``, and ``tombstone_note`` on the row keyed
+        by ``(org_id, resource_type, ltd_id|ltd_slug)``. If no such
+        row exists — the ``lifecycle_preemptive`` case may fire
+        against an LTD edition that was never imported — a fresh row
+        with ``docverse_id=NULL`` is created carrying the tombstone
+        fields directly.
+
+        ``ltd_slug`` is required for ``project`` rows and ``ltd_id``
+        for ``edition`` / ``build`` rows; see
+        :func:`docverse.storage.keeper_sync.state_store._key_clauses`.
+        """
+        clauses = _key_clauses(
+            org_id=org_id,
+            resource_type=resource_type,
+            ltd_id=ltd_id,
+            ltd_slug=ltd_slug,
+        )
+        existing = await self._session.execute(
+            select(SqlKeeperSyncState).where(*clauses)
+        )
+        row = existing.scalar_one_or_none()
+        now = datetime.now(tz=UTC)
+        if row is None:
+            # Lifecycle-preemptive path: no Docverse row exists yet, so
+            # synthesise a state row carrying only the tombstone fields.
+            row = SqlKeeperSyncState(
+                org_id=org_id,
+                resource_type=resource_type.value,
+                ltd_id=ltd_id,
+                ltd_slug=ltd_slug if ltd_slug is not None else str(ltd_id),
+                date_tombstoned=now,
+                tombstone_reason=reason.value,
+                tombstone_note=note,
+            )
+            self._session.add(row)
+        else:
+            row.date_tombstoned = now
+            row.tombstone_reason = reason.value
+            row.tombstone_note = note
+        await self._session.flush()
+        await self._session.refresh(row)
+        self._logger.info(
+            "Sync tombstone recorded",
+            org_id=org_id,
+            resource_type=resource_type.value,
+            ltd_id=ltd_id,
+            ltd_slug=ltd_slug,
+            reason=reason.value,
+        )
+        return KeeperSyncState.model_validate(row)
+
+    async def is_tombstoned(
+        self,
+        *,
+        org_id: int,
+        resource_type: ResourceType,
+        ltd_id: int | None = None,
+        ltd_slug: str | None = None,
+    ) -> bool:
+        """Return True when the matching state row is tombstoned.
+
+        A row is tombstoned iff ``date_tombstoned IS NOT NULL``. The
+        absence of a row is treated as "not tombstoned" — the LTD
+        resource has never been seen and is not vetoed.
+        """
+        row = await self._state_store.get(
+            org_id=org_id,
+            resource_type=resource_type,
+            ltd_id=ltd_id,
+            ltd_slug=ltd_slug,
+            include_tombstoned=True,
+        )
+        return row is not None and row.date_tombstoned is not None

--- a/src/docverse/services/keeper_sync_tombstone.py
+++ b/src/docverse/services/keeper_sync_tombstone.py
@@ -284,7 +284,10 @@ class KeeperSyncTombstoneService:
             row is treated as "no such tombstone" — the admin URL is
             meaningful only on a tombstoned row.)
         """
-        from docverse.exceptions import NotFoundError  # noqa: PLC0415
+        from docverse.exceptions import (  # noqa: PLC0415
+            KeeperSyncInvariantError,
+            NotFoundError,
+        )
 
         state = await self._state_store.get_by_id_for_org(
             state_id=state_id, org_id=org_id
@@ -333,7 +336,12 @@ class KeeperSyncTombstoneService:
         cleared = await self._state_store.get_by_id_for_org(
             state_id=state_id, org_id=org_id
         )
-        assert cleared is not None  # we just cleared it; row still exists
+        if cleared is None:
+            msg = (
+                f"State row state_id={state_id} vanished after clearing its "
+                "tombstone"
+            )
+            raise KeeperSyncInvariantError(msg)
         self._logger.info(
             "Sync tombstone cleared",
             org_id=org_id,

--- a/src/docverse/services/project.py
+++ b/src/docverse/services/project.py
@@ -18,6 +18,7 @@ from docverse.domain.organization import Organization
 from docverse.domain.project import Project
 from docverse.exceptions import ConflictError, NotFoundError
 from docverse.storage.edition_store import EditionStore
+from docverse.storage.keeper_sync import TombstoneReason
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.pagination import ProjectSearchCursor
 from docverse.storage.project_store import ProjectStore
@@ -266,7 +267,11 @@ class ProjectService:
             raise NotFoundError(msg)
         editions = await self._edition_store.list_all_by_project(project.id)
         edition_slugs = [e.slug for e in editions]
-        deleted = await self._store.soft_delete(org_id=org.id, slug=slug)
+        deleted = await self._store.soft_delete(
+            org_id=org.id,
+            slug=slug,
+            reason=TombstoneReason.manual_delete,
+        )
         if not deleted:
             msg = f"Project {slug!r} not found"
             raise NotFoundError(msg)

--- a/src/docverse/services/ref_deleted_processor.py
+++ b/src/docverse/services/ref_deleted_processor.py
@@ -10,8 +10,10 @@ import structlog
 
 from docverse.client.models.dashboard_template import normalize_github_ref
 from docverse.domain.project import Project
+from docverse.services.edition import EditionService
 from docverse.services.edition_publishing import EditionPublishingService
 from docverse.storage.edition_store import EditionStore
+from docverse.storage.keeper_sync import TombstoneReason
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 
@@ -85,17 +87,19 @@ class RefDeletedWebhookProcessor:
     opens its own ``session.begin()``.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         project_store: ProjectStore,
         edition_store: EditionStore,
+        edition_service: EditionService,
         org_store: OrganizationStore,
         publishing_service: EditionPublishingService,
         logger: structlog.stdlib.BoundLogger,
     ) -> None:
         self._project_store = project_store
         self._edition_store = edition_store
+        self._edition_service = edition_service
         self._org_store = org_store
         self._publishing_service = publishing_service
         self._logger = logger
@@ -241,8 +245,12 @@ class RefDeletedWebhookProcessor:
         )
         deleted: list[int] = []
         for edition in editions:
-            was_deleted = await self._edition_store.soft_delete(
-                project_id=project.id, slug=edition.slug
+            was_deleted = await self._edition_service.soft_delete(
+                org_id=project.org_id,
+                project_id=project.id,
+                edition_id=edition.id,
+                edition_slug=edition.slug,
+                reason=TombstoneReason.lifecycle_delete,
             )
             if not was_deleted:
                 continue

--- a/src/docverse/storage/edition_store.py
+++ b/src/docverse/storage/edition_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -10,7 +11,7 @@ from safir.database import (
     CountedPaginatedQueryRunner,
     PaginationCursor,
 )
-from sqlalchemy import Select, select
+from sqlalchemy import Select, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
@@ -24,6 +25,7 @@ from docverse.client.models import (
 from docverse.client.models.queue_enums import PublishStatus
 from docverse.dbschema.build import SqlBuild
 from docverse.dbschema.edition import SqlEdition
+from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
 from docverse.domain.edition import Edition
 from docverse.domain.version import (
     EupsDailyVersion,
@@ -32,6 +34,7 @@ from docverse.domain.version import (
     LsstDocVersion,
     SemverVersion,
 )
+from docverse.storage.keeper_sync import ResourceType, TombstoneReason
 
 
 class EditionStore:
@@ -428,10 +431,24 @@ class EditionStore:
         row.alternate_name = alternate_name
         await self._session.flush()
 
-    async def soft_delete(self, *, project_id: int, slug: str) -> bool:
-        """Soft-delete an edition by setting date_deleted.
+    async def soft_delete(
+        self,
+        *,
+        org_id: int,
+        project_id: int,
+        slug: str,
+        reason: TombstoneReason,
+    ) -> bool:
+        """Soft-delete an edition and stamp the keeper-sync tombstone.
 
         Slug matching is case-insensitive (see :meth:`get_by_slug`).
+        The physical chokepoint for centralized soft-delete (PRD #332):
+        in the same flush that stamps ``date_deleted``, this records
+        the tombstone fields on the matching ``keeper_sync_state`` row
+        (located by ``(org_id, resource_type='edition', docverse_id=
+        <edition.id>)``). The tombstone write is a no-op when no state
+        row exists for this edition (e.g. a manually-created edition
+        never imported from LTD).
 
         Returns
         -------
@@ -449,6 +466,19 @@ class EditionStore:
         if row is None:
             return False
         row.date_deleted = func.now()
+        await self._session.execute(
+            update(SqlKeeperSyncState)
+            .where(
+                SqlKeeperSyncState.org_id == org_id,
+                SqlKeeperSyncState.resource_type == ResourceType.edition.value,
+                SqlKeeperSyncState.docverse_id == row.id,
+            )
+            .values(
+                date_tombstoned=datetime.now(tz=UTC),
+                tombstone_reason=reason.value,
+                tombstone_note=None,
+            )
+        )
         await self._session.flush()
         return True
 

--- a/src/docverse/storage/edition_store.py
+++ b/src/docverse/storage/edition_store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -474,7 +473,7 @@ class EditionStore:
                 SqlKeeperSyncState.docverse_id == row.id,
             )
             .values(
-                date_tombstoned=datetime.now(tz=UTC),
+                date_tombstoned=func.now(),
                 tombstone_reason=reason.value,
                 tombstone_note=None,
             )

--- a/src/docverse/storage/keeper_sync/__init__.py
+++ b/src/docverse/storage/keeper_sync/__init__.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from .state_store import KeeperSyncState, KeeperSyncStateStore, ResourceType
+from .state_store import (
+    KeeperSyncState,
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
 
 __all__ = [
     "KeeperSyncState",
     "KeeperSyncStateStore",
     "ResourceType",
+    "TombstoneReason",
 ]

--- a/src/docverse/storage/keeper_sync/state_store.py
+++ b/src/docverse/storage/keeper_sync/state_store.py
@@ -25,7 +25,10 @@ from sqlalchemy.sql import ColumnElement
 from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
 
 if TYPE_CHECKING:
-    from docverse.storage.pagination import KeeperSyncProjectStateIdCursor
+    from docverse.storage.pagination import (
+        KeeperSyncProjectStateIdCursor,
+        KeeperSyncStateDateTombstonedCursor,
+    )
 
 __all__ = [
     "KeeperSyncState",
@@ -321,11 +324,13 @@ class KeeperSyncStateStore:
         self,
         *,
         org_id: int,
-        cursor: KeeperSyncProjectStateIdCursor | None,
+        cursor: KeeperSyncStateDateTombstonedCursor | None,
         limit: int,
         resource_type: ResourceType | None = None,
         tombstone_reason: str | None = None,
-    ) -> CountedPaginatedList[KeeperSyncState, KeeperSyncProjectStateIdCursor]:
+    ) -> CountedPaginatedList[
+        KeeperSyncState, KeeperSyncStateDateTombstonedCursor
+    ]:
         """Return a paginated page of tombstoned state rows for an org.
 
         Backs the admin ``GET /orgs/{org}/keeper-sync/tombstones``
@@ -339,18 +344,16 @@ class KeeperSyncStateStore:
           ``lifecycle_delete`` / ``lifecycle_preemptive``).
 
         Pagination uses
-        :class:`docverse.storage.pagination.KeeperSyncProjectStateIdCursor`
-        (id DESC) — the cursor's name retains the original
-        project-listing call site but its underlying column is the
-        table's plain primary key, so it is correct for tombstone rows
-        of any resource type. Ordering by ``id`` puts the most-recently
-        inserted state rows first; tombstones written on long-standing
-        rows therefore intermix with newer ones, but each row's
-        ``date_tombstoned`` is included in the response so an operator
-        can still sort client-side if needed.
+        :class:`docverse.storage.pagination.KeeperSyncStateDateTombstonedCursor`
+        (``date_tombstoned DESC, id DESC``) so the most-recently
+        tombstoned rows lead the page — the operator-facing "what was
+        just deleted?" ordering. A tombstone stamped today on a
+        long-standing low-id row therefore sorts ahead of an older
+        tombstone on a newer row, which the previous ``id DESC``
+        ordering buried at the bottom.
         """
         from docverse.storage.pagination import (  # noqa: PLC0415
-            KeeperSyncProjectStateIdCursor,
+            KeeperSyncStateDateTombstonedCursor,
         )
 
         clauses: list[ColumnElement[bool]] = [
@@ -368,7 +371,7 @@ class KeeperSyncStateStore:
         stmt = select(SqlKeeperSyncState).where(*clauses)
         runner = CountedPaginatedQueryRunner(
             entry_type=KeeperSyncState,
-            cursor_type=KeeperSyncProjectStateIdCursor,
+            cursor_type=KeeperSyncStateDateTombstonedCursor,
         )
         return await runner.query_object(
             self._session, stmt, cursor=cursor, limit=limit

--- a/src/docverse/storage/keeper_sync/state_store.py
+++ b/src/docverse/storage/keeper_sync/state_store.py
@@ -317,6 +317,89 @@ class KeeperSyncStateStore:
             self._session, stmt, cursor=cursor, limit=limit
         )
 
+    async def list_tombstones_for_org(
+        self,
+        *,
+        org_id: int,
+        cursor: KeeperSyncProjectStateIdCursor | None,
+        limit: int,
+        resource_type: ResourceType | None = None,
+        tombstone_reason: str | None = None,
+    ) -> CountedPaginatedList[KeeperSyncState, KeeperSyncProjectStateIdCursor]:
+        """Return a paginated page of tombstoned state rows for an org.
+
+        Backs the admin ``GET /orgs/{org}/keeper-sync/tombstones``
+        endpoint. Only rows with ``date_tombstoned IS NOT NULL`` are
+        returned. Filters are optional and stack:
+
+        - ``resource_type`` — narrows to ``project`` / ``edition`` /
+          ``build`` rows.
+        - ``tombstone_reason`` — narrows to one of the
+          :class:`TombstoneReason` wire values (``manual_delete`` /
+          ``lifecycle_delete`` / ``lifecycle_preemptive``).
+
+        Pagination uses
+        :class:`docverse.storage.pagination.KeeperSyncProjectStateIdCursor`
+        (id DESC) — the cursor's name retains the original
+        project-listing call site but its underlying column is the
+        table's plain primary key, so it is correct for tombstone rows
+        of any resource type. Ordering by ``id`` puts the most-recently
+        inserted state rows first; tombstones written on long-standing
+        rows therefore intermix with newer ones, but each row's
+        ``date_tombstoned`` is included in the response so an operator
+        can still sort client-side if needed.
+        """
+        from docverse.storage.pagination import (  # noqa: PLC0415
+            KeeperSyncProjectStateIdCursor,
+        )
+
+        clauses: list[ColumnElement[bool]] = [
+            SqlKeeperSyncState.org_id == org_id,
+            SqlKeeperSyncState.date_tombstoned.is_not(None),
+        ]
+        if resource_type is not None:
+            clauses.append(
+                SqlKeeperSyncState.resource_type == resource_type.value
+            )
+        if tombstone_reason is not None:
+            clauses.append(
+                SqlKeeperSyncState.tombstone_reason == tombstone_reason
+            )
+        stmt = select(SqlKeeperSyncState).where(*clauses)
+        runner = CountedPaginatedQueryRunner(
+            entry_type=KeeperSyncState,
+            cursor_type=KeeperSyncProjectStateIdCursor,
+        )
+        return await runner.query_object(
+            self._session, stmt, cursor=cursor, limit=limit
+        )
+
+    async def get_by_id_for_org(
+        self,
+        *,
+        state_id: int,
+        org_id: int,
+    ) -> KeeperSyncState | None:
+        """Fetch a state row by primary key, scoped to an org.
+
+        The admin tombstones DELETE endpoint addresses rows by their
+        plain primary key (``state_id``); scoping to ``org_id`` keeps
+        the lookup org-isolated so a misformatted URL or guessed id
+        from a different org returns ``None`` (404) rather than the
+        wrong row. Tombstoned rows are visible to this lookup — the
+        admin clear path is the only caller and must be able to see
+        the row it is about to un-tombstone.
+        """
+        stmt = select(SqlKeeperSyncState).where(
+            SqlKeeperSyncState.id == state_id,
+            SqlKeeperSyncState.org_id == org_id,
+        )
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return KeeperSyncState.model_validate(row)
+
     async def upsert(  # noqa: PLR0913
         self,
         *,

--- a/src/docverse/storage/keeper_sync/state_store.py
+++ b/src/docverse/storage/keeper_sync/state_store.py
@@ -31,6 +31,7 @@ __all__ = [
     "KeeperSyncState",
     "KeeperSyncStateStore",
     "ResourceType",
+    "TombstoneReason",
 ]
 
 
@@ -40,6 +41,27 @@ class ResourceType(StrEnum):
     project = "project"
     edition = "edition"
     build = "build"
+
+
+class TombstoneReason(StrEnum):
+    """Why a ``keeper_sync_state`` row was tombstoned.
+
+    Mirrors the SQL ``CheckConstraint`` on ``tombstone_reason``. The
+    values are stable wire identifiers — admin API responses and
+    operator-facing logs use them as-is.
+    """
+
+    manual_delete = "manual_delete"
+    """Operator-driven soft-delete of the Docverse-side resource."""
+
+    lifecycle_delete = "lifecycle_delete"
+    """Automated soft-delete by ``lifecycle_eval`` / ``git_ref_audit`` /
+    the ``ref_deleted`` webhook."""
+
+    lifecycle_preemptive = "lifecycle_preemptive"
+    """Sync itself short-circuited an LTD edition that the lifecycle
+    rules would immediately delete, before the build content was
+    copied. No matching Docverse row exists in this case."""
 
 
 class KeeperSyncState(BaseModel):
@@ -80,6 +102,9 @@ class KeeperSyncState(BaseModel):
     last_seen_etag: str | None = None
     content_hash: str | None = None
     annotations: dict[str, Any] | None = None
+    date_tombstoned: datetime | None = None
+    tombstone_reason: str | None = None
+    tombstone_note: str | None = None
 
 
 def _key_clauses(
@@ -138,11 +163,16 @@ class KeeperSyncStateStore:
         resource_type: ResourceType,
         ltd_id: int | None = None,
         ltd_slug: str | None = None,
+        include_tombstoned: bool = False,
     ) -> KeeperSyncState | None:
         """Fetch a row by its per-resource idempotency key.
 
         Pass ``ltd_slug`` for projects and ``ltd_id`` for editions /
-        builds; see :func:`_key_clauses`.
+        builds; see :func:`_key_clauses`. Tombstoned rows are filtered
+        out by default so existing convergence / short-circuit callers
+        treat a tombstoned LTD resource as "not present"; pass
+        ``include_tombstoned=True`` for the tombstone-service write
+        path and admin endpoints that need to see them.
         """
         clauses = _key_clauses(
             org_id=org_id,
@@ -150,6 +180,8 @@ class KeeperSyncStateStore:
             ltd_id=ltd_id,
             ltd_slug=ltd_slug,
         )
+        if not include_tombstoned:
+            clauses.append(SqlKeeperSyncState.date_tombstoned.is_(None))
         stmt = select(SqlKeeperSyncState).where(*clauses)
         result = await self._session.execute(stmt)
         row = result.scalar_one_or_none()
@@ -192,6 +224,7 @@ class KeeperSyncStateStore:
         resource_type: ResourceType,
         ltd_ids: Iterable[int] | None = None,
         docverse_ids: Iterable[int] | None = None,
+        include_tombstoned: bool = False,
     ) -> list[KeeperSyncState]:
         """Return every state row for ``(org_id, resource_type)``.
 
@@ -207,6 +240,12 @@ class KeeperSyncStateStore:
         column, so the Docverse edition ids are the natural project
         scope). Passing an empty ``ltd_ids`` or ``docverse_ids``
         returns ``[]`` without hitting the database.
+
+        Tombstoned rows are filtered out by default so the
+        convergence and short-circuit callers see a tombstoned LTD
+        resource as "not present"; admin endpoints and the
+        tombstone-service write path opt in with
+        ``include_tombstoned=True``.
         """
         if ltd_ids is not None:
             ltd_id_list = list(ltd_ids)
@@ -230,6 +269,8 @@ class KeeperSyncStateStore:
             clauses.append(
                 SqlKeeperSyncState.docverse_id.in_(docverse_id_list)
             )
+        if not include_tombstoned:
+            clauses.append(SqlKeeperSyncState.date_tombstoned.is_(None))
         stmt = select(SqlKeeperSyncState).where(*clauses)
         result = await self._session.execute(stmt)
         return [
@@ -243,6 +284,7 @@ class KeeperSyncStateStore:
         org_id: int,
         cursor: KeeperSyncProjectStateIdCursor | None,
         limit: int,
+        include_tombstoned: bool = False,
     ) -> CountedPaginatedList[KeeperSyncState, KeeperSyncProjectStateIdCursor]:
         """Return a paginated page of project-resource rows for an org.
 
@@ -250,15 +292,23 @@ class KeeperSyncStateStore:
         Ordered by ``id DESC`` via
         :class:`docverse.storage.pagination.KeeperSyncProjectStateIdCursor`
         so newest-discovered projects appear first.
+
+        Tombstoned rows are filtered out by default so the operator
+        projects listing does not show LTD products that have been
+        deleted on the Docverse side; pass ``include_tombstoned=True``
+        from the admin tombstones endpoint.
         """
         from docverse.storage.pagination import (  # noqa: PLC0415
             KeeperSyncProjectStateIdCursor,
         )
 
-        stmt = select(SqlKeeperSyncState).where(
+        clauses: list[ColumnElement[bool]] = [
             SqlKeeperSyncState.org_id == org_id,
             SqlKeeperSyncState.resource_type == ResourceType.project.value,
-        )
+        ]
+        if not include_tombstoned:
+            clauses.append(SqlKeeperSyncState.date_tombstoned.is_(None))
+        stmt = select(SqlKeeperSyncState).where(*clauses)
         runner = CountedPaginatedQueryRunner(
             entry_type=KeeperSyncState,
             cursor_type=KeeperSyncProjectStateIdCursor,

--- a/src/docverse/storage/pagination.py
+++ b/src/docverse/storage/pagination.py
@@ -38,6 +38,7 @@ __all__ = [
     "KEEPER_SYNC_EDITION_CURSOR_TYPE",
     "KEEPER_SYNC_PROJECT_STATE_CURSOR_TYPE",
     "KEEPER_SYNC_RUN_CURSOR_TYPE",
+    "KEEPER_SYNC_TOMBSTONE_CURSOR_TYPE",
     "MAX_PAGE_LIMIT",
     "PROJECT_CURSOR_TYPES",
     "QUEUE_JOB_CURSOR_TYPE",
@@ -50,6 +51,7 @@ __all__ = [
     "KeeperSyncEditionSlugCursor",
     "KeeperSyncProjectStateIdCursor",
     "KeeperSyncRunDateStartedCursor",
+    "KeeperSyncStateDateTombstonedCursor",
     "ProjectDateCreatedCursor",
     "ProjectSearchCursor",
     "ProjectSlugCursor",
@@ -454,6 +456,50 @@ class KeeperSyncRunDateStartedCursor(_TzAwareDatetimeIdCursor[KeeperSyncRun]):
 
 
 @dataclass(slots=True)
+class KeeperSyncStateDateTombstonedCursor(
+    _TzAwareDatetimeIdCursor[KeeperSyncState]
+):
+    """Keyset cursor for tombstoned ``keeper_sync_state`` rows.
+
+    Orders by ``date_tombstoned DESC, id DESC`` so the admin
+    ``GET /orgs/{org}/keeper-sync/tombstones`` view surfaces the
+    most-recently tombstoned rows first — the operator-facing "what was
+    just deleted?" expectation. Unlike
+    :class:`KeeperSyncProjectStateIdCursor` (id DESC, discovery order),
+    a tombstone stamped *today* on a long-standing low-id row sorts to
+    the top rather than the bottom.
+
+    Only rows with a non-null ``date_tombstoned`` are paginated with
+    this cursor — the tombstone listing query filters them in — so
+    :meth:`from_entry` treats a missing timestamp as a programming
+    error rather than guessing a sort position.
+    """
+
+    @staticmethod
+    @override
+    def id_column() -> InstrumentedAttribute[int]:
+        return SqlKeeperSyncState.id
+
+    @staticmethod
+    @override
+    def time_column() -> InstrumentedAttribute[datetime | None]:
+        return SqlKeeperSyncState.date_tombstoned
+
+    @override
+    @classmethod
+    def from_entry(
+        cls, entry: KeeperSyncState, *, reverse: bool = False
+    ) -> Self:
+        if entry.date_tombstoned is None:
+            msg = (
+                "KeeperSyncState row has no date_tombstoned; cannot build "
+                "a tombstone cursor for a non-tombstoned row"
+            )
+            raise ValueError(msg)
+        return cls(time=entry.date_tombstoned, id=entry.id, previous=reverse)
+
+
+@dataclass(slots=True)
 class QueueJobDateCreatedCursor(_TzAwareDatetimeIdCursor[QueueJob]):
     """Keyset cursor for queue jobs ordered by date_created DESC, id DESC."""
 
@@ -568,6 +614,10 @@ KEEPER_SYNC_RUN_CURSOR_TYPE: type[KeeperSyncRunDateStartedCursor] = (
 KEEPER_SYNC_PROJECT_STATE_CURSOR_TYPE: type[KeeperSyncProjectStateIdCursor] = (
     KeeperSyncProjectStateIdCursor
 )
+
+KEEPER_SYNC_TOMBSTONE_CURSOR_TYPE: type[
+    KeeperSyncStateDateTombstonedCursor
+] = KeeperSyncStateDateTombstonedCursor
 
 QUEUE_JOB_CURSOR_TYPE: type[QueueJobDateCreatedCursor] = (
     QueueJobDateCreatedCursor

--- a/src/docverse/storage/project_store.py
+++ b/src/docverse/storage/project_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -15,8 +16,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import expression, func
 
 from docverse.client.models import ProjectCreate, ProjectUpdate
+from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
 from docverse.dbschema.project import SqlProject
 from docverse.domain.project import Project
+from docverse.storage.keeper_sync import ResourceType, TombstoneReason
 from docverse.storage.pagination import ProjectSearchCursor
 
 _TRGM_SIMILARITY_THRESHOLD = 0.1
@@ -625,8 +628,19 @@ class ProjectStore:
         await self._session.flush()
         return result.first() is not None
 
-    async def soft_delete(self, *, org_id: int, slug: str) -> bool:
-        """Soft-delete a project by setting date_deleted.
+    async def soft_delete(
+        self, *, org_id: int, slug: str, reason: TombstoneReason
+    ) -> bool:
+        """Soft-delete a project and stamp the keeper-sync tombstone.
+
+        The physical chokepoint for centralized project soft-delete
+        (PRD #332): in the same flush that stamps ``date_deleted``,
+        this records the tombstone fields on the matching
+        ``keeper_sync_state`` row (located by
+        ``(org_id, resource_type='project', docverse_id=<project.id>)``).
+        The tombstone write is a no-op when no state row exists for
+        this project (e.g. a manually-created project never imported
+        from LTD).
 
         Returns
         -------
@@ -644,5 +658,18 @@ class ProjectStore:
         if row is None:
             return False
         row.date_deleted = func.now()
+        await self._session.execute(
+            update(SqlKeeperSyncState)
+            .where(
+                SqlKeeperSyncState.org_id == org_id,
+                SqlKeeperSyncState.resource_type == ResourceType.project.value,
+                SqlKeeperSyncState.docverse_id == row.id,
+            )
+            .values(
+                date_tombstoned=datetime.now(tz=UTC),
+                tombstone_reason=reason.value,
+                tombstone_note=None,
+            )
+        )
         await self._session.flush()
         return True

--- a/src/docverse/storage/project_store.py
+++ b/src/docverse/storage/project_store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -666,7 +665,7 @@ class ProjectStore:
                 SqlKeeperSyncState.docverse_id == row.id,
             )
             .values(
-                date_tombstoned=datetime.now(tz=UTC),
+                date_tombstoned=func.now(),
                 tombstone_reason=reason.value,
                 tombstone_note=None,
             )

--- a/src/docverse/worker/functions/git_ref_audit.py
+++ b/src/docverse/worker/functions/git_ref_audit.py
@@ -59,6 +59,7 @@ from docverse.storage.github import (
     RepositoryRefFetchError,
     RepositoryRefSet,
 )
+from docverse.storage.keeper_sync import TombstoneReason
 
 __all__ = ["git_ref_audit"]
 
@@ -353,7 +354,7 @@ async def _apply_deletions(  # noqa: PLR0913
         e.id: e for editions in editions_by_project.values() for e in editions
     }
     async with session.begin():
-        edition_store = factory.create_edition_store()
+        edition_service = factory.create_edition_service()
         publishing_service = factory.create_edition_publishing_service()
         for project in projects:
             matched_ids = matches_by_project.get(project.id)
@@ -364,8 +365,12 @@ async def _apply_deletions(  # noqa: PLR0913
                 edition = editions_index.get(edition_id)
                 if edition is None:
                     continue
-                deleted = await edition_store.soft_delete(
-                    project_id=project.id, slug=edition.slug
+                deleted = await edition_service.soft_delete(
+                    org_id=org_id,
+                    project_id=project.id,
+                    edition_id=edition.id,
+                    edition_slug=edition.slug,
+                    reason=TombstoneReason.lifecycle_delete,
                 )
                 if not deleted:
                     continue

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -511,6 +511,9 @@ async def _enqueue_publish_for_synced_edition(  # noqa: PLR0913
     their ``publish_status`` is still ``NULL``. Skips when the build
     outcome is missing or carries no Docverse build id (a no-op edition
     or a convergence outcome that did not point at a publishable row).
+    Skips when the edition outcome carries no Docverse edition id —
+    a tombstoned ``keeper_sync_state`` row whose ``docverse_id`` is
+    ``NULL`` short-circuited before the edition was ever imported.
     """
     build_outcome = outcome.build_outcome
     if build_outcome is None:
@@ -521,6 +524,9 @@ async def _enqueue_publish_for_synced_edition(  # noqa: PLR0913
         build_outcome.docverse_build_id is None
         or build_outcome.docverse_build_public_id is None
     ):
+        return
+    edition_id = outcome.docverse_edition_id
+    if edition_id is None:
         return
 
     edition_store = factory.create_edition_store()
@@ -536,7 +542,7 @@ async def _enqueue_publish_for_synced_edition(  # noqa: PLR0913
         org_id=org_id,
         project_id=outcome.docverse_project_id,
         project_slug=outcome.docverse_project_slug,
-        edition_id=outcome.docverse_edition_id,
+        edition_id=edition_id,
         edition_slug=outcome.docverse_slug,
         build_id=build_outcome.docverse_build_id,
         build_public_id=build_outcome.docverse_build_public_id,
@@ -586,17 +592,24 @@ async def _self_heal_unpublished_editions(  # noqa: PLR0913
     short-circuited and is already published, or was freshly synced and
     just got published by the per-edition callback).
     """
+    project_id = sync_result.docverse_project_id
+    if project_id is None:
+        # A tombstoned project short-circuit returned no edition
+        # outcomes; nothing to self-heal.
+        return
     edition_store = factory.create_edition_store()
     history_store = factory.create_edition_build_history_store()
     queue_backend = factory.create_queue_backend()
     project_slug = sync_result.docverse_project_slug
-    project_id = sync_result.docverse_project_id
 
     for outcome in sync_result.edition_outcomes:
         build_outcome = outcome.build_outcome
         if build_outcome is None:
             continue
         if not build_outcome.short_circuited:
+            continue
+        edition_id = outcome.docverse_edition_id
+        if edition_id is None:
             continue
 
         target = await _resolve_self_heal_target(
@@ -618,7 +631,7 @@ async def _self_heal_unpublished_editions(  # noqa: PLR0913
             org_id=org_id,
             project_id=project_id,
             project_slug=project_slug,
-            edition_id=outcome.docverse_edition_id,
+            edition_id=edition_id,
             edition_slug=outcome.docverse_slug,
             build_id=build_id,
             build_public_id=build_public_id,

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -256,10 +256,23 @@ async def keeper_sync_run_discovery(
                 factory=factory, config=config, logger=logger
             )
             in_scope = _filter_to_allowlist(ltd_slugs, config.project_slugs)
+            # Drop tombstoned project slugs from the fan-out so we do
+            # not enqueue ``keeper_sync_project`` children that
+            # ``sync_project`` would only short-circuit on its own
+            # tombstone check (PRD #332 / user story 17). The empty-
+            # fan-out finalisation path below covers the case where
+            # tombstones consume the entire in-scope set.
+            state_store = factory.create_keeper_sync_state_store()
+            tombstoned_slugs = await _fetch_tombstoned_project_slugs(
+                state_store=state_store, session=session, org_id=org_id
+            )
+            if tombstoned_slugs:
+                in_scope = [s for s in in_scope if s not in tombstoned_slugs]
             logger.info(
                 "Resolved keeper-sync run scope",
                 ltd_count=len(ltd_slugs),
                 in_scope_count=len(in_scope),
+                tombstoned_count=len(tombstoned_slugs),
             )
 
             enqueued_count = await _enqueue_children(
@@ -729,6 +742,33 @@ def _filter_to_allowlist(
     return [slug for slug in ltd_slugs if slug in allowed]
 
 
+async def _fetch_tombstoned_project_slugs(
+    *,
+    state_store: KeeperSyncStateStore,
+    session: AsyncSession,
+    org_id: int,
+) -> set[str]:
+    """Return the LTD slugs of all tombstoned project state rows.
+
+    The four discovery paths (``keeper_sync_run_discovery`` plus the
+    three tier crons) call this once per pass and subtract the result
+    from their in-scope slug list, so a ``keeper_sync_project`` child
+    is never enqueued for a Docverse-side-vetoed project. Without the
+    filter, ``sync_project`` would short-circuit on its own tombstone
+    check (PRD #332 §"Sync-side skip checks") a few milliseconds later
+    — same outcome, wasted queue + DB work. Issue #396 / user story 17.
+    """
+    async with session.begin():
+        project_states = await state_store.list_for_org(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            include_tombstoned=True,
+        )
+    return {
+        s.ltd_slug for s in project_states if s.date_tombstoned is not None
+    }
+
+
 async def _enqueue_children(  # noqa: PLR0913
     *,
     ctx: dict[str, Any],
@@ -1029,6 +1069,14 @@ async def _tier_main_for_org(
     queue_job_store = factory.create_queue_job_store()
     arq_queue = ctx["arq_queue"]
     now = datetime.now(tz=UTC)
+    # Drop tombstoned project slugs from the candidate set up front:
+    # ``sync_project`` would only short-circuit on them a few
+    # milliseconds later (issue #396 / PRD #332 user story 17).
+    tombstoned_slugs = await _fetch_tombstoned_project_slugs(
+        state_store=state_store, session=session, org_id=org.id
+    )
+    if tombstoned_slugs:
+        in_scope = [s for s in in_scope if s not in tombstoned_slugs]
     enqueued = 0
     for ltd_slug in in_scope:
         async with session.begin():
@@ -1081,14 +1129,11 @@ async def _tier_main_for_org(
         )
         if main_edition is None:
             continue
-        async with session.begin():
-            state = await state_store.get(
-                org_id=org.id,
-                resource_type=ResourceType.edition,
-                ltd_id=main_edition.ltd_id,
-            )
-        if not should_refresh_main_edition(
-            state=state, ltd_date_rebuilt=main_edition.date_rebuilt
+        if not await _tier_main_should_enqueue_edition(
+            state_store=state_store,
+            session=session,
+            org_id=org.id,
+            main_edition=main_edition,
         ):
             continue
         if await _enqueue_tier_project_sync(
@@ -1138,14 +1183,31 @@ async def _tier_discovery_for_org(
     queue_job_store = factory.create_queue_job_store()
     arq_queue = ctx["arq_queue"]
     now = datetime.now(tz=UTC)
+    # Drop tombstoned project slugs up front (issue #396 / PRD #332
+    # user story 17): ``sync_project`` would short-circuit on its own
+    # tombstone check, so the enqueue is pure waste.
+    tombstoned_slugs = await _fetch_tombstoned_project_slugs(
+        state_store=state_store, session=session, org_id=org.id
+    )
+    if tombstoned_slugs:
+        in_scope = [s for s in in_scope if s not in tombstoned_slugs]
     # Hoist the org-wide edition-state read out of the per-slug loop.
     # The previous shape called ``list_for_org`` from inside
     # ``_project_needs_discovery``, so a 1500-slug discovery tick
     # scanned the org's ~15 000 edition state rows 1500 times per
     # tick. The map is consulted in memory per slug.
+    #
+    # ``include_tombstoned=True`` keeps tombstoned edition rows in the
+    # dict so :func:`is_unknown_resource` reads them as known
+    # (non-``None``) and ``_project_needs_discovery`` does not fire
+    # the "unseen LTD edition" enqueue branch on them. Without the
+    # flag, a tombstoned edition is filtered out and reads as missing
+    # — the very state the enqueue branch reacts to. Issue #396.
     async with session.begin():
         edition_states = await state_store.list_for_org(
-            org_id=org.id, resource_type=ResourceType.edition
+            org_id=org.id,
+            resource_type=ResourceType.edition,
+            include_tombstoned=True,
         )
     edition_state_by_ltd_id = {
         s.ltd_id: s for s in edition_states if s.ltd_id is not None
@@ -1253,6 +1315,16 @@ async def _tier_other_for_org(
     queue_job_store = factory.create_queue_job_store()
     arq_queue = ctx["arq_queue"]
     now = datetime.now(tz=UTC)
+    # Drop tombstoned project slugs up front (issue #396 / PRD #332
+    # user story 17). ``_has_stale_non_main_edition``'s default
+    # ``include_tombstoned=False`` already excludes tombstoned
+    # editions from the staleness scan, so no edition-level filter is
+    # needed here.
+    tombstoned_slugs = await _fetch_tombstoned_project_slugs(
+        state_store=state_store, session=session, org_id=org.id
+    )
+    if tombstoned_slugs:
+        in_scope = [s for s in in_scope if s not in tombstoned_slugs]
     enqueued = 0
     for ltd_slug in in_scope:
         async with session.begin():
@@ -1384,6 +1456,42 @@ async def _find_main_edition(
                 return edition
     return await _walk_for_main_edition(
         ltd_client=ltd_client, product_slug=ltd_slug
+    )
+
+
+async def _tier_main_should_enqueue_edition(
+    *,
+    state_store: KeeperSyncStateStore,
+    session: AsyncSession,
+    org_id: int,
+    main_edition: LtdEdition,
+) -> bool:
+    """Return ``True`` iff a resolved main edition warrants an enqueue.
+
+    Reads the matching edition state row (including tombstoned rows)
+    and runs the two skip predicates the per-slug loop consults
+    after :func:`_find_main_edition` succeeds:
+
+    * Skip on tombstoned state row — ``sync_edition`` would only
+      short-circuit on its own tombstone check (issue #396 / PRD #332
+      user story 17).
+    * Otherwise defer to :func:`should_refresh_main_edition` for the
+      LTD ``date_rebuilt`` vs ``state.date_rebuilt_seen`` decision.
+
+    Lifted out of :func:`_tier_main_for_org` to keep the per-slug
+    loop's cyclomatic complexity under the project's ruff C901 ceiling.
+    """
+    async with session.begin():
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=main_edition.ltd_id,
+            include_tombstoned=True,
+        )
+    if state is not None and state.date_tombstoned is not None:
+        return False
+    return should_refresh_main_edition(
+        state=state, ltd_date_rebuilt=main_edition.date_rebuilt
     )
 
 

--- a/src/docverse/worker/functions/lifecycle_eval.py
+++ b/src/docverse/worker/functions/lifecycle_eval.py
@@ -46,6 +46,7 @@ from docverse.factory import Factory
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_slug,
 )
+from docverse.services.edition import EditionService
 from docverse.services.edition_publishing import EditionPublishingService
 from docverse.services.lifecycle.evaluator import (
     LifecycleDecision,
@@ -58,7 +59,7 @@ from docverse.services.lifecycle_finalisation import (
     maybe_finalise_lifecycle_run,
 )
 from docverse.storage.build_store import BuildStore
-from docverse.storage.edition_store import EditionStore
+from docverse.storage.keeper_sync import TombstoneReason
 
 __all__ = ["lifecycle_eval"]
 
@@ -209,12 +210,12 @@ async def _evaluate_org(
     projects_with_edition_deletes: list[str] = []
 
     async with session.begin():
-        edition_store = factory.create_edition_store()
+        edition_service = factory.create_edition_service()
         build_store = factory.create_build_store()
         publishing_service = factory.create_edition_publishing_service()
         for project, rule_set, decision in decisions:
             editions_deleted = await _apply_decision(
-                edition_store=edition_store,
+                edition_service=edition_service,
                 build_store=build_store,
                 publishing_service=publishing_service,
                 project=project,
@@ -331,7 +332,7 @@ def _index_builds_by_id(
 
 async def _apply_decision(  # noqa: PLR0913
     *,
-    edition_store: EditionStore,
+    edition_service: EditionService,
     build_store: BuildStore,
     publishing_service: EditionPublishingService,
     project: Project,
@@ -372,8 +373,12 @@ async def _apply_decision(  # noqa: PLR0913
             continue
         rule_type = decision.edition_matches[edition_id]
         rule = rules_by_type.get(rule_type)
-        deleted = await edition_store.soft_delete(
-            project_id=project.id, slug=edition.slug
+        deleted = await edition_service.soft_delete(
+            org_id=org_id,
+            project_id=project.id,
+            edition_id=edition.id,
+            edition_slug=edition.slug,
+            reason=TombstoneReason.lifecycle_delete,
         )
         if not deleted:
             continue

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -27,6 +27,7 @@ from docverse.exceptions import (
     InvalidBuildStateError,
     InvalidJobStateError,
     JobNotFoundError,
+    KeeperSyncInvariantError,
 )
 
 
@@ -63,11 +64,16 @@ def _make_job_not_found() -> JobNotFoundError:
     )
 
 
+def _make_keeper_sync_invariant() -> KeeperSyncInvariantError:
+    return KeeperSyncInvariantError("state_id=42 has no tombstone")
+
+
 _FACTORIES: list[tuple[str, Callable[[], DocverseSlackException]]] = [
     ("InvalidJobStateError", _make_invalid_job_state),
     ("InvalidBuildStateError", _make_invalid_build_state),
     ("JobNotFoundError", _make_job_not_found),
     ("InvalidSlugError", _make_invalid_slug),
+    ("KeeperSyncInvariantError", _make_keeper_sync_invariant),
 ]
 
 

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -25,6 +25,7 @@ from docverse.storage.editionpublisher import (
     EditionPublisher,
     MockEditionPublisher,
 )
+from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from tests.conftest import seed_org_with_admin
@@ -244,6 +245,74 @@ async def test_delete_edition_unpublishes_from_cdn(
     call = mock_publisher.unpublish_calls[0]
     assert call.project_slug == "ed-proj"
     assert call.edition_slug == "cdn-del"
+
+
+@pytest.mark.asyncio
+async def test_delete_edition_writes_manual_delete_tombstone(
+    client: AsyncClient,
+) -> None:
+    """DELETE handler stamps a ``manual_delete`` tombstone on the row."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "tomb-ed",
+            "title": "Tomb Me",
+            "kind": "draft",
+            "tracking_mode": "git_ref",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+
+    # Seed a matching keeper_sync_state row for this edition so the
+    # tombstone write at the chokepoint has a target to stamp.
+    logger = structlog.get_logger("test")
+    async for session in db_session_dependency():
+        async with session.begin():
+            org_store = OrganizationStore(session=session, logger=logger)
+            project_store = ProjectStore(session=session, logger=logger)
+            edition_store = EditionStore(session=session, logger=logger)
+            org = await org_store.get_by_slug("ed-org")
+            assert org is not None
+            project = await project_store.get_by_slug(
+                org_id=org.id, slug="ed-proj"
+            )
+            assert project is not None
+            edition = await edition_store.get_by_slug(
+                project_id=project.id, slug="tomb-ed"
+            )
+            assert edition is not None
+            state_store = KeeperSyncStateStore(session=session, logger=logger)
+            await state_store.upsert(
+                org_id=org.id,
+                resource_type=ResourceType.edition,
+                ltd_id=33001,
+                ltd_slug="tomb-ed",
+                docverse_id=edition.id,
+            )
+            await session.commit()
+
+    response = await client.delete(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions/tomb-ed",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 204
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            org_store = OrganizationStore(session=session, logger=logger)
+            org = await org_store.get_by_slug("ed-org")
+            assert org is not None
+            state_store = KeeperSyncStateStore(session=session, logger=logger)
+            state = await state_store.get(
+                org_id=org.id,
+                resource_type=ResourceType.edition,
+                ltd_id=33001,
+                include_tombstoned=True,
+            )
+    assert state is not None
+    assert state.date_tombstoned is not None
+    assert state.tombstone_reason == "manual_delete"
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/keeper_sync_tombstones_test.py
+++ b/tests/handlers/keeper_sync_tombstones_test.py
@@ -1,0 +1,519 @@
+"""Tests for ``GET`` / ``DELETE /orgs/{org}/keeper-sync/tombstones``.
+
+Backs PRD #332's admin API for tombstone visibility and recovery.
+"""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from httpx import AsyncClient
+from safir.dependencies.db_session import db_session_dependency
+
+from docverse.client.models import (
+    EditionCreate,
+    EditionKind,
+    OrgRole,
+    ProjectCreate,
+    TrackingMode,
+)
+from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
+from docverse.storage.edition_store import EditionStore
+from docverse.storage.keeper_sync import (
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+from tests.conftest import seed_member, seed_org_with_admin
+
+_ADMIN = "admin-user"
+_ORG = "ks-tomb-handler"
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("test")  # type: ignore[no-any-return]
+
+
+async def _setup(client: AsyncClient) -> None:
+    await seed_org_with_admin(client, _ORG, _ADMIN)
+
+
+async def _get_org_id() -> int:
+    async for session in db_session_dependency():
+        store = OrganizationStore(session=session, logger=_logger())
+        org = await store.get_by_slug(_ORG)
+        assert org is not None
+        return org.id
+    msg = "no session"
+    raise AssertionError(msg)
+
+
+async def _record_tombstone(
+    *,
+    org_id: int,
+    resource_type: ResourceType,
+    reason: TombstoneReason,
+    ltd_id: int | None = None,
+    ltd_slug: str | None = None,
+    note: str | None = None,
+) -> int:
+    """Record a tombstone via the service and return the state row id."""
+    async for session in db_session_dependency():
+        async with session.begin():
+            state_store = KeeperSyncStateStore(
+                session=session, logger=_logger()
+            )
+            service = KeeperSyncTombstoneService(
+                session=session,
+                state_store=state_store,
+                logger=_logger(),
+            )
+            state = await service.record(
+                org_id=org_id,
+                resource_type=resource_type,
+                reason=reason,
+                ltd_id=ltd_id,
+                ltd_slug=ltd_slug,
+                note=note,
+            )
+            await session.commit()
+        return state.id
+    msg = "no session"
+    raise AssertionError(msg)
+
+
+async def _seed_imported_edition(
+    *,
+    org_id: int,
+    project_slug: str,
+    edition_slug: str,
+    ltd_id: int,
+) -> tuple[int, int]:
+    """Create a Docverse project + edition + matching state row."""
+    async for session in db_session_dependency():
+        async with session.begin():
+            proj_store = ProjectStore(session=session, logger=_logger())
+            edition_store = EditionStore(session=session, logger=_logger())
+            state_store = KeeperSyncStateStore(
+                session=session, logger=_logger()
+            )
+            project = await proj_store.create(
+                org_id=org_id,
+                data=ProjectCreate(
+                    slug=project_slug,
+                    title=project_slug.title(),
+                    source_url=f"https://example.com/x/{project_slug}",
+                ),
+            )
+            edition = await edition_store.create(
+                project_id=project.id,
+                data=EditionCreate(
+                    slug=edition_slug,
+                    title=edition_slug,
+                    kind=EditionKind.draft,
+                    tracking_mode=TrackingMode.git_ref,
+                ),
+            )
+            await state_store.upsert(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=ltd_id,
+                ltd_slug=edition_slug,
+                docverse_id=edition.id,
+            )
+            await session.commit()
+        return project.id, edition.id
+    msg = "no session"
+    raise AssertionError(msg)
+
+
+async def _soft_delete_edition(
+    *,
+    org_id: int,
+    project_id: int,
+    slug: str,
+) -> None:
+    """Soft-delete an edition through the centralized chokepoint."""
+    async for session in db_session_dependency():
+        async with session.begin():
+            edition_store = EditionStore(session=session, logger=_logger())
+            await edition_store.soft_delete(
+                org_id=org_id,
+                project_id=project_id,
+                slug=slug,
+                reason=TombstoneReason.manual_delete,
+            )
+            await session.commit()
+        return
+    msg = "no session"
+    raise AssertionError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Auth gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tombstones_403_for_non_admin(client: AsyncClient) -> None:
+    await _setup(client)
+    await seed_member(_ORG, "reader-user", OrgRole.reader)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones",
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_tombstones_403_without_auth(client: AsyncClient) -> None:
+    await _setup(client)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones",
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_tombstones_404_for_unknown_org(
+    client: AsyncClient,
+) -> None:
+    response = await client.get(
+        "/docverse/orgs/no-such-org/keeper-sync/tombstones",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstone_403_for_non_admin(
+    client: AsyncClient,
+) -> None:
+    await _setup(client)
+    await seed_member(_ORG, "reader-user", OrgRole.reader)
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/1",
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET — listing & filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tombstones_returns_empty_initially(
+    client: AsyncClient,
+) -> None:
+    """An org with no tombstones returns ``[]`` with ``X-Total-Count: 0``."""
+    await _setup(client)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+    assert response.headers["X-Total-Count"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_list_tombstones_returns_recorded_rows(
+    client: AsyncClient,
+) -> None:
+    """A recorded tombstone appears in the listing with all expected fields."""
+    await _setup(client)
+    org_id = await _get_org_id()
+    state_id = await _record_tombstone(
+        org_id=org_id,
+        resource_type=ResourceType.edition,
+        reason=TombstoneReason.lifecycle_delete,
+        ltd_id=4242,
+        ltd_slug="aged-out",
+        note="auto-aged",
+    )
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    entry = body[0]
+    assert entry["state_id"] == state_id
+    assert entry["resource_type"] == "edition"
+    assert entry["ltd_id"] == 4242
+    assert entry["ltd_slug"] == "aged-out"
+    assert entry["tombstone_reason"] == "lifecycle_delete"
+    assert entry["tombstone_note"] == "auto-aged"
+    assert entry["date_tombstoned"] is not None
+    assert entry["display_path"] == "aged-out"
+    assert entry["self_url"].endswith(
+        f"/orgs/{_ORG}/keeper-sync/tombstones/{state_id}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_tombstones_filters_by_resource_type(
+    client: AsyncClient,
+) -> None:
+    """``?resource_type=edition`` excludes project rows."""
+    await _setup(client)
+    org_id = await _get_org_id()
+    await _record_tombstone(
+        org_id=org_id,
+        resource_type=ResourceType.project,
+        reason=TombstoneReason.manual_delete,
+        ltd_slug="a-proj",
+    )
+    await _record_tombstone(
+        org_id=org_id,
+        resource_type=ResourceType.edition,
+        reason=TombstoneReason.lifecycle_delete,
+        ltd_id=99,
+    )
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones?resource_type=edition",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert [entry["resource_type"] for entry in body] == ["edition"]
+
+
+@pytest.mark.asyncio
+async def test_list_tombstones_filters_by_reason(
+    client: AsyncClient,
+) -> None:
+    """``?tombstone_reason=manual_delete`` excludes other reasons."""
+    await _setup(client)
+    org_id = await _get_org_id()
+    await _record_tombstone(
+        org_id=org_id,
+        resource_type=ResourceType.edition,
+        reason=TombstoneReason.manual_delete,
+        ltd_id=1,
+    )
+    await _record_tombstone(
+        org_id=org_id,
+        resource_type=ResourceType.edition,
+        reason=TombstoneReason.lifecycle_delete,
+        ltd_id=2,
+    )
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones"
+        "?tombstone_reason=manual_delete",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert [entry["tombstone_reason"] for entry in body] == ["manual_delete"]
+    assert [entry["ltd_id"] for entry in body] == [1]
+
+
+@pytest.mark.asyncio
+async def test_list_tombstones_pagination_link_header(
+    client: AsyncClient,
+) -> None:
+    """``?limit=1`` page includes a Link header for the next page."""
+    await _setup(client)
+    org_id = await _get_org_id()
+    for ltd_id in (10, 11, 12):
+        await _record_tombstone(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            reason=TombstoneReason.lifecycle_delete,
+            ltd_id=ltd_id,
+        )
+
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones?limit=1",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.headers["X-Total-Count"] == "3"
+    assert 'rel="next"' in response.headers["Link"]
+
+
+# ---------------------------------------------------------------------------
+# DELETE — clear (with revive-on-clear)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstone_returns_204(client: AsyncClient) -> None:
+    """A successful clear returns 204 with no body."""
+    await _setup(client)
+    org_id = await _get_org_id()
+    state_id = await _record_tombstone(
+        org_id=org_id,
+        resource_type=ResourceType.edition,
+        reason=TombstoneReason.manual_delete,
+        ltd_id=51,
+    )
+
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state_id}",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstone_clears_state_row(client: AsyncClient) -> None:
+    """After DELETE, the state row's tombstone fields are NULL."""
+    await _setup(client)
+    org_id = await _get_org_id()
+    state_id = await _record_tombstone(
+        org_id=org_id,
+        resource_type=ResourceType.edition,
+        reason=TombstoneReason.manual_delete,
+        ltd_id=53,
+        note="recover me",
+    )
+
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state_id}",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 204
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            state_store = KeeperSyncStateStore(
+                session=session, logger=_logger()
+            )
+            state = await state_store.get_by_id_for_org(
+                state_id=state_id, org_id=org_id
+            )
+    assert state is not None
+    assert state.date_tombstoned is None
+    assert state.tombstone_reason is None
+    assert state.tombstone_note is None
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstone_revives_soft_deleted_edition(
+    client: AsyncClient,
+) -> None:
+    """A soft-deleted edition is revived after DELETE."""
+    await _setup(client)
+    org_id = await _get_org_id()
+    project_id, edition_id = await _seed_imported_edition(
+        org_id=org_id,
+        project_slug="rev-proj",
+        edition_slug="rev-ed",
+        ltd_id=2000,
+    )
+    await _soft_delete_edition(
+        org_id=org_id, project_id=project_id, slug="rev-ed"
+    )
+    # The chokepoint stamped the tombstone — find its state_id.
+    async for session in db_session_dependency():
+        async with session.begin():
+            state_store = KeeperSyncStateStore(
+                session=session, logger=_logger()
+            )
+            state = await state_store.get(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=2000,
+                include_tombstoned=True,
+            )
+    assert state is not None
+    assert state.date_tombstoned is not None
+    state_id = state.id
+
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state_id}",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 204
+
+    # Edition's date_deleted is NULL — the slug-clash crash for a
+    # subsequent ``sync_edition`` is no longer reachable on this row.
+    async for session in db_session_dependency():
+        async with session.begin():
+            edition_store = EditionStore(session=session, logger=_logger())
+            revived = await edition_store.get_by_slug(
+                project_id=project_id, slug="rev-ed"
+            )
+    assert revived is not None
+    assert revived.id == edition_id
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstone_404_for_unknown_state_id(
+    client: AsyncClient,
+) -> None:
+    """A non-existent state_id returns 404."""
+    await _setup(client)
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/999999",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstone_404_for_other_org(
+    client: AsyncClient,
+) -> None:
+    """A state_id from another org returns 404 (org-scoped, not silent)."""
+    await _setup(client)
+    other_org = "ks-tomb-other"
+    await seed_org_with_admin(client, other_org, _ADMIN)
+
+    async for session in db_session_dependency():
+        store = OrganizationStore(session=session, logger=_logger())
+        other = await store.get_by_slug(other_org)
+        assert other is not None
+        other_id = other.id
+        break
+
+    state_id = await _record_tombstone(
+        org_id=other_id,
+        resource_type=ResourceType.edition,
+        reason=TombstoneReason.manual_delete,
+        ltd_id=88,
+    )
+
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state_id}",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstone_404_when_not_tombstoned(
+    client: AsyncClient,
+) -> None:
+    """An untombstoned state row returns 404 from the DELETE endpoint."""
+    await _setup(client)
+    org_id = await _get_org_id()
+    async for session in db_session_dependency():
+        async with session.begin():
+            store = KeeperSyncStateStore(session=session, logger=_logger())
+            state = await store.upsert(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=400,
+                ltd_slug="alive",
+            )
+            await session.commit()
+        break
+
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state.id}",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404

--- a/tests/handlers/projects_test.py
+++ b/tests/handlers/projects_test.py
@@ -18,6 +18,8 @@ from docverse.storage.editionpublisher import (
     EditionPublisher,
     MockEditionPublisher,
 )
+from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
+from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from tests.conftest import seed_org_with_admin
 
@@ -308,6 +310,65 @@ async def test_delete_project(client: AsyncClient) -> None:
         headers={"X-Auth-Request-User": "testuser"},
     )
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_project_writes_manual_delete_tombstone(
+    client: AsyncClient,
+) -> None:
+    """DELETE handler stamps a ``manual_delete`` tombstone on the row."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "tomb-proj",
+            "title": "Tomb Project",
+            "source_url": "https://example.com/example/tomb",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+
+    logger = structlog.get_logger("test")
+    async for session in db_session_dependency():
+        async with session.begin():
+            org_store = OrganizationStore(session=session, logger=logger)
+            project_store = ProjectStore(session=session, logger=logger)
+            org = await org_store.get_by_slug("proj-org")
+            assert org is not None
+            project = await project_store.get_by_slug(
+                org_id=org.id, slug="tomb-proj"
+            )
+            assert project is not None
+            state_store = KeeperSyncStateStore(session=session, logger=logger)
+            await state_store.upsert(
+                org_id=org.id,
+                resource_type=ResourceType.project,
+                ltd_slug="tomb-proj",
+                docverse_id=project.id,
+            )
+            await session.commit()
+
+    response = await client.delete(
+        "/docverse/orgs/proj-org/projects/tomb-proj",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 204
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            org_store = OrganizationStore(session=session, logger=logger)
+            org = await org_store.get_by_slug("proj-org")
+            assert org is not None
+            state_store = KeeperSyncStateStore(session=session, logger=logger)
+            state = await state_store.get(
+                org_id=org.id,
+                resource_type=ResourceType.project,
+                ltd_slug="tomb-proj",
+                include_tombstoned=True,
+            )
+    assert state is not None
+    assert state.date_tombstoned is not None
+    assert state.tombstone_reason == "manual_delete"
 
 
 async def _enable_cdn(org_slug: str) -> None:

--- a/tests/services/keeper_sync/service_test.py
+++ b/tests/services/keeper_sync/service_test.py
@@ -1619,7 +1619,10 @@ async def test_sync_edition_does_not_crash_on_soft_deleted_tombstoned_row(
         )
         assert project is not None
         soft_deleted = await edition_store.soft_delete(
-            project_id=project.id, slug="__main"
+            org_id=org_id,
+            project_id=project.id,
+            slug="__main",
+            reason=TombstoneReason.manual_delete,
         )
         assert soft_deleted is True
         await tombstone_service.record(

--- a/tests/services/keeper_sync/service_test.py
+++ b/tests/services/keeper_sync/service_test.py
@@ -36,10 +36,15 @@ from docverse.services.keeper_sync.service import (
     KeeperSyncService,
     _now,
 )
+from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
 from docverse.services.project import ProjectService
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_store import EditionStore
-from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
+from docverse.storage.keeper_sync import (
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
 from docverse.storage.ltd import LtdClient, LtdSourceProtocol
 from docverse.storage.objectstore import MockObjectStore
 from docverse.storage.organization_store import OrganizationStore
@@ -1384,3 +1389,253 @@ async def test_sync_project_continues_when_callback_raises(
     outcome_slugs = [o.docverse_slug for o in result.edition_outcomes]
     assert "__main" in outcome_slugs
     assert "u-jsick-feature" in outcome_slugs
+
+
+@pytest.mark.asyncio
+async def test_sync_edition_short_circuits_when_tombstoned(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+) -> None:
+    """A tombstoned edition state row short-circuits ``sync_edition``.
+
+    The build copy must not run, the build store must not be touched,
+    and ``date_last_synced`` on the tombstoned state row must remain
+    untouched (proves ``_ensure_edition`` / state ``upsert`` were
+    skipped).
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-edition")
+
+    _seed_ltd(mock_discovery)
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v1</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+
+    # First sync imports the edition + build normally.
+    first = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+    assert first.edition_outcomes
+    keys_after_first = set(object_store.objects.keys())
+    assert keys_after_first
+
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    tombstone_service = KeeperSyncTombstoneService(
+        session=db_session,
+        state_store=state_store,
+        logger=structlog.get_logger("test"),
+    )
+
+    # Tombstone the edition state row + snapshot ``date_last_synced``
+    # so the post-sync assertion can prove the upsert was skipped.
+    async with db_session.begin():
+        await tombstone_service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            reason=TombstoneReason.lifecycle_delete,
+        )
+        state_before = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            include_tombstoned=True,
+        )
+    assert state_before is not None
+    assert state_before.date_tombstoned is not None
+    date_last_synced_before = state_before.date_last_synced
+
+    # LTD pretends a fresh build arrived — without the short-circuit
+    # the sync would copy bucket content into Docverse.
+    edition_v2 = _load("edition_main_git_refs.json")
+    edition_v2["date_rebuilt"] = "2026-05-04T12:00:00.000000+00:00"
+    edition_v2["build_url"] = f"{LTD_BASE}/builds/43"
+    build_v2 = _load("build.json")
+    build_v2["self_url"] = f"{LTD_BASE}/builds/43"
+    build_v2["bucket_root_dir"] = "pipelines/builds/43"
+    mock_discovery.reset()
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(200, json=_load("product_pipelines.json"))
+    )
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
+        return_value=httpx.Response(
+            200, json={"editions": [f"{LTD_BASE}/editions/1"]}
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/editions/1").mock(
+        return_value=httpx.Response(200, json=edition_v2)
+    )
+    builds_43_route = mock_discovery.get(f"{LTD_BASE}/builds/43").mock(
+        return_value=httpx.Response(200, json=build_v2)
+    )
+
+    source_objects_v2 = {
+        "pipelines/builds/43/index.html": b"<html>v2</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects_v2
+    )
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    # The edition outcome is present but carries no build_outcome — the
+    # short-circuit fired before ``sync_build`` had a chance to run.
+    assert len(result.edition_outcomes) == 1
+    outcome = result.edition_outcomes[0]
+    assert outcome.docverse_slug == "__main"
+    assert outcome.build_outcome is None
+
+    # No new bytes landed in the destination object store, and the
+    # build endpoint was never fetched — short-circuit fired before
+    # any sync_build work could begin.
+    assert set(object_store.objects.keys()) == keys_after_first
+    assert builds_43_route.call_count == 0
+
+    # The tombstoned state row is unchanged — no upsert ran inside
+    # the short-circuited sync_edition.
+    async with db_session.begin():
+        state_after = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            include_tombstoned=True,
+        )
+    assert state_after is not None
+    assert state_after.date_tombstoned is not None
+    assert state_after.date_last_synced == date_last_synced_before
+
+
+@pytest.mark.asyncio
+async def test_sync_project_short_circuits_when_tombstoned(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+) -> None:
+    """A tombstoned project state row short-circuits ``sync_project``.
+
+    The LTD product fetch must not run and ``edition_outcomes`` must
+    be empty.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-project")
+
+    _seed_ltd(mock_discovery)
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v1</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+
+    # First sync imports the project + writes the project state row.
+    await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    tombstone_service = KeeperSyncTombstoneService(
+        session=db_session,
+        state_store=state_store,
+        logger=structlog.get_logger("test"),
+    )
+    async with db_session.begin():
+        await tombstone_service.record(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="pipelines",
+            reason=TombstoneReason.manual_delete,
+        )
+
+    # Clear LTD call stats — the short-circuit must issue zero LTD
+    # calls, so any post-tombstone delta would indicate the sync
+    # still walked LTD. ``reset()`` keeps the routes registered so a
+    # missed short-circuit still returns the stubbed responses (no
+    # passthrough surprises) while the call counter remains pinnable.
+    mock_discovery.reset()
+
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    assert result.edition_outcomes == []
+    assert mock_discovery.calls.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_edition_does_not_crash_on_soft_deleted_tombstoned_row(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+) -> None:
+    """Regression: tombstone short-circuit defuses the slug-clash crash.
+
+    Without the short-circuit, a soft-deleted Docverse edition row
+    whose LTD source still exists makes ``_ensure_edition`` /
+    ``EditionStore.create_internal`` hit a ``uq_editions_project_lower_slug``
+    conflict against the soft-deleted row, ``ON CONFLICT DO NOTHING``
+    short-circuits the insert, and the follow-up ``get_by_slug``
+    (which filters ``date_deleted IS NULL``) returns ``None`` —
+    raising ``"create_internal lost ON CONFLICT race"``. The tombstone
+    must defuse that crash by short-circuiting ``sync_edition`` before
+    ``_ensure_edition`` runs.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-soft-deleted")
+
+    _seed_ltd(mock_discovery)
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>v1</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+    await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    project_store = ProjectStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    edition_store = EditionStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    tombstone_service = KeeperSyncTombstoneService(
+        session=db_session,
+        state_store=state_store,
+        logger=structlog.get_logger("test"),
+    )
+
+    async with db_session.begin():
+        project = await project_store.get_by_slug(
+            org_id=org_id, slug="pipelines"
+        )
+        assert project is not None
+        soft_deleted = await edition_store.soft_delete(
+            project_id=project.id, slug="__main"
+        )
+        assert soft_deleted is True
+        await tombstone_service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            reason=TombstoneReason.manual_delete,
+        )
+
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+    # Without the short-circuit this raises "lost ON CONFLICT race".
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    assert len(result.edition_outcomes) == 1
+    outcome = result.edition_outcomes[0]
+    assert outcome.docverse_slug == "__main"
+    assert outcome.build_outcome is None

--- a/tests/services/keeper_sync/service_test.py
+++ b/tests/services/keeper_sync/service_test.py
@@ -19,6 +19,7 @@ import pytest
 import pytest_asyncio
 import respx
 import structlog
+from safir.github import GitHubAppClientFactory
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,6 +31,12 @@ from docverse.client.models import (
     TrackingMode,
 )
 from docverse.dbschema.build import SqlBuild
+from docverse.domain.lifecycle import (
+    BuildHistoryOrphanRule,
+    DraftInactivityRule,
+    LifecycleRuleSet,
+    RefDeletedRule,
+)
 from docverse.services.keeper_sync.copier import BuildContentCopier
 from docverse.services.keeper_sync.service import (
     KeeperSyncContext,
@@ -38,8 +45,16 @@ from docverse.services.keeper_sync.service import (
 )
 from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
 from docverse.services.project import ProjectService
+from docverse.services.project_github_binding import (
+    ProjectGitHubBindingResolver,
+)
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_store import EditionStore
+from docverse.storage.github import (
+    GITHUB_API_BASE_URL,
+    GitHubAppClient,
+    GitHubRefSetFetcher,
+)
 from docverse.storage.keeper_sync import (
     KeeperSyncStateStore,
     ResourceType,
@@ -49,6 +64,7 @@ from docverse.storage.ltd import LtdClient, LtdSourceProtocol
 from docverse.storage.objectstore import MockObjectStore
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
+from tests.support.github_mock import DEFAULT_APP_NAME, GitHubMock
 
 FIXTURES_DIR = (
     Path(__file__).parent.parent.parent / "storage" / "ltd" / "fixtures"
@@ -80,7 +96,12 @@ async def http_client() -> AsyncGenerator[httpx.AsyncClient]:
         yield client
 
 
-async def _seed_org(session: AsyncSession, *, slug: str = "ks-svc") -> int:
+async def _seed_org(
+    session: AsyncSession,
+    *,
+    slug: str = "ks-svc",
+    lifecycle_rules: LifecycleRuleSet | None = None,
+) -> int:
     logger = structlog.get_logger("test")
     store = OrganizationStore(session=session, logger=logger)
     org = await store.create(
@@ -88,6 +109,7 @@ async def _seed_org(session: AsyncSession, *, slug: str = "ks-svc") -> int:
             slug=slug,
             title="ks-svc",
             base_domain=f"{slug}.example.com",
+            lifecycle_rules=lifecycle_rules,
         )
     )
     return org.id
@@ -98,8 +120,18 @@ def _build_service(
     http_client: httpx.AsyncClient,
     object_store: MockObjectStore,
     source_objects: dict[str, bytes],
+    *,
+    binding_resolver: ProjectGitHubBindingResolver | None = None,
+    ref_set_fetcher: GitHubRefSetFetcher | None = None,
+    tombstone_service: KeeperSyncTombstoneService | None = None,
 ) -> KeeperSyncService:
-    """Construct a real ``KeeperSyncService`` against the test DB."""
+    """Construct a real ``KeeperSyncService`` against the test DB.
+
+    Optional ``binding_resolver`` / ``ref_set_fetcher`` /
+    ``tombstone_service`` wire the proactive-lifecycle path; tests
+    that don't care about that path leave them unset and get the
+    pre-PRD-#332 behavior (proactive pass is a no-op).
+    """
     logger = structlog.get_logger("test")
     org_store = OrganizationStore(session=session, logger=logger)
     project_store = ProjectStore(session=session, logger=logger)
@@ -146,7 +178,96 @@ def _build_service(
         copy_callable=copy_callable,  # type: ignore[arg-type]
         manifest_callable=manifest_callable,
         logger=logger,
+        tombstone_service=tombstone_service,
+        binding_resolver=binding_resolver,
+        ref_set_fetcher=ref_set_fetcher,
     )
+
+
+def _make_proactive_deps(
+    *,
+    session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_github: GitHubMock,
+) -> tuple[
+    ProjectGitHubBindingResolver,
+    GitHubRefSetFetcher,
+    KeeperSyncTombstoneService,
+]:
+    """Build the three proactive-lifecycle deps for a sync_project test.
+
+    Mirrors the production factory wiring at the unit-test layer: the
+    resolver, ref fetcher, and tombstone service are the same concrete
+    classes the production ``Factory.create_keeper_sync_service`` would
+    construct. Tests pass these straight into ``_build_service`` to
+    exercise the proactive path.
+    """
+    logger = structlog.get_logger("test")
+    project_store = ProjectStore(session=session, logger=logger)
+    state_store = KeeperSyncStateStore(session=session, logger=logger)
+    safir_factory = GitHubAppClientFactory(
+        id=mock_github.app_id,
+        key=mock_github.private_key_pem,
+        name=DEFAULT_APP_NAME,
+        http_client=http_client,
+    )
+    app_client = GitHubAppClient(
+        factory=safir_factory,
+        http_client=http_client,
+        logger=logger,
+    )
+    resolver = ProjectGitHubBindingResolver(
+        session=session,
+        project_store=project_store,
+        app_client=app_client,
+        logger=logger,
+    )
+    fetcher = GitHubRefSetFetcher(http_client=http_client)
+    tombstone_service = KeeperSyncTombstoneService(
+        session=session, state_store=state_store, logger=logger
+    )
+    return resolver, fetcher, tombstone_service
+
+
+def _ref_entry(ref: str) -> dict[str, object]:
+    return {
+        "ref": ref,
+        "node_id": f"node-{ref}",
+        "url": f"https://api.github.com/{ref}",
+        "object": {"sha": "deadbeef", "type": "commit"},
+    }
+
+
+def _seed_github_refs(
+    router: respx.Router,
+    *,
+    owner: str,
+    repo: str,
+    branches: list[str] | None = None,
+    tags: list[str] | None = None,
+) -> tuple[respx.Route, respx.Route]:
+    """Seed the matching-refs endpoints for one repo; return the routes.
+
+    Returning the routes lets the caller pin call counts on the
+    heads/tags endpoints (the "fetched once per sync_project" assertion).
+    """
+    branches = branches if branches is not None else []
+    tags = tags if tags is not None else []
+    heads_route = router.get(
+        f"{GITHUB_API_BASE_URL}/repos/{owner}/{repo}/git/matching-refs/heads"
+    ).mock(
+        return_value=httpx.Response(
+            200, json=[_ref_entry(f"refs/heads/{n}") for n in branches]
+        )
+    )
+    tags_route = router.get(
+        f"{GITHUB_API_BASE_URL}/repos/{owner}/{repo}/git/matching-refs/tags"
+    ).mock(
+        return_value=httpx.Response(
+            200, json=[_ref_entry(f"refs/tags/{n}") for n in tags]
+        )
+    )
+    return heads_route, tags_route
 
 
 def _seed_ltd(
@@ -1642,3 +1763,692 @@ async def test_sync_edition_does_not_crash_on_soft_deleted_tombstoned_row(
     outcome = result.edition_outcomes[0]
     assert outcome.docverse_slug == "__main"
     assert outcome.build_outcome is None
+
+
+# ---------------------------------------------------------------------------
+# Proactive lifecycle evaluation (PRD #332 / DM-54914) — sync_project
+# pre-filters LTD editions that ``draft_inactivity`` or ``ref_deleted``
+# would immediately tombstone, so the migration does not spend bandwidth
+# copying build assets the lifecycle pass would delete seconds later.
+# ---------------------------------------------------------------------------
+
+
+def _seed_two_editions_main_and_draft(
+    mock_discovery: respx.Router,
+    *,
+    draft_payload: dict | None = None,  # type: ignore[type-arg]
+    draft_build_payload: dict | None = None,  # type: ignore[type-arg]
+) -> None:
+    """Stub LTD's view of a project with main + one draft edition.
+
+    Two edition resources at ``/editions/1`` (main, build 42) and
+    ``/editions/2`` (the supplied draft, build 43). The draft's
+    ``tracked_refs`` and ``date_rebuilt`` are driven by the caller via
+    ``draft_payload`` so individual tests can express their scenario
+    (ref present / ref deleted / stale / fresh) directly.
+    """
+    if draft_payload is None:
+        draft_payload = _load("edition_branch_git_refs.json")
+    if draft_build_payload is None:
+        draft_build_payload = _load("build.json")
+        draft_build_payload["self_url"] = f"{LTD_BASE}/builds/43"
+        draft_build_payload["bucket_root_dir"] = "pipelines/builds/43"
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(200, json=_load("product_pipelines.json"))
+    )
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "editions": [
+                    f"{LTD_BASE}/editions/1",
+                    f"{LTD_BASE}/editions/2",
+                ]
+            },
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/editions/1").mock(
+        return_value=httpx.Response(
+            200, json=_load("edition_main_git_refs.json")
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/builds/42").mock(
+        return_value=httpx.Response(200, json=_load("build.json"))
+    )
+    mock_discovery.get(f"{LTD_BASE}/editions/2").mock(
+        return_value=httpx.Response(200, json=draft_payload)
+    )
+    mock_discovery.get(f"{LTD_BASE}/builds/43").mock(
+        return_value=httpx.Response(200, json=draft_build_payload)
+    )
+
+
+# The ``pipelines`` LTD product's ``doc_repo`` parses to
+# (lsst, pipelines_lsst_io); every proactive test seeds GitHub refs for
+# that coordinate. Keep the constant here so the wiring is obvious at
+# the test call sites.
+_LSST_OWNER = "lsst"
+_LSST_REPO = "pipelines_lsst_io"
+
+
+@pytest.mark.asyncio
+async def test_proactive_ref_deleted_tombstones_and_skips_sync_edition(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+    mock_github: GitHubMock,
+) -> None:
+    """A draft tracking a missing GitHub branch is tombstoned pre-import.
+
+    Seeds an org with ``RefDeletedRule`` configured, an LTD product
+    whose ``doc_repo`` is a public GitHub repo, and a draft edition
+    tracking a branch that no longer exists on GitHub. The proactive
+    evaluator must tombstone the draft ``lifecycle_preemptive``, skip
+    its ``sync_edition`` call entirely (no Docverse edition row, no
+    LTD build endpoint hit, no bytes in the destination store), and
+    sync the main edition normally.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(
+            db_session,
+            slug="ks-proactive-ref",
+            lifecycle_rules=LifecycleRuleSet(root=[RefDeletedRule()]),
+        )
+
+    draft_payload = _load("edition_branch_git_refs.json")
+    # Track a branch that the GitHub mock will NOT list as live.
+    draft_payload["tracked_refs"] = ["tickets/DM-deleted"]
+    _seed_two_editions_main_and_draft(
+        mock_discovery, draft_payload=draft_payload
+    )
+    _seed_github_refs(
+        mock_github.router,
+        owner=_LSST_OWNER,
+        repo=_LSST_REPO,
+        branches=["main"],
+        tags=[],
+    )
+    # Track the draft build endpoint so we can prove it was not fetched.
+    draft_build_route = mock_discovery.get(f"{LTD_BASE}/builds/43")
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>main</html>",
+        "pipelines/builds/43/index.html": b"<html>draft</html>",
+    }
+    resolver, fetcher, tombstone_service = _make_proactive_deps(
+        session=db_session,
+        http_client=http_client,
+        mock_github=mock_github,
+    )
+    service = _build_service(
+        db_session,
+        http_client,
+        object_store,
+        source_objects,
+        binding_resolver=resolver,
+        ref_set_fetcher=fetcher,
+        tombstone_service=tombstone_service,
+    )
+
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    # Only the main edition produced an outcome — the draft was
+    # tombstoned pre-import and skipped.
+    assert len(result.edition_outcomes) == 1
+    assert result.edition_outcomes[0].docverse_slug == "__main"
+
+    # The draft's LTD build endpoint was never fetched.
+    assert draft_build_route.call_count == 0
+
+    # No draft edition row was created in Docverse.
+    project_store = ProjectStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    edition_store = EditionStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    async with db_session.begin():
+        project = await project_store.get_by_slug(
+            org_id=org_id, slug="pipelines"
+        )
+        assert project is not None
+        draft = await edition_store.get_by_slug(
+            project_id=project.id, slug="u-jsick-feature"
+        )
+        assert draft is None
+
+        # ...but the tombstone state row IS present.
+        tombstone = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            include_tombstoned=True,
+        )
+        assert tombstone is not None
+        assert tombstone.date_tombstoned is not None
+        assert tombstone.tombstone_reason == (
+            TombstoneReason.lifecycle_preemptive.value
+        )
+        # No Docverse row was created — the tombstone is a pure veto.
+        assert tombstone.docverse_id is None
+
+    # No draft bytes landed in the destination object store.
+    assert not any(
+        k.startswith("pipelines/builds/43") for k in object_store.objects
+    )
+
+
+@pytest.mark.asyncio
+async def test_proactive_draft_inactivity_tombstones_and_skips(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+    mock_github: GitHubMock,
+) -> None:
+    """A draft past its inactivity threshold is tombstoned pre-import.
+
+    ``draft_inactivity`` does not read ``live_refs`` — the rule fires
+    purely on edition kind + age. This test seeds GitHub refs so the
+    binding resolves cleanly, then backdates the LTD draft's
+    ``date_rebuilt`` / ``date_created`` well past the configured
+    inactivity threshold so the proactive evaluator tombstones it.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(
+            db_session,
+            slug="ks-proactive-stale",
+            lifecycle_rules=LifecycleRuleSet(
+                root=[DraftInactivityRule(max_days_inactive=30)]
+            ),
+        )
+
+    draft_payload = _load("edition_branch_git_refs.json")
+    # Backdate ``date_rebuilt`` and ``date_created`` past the threshold.
+    stale_date = (datetime.now(tz=UTC) - timedelta(days=60)).isoformat()
+    draft_payload["date_rebuilt"] = stale_date
+    draft_payload["date_created"] = stale_date
+    _seed_two_editions_main_and_draft(
+        mock_discovery, draft_payload=draft_payload
+    )
+    _seed_github_refs(
+        mock_github.router,
+        owner=_LSST_OWNER,
+        repo=_LSST_REPO,
+        branches=["main", "u/jsick/feature"],
+        tags=[],
+    )
+    draft_build_route = mock_discovery.get(f"{LTD_BASE}/builds/43")
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>main</html>",
+        "pipelines/builds/43/index.html": b"<html>draft</html>",
+    }
+    resolver, fetcher, tombstone_service = _make_proactive_deps(
+        session=db_session,
+        http_client=http_client,
+        mock_github=mock_github,
+    )
+    service = _build_service(
+        db_session,
+        http_client,
+        object_store,
+        source_objects,
+        binding_resolver=resolver,
+        ref_set_fetcher=fetcher,
+        tombstone_service=tombstone_service,
+    )
+
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    # Only the main edition produced an outcome.
+    assert len(result.edition_outcomes) == 1
+    assert result.edition_outcomes[0].docverse_slug == "__main"
+    assert draft_build_route.call_count == 0
+
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    async with db_session.begin():
+        tombstone = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            include_tombstoned=True,
+        )
+        assert tombstone is not None
+        assert tombstone.tombstone_reason == (
+            TombstoneReason.lifecycle_preemptive.value
+        )
+
+
+@pytest.mark.asyncio
+async def test_proactive_keep_proceeds_through_sync_edition(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+    mock_github: GitHubMock,
+) -> None:
+    """A draft whose ref still exists is NOT tombstoned and syncs normally.
+
+    ``RefDeletedRule`` is configured. GitHub lists the draft's branch
+    as live, so the proactive evaluator returns KEEP and the regular
+    ``sync_edition`` flow imports the edition + build.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(
+            db_session,
+            slug="ks-proactive-keep",
+            lifecycle_rules=LifecycleRuleSet(root=[RefDeletedRule()]),
+        )
+
+    draft_payload = _load("edition_branch_git_refs.json")
+    draft_payload["tracked_refs"] = ["u/jsick/feature"]
+    _seed_two_editions_main_and_draft(
+        mock_discovery, draft_payload=draft_payload
+    )
+    _seed_github_refs(
+        mock_github.router,
+        owner=_LSST_OWNER,
+        repo=_LSST_REPO,
+        branches=["main", "u/jsick/feature"],
+        tags=[],
+    )
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>main</html>",
+        "pipelines/builds/43/index.html": b"<html>draft</html>",
+    }
+    resolver, fetcher, tombstone_service = _make_proactive_deps(
+        session=db_session,
+        http_client=http_client,
+        mock_github=mock_github,
+    )
+    service = _build_service(
+        db_session,
+        http_client,
+        object_store,
+        source_objects,
+        binding_resolver=resolver,
+        ref_set_fetcher=fetcher,
+        tombstone_service=tombstone_service,
+    )
+
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    # Both editions produced outcomes — the draft was kept and synced.
+    assert len(result.edition_outcomes) == 2
+    outcome_slugs = {o.docverse_slug for o in result.edition_outcomes}
+    assert "__main" in outcome_slugs
+    assert "u-jsick-feature" in outcome_slugs
+
+    project_store = ProjectStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    edition_store = EditionStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    async with db_session.begin():
+        project = await project_store.get_by_slug(
+            org_id=org_id, slug="pipelines"
+        )
+        assert project is not None
+        draft = await edition_store.get_by_slug(
+            project_id=project.id, slug="u-jsick-feature"
+        )
+        assert draft is not None
+        # No tombstone for the kept edition.
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            include_tombstoned=True,
+        )
+        assert state is not None
+        assert state.date_tombstoned is None
+
+
+@pytest.mark.asyncio
+async def test_proactive_build_history_orphan_never_fires(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+    mock_github: GitHubMock,
+) -> None:
+    """``build_history_orphan`` is excluded from the proactive filter.
+
+    Even when configured on the org, the rule must NOT fire during
+    ``sync_project`` — it matches against the Docverse build-history
+    chain that does not exist until import, and is owned by the
+    post-import ``lifecycle_eval`` pass. The draft edition syncs
+    normally despite the rule being configured.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(
+            db_session,
+            slug="ks-proactive-orphan",
+            lifecycle_rules=LifecycleRuleSet(
+                root=[BuildHistoryOrphanRule(min_position=1, min_age_days=0)]
+            ),
+        )
+
+    draft_payload = _load("edition_branch_git_refs.json")
+    _seed_two_editions_main_and_draft(
+        mock_discovery, draft_payload=draft_payload
+    )
+    _seed_github_refs(
+        mock_github.router,
+        owner=_LSST_OWNER,
+        repo=_LSST_REPO,
+        branches=["main"],
+        tags=[],
+    )
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>main</html>",
+        "pipelines/builds/43/index.html": b"<html>draft</html>",
+    }
+    resolver, fetcher, tombstone_service = _make_proactive_deps(
+        session=db_session,
+        http_client=http_client,
+        mock_github=mock_github,
+    )
+    service = _build_service(
+        db_session,
+        http_client,
+        object_store,
+        source_objects,
+        binding_resolver=resolver,
+        ref_set_fetcher=fetcher,
+        tombstone_service=tombstone_service,
+    )
+
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    # Both editions synced; no tombstone written.
+    assert len(result.edition_outcomes) == 2
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    async with db_session.begin():
+        draft_state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            include_tombstoned=True,
+        )
+        assert draft_state is not None
+        assert draft_state.date_tombstoned is None
+
+
+@pytest.mark.asyncio
+async def test_proactive_fetch_failure_disables_ref_deleted_only(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+    mock_github: GitHubMock,
+) -> None:
+    """A 500 from GitHub falls through to KEEP; editions sync normally.
+
+    The proactive evaluator's ``RepositoryRefFetchError`` handling
+    leaves ``live_refs`` unset, which disables ``ref_deleted`` for
+    this project pass. The draft tracking a ref that would otherwise
+    look deleted is therefore kept (and synced); the regular
+    ``git_ref_audit`` cron catches up later if needed.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(
+            db_session,
+            slug="ks-proactive-fetch-fail",
+            lifecycle_rules=LifecycleRuleSet(root=[RefDeletedRule()]),
+        )
+
+    draft_payload = _load("edition_branch_git_refs.json")
+    draft_payload["tracked_refs"] = ["tickets/DM-anything"]
+    _seed_two_editions_main_and_draft(
+        mock_discovery, draft_payload=draft_payload
+    )
+    # 500 on the heads endpoint → RepositoryRefFetchError → live_refs
+    # stays unset → ref_deleted disabled.
+    mock_github.router.get(
+        f"{GITHUB_API_BASE_URL}/repos/{_LSST_OWNER}/{_LSST_REPO}"
+        "/git/matching-refs/heads"
+    ).mock(return_value=httpx.Response(500, json={"message": "boom"}))
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>main</html>",
+        "pipelines/builds/43/index.html": b"<html>draft</html>",
+    }
+    resolver, fetcher, tombstone_service = _make_proactive_deps(
+        session=db_session,
+        http_client=http_client,
+        mock_github=mock_github,
+    )
+    service = _build_service(
+        db_session,
+        http_client,
+        object_store,
+        source_objects,
+        binding_resolver=resolver,
+        ref_set_fetcher=fetcher,
+        tombstone_service=tombstone_service,
+    )
+
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    # Both editions synced — fetch failure did not abort the pass.
+    assert len(result.edition_outcomes) == 2
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    async with db_session.begin():
+        draft_state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            include_tombstoned=True,
+        )
+        assert draft_state is not None
+        assert draft_state.date_tombstoned is None
+
+
+@pytest.mark.asyncio
+async def test_proactive_no_binding_skips_fetch_and_syncs(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+    mock_github: GitHubMock,
+) -> None:
+    """A project with no GitHub binding skips the fetch entirely.
+
+    Substitutes a non-GitHub ``doc_repo`` (parses to ``None`` via
+    ``parse_github_url``) so the resolved binding is ``None``. The
+    proactive evaluator must not call GitHub for that project; the
+    ``ref_deleted`` rule simply does not fire and editions sync
+    normally.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(
+            db_session,
+            slug="ks-proactive-no-binding",
+            lifecycle_rules=LifecycleRuleSet(root=[RefDeletedRule()]),
+        )
+
+    product_payload = _load("product_pipelines.json")
+    product_payload["doc_repo"] = "https://gitlab.example.com/lsst/pipelines"
+    draft_payload = _load("edition_branch_git_refs.json")
+    draft_payload["tracked_refs"] = ["tickets/DM-anything"]
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(200, json=product_payload)
+    )
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "editions": [
+                    f"{LTD_BASE}/editions/1",
+                    f"{LTD_BASE}/editions/2",
+                ]
+            },
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/editions/1").mock(
+        return_value=httpx.Response(
+            200, json=_load("edition_main_git_refs.json")
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/builds/42").mock(
+        return_value=httpx.Response(200, json=_load("build.json"))
+    )
+    mock_discovery.get(f"{LTD_BASE}/editions/2").mock(
+        return_value=httpx.Response(200, json=draft_payload)
+    )
+    draft_build = _load("build.json")
+    draft_build["self_url"] = f"{LTD_BASE}/builds/43"
+    draft_build["bucket_root_dir"] = "pipelines/builds/43"
+    mock_discovery.get(f"{LTD_BASE}/builds/43").mock(
+        return_value=httpx.Response(200, json=draft_build)
+    )
+    # Seed the GitHub refs endpoints so we can prove they were NOT
+    # called by the proactive evaluator (the project has no GitHub
+    # binding, so no resolve / fetch happens).
+    heads_route, tags_route = _seed_github_refs(
+        mock_github.router,
+        owner=_LSST_OWNER,
+        repo=_LSST_REPO,
+        branches=["main"],
+        tags=[],
+    )
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>main</html>",
+        "pipelines/builds/43/index.html": b"<html>draft</html>",
+    }
+    resolver, fetcher, tombstone_service = _make_proactive_deps(
+        session=db_session,
+        http_client=http_client,
+        mock_github=mock_github,
+    )
+    service = _build_service(
+        db_session,
+        http_client,
+        object_store,
+        source_objects,
+        binding_resolver=resolver,
+        ref_set_fetcher=fetcher,
+        tombstone_service=tombstone_service,
+    )
+
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    assert len(result.edition_outcomes) == 2
+    # GitHub endpoints were never called.
+    assert heads_route.call_count == 0
+    assert tags_route.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_proactive_ref_set_fetched_once_per_sync_project(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+    mock_github: GitHubMock,
+) -> None:
+    """The ref set is fetched exactly once even with many editions.
+
+    Seeds five LTD editions (one main + four drafts); the GitHub
+    matching-refs endpoints must each be hit exactly once across the
+    whole ``sync_project`` invocation, demonstrating the per-project
+    cache the PRD calls out for GitHub API budget reasons.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(
+            db_session,
+            slug="ks-proactive-once",
+            lifecycle_rules=LifecycleRuleSet(root=[RefDeletedRule()]),
+        )
+
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(200, json=_load("product_pipelines.json"))
+    )
+    edition_urls = [f"{LTD_BASE}/editions/{i}" for i in range(1, 6)]
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
+        return_value=httpx.Response(200, json={"editions": edition_urls})
+    )
+    # main → /editions/1, /builds/42
+    mock_discovery.get(f"{LTD_BASE}/editions/1").mock(
+        return_value=httpx.Response(
+            200, json=_load("edition_main_git_refs.json")
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/builds/42").mock(
+        return_value=httpx.Response(200, json=_load("build.json"))
+    )
+    source_objects = {
+        "pipelines/builds/42/index.html": b"<html>main</html>",
+    }
+    # Four drafts, each on its own ref; all four refs are live so they
+    # KEEP and proceed to sync_edition.
+    for i, ref in enumerate(["feat-a", "feat-b", "feat-c", "feat-d"], start=2):
+        draft_payload = _load("edition_branch_git_refs.json")
+        draft_payload["self_url"] = f"{LTD_BASE}/editions/{i}"
+        draft_payload["slug"] = f"u-jsick-{ref}"
+        draft_payload["title"] = f"u/jsick/{ref}"
+        draft_payload["tracked_refs"] = [ref]
+        build_id = 100 + i
+        draft_payload["build_url"] = f"{LTD_BASE}/builds/{build_id}"
+        mock_discovery.get(f"{LTD_BASE}/editions/{i}").mock(
+            return_value=httpx.Response(200, json=draft_payload)
+        )
+        draft_build = _load("build.json")
+        draft_build["self_url"] = f"{LTD_BASE}/builds/{build_id}"
+        draft_build["bucket_root_dir"] = f"pipelines/builds/{build_id}"
+        mock_discovery.get(f"{LTD_BASE}/builds/{build_id}").mock(
+            return_value=httpx.Response(200, json=draft_build)
+        )
+        source_objects[f"pipelines/builds/{build_id}/index.html"] = (
+            f"<html>{ref}</html>".encode()
+        )
+
+    heads_route, tags_route = _seed_github_refs(
+        mock_github.router,
+        owner=_LSST_OWNER,
+        repo=_LSST_REPO,
+        branches=["main", "feat-a", "feat-b", "feat-c", "feat-d"],
+        tags=[],
+    )
+
+    object_store = MockObjectStore()
+    resolver, fetcher, tombstone_service = _make_proactive_deps(
+        session=db_session,
+        http_client=http_client,
+        mock_github=mock_github,
+    )
+    service = _build_service(
+        db_session,
+        http_client,
+        object_store,
+        source_objects,
+        binding_resolver=resolver,
+        ref_set_fetcher=fetcher,
+        tombstone_service=tombstone_service,
+    )
+
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    # All five editions synced.
+    assert len(result.edition_outcomes) == 5
+    # GitHub refs endpoints each hit exactly once.
+    assert heads_route.call_count == 1
+    assert tags_route.call_count == 1

--- a/tests/services/keeper_sync_tombstone_test.py
+++ b/tests/services/keeper_sync_tombstone_test.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 import structlog
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog.testing import capture_logs
 
@@ -14,6 +17,7 @@ from docverse.client.models import (
     ProjectCreate,
     TrackingMode,
 )
+from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
 from docverse.exceptions import NotFoundError
 from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
 from docverse.storage.edition_store import EditionStore
@@ -279,6 +283,130 @@ async def test_list_for_org_returns_only_tombstoned_rows(
         if entry.ltd_id is not None
     )
     assert ltd_ids == [2]
+
+
+async def _set_date_tombstoned(
+    session: AsyncSession, *, org_id: int, ltd_id: int, when: datetime
+) -> None:
+    """Force a row's ``date_tombstoned`` so ordering is deterministic."""
+    await session.execute(
+        update(SqlKeeperSyncState)
+        .where(
+            SqlKeeperSyncState.org_id == org_id,
+            SqlKeeperSyncState.ltd_id == ltd_id,
+        )
+        .values(date_tombstoned=when)
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_for_org_orders_by_date_tombstoned_desc(
+    db_session: AsyncSession,
+) -> None:
+    """Most-recently-tombstoned rows sort first, regardless of row id.
+
+    A tombstone stamped recently on a long-standing (low-id) row must
+    sort ahead of an older tombstone on a newer (high-id) row. This
+    guards against regressing to the previous ``id DESC`` ordering,
+    which buried freshly-deleted aged resources at the bottom.
+    """
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-list-order")
+
+    service = _build_service(db_session, logger=logger)
+    # ltd_id=1 is recorded first → lowest id; ltd_id=2 → higher id.
+    async with db_session.begin():
+        await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            reason=TombstoneReason.lifecycle_delete,
+        )
+        await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            reason=TombstoneReason.lifecycle_delete,
+        )
+
+    # Give the low-id row the *newer* tombstone time so date-ordering
+    # and id-ordering disagree.
+    async with db_session.begin():
+        await _set_date_tombstoned(
+            db_session,
+            org_id=org_id,
+            ltd_id=1,
+            when=datetime(2026, 5, 1, tzinfo=UTC),
+        )
+        await _set_date_tombstoned(
+            db_session,
+            org_id=org_id,
+            ltd_id=2,
+            when=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+    async with db_session.begin():
+        result = await service.list_for_org(
+            org_id=org_id, cursor=None, limit=25
+        )
+
+    assert [entry.ltd_id for entry in result.page.entries] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_list_for_org_paginates_in_date_tombstoned_order(
+    db_session: AsyncSession,
+) -> None:
+    """Walking pages by cursor yields newest-tombstoned rows first.
+
+    Exercises the ``date_tombstoned``-keyed cursor's ``apply_cursor``
+    across page boundaries: with timestamps assigned opposite to id
+    order, paging with ``limit=1`` must still surface rows newest-first
+    and visit each exactly once.
+    """
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-list-page-order")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        for ltd_id in (1, 2, 3):
+            await service.record(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=ltd_id,
+                reason=TombstoneReason.lifecycle_delete,
+            )
+
+    # Tombstone times decrease as ltd_id increases, the reverse of id
+    # order, so the expected page order is ltd_id 1, 2, 3.
+    times = {
+        1: datetime(2026, 5, 3, tzinfo=UTC),
+        2: datetime(2026, 5, 2, tzinfo=UTC),
+        3: datetime(2026, 5, 1, tzinfo=UTC),
+    }
+    async with db_session.begin():
+        for ltd_id, when in times.items():
+            await _set_date_tombstoned(
+                db_session, org_id=org_id, ltd_id=ltd_id, when=when
+            )
+
+    seen: list[int | None] = []
+    cursor = None
+    async with db_session.begin():
+        while True:
+            page = (
+                await service.list_for_org(
+                    org_id=org_id, cursor=cursor, limit=1
+                )
+            ).page
+            seen.extend(entry.ltd_id for entry in page.entries)
+            if page.next_cursor is None:
+                break
+            cursor = page.next_cursor
+
+    assert seen == [1, 2, 3]
 
 
 @pytest.mark.asyncio

--- a/tests/services/keeper_sync_tombstone_test.py
+++ b/tests/services/keeper_sync_tombstone_test.py
@@ -1,0 +1,223 @@
+"""Tests for :class:`KeeperSyncTombstoneService`."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+from docverse.client.models import OrganizationCreate
+from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
+from docverse.storage.keeper_sync import (
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
+from docverse.storage.organization_store import OrganizationStore
+
+
+async def _seed_org(session: AsyncSession, *, slug: str = "ks-tomb") -> int:
+    logger = structlog.get_logger("test")
+    store = OrganizationStore(session=session, logger=logger)
+    org = await store.create(
+        OrganizationCreate(
+            slug=slug,
+            title="ks-tomb",
+            base_domain=f"{slug}.example.com",
+        )
+    )
+    return org.id
+
+
+def _build_service(
+    session: AsyncSession,
+    *,
+    logger: structlog.stdlib.BoundLogger | None = None,
+) -> KeeperSyncTombstoneService:
+    log = logger or structlog.get_logger("test")
+    state_store = KeeperSyncStateStore(session=session, logger=log)
+    return KeeperSyncTombstoneService(
+        session=session, state_store=state_store, logger=log
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_writes_tombstone_on_existing_edition_row(
+    db_session: AsyncSession,
+) -> None:
+    """Existing state row picks up tombstone fields on ``record``."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=42,
+            ltd_slug="main",
+            docverse_id=7,
+        )
+
+    service = KeeperSyncTombstoneService(
+        session=db_session, state_store=state_store, logger=logger
+    )
+    async with db_session.begin():
+        state = await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=42,
+            reason=TombstoneReason.lifecycle_delete,
+            note="aged-out draft",
+        )
+
+    assert state.date_tombstoned is not None
+    assert state.tombstone_reason == "lifecycle_delete"
+    assert state.tombstone_note == "aged-out draft"
+    assert state.docverse_id == 7
+
+
+@pytest.mark.asyncio
+async def test_record_creates_row_when_none_exists_for_preemptive(
+    db_session: AsyncSession,
+) -> None:
+    """``lifecycle_preemptive`` writes a new row with ``docverse_id=NULL``."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-preemptive")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        state = await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=99,
+            reason=TombstoneReason.lifecycle_preemptive,
+        )
+
+    assert state.id > 0
+    assert state.docverse_id is None
+    assert state.date_tombstoned is not None
+    assert state.tombstone_reason == "lifecycle_preemptive"
+    assert state.tombstone_note is None
+    assert state.ltd_id == 99
+
+
+@pytest.mark.asyncio
+async def test_record_creates_project_row_with_slug_key(
+    db_session: AsyncSession,
+) -> None:
+    """Project rows are slug-keyed; ``record`` honours the slug variant."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-project")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        state = await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="pipelines",
+            reason=TombstoneReason.manual_delete,
+        )
+
+    assert state.ltd_slug == "pipelines"
+    assert state.tombstone_reason == "manual_delete"
+    assert state.date_tombstoned is not None
+
+
+@pytest.mark.asyncio
+async def test_is_tombstoned_returns_true_only_when_stamped(
+    db_session: AsyncSession,
+) -> None:
+    """``is_tombstoned`` is true iff ``date_tombstoned IS NOT NULL``."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-check")
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            ltd_slug="main",
+        )
+
+    service = KeeperSyncTombstoneService(
+        session=db_session, state_store=state_store, logger=logger
+    )
+    async with db_session.begin():
+        assert (
+            await service.is_tombstoned(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=1,
+            )
+            is False
+        )
+        await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            reason=TombstoneReason.manual_delete,
+        )
+        assert (
+            await service.is_tombstoned(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=1,
+            )
+            is True
+        )
+
+
+@pytest.mark.asyncio
+async def test_is_tombstoned_false_for_missing_row(
+    db_session: AsyncSession,
+) -> None:
+    """Absence of a state row is "not tombstoned", not an error."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-missing")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        assert (
+            await service.is_tombstoned(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=12345,
+            )
+            is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_record_emits_structured_log(
+    db_session: AsyncSession,
+) -> None:
+    """``record`` emits a log line with org, resource_type, ltd_id, reason."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-log")
+
+    service = _build_service(db_session, logger=logger)
+    with capture_logs() as captured:
+        async with db_session.begin():
+            await service.record(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=42,
+                reason=TombstoneReason.lifecycle_preemptive,
+            )
+
+    events = [
+        e for e in captured if e.get("event") == "Sync tombstone recorded"
+    ]
+    assert events, "expected a Sync tombstone recorded log line"
+    event = events[-1]
+    assert event["org_id"] == org_id
+    assert event["resource_type"] == "edition"
+    assert event["ltd_id"] == 42
+    assert event["reason"] == "lifecycle_preemptive"

--- a/tests/services/keeper_sync_tombstone_test.py
+++ b/tests/services/keeper_sync_tombstone_test.py
@@ -7,14 +7,23 @@ import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog.testing import capture_logs
 
-from docverse.client.models import OrganizationCreate
+from docverse.client.models import (
+    EditionCreate,
+    EditionKind,
+    OrganizationCreate,
+    ProjectCreate,
+    TrackingMode,
+)
+from docverse.exceptions import NotFoundError
 from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
+from docverse.storage.edition_store import EditionStore
 from docverse.storage.keeper_sync import (
     KeeperSyncStateStore,
     ResourceType,
     TombstoneReason,
 )
 from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
 
 
 async def _seed_org(session: AsyncSession, *, slug: str = "ks-tomb") -> int:
@@ -221,3 +230,512 @@ async def test_record_emits_structured_log(
     assert event["resource_type"] == "edition"
     assert event["ltd_id"] == 42
     assert event["reason"] == "lifecycle_preemptive"
+
+
+# ---------------------------------------------------------------------------
+# list_for_org
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_for_org_returns_only_tombstoned_rows(
+    db_session: AsyncSession,
+) -> None:
+    """Untombstoned rows do not appear in the listing."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-list-only-tomb")
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            ltd_slug="alive",
+        )
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            ltd_slug="dead",
+        )
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            reason=TombstoneReason.manual_delete,
+        )
+    async with db_session.begin():
+        result = await service.list_for_org(
+            org_id=org_id, cursor=None, limit=25
+        )
+
+    ltd_ids = sorted(
+        entry.ltd_id
+        for entry in result.page.entries
+        if entry.ltd_id is not None
+    )
+    assert ltd_ids == [2]
+
+
+@pytest.mark.asyncio
+async def test_list_for_org_filters_by_resource_type(
+    db_session: AsyncSession,
+) -> None:
+    """``resource_type=edition`` excludes tombstoned project rows."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-list-restype")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="proj-a",
+            reason=TombstoneReason.manual_delete,
+        )
+        await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=7,
+            reason=TombstoneReason.lifecycle_delete,
+        )
+
+    async with db_session.begin():
+        editions_only = await service.list_for_org(
+            org_id=org_id,
+            cursor=None,
+            limit=25,
+            resource_type=ResourceType.edition,
+        )
+        projects_only = await service.list_for_org(
+            org_id=org_id,
+            cursor=None,
+            limit=25,
+            resource_type=ResourceType.project,
+        )
+
+    assert [e.resource_type for e in editions_only.page.entries] == ["edition"]
+    assert [e.resource_type for e in projects_only.page.entries] == ["project"]
+
+
+@pytest.mark.asyncio
+async def test_list_for_org_filters_by_reason(
+    db_session: AsyncSession,
+) -> None:
+    """``tombstone_reason=lifecycle_delete`` excludes other reasons."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-list-reason")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            reason=TombstoneReason.manual_delete,
+        )
+        await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            reason=TombstoneReason.lifecycle_delete,
+        )
+
+    async with db_session.begin():
+        lifecycle_only = await service.list_for_org(
+            org_id=org_id,
+            cursor=None,
+            limit=25,
+            tombstone_reason=TombstoneReason.lifecycle_delete,
+        )
+    ltd_ids = [entry.ltd_id for entry in lifecycle_only.page.entries]
+    assert ltd_ids == [2]
+
+
+@pytest.mark.asyncio
+async def test_list_for_org_scopes_to_org(
+    db_session: AsyncSession,
+) -> None:
+    """Tombstones on one org are invisible to another org's listing."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_a = await _seed_org(db_session, slug="ks-list-scope-a")
+        org_b = await _seed_org(db_session, slug="ks-list-scope-b")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        await service.record(
+            org_id=org_a,
+            resource_type=ResourceType.edition,
+            ltd_id=99,
+            reason=TombstoneReason.manual_delete,
+        )
+
+    async with db_session.begin():
+        result = await service.list_for_org(
+            org_id=org_b, cursor=None, limit=25
+        )
+    assert result.page.entries == []
+    assert result.page.count == 0
+
+
+@pytest.mark.asyncio
+async def test_list_for_org_includes_display_path_for_edition(
+    db_session: AsyncSession,
+) -> None:
+    """Edition rows derive ``<project_slug>/<edition_slug>``."""
+    logger = structlog.get_logger("test")
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+    edition_store = EditionStore(session=db_session, logger=logger)
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+
+    async with db_session.begin():
+        org = await org_store.create(
+            OrganizationCreate(
+                slug="ks-disp-ed",
+                title="ks-disp-ed",
+                base_domain="ks-disp-ed.example.com",
+            )
+        )
+        project = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug="my-proj",
+                title="My Proj",
+                source_url="https://example.com/x/y",
+            ),
+        )
+        edition = await edition_store.create(
+            project_id=project.id,
+            data=EditionCreate(
+                slug="v1",
+                title="Version 1",
+                kind=EditionKind.release,
+                tracking_mode=TrackingMode.git_ref,
+            ),
+        )
+        await state_store.upsert(
+            org_id=org.id,
+            resource_type=ResourceType.edition,
+            ltd_id=4242,
+            ltd_slug="v1",
+            docverse_id=edition.id,
+        )
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        await service.record(
+            org_id=org.id,
+            resource_type=ResourceType.edition,
+            ltd_id=4242,
+            reason=TombstoneReason.lifecycle_delete,
+        )
+
+    async with db_session.begin():
+        result = await service.list_for_org(
+            org_id=org.id, cursor=None, limit=25
+        )
+
+    assert len(result.page.entries) == 1
+    entry = result.page.entries[0]
+    assert result.display_path_by_state_id[entry.id] == "my-proj/v1"
+
+
+@pytest.mark.asyncio
+async def test_list_for_org_display_path_falls_back_for_preemptive(
+    db_session: AsyncSession,
+) -> None:
+    """Preemptive rows have no Docverse row; fall back to ltd_slug."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-disp-preempt")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=900,
+            ltd_slug="never-imported",
+            reason=TombstoneReason.lifecycle_preemptive,
+        )
+
+    async with db_session.begin():
+        result = await service.list_for_org(
+            org_id=org_id, cursor=None, limit=25
+        )
+
+    entry = result.page.entries[0]
+    assert result.display_path_by_state_id[entry.id] == "never-imported"
+
+
+# ---------------------------------------------------------------------------
+# clear (with revive-on-clear)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_un_tombstones_state_row(
+    db_session: AsyncSession,
+) -> None:
+    """``clear`` nulls ``date_tombstoned`` / reason / note on the state row."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-clear-basic")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        recorded = await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=51,
+            reason=TombstoneReason.manual_delete,
+            note="recover me",
+        )
+
+    async with db_session.begin():
+        cleared = await service.clear(state_id=recorded.id, org_id=org_id)
+
+    assert cleared.state.date_tombstoned is None
+    assert cleared.state.tombstone_reason is None
+    assert cleared.state.tombstone_note is None
+    assert cleared.revived_docverse_row is False  # no docverse row linked
+
+
+@pytest.mark.asyncio
+async def test_clear_revives_soft_deleted_edition(
+    db_session: AsyncSession,
+) -> None:
+    """A soft-deleted edition is revived in the same transaction."""
+    logger = structlog.get_logger("test")
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+    edition_store = EditionStore(session=db_session, logger=logger)
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+
+    async with db_session.begin():
+        org = await org_store.create(
+            OrganizationCreate(
+                slug="ks-clear-revive",
+                title="ks-clear-revive",
+                base_domain="ks-clear-revive.example.com",
+            )
+        )
+        project = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug="proj-r",
+                title="Proj R",
+                source_url="https://example.com/r/r",
+            ),
+        )
+        edition = await edition_store.create(
+            project_id=project.id,
+            data=EditionCreate(
+                slug="ed-r",
+                title="Ed R",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+            ),
+        )
+        await state_store.upsert(
+            org_id=org.id,
+            resource_type=ResourceType.edition,
+            ltd_id=100,
+            ltd_slug="ed-r",
+            docverse_id=edition.id,
+        )
+        # Soft-delete via the centralized chokepoint → stamps the tombstone.
+        await edition_store.soft_delete(
+            org_id=org.id,
+            project_id=project.id,
+            slug="ed-r",
+            reason=TombstoneReason.manual_delete,
+        )
+
+    # Find the tombstoned state row.
+    async with db_session.begin():
+        state = await state_store.get(
+            org_id=org.id,
+            resource_type=ResourceType.edition,
+            ltd_id=100,
+            include_tombstoned=True,
+        )
+    assert state is not None
+    assert state.date_tombstoned is not None
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        cleared = await service.clear(state_id=state.id, org_id=org.id)
+
+    assert cleared.revived_docverse_row is True
+    # Edition is now visible via the default (date_deleted IS NULL) read.
+    async with db_session.begin():
+        revived = await edition_store.get_by_slug(
+            project_id=project.id, slug="ed-r"
+        )
+    assert revived is not None
+    assert revived.id == edition.id
+
+
+@pytest.mark.asyncio
+async def test_clear_revives_soft_deleted_project(
+    db_session: AsyncSession,
+) -> None:
+    """A soft-deleted project is revived in the same transaction."""
+    logger = structlog.get_logger("test")
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+
+    async with db_session.begin():
+        org = await org_store.create(
+            OrganizationCreate(
+                slug="ks-clear-proj",
+                title="ks-clear-proj",
+                base_domain="ks-clear-proj.example.com",
+            )
+        )
+        project = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug="kill-me",
+                title="Kill Me",
+                source_url="https://example.com/k/m",
+            ),
+        )
+        await state_store.upsert(
+            org_id=org.id,
+            resource_type=ResourceType.project,
+            ltd_slug="kill-me",
+            docverse_id=project.id,
+        )
+        await proj_store.soft_delete(
+            org_id=org.id,
+            slug="kill-me",
+            reason=TombstoneReason.manual_delete,
+        )
+
+    async with db_session.begin():
+        state = await state_store.get(
+            org_id=org.id,
+            resource_type=ResourceType.project,
+            ltd_slug="kill-me",
+            include_tombstoned=True,
+        )
+    assert state is not None
+    assert state.date_tombstoned is not None
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        cleared = await service.clear(state_id=state.id, org_id=org.id)
+
+    assert cleared.revived_docverse_row is True
+    async with db_session.begin():
+        revived = await proj_store.get_by_slug(org_id=org.id, slug="kill-me")
+    assert revived is not None
+    assert revived.id == project.id
+
+
+@pytest.mark.asyncio
+async def test_clear_raises_when_state_not_found(
+    db_session: AsyncSession,
+) -> None:
+    """A non-existent state_id raises NotFoundError."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-clear-miss")
+
+    service = _build_service(db_session, logger=logger)
+    with pytest.raises(NotFoundError):
+        async with db_session.begin():
+            await service.clear(state_id=999_999, org_id=org_id)
+
+
+@pytest.mark.asyncio
+async def test_clear_raises_when_row_not_tombstoned(
+    db_session: AsyncSession,
+) -> None:
+    """An untombstoned row is treated as "no such tombstone" → 404."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-clear-no-tomb")
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        state = await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=12,
+            ltd_slug="alive",
+        )
+
+    service = _build_service(db_session, logger=logger)
+    with pytest.raises(NotFoundError):
+        async with db_session.begin():
+            await service.clear(state_id=state.id, org_id=org_id)
+
+
+@pytest.mark.asyncio
+async def test_clear_is_org_scoped(
+    db_session: AsyncSession,
+) -> None:
+    """A state_id from another org raises NotFoundError, not silent clear."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_a = await _seed_org(db_session, slug="ks-clear-org-a")
+        org_b = await _seed_org(db_session, slug="ks-clear-org-b")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        recorded = await service.record(
+            org_id=org_a,
+            resource_type=ResourceType.edition,
+            ltd_id=77,
+            reason=TombstoneReason.manual_delete,
+        )
+
+    with pytest.raises(NotFoundError):
+        async with db_session.begin():
+            await service.clear(state_id=recorded.id, org_id=org_b)
+
+
+@pytest.mark.asyncio
+async def test_clear_emits_structured_log(
+    db_session: AsyncSession,
+) -> None:
+    """``clear`` emits an audit log with org / resource_type / ltd_id."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-clear-log")
+
+    service = _build_service(db_session, logger=logger)
+    async with db_session.begin():
+        recorded = await service.record(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=24,
+            reason=TombstoneReason.lifecycle_delete,
+        )
+
+    with capture_logs() as captured:
+        async with db_session.begin():
+            await service.clear(state_id=recorded.id, org_id=org_id)
+
+    events = [
+        e for e in captured if e.get("event") == "Sync tombstone cleared"
+    ]
+    assert events, "expected a Sync tombstone cleared log line"
+    event = events[-1]
+    assert event["org_id"] == org_id
+    assert event["state_id"] == recorded.id
+    assert event["resource_type"] == "edition"
+    assert event["ltd_id"] == 24
+    assert event["previous_reason"] == "lifecycle_delete"
+    assert event["revived_docverse_row"] is False

--- a/tests/services/ref_deleted_processor_test.py
+++ b/tests/services/ref_deleted_processor_test.py
@@ -17,14 +17,22 @@ from docverse.client.models import (
     TrackingMode,
 )
 from docverse.client.models.projects import ProjectGitHubBindingCreate
+from docverse.services.edition import EditionService
 from docverse.services.ref_deleted_processor import (
     AffectedProject,
     RefDeletedResult,
     RefDeletedWebhookProcessor,
 )
+from docverse.storage.build_store import BuildStore
+from docverse.storage.edition_build_history_store import (
+    EditionBuildHistoryStore,
+)
 from docverse.storage.edition_store import EditionStore
+from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
+from docverse.storage.queue_backend import NullQueueBackend
+from docverse.storage.queue_job_store import QueueJobStore
 
 
 def _logger() -> structlog.stdlib.BoundLogger:
@@ -65,6 +73,20 @@ class _StubPublishingService:
             raise self.raise_on_unpublish
 
 
+def _make_edition_service(session: AsyncSession) -> EditionService:
+    log = _logger()
+    return EditionService(
+        store=EditionStore(session=session, logger=log),
+        org_store=OrganizationStore(session=session, logger=log),
+        project_store=ProjectStore(session=session, logger=log),
+        logger=log,
+        history_store=EditionBuildHistoryStore(session=session, logger=log),
+        build_store=BuildStore(session=session, logger=log),
+        queue_backend=NullQueueBackend(),
+        queue_job_store=QueueJobStore(session=session, logger=log),
+    )
+
+
 def _make_processor(
     session: AsyncSession,
     *,
@@ -73,6 +95,7 @@ def _make_processor(
     return RefDeletedWebhookProcessor(
         project_store=ProjectStore(session=session, logger=_logger()),
         edition_store=EditionStore(session=session, logger=_logger()),
+        edition_service=_make_edition_service(session),
         org_store=OrganizationStore(session=session, logger=_logger()),
         publishing_service=publishing_service or _StubPublishingService(),  # type: ignore[arg-type]
         logger=_logger(),
@@ -706,3 +729,51 @@ async def test_process_unpublish_failure_propagates(
         assert not await _is_deleted(
             db_session, project_id=project_id, slug="dm-1"
         )
+
+
+@pytest.mark.asyncio
+async def test_process_writes_lifecycle_delete_tombstone(
+    db_session: AsyncSession,
+) -> None:
+    """A webhook-driven soft-delete stamps a ``lifecycle_delete`` tombstone."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, "ref-del-tomb")
+        project_id = await _seed_project(
+            db_session, org_id=org_id, slug="docs", repo_id=12345
+        )
+        edition_id = await _seed_draft_edition(
+            db_session,
+            project_id=project_id,
+            slug="dm-tomb",
+            git_ref="tickets/DM-1",
+        )
+        state_store = KeeperSyncStateStore(
+            session=db_session, logger=_logger()
+        )
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=5050,
+            ltd_slug="dm-tomb",
+            docverse_id=edition_id,
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        result = await _make_processor(db_session).process(_delete_payload())
+        await db_session.commit()
+
+    assert result.deleted_edition_ids == [edition_id]
+    async with db_session.begin():
+        state_store = KeeperSyncStateStore(
+            session=db_session, logger=_logger()
+        )
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=5050,
+            include_tombstoned=True,
+        )
+    assert state is not None
+    assert state.date_tombstoned is not None
+    assert state.tombstone_reason == "lifecycle_delete"

--- a/tests/storage/edition_store_test.py
+++ b/tests/storage/edition_store_test.py
@@ -29,6 +29,11 @@ from docverse.dbschema.build import SqlBuild
 from docverse.dbschema.edition import SqlEdition
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_store import EditionStore
+from docverse.storage.keeper_sync import (
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.pagination import EditionSlugCursor
 from docverse.storage.project_store import ProjectStore
@@ -44,9 +49,9 @@ def edition_store(
     return EditionStore(session=db_session, logger=logger)
 
 
-async def _create_project(
+async def _create_project_with_org(
     db_session: AsyncSession,
-) -> int:
+) -> tuple[int, int]:
     logger = structlog.get_logger("docverse")
     org_store = OrganizationStore(session=db_session, logger=logger)
     proj_store = ProjectStore(session=db_session, logger=logger)
@@ -65,7 +70,14 @@ async def _create_project(
             source_url="https://example.com/example/repo",
         ),
     )
-    return project.id
+    return org.id, project.id
+
+
+async def _create_project(
+    db_session: AsyncSession,
+) -> int:
+    _, project_id = await _create_project_with_org(db_session)
+    return project_id
 
 
 @pytest.mark.asyncio
@@ -482,7 +494,7 @@ async def test_soft_delete_edition(
     edition_store: EditionStore,
 ) -> None:
     async with db_session.begin():
-        project_id = await _create_project(db_session)
+        org_id, project_id = await _create_project_with_org(db_session)
         await edition_store.create(
             project_id=project_id,
             data=EditionCreate(
@@ -493,7 +505,10 @@ async def test_soft_delete_edition(
             ),
         )
         deleted = await edition_store.soft_delete(
-            project_id=project_id, slug="del-ed"
+            org_id=org_id,
+            project_id=project_id,
+            slug="del-ed",
+            reason=TombstoneReason.manual_delete,
         )
         assert deleted is True
         found = await edition_store.get_by_slug(
@@ -501,6 +516,196 @@ async def test_soft_delete_edition(
         )
         await db_session.commit()
     assert found is None
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_edition_stamps_tombstone_when_state_row_exists(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """A state row is stamped in the same flush as ``date_deleted``."""
+    logger = structlog.get_logger("docverse")
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        org_id, project_id = await _create_project_with_org(db_session)
+        edition = await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="del-tomb",
+                title="Tombstone Me",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+            ),
+        )
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=4242,
+            ltd_slug="del-tomb",
+            docverse_id=edition.id,
+        )
+        deleted = await edition_store.soft_delete(
+            org_id=org_id,
+            project_id=project_id,
+            slug="del-tomb",
+            reason=TombstoneReason.lifecycle_delete,
+        )
+        assert deleted is True
+        await db_session.commit()
+
+    async with db_session.begin():
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=4242,
+            include_tombstoned=True,
+        )
+    assert state is not None
+    assert state.date_tombstoned is not None
+    assert state.tombstone_reason == "lifecycle_delete"
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_edition_no_state_row_is_tombstone_noop(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """The soft-delete succeeds without creating a tombstone row."""
+    logger = structlog.get_logger("docverse")
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        org_id, project_id = await _create_project_with_org(db_session)
+        edition = await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="noimport",
+                title="No Import",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+            ),
+        )
+        deleted = await edition_store.soft_delete(
+            org_id=org_id,
+            project_id=project_id,
+            slug="noimport",
+            reason=TombstoneReason.manual_delete,
+        )
+        assert deleted is True
+        await db_session.commit()
+
+    async with db_session.begin():
+        rows = await state_store.list_for_org(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            docverse_ids=[edition.id],
+            include_tombstoned=True,
+        )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_edition_records_reason_as_passed(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """``reason=manual_delete`` is recorded on the state row as-is."""
+    logger = structlog.get_logger("docverse")
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        org_id, project_id = await _create_project_with_org(db_session)
+        edition = await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="manual",
+                title="Manual",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+            ),
+        )
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=7777,
+            ltd_slug="manual",
+            docverse_id=edition.id,
+        )
+        await edition_store.soft_delete(
+            org_id=org_id,
+            project_id=project_id,
+            slug="manual",
+            reason=TombstoneReason.manual_delete,
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=7777,
+            include_tombstoned=True,
+        )
+    assert state is not None
+    assert state.tombstone_reason == "manual_delete"
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_edition_rollback_unwinds_both(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """A rollback after ``soft_delete`` leaves both rows untouched."""
+    logger = structlog.get_logger("docverse")
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        org_id, project_id = await _create_project_with_org(db_session)
+        edition = await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="rollback-me",
+                title="Rollback",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+            ),
+        )
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=8888,
+            ltd_slug="rollback-me",
+            docverse_id=edition.id,
+        )
+        await db_session.commit()
+
+    # Start a write transaction, perform the soft-delete + tombstone
+    # write, then rollback by raising out of the ``begin()`` block.
+    async def _run() -> None:
+        async with db_session.begin():
+            await edition_store.soft_delete(
+                org_id=org_id,
+                project_id=project_id,
+                slug="rollback-me",
+                reason=TombstoneReason.lifecycle_delete,
+            )
+            msg = "trigger rollback"
+            raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="trigger rollback"):
+        await _run()
+
+    async with db_session.begin():
+        found = await edition_store.get_by_slug(
+            project_id=project_id, slug="rollback-me"
+        )
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=8888,
+            include_tombstoned=True,
+        )
+    assert found is not None
+    assert state is not None
+    assert state.date_tombstoned is None
+    assert state.tombstone_reason is None
 
 
 @pytest.mark.asyncio
@@ -1095,7 +1300,7 @@ async def test_get_by_slug_case_insensitive(
 ) -> None:
     """get_by_slug matches across case and skips soft-deleted rows."""
     async with db_session.begin():
-        project_id = await _create_project(db_session)
+        org_id, project_id = await _create_project_with_org(db_session)
         await edition_store.create(
             project_id=project_id,
             data=EditionCreate(
@@ -1128,7 +1333,12 @@ async def test_get_by_slug_case_insensitive(
 
     # Soft-deleting the row releases the slug for reuse.
     async with db_session.begin():
-        await edition_store.soft_delete(project_id=project_id, slug="DM-54112")
+        await edition_store.soft_delete(
+            org_id=org_id,
+            project_id=project_id,
+            slug="DM-54112",
+            reason=TombstoneReason.manual_delete,
+        )
         assert (
             await edition_store.get_by_slug(
                 project_id=project_id, slug="dm-54112"
@@ -1405,7 +1615,7 @@ async def test_list_draft_editions_by_git_ref_excludes_soft_deleted(
 ) -> None:
     """Already-soft-deleted draft editions are filtered out."""
     async with db_session.begin():
-        project_id = await _create_project(db_session)
+        org_id, project_id = await _create_project_with_org(db_session)
         await edition_store.create(
             project_id=project_id,
             data=EditionCreate(
@@ -1416,7 +1626,12 @@ async def test_list_draft_editions_by_git_ref_excludes_soft_deleted(
                 tracking_params={"git_ref": "tickets/DM-2"},
             ),
         )
-        await edition_store.soft_delete(project_id=project_id, slug="dm-2")
+        await edition_store.soft_delete(
+            org_id=org_id,
+            project_id=project_id,
+            slug="dm-2",
+            reason=TombstoneReason.manual_delete,
+        )
         result = await edition_store.list_draft_editions_by_git_ref(
             project_id=project_id, git_ref="tickets/DM-2"
         )

--- a/tests/storage/keeper_sync/state_store_test.py
+++ b/tests/storage/keeper_sync/state_store_test.py
@@ -6,9 +6,11 @@ from datetime import UTC, datetime
 
 import pytest
 import structlog
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import OrganizationCreate
+from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
 from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
 from docverse.storage.organization_store import OrganizationStore
 
@@ -456,3 +458,133 @@ async def test_get_by_docverse_id_isolates_by_org_and_resource_type(
     assert row is not None
     assert row.org_id == org_a
     assert row.resource_type == ResourceType.edition.value
+
+
+async def _set_tombstone(
+    session: AsyncSession,
+    *,
+    row_id: int,
+    reason: str = "manual_delete",
+    note: str | None = None,
+) -> None:
+    """Stamp tombstone fields directly on a state row via the ORM."""
+    stmt = select(SqlKeeperSyncState).where(SqlKeeperSyncState.id == row_id)
+    row = (await session.execute(stmt)).scalar_one()
+    row.date_tombstoned = datetime(2026, 5, 27, tzinfo=UTC)
+    row.tombstone_reason = reason
+    row.tombstone_note = note
+
+
+@pytest.mark.asyncio
+async def test_get_hides_tombstoned_row_by_default(
+    db_session: AsyncSession,
+) -> None:
+    """A tombstoned row is invisible to the default ``get`` read."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-get")
+    store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        state = await store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            ltd_slug="main",
+        )
+        await _set_tombstone(db_session, row_id=state.id)
+
+    async with db_session.begin():
+        hidden = await store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+        )
+        visible = await store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            include_tombstoned=True,
+        )
+    assert hidden is None
+    assert visible is not None
+    assert visible.date_tombstoned is not None
+    assert visible.tombstone_reason == "manual_delete"
+
+
+@pytest.mark.asyncio
+async def test_list_for_org_hides_tombstoned_rows_by_default(
+    db_session: AsyncSession,
+) -> None:
+    """``list_for_org`` filters tombstoned rows out unless asked."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-list")
+    store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        await store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            ltd_slug="main",
+        )
+        tombstoned = await store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            ltd_slug="u-jsick-feature",
+        )
+        await _set_tombstone(
+            db_session, row_id=tombstoned.id, reason="lifecycle_delete"
+        )
+
+    async with db_session.begin():
+        default_rows = await store.list_for_org(
+            org_id=org_id, resource_type=ResourceType.edition
+        )
+        all_rows = await store.list_for_org(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            include_tombstoned=True,
+        )
+    assert sorted(r.ltd_id for r in default_rows if r.ltd_id is not None) == [
+        1
+    ]
+    assert sorted(r.ltd_id for r in all_rows if r.ltd_id is not None) == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_list_project_resources_hides_tombstoned_by_default(
+    db_session: AsyncSession,
+) -> None:
+    """``list_project_resources_for_org`` skips tombstoned rows by default."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-projects")
+    store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        await store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="pipelines",
+        )
+        deleted = await store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="dmtn-123",
+        )
+        await _set_tombstone(
+            db_session, row_id=deleted.id, reason="manual_delete"
+        )
+
+    async with db_session.begin():
+        default_page = await store.list_project_resources_for_org(
+            org_id=org_id, cursor=None, limit=50
+        )
+        all_page = await store.list_project_resources_for_org(
+            org_id=org_id, cursor=None, limit=50, include_tombstoned=True
+        )
+    assert sorted(r.ltd_slug for r in default_page.entries) == ["pipelines"]
+    assert sorted(r.ltd_slug for r in all_page.entries) == [
+        "dmtn-123",
+        "pipelines",
+    ]

--- a/tests/storage/keeper_sync_test.py
+++ b/tests/storage/keeper_sync_test.py
@@ -228,3 +228,41 @@ async def test_keeper_sync_state_resource_type_check_rejects_invalid(
                     ltd_slug="g-99",
                 )
             )
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_state_tombstone_reason_check_rejects_invalid(
+    db_session: AsyncSession,
+) -> None:
+    """A ``tombstone_reason`` outside the allowed set fails the CHECK."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-check")
+
+    with pytest.raises(IntegrityError):
+        async with db_session.begin():
+            db_session.add(
+                SqlKeeperSyncState(
+                    org_id=org_id,
+                    resource_type="edition",
+                    ltd_id=1,
+                    ltd_slug="main",
+                    tombstone_reason="garbage",
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_state_tombstone_reason_check_allows_null(
+    db_session: AsyncSession,
+) -> None:
+    """``tombstone_reason=NULL`` (the not-tombstoned default) is accepted."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-tomb-check-null")
+        db_session.add(
+            SqlKeeperSyncState(
+                org_id=org_id,
+                resource_type="edition",
+                ltd_id=1,
+                ltd_slug="main",
+            )
+        )

--- a/tests/storage/project_store_test.py
+++ b/tests/storage/project_store_test.py
@@ -14,6 +14,11 @@ from docverse.client.models import (
     ProjectGitHubBindingCreate,
     ProjectUpdate,
 )
+from docverse.storage.keeper_sync import (
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.pagination import ProjectSlugCursor
 from docverse.storage.project_store import ProjectStore
@@ -404,12 +409,98 @@ async def test_soft_delete(
                 source_url="https://example.com/example/repo",
             ),
         )
-        deleted = await store.soft_delete(org_id=org_id, slug="del-proj")
+        deleted = await store.soft_delete(
+            org_id=org_id,
+            slug="del-proj",
+            reason=TombstoneReason.manual_delete,
+        )
         assert deleted is True
         # Should not be found after soft delete
         found = await store.get_by_slug(org_id=org_id, slug="del-proj")
         await db_session.commit()
     assert found is None
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_project_stamps_tombstone_when_state_row_exists(
+    db_session: AsyncSession,
+    store: ProjectStore,
+    org_store: OrganizationStore,
+) -> None:
+    """A project state row is stamped in the same flush as ``date_deleted``."""
+    logger = structlog.get_logger("docverse")
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        org_id = await _create_org(org_store, slug="proj-tomb-org")
+        project = await store.create(
+            org_id=org_id,
+            data=ProjectCreate(
+                slug="del-tomb-proj",
+                title="Tomb Me",
+                source_url="https://example.com/example/repo",
+            ),
+        )
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="del-tomb-proj",
+            docverse_id=project.id,
+        )
+        deleted = await store.soft_delete(
+            org_id=org_id,
+            slug="del-tomb-proj",
+            reason=TombstoneReason.manual_delete,
+        )
+        assert deleted is True
+        await db_session.commit()
+
+    async with db_session.begin():
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="del-tomb-proj",
+            include_tombstoned=True,
+        )
+    assert state is not None
+    assert state.date_tombstoned is not None
+    assert state.tombstone_reason == "manual_delete"
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_project_no_state_row_is_tombstone_noop(
+    db_session: AsyncSession,
+    store: ProjectStore,
+    org_store: OrganizationStore,
+) -> None:
+    """The soft-delete succeeds without creating a tombstone row."""
+    logger = structlog.get_logger("docverse")
+    state_store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        org_id = await _create_org(org_store, slug="proj-no-state-org")
+        await store.create(
+            org_id=org_id,
+            data=ProjectCreate(
+                slug="del-no-state-proj",
+                title="No State",
+                source_url="https://example.com/example/repo",
+            ),
+        )
+        deleted = await store.soft_delete(
+            org_id=org_id,
+            slug="del-no-state-proj",
+            reason=TombstoneReason.manual_delete,
+        )
+        assert deleted is True
+        await db_session.commit()
+
+    async with db_session.begin():
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="del-no-state-proj",
+            include_tombstoned=True,
+        )
+    assert state is None
 
 
 # ── list_by_github_repo ───────────────────────────────────────────────────
@@ -620,7 +711,11 @@ async def test_list_by_github_repo_excludes_soft_deleted(
             github_owner="acme",
             github_repo="templates",
         )
-        await store.soft_delete(org_id=org_id, slug="docs")
+        await store.soft_delete(
+            org_id=org_id,
+            slug="docs",
+            reason=TombstoneReason.manual_delete,
+        )
         result = await store.list_by_github_repo(
             repo_id=None, owner="acme", repo="templates"
         )
@@ -761,7 +856,11 @@ async def test_list_org_ids_with_github_bound_projects_excludes_deleted(
             github_owner="acme",
             github_repo="deletable",
         )
-        await store.soft_delete(org_id=org_id, slug="deletable")
+        await store.soft_delete(
+            org_id=org_id,
+            slug="deletable",
+            reason=TombstoneReason.manual_delete,
+        )
         result = await store.list_org_ids_with_github_bound_projects()
         await db_session.commit()
     assert org_id not in result
@@ -843,7 +942,11 @@ async def test_list_github_bound_by_org_excludes_deleted(
             github_owner="acme",
             github_repo="deleted",
         )
-        await store.soft_delete(org_id=org_id, slug="deleted")
+        await store.soft_delete(
+            org_id=org_id,
+            slug="deleted",
+            reason=TombstoneReason.manual_delete,
+        )
         result = await store.list_github_bound_by_org(org_id)
         await db_session.commit()
     assert [p.slug for p in result] == [kept.slug]

--- a/tests/worker/git_ref_audit_test.py
+++ b/tests/worker/git_ref_audit_test.py
@@ -43,6 +43,7 @@ from docverse.domain.queue import JobStatus
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.git_ref_audit_run_store import GitRefAuditRunStore
 from docverse.storage.github import GITHUB_API_BASE_URL
+from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
@@ -845,3 +846,81 @@ async def test_git_ref_audit_does_not_fire_draft_inactivity(
                 )
             )
             assert row.scalar_one() is not None
+
+
+@pytest.mark.asyncio
+async def test_git_ref_audit_writes_lifecycle_delete_tombstone(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """Soft-delete via the worker stamps a ``lifecycle_delete`` tombstone."""
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, slug="gra-tomb")
+        installation_id = mock_github.seed_installation(
+            "acme", "tomb", installation_id=77, owner_id=333
+        )
+        proj = await _seed_github_project(
+            db_session,
+            org_id=org_id,
+            slug="tomb-project",
+            owner="acme",
+            repo="tomb",
+            installation_id=installation_id,
+        )
+        deleted_id = await _seed_draft_edition(
+            db_session,
+            project_id=proj,
+            slug="dead-ref",
+            git_ref="tickets/DM-dead",
+        )
+        state_store = KeeperSyncStateStore(
+            session=db_session, logger=_logger()
+        )
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=4242,
+            ltd_slug="dead-ref",
+            docverse_id=deleted_id,
+        )
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id, org_slug=org_slug
+        )
+
+    _seed_refs(
+        mock_github.router,
+        owner="acme",
+        repo="tomb",
+        branches=["main"],
+        tags=[],
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(http_client=http_client, mock_github=mock_github)
+        result = await git_ref_audit(
+            ctx,
+            {
+                "org_id": org_id,
+                "org_slug": org_slug,
+                "git_ref_audit_run_id": run_id,
+                "queue_job_id": queue_job_id,
+            },
+        )
+
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            state_store = KeeperSyncStateStore(
+                session=session, logger=_logger()
+            )
+            state = await state_store.get(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=4242,
+                include_tombstoned=True,
+            )
+            assert state is not None
+            assert state.date_tombstoned is not None
+            assert state.tombstone_reason == "lifecycle_delete"

--- a/tests/worker/keeper_sync_run_discovery_test.py
+++ b/tests/worker/keeper_sync_run_discovery_test.py
@@ -25,6 +25,12 @@ from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.queue import JobStatus
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
+from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
+from docverse.storage.keeper_sync import (
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
 from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.queue_job_store import QueueJobStore
@@ -511,3 +517,79 @@ async def test_discovery_leaves_recent_unenqueued_children_alone(
             untouched = await queue_job_store.get(recent.id)
             assert untouched is not None
             assert untouched.status == JobStatus.queued
+
+
+@pytest.mark.asyncio
+async def test_discovery_skips_tombstoned_project_slugs(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """Tombstoned project slugs drop out of the fan-out candidate set.
+
+    Issue #396 acceptance criterion: an org with a tombstoned project
+    produces no ``keeper_sync_project`` child job for that resource.
+    Without the filter, ``run_discovery`` would fan out a child per
+    in-scope slug and the per-slug ``keeper_sync_project`` worker
+    would short-circuit inside ``sync_project`` — wasted queue and DB
+    work the filter avoids.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, project_slugs=["dmtn-001", "sqr-112"]
+        )
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_discovery_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+        # Tombstone one of the two in-scope project slugs.
+        state_store = KeeperSyncStateStore(
+            session=db_session, logger=_logger()
+        )
+        tombstone_service = KeeperSyncTombstoneService(
+            session=db_session,
+            state_store=state_store,
+            logger=_logger(),
+        )
+        await tombstone_service.record(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="dmtn-001",
+            reason=TombstoneReason.manual_delete,
+        )
+
+    _mock_ltd_products(mock_discovery, ["dmtn-001", "sqr-112"])
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await keeper_sync_run_discovery(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    # Only the non-tombstoned slug is enqueued.
+    project_jobs = get_jobs_by_name(
+        mock_arq, "keeper_sync_project", queue_name=KEEPER_SYNC_QUEUE_NAME
+    )
+    assert len(project_jobs) == 1
+    assert project_jobs[0].kwargs["payload"]["ltd_slug"] == "sqr-112"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            stmt = select(SqlQueueJob).where(
+                SqlQueueJob.keeper_sync_run_id == run_id,
+                SqlQueueJob.kind == JobKind.keeper_sync_project.value,
+            )
+            child_rows = (await session.execute(stmt)).scalars().all()
+            assert len(child_rows) == 1
+            assert child_rows[0].subject_label == "sqr-112"

--- a/tests/worker/keeper_sync_tier_test.py
+++ b/tests/worker/keeper_sync_tier_test.py
@@ -37,7 +37,12 @@ from docverse.client.models import (
 )
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
-from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
+from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
+from docverse.storage.keeper_sync import (
+    KeeperSyncStateStore,
+    ResourceType,
+    TombstoneReason,
+)
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.keeper_sync import (
@@ -219,6 +224,35 @@ async def _seed_state(
         docverse_id=docverse_id,
         date_last_synced=date_last_synced,
         date_rebuilt_seen=date_rebuilt_seen,
+    )
+
+
+async def _seed_tombstone(
+    db_session: AsyncSession,
+    *,
+    org_id: int,
+    resource_type: ResourceType,
+    ltd_id: int | None = None,
+    ltd_slug: str | None = None,
+    reason: TombstoneReason = TombstoneReason.manual_delete,
+) -> None:
+    """Stamp a tombstone on the matching ``keeper_sync_state`` row.
+
+    Uses the same service entrypoint the production deletion paths
+    will use (PRD #332 §"Centralized edition soft-delete"), so the
+    tier-cron filter behavior is exercised against rows produced the
+    same way operators and lifecycle workers produce them.
+    """
+    state_store = KeeperSyncStateStore(session=db_session, logger=_logger())
+    service = KeeperSyncTombstoneService(
+        session=db_session, state_store=state_store, logger=_logger()
+    )
+    await service.record(
+        org_id=org_id,
+        resource_type=resource_type,
+        ltd_id=ltd_id,
+        ltd_slug=ltd_slug,
+        reason=reason,
     )
 
 
@@ -1077,6 +1111,143 @@ async def test_tier_main_skips_when_active_keeper_sync_project_exists(
     assert rows[0].id == existing.id
 
 
+@pytest.mark.asyncio
+async def test_tier_main_skips_tombstoned_project_slug(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """A tombstoned project state row keeps its slug out of the candidate set.
+
+    Issue #396: the tier crons must filter tombstoned state rows out
+    of their candidate set up front so they do not enqueue child jobs
+    that ``sync_project`` would only short-circuit. The non-tombstoned
+    slug in the same org still gets its enqueue, locking the
+    "non-tombstoned resources are still discovered" half of the
+    acceptance criterion.
+    """
+    async with db_session.begin():
+        org_id, _ = await _seed_org(
+            db_session,
+            slug="ks-tier-main-tomb",
+            project_slugs=["pipelines", "live-proj"],
+        )
+        # Tombstoned project: the per-slug pre-check must skip without
+        # touching LTD.
+        await _seed_tombstone(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="pipelines",
+        )
+        # Live project: the main edition state lags LTD so the normal
+        # enqueue path fires.
+        await _seed_state(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            ltd_slug="main",
+            date_rebuilt_seen=_FIXTURE_MAIN_DATE_REBUILT - timedelta(hours=2),
+        )
+
+    _stub_products(mock_discovery, ["pipelines", "live-proj"])
+    # Live-proj's main edition listing + edition payload — ``pipelines``
+    # is tombstoned and must never be polled, so no stubs for it.
+    _stub_editions_listing(
+        mock_discovery, product_slug="live-proj", edition_ids=[2]
+    )
+    _stub_edition(
+        mock_discovery,
+        edition_id=2,
+        slug="main",
+        date_rebuilt=_FIXTURE_MAIN_DATE_REBUILT,
+    )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        result = await keeper_sync_tier_main(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    children = get_jobs_by_name(
+        ctx["arq_queue"],
+        "keeper_sync_project",
+        queue_name=KEEPER_SYNC_QUEUE_NAME,
+    )
+    slugs = {c.kwargs["payload"]["ltd_slug"] for c in children}
+    assert slugs == {"live-proj"}
+
+
+@pytest.mark.asyncio
+async def test_tier_main_skips_tombstoned_main_edition(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """A tombstoned main-edition state row keeps the project from enqueueing.
+
+    Issue #396: even when the project itself is not tombstoned, a
+    tombstoned main edition must not produce a ``keeper_sync_project``
+    enqueue — the resulting ``sync_edition`` would only short-circuit.
+    The seeded ``date_rebuilt_seen`` would otherwise lag LTD and trip
+    :func:`should_refresh_main_edition` into enqueueing, so the only
+    reason no enqueue lands is the tombstone filter.
+    """
+    async with db_session.begin():
+        org_id, _ = await _seed_org(
+            db_session,
+            slug="ks-tier-main-edition-tomb",
+            project_slugs=["pipelines"],
+        )
+        # Edition state lags LTD but is tombstoned — must not enqueue.
+        await _seed_state(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            ltd_slug="main",
+            date_rebuilt_seen=_FIXTURE_MAIN_DATE_REBUILT - timedelta(hours=2),
+        )
+        await _seed_tombstone(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            reason=TombstoneReason.lifecycle_delete,
+        )
+
+    _stub_products(mock_discovery, ["pipelines"])
+    _stub_editions_listing(
+        mock_discovery, product_slug="pipelines", edition_ids=[1]
+    )
+    _stub_edition(
+        mock_discovery,
+        edition_id=1,
+        slug="main",
+        date_rebuilt=_FIXTURE_MAIN_DATE_REBUILT,
+    )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        result = await keeper_sync_tier_main(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    assert (
+        get_jobs_by_name(
+            ctx["arq_queue"],
+            "keeper_sync_project",
+            queue_name=KEEPER_SYNC_QUEUE_NAME,
+        )
+        == []
+    )
+
+
 # ---------------------------------------------------------------------------
 # tier_discovery
 # ---------------------------------------------------------------------------
@@ -1276,15 +1447,15 @@ async def test_tier_discovery_batches_edition_state_lookups(
     # short-circuit (now shared between :func:`should_poll_for_tier`
     # and :func:`_project_needs_discovery`), and one inside
     # :func:`_record_tier_polled` to merge with prior annotations
-    # before stamping ``date_discovery_last_polled``. One
-    # ``list_for_org`` for the edition lookup, now hoisted out of
-    # :func:`_project_needs_discovery` and called once before the
-    # per-slug loop (see
+    # before stamping ``date_discovery_last_polled``. Two
+    # ``list_for_org`` calls: one for the project-tombstone filter
+    # (issue #396) and one for the org-wide edition lookup hoisted
+    # out of :func:`_project_needs_discovery` (see
     # :func:`test_tier_discovery_batches_edition_state_lookups_across_slugs`
     # for the cross-slug lock). Five-edition fixture still proves the
     # count is independent of edition cardinality.
     assert recorder.get_calls == 2
-    assert recorder.list_for_org_calls == 1
+    assert recorder.list_for_org_calls == 2
 
 
 @pytest.mark.asyncio
@@ -1659,6 +1830,141 @@ async def test_tier_discovery_records_polled_annotation_on_ltd_error(
     assert (now - stamped) < timedelta(minutes=5)
 
 
+@pytest.mark.asyncio
+async def test_tier_discovery_skips_tombstoned_project_slug(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """A tombstoned project state row keeps its slug out of the candidate set.
+
+    Issue #396 acceptance criterion: an org with a tombstoned project
+    produces no ``keeper_sync_project`` child jobs for that resource.
+    The non-tombstoned slug in the same org still enqueues — its
+    project has no state row, so ``_project_needs_discovery``'s
+    cheap-path short-circuit fires.
+    """
+    async with db_session.begin():
+        org_id, _ = await _seed_org(
+            db_session,
+            slug="ks-tier-disc-tomb",
+            project_slugs=["pipelines", "live-proj"],
+        )
+        await _seed_tombstone(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="pipelines",
+        )
+
+    _stub_products(mock_discovery, ["pipelines", "live-proj"])
+    # No editions stub for ``pipelines`` — the per-slug pre-check
+    # must skip without touching LTD.
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        result = await keeper_sync_tier_discovery(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    children = get_jobs_by_name(
+        ctx["arq_queue"],
+        "keeper_sync_project",
+        queue_name=KEEPER_SYNC_QUEUE_NAME,
+    )
+    slugs = {c.kwargs["payload"]["ltd_slug"] for c in children}
+    assert slugs == {"live-proj"}
+
+
+@pytest.mark.asyncio
+async def test_tier_discovery_does_not_treat_tombstoned_edition_as_unknown(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """A tombstoned edition counts as known, not unknown.
+
+    Issue #396: without the filter, ``_project_needs_discovery`` would
+    consult the org-wide edition-state dict, find no entry for the
+    tombstoned edition (default ``include_tombstoned=False`` filters
+    it out), call :func:`is_unknown_resource` which returns True for a
+    ``None`` state, and enqueue ``keeper_sync_project`` — which would
+    then iterate LTD editions, hit the tombstoned edition, and have
+    ``sync_edition`` short-circuit. The fix keeps tombstoned editions
+    visible to the dict so they read as known, not unknown.
+    """
+    async with db_session.begin():
+        org_id, _ = await _seed_org(
+            db_session,
+            slug="ks-tier-disc-tomb-ed",
+            project_slugs=["pipelines"],
+        )
+        # Project state exists — no cheap-path enqueue.
+        await _seed_state(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_id=None,
+            ltd_slug="pipelines",
+        )
+        # Main edition state present + a tombstoned non-main edition.
+        # Without the filter, the tombstoned edition reads as unknown
+        # and ``_project_needs_discovery`` returns True.
+        await _seed_state(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            ltd_slug="main",
+            date_rebuilt_seen=_FIXTURE_MAIN_DATE_REBUILT,
+        )
+        await _seed_tombstone(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            reason=TombstoneReason.lifecycle_delete,
+        )
+
+    _stub_products(mock_discovery, ["pipelines"])
+    # LTD still lists the tombstoned edition (id=2) — it has not been
+    # deleted on the LTD side, only Docverse-side.
+    _stub_editions_listing(
+        mock_discovery, product_slug="pipelines", edition_ids=[2, 1]
+    )
+    _stub_edition(
+        mock_discovery,
+        edition_id=1,
+        slug="main",
+        date_rebuilt=_FIXTURE_MAIN_DATE_REBUILT,
+    )
+    _stub_edition(
+        mock_discovery,
+        edition_id=2,
+        slug="u-jsick-feature",
+        date_rebuilt=datetime(2026, 4, 29, tzinfo=UTC),
+    )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        result = await keeper_sync_tier_discovery(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    assert (
+        get_jobs_by_name(
+            ctx["arq_queue"],
+            "keeper_sync_project",
+            queue_name=KEEPER_SYNC_QUEUE_NAME,
+        )
+        == []
+    )
+
+
 # ---------------------------------------------------------------------------
 # tier_other
 # ---------------------------------------------------------------------------
@@ -1960,12 +2266,13 @@ async def test_tier_other_batches_edition_state_lookups(
     # Two ``get`` calls per project per tick: one for the dormancy
     # planner read at the top of the loop and one inside
     # :func:`_record_tier_polled` to merge with prior annotations
-    # before stamping ``date_other_last_polled``. Exactly one
-    # ``list_for_org`` regardless of LTD's edition cardinality —
-    # the per-project edition-state cost stays independent of the
-    # branch count.
+    # before stamping ``date_other_last_polled``. Two
+    # ``list_for_org`` calls: one for the project-tombstone filter
+    # (issue #396) and one for the non-main edition staleness scan
+    # in :func:`_has_stale_non_main_edition`. The per-project
+    # edition-state cost stays independent of the branch count.
     assert recorder.get_calls == 2
-    assert recorder.list_for_org_calls == 1
+    assert recorder.list_for_org_calls == 2
 
 
 @pytest.mark.asyncio
@@ -2199,6 +2506,81 @@ async def test_tier_other_records_polled_annotation_on_ltd_error(
     stamped = datetime.fromisoformat(raw)
     # Update fired during this tick, not 49h ago.
     assert (now - stamped) < timedelta(minutes=5)
+
+
+@pytest.mark.asyncio
+async def test_tier_other_skips_tombstoned_project_slug(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+) -> None:
+    """A tombstoned project state row keeps its slug out of the candidate set.
+
+    Issue #396: a tier_other tick must not call
+    ``GET /products/<slug>/editions/`` for a tombstoned project, nor
+    enqueue a ``keeper_sync_project`` child for it. The non-tombstoned
+    slug in the same org still enqueues from its stale non-main
+    edition.
+    """
+    stale = datetime.now(tz=UTC) - timedelta(hours=2)
+    async with db_session.begin():
+        org_id, _ = await _seed_org(
+            db_session,
+            slug="ks-tier-other-tomb",
+            project_slugs=["pipelines", "live-proj"],
+        )
+        # Tombstoned project: must be skipped entirely.
+        await _seed_tombstone(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="pipelines",
+        )
+        # Live project: a stale non-main edition triggers the normal
+        # enqueue path.
+        await _seed_state(
+            db_session,
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=20,
+            ltd_slug="u-jsick-feature",
+            date_last_synced=stale,
+        )
+
+    _stub_products(mock_discovery, ["pipelines", "live-proj"])
+    # Only stub live-proj's editions — the tombstoned ``pipelines``
+    # must not hit LTD.
+    _stub_editions_listing(
+        mock_discovery, product_slug="live-proj", edition_ids=[20, 10]
+    )
+    _stub_edition(
+        mock_discovery,
+        edition_id=10,
+        slug="main",
+        date_rebuilt=_FIXTURE_MAIN_DATE_REBUILT,
+    )
+    _stub_edition(
+        mock_discovery,
+        edition_id=20,
+        slug="u-jsick-feature",
+        date_rebuilt=datetime(2026, 4, 29, tzinfo=UTC),
+    )
+
+    http_client = httpx.AsyncClient()
+    ctx = _make_ctx(http_client)
+    try:
+        result = await keeper_sync_tier_other(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    children = get_jobs_by_name(
+        ctx["arq_queue"],
+        "keeper_sync_project",
+        queue_name=KEEPER_SYNC_QUEUE_NAME,
+    )
+    slugs = {c.kwargs["payload"]["ltd_slug"] for c in children}
+    assert slugs == {"live-proj"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/worker/lifecycle_eval_test.py
+++ b/tests/worker/lifecycle_eval_test.py
@@ -49,6 +49,7 @@ from docverse.storage.editionpublisher import (
     EditionPublisher,
     MockEditionPublisher,
 )
+from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
 from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
@@ -1028,3 +1029,70 @@ async def test_lifecycle_eval_unpublishes_each_soft_deleted_edition(
     assert recorded_slugs == ["stale-a", "stale-b"]
     for call in mock_publisher.unpublish_calls:
         assert call.project_slug == "unpub-proj"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_writes_lifecycle_delete_tombstone(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """The worker's soft-delete stamps a ``lifecycle_delete`` tombstone."""
+    org_rules = LifecycleRuleSet(
+        root=[DraftInactivityRule(max_days_inactive=30)]
+    )
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, slug="lce-tomb-org", lifecycle_rules=org_rules
+        )
+        project_id = await _seed_project(
+            db_session, org_id=org_id, slug="lce-tomb-proj"
+        )
+        stale_id = await _seed_edition(
+            db_session,
+            project_id=project_id,
+            slug="stale-tomb",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+        )
+        state_store = KeeperSyncStateStore(
+            session=db_session, logger=_logger()
+        )
+        await state_store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=9090,
+            ltd_slug="stale-tomb",
+            docverse_id=stale_id,
+        )
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id, org_slug=org_slug
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client)
+    result = await lifecycle_eval(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "lifecycle_eval_run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await http_client.aclose()
+    assert result == "completed"
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            state_store = KeeperSyncStateStore(
+                session=session, logger=_logger()
+            )
+            state = await state_store.get(
+                org_id=org_id,
+                resource_type=ResourceType.edition,
+                ltd_id=9090,
+                include_tombstoned=True,
+            )
+            assert state is not None
+            assert state.date_tombstoned is not None
+            assert state.tombstone_reason == "lifecycle_delete"


### PR DESCRIPTION
## Summary

- Add the foundational data layer for keeper-sync tombstones: a migration tacks three nullable columns (`date_tombstoned`, `tombstone_reason`, `tombstone_note`) onto `keeper_sync_state` with a `CheckConstraint` mirroring the existing `resource_type` pattern, and the read paths gain an `include_tombstoned: bool = False` opt-in so today's convergence callers default to "tombstoned rows are invisible". `KeeperSyncTombstoneService` exposes `record` / `is_tombstoned` / `list_for_org` / `clear`.
- Short-circuit `KeeperSyncService.sync_project` before the LTD product fetch when the project's state row is tombstoned, and `sync_edition` before `_ensure_edition` runs when the edition's state row is tombstoned. This alone defuses the "sync crashes on a soft-deleted edition" `RuntimeError` raised by `editions.uq_editions_project_lower_slug`'s `ON CONFLICT DO NOTHING` race.
- Centralize edition soft-delete on `EditionService.soft_delete` and stamp the tombstone at the `EditionStore.soft_delete` chokepoint in the same flush as `date_deleted`. The three automated callers (`lifecycle_eval`, `git_ref_audit`, `RefDeletedWebhookProcessor`) and the manual-delete handler now share one path; `ProjectStore.soft_delete` gets the analogous project-tombstone write.
- Filter tombstoned state rows out of the four keeper-sync discovery paths (`keeper_sync_run_discovery` plus the three tier crons) up front, so a `keeper_sync_project` child is never enqueued for a Docverse-side vetoed project and a tombstoned non-main edition no longer counts as "unknown" against the discovery tier's enqueue branch.
- Land the admin API for tombstone visibility and recovery: `GET /orgs/{org}/keeper-sync/tombstones` paginates the org's tombstoned rows with `resource_type` + `tombstone_reason` filters; `DELETE /orgs/{org}/keeper-sync/tombstones/{state_id}` clears one tombstone and revives the still-soft-deleted Docverse row in the same transaction so the next `sync_edition` does not crash on the slug clash.
- Add proactive lifecycle evaluation to `KeeperSyncService.sync_project`: the project's live GitHub ref set is pre-fetched once per invocation and shared across every edition; each LTD edition is run through `evaluate_lifecycle` (filtered to `draft_inactivity` + `ref_deleted`) before `sync_edition`, so editions a lifecycle rule would immediately delete are tombstoned `lifecycle_preemptive` and never trigger a build-content copy. `build_history_orphan` is explicitly excluded from the proactive pass; `RepositoryNotAccessibleError` / `RepositoryRefFetchError` and missing-binding projects fall through to KEEP.

## Validation steps

- [ ] Run the new migration forward against a non-empty `keeper_sync_state` and confirm every existing row reads `date_tombstoned IS NULL`. Backward migration drops the three columns and the `ck_keeper_sync_state_tombstone_reason` CHECK cleanly.
- [ ] Insert a row with `tombstone_reason='garbage'` directly via psql and confirm the CHECK rejects it; `NULL` is still accepted.
- [ ] Use `KeeperSyncTombstoneService.record(reason=lifecycle_preemptive)` against a `(resource_type, ltd_id)` that has no state row and confirm a fresh row is created with `docverse_id=NULL` and the tombstone fields stamped. Tail the worker log and confirm one structured line containing `org_id`, `resource_type`, `ltd_id`, and `reason`.
- [ ] Reproduce the legacy crash on `main` by soft-deleting an edition while LTD still carries it and triggering a sync — confirm the "lost ON CONFLICT race" `RuntimeError`. On this branch, the next `keeper_sync_project` run completes without raising.
- [ ] Tombstone a project via `KeeperSyncTombstoneService.record(reason=manual_delete)` and invoke `sync_project` — confirm the result carries empty `edition_outcomes` and no `GET /products/{slug}` LTD call appears in the worker logs.
- [ ] Tombstone an already-imported edition and trigger the next `keeper_sync_project` pass — confirm `keeper_sync_state.date_last_synced` is unchanged and no new R2 objects appear under the tombstoned edition's build prefix.
- [ ] DELETE an edition via the public API and confirm both `editions.date_deleted` and the matching `keeper_sync_state.date_tombstoned` land in the same transaction. Soft-deleting an edition with no sync-state row is a tombstone no-op.
- [ ] Drive `lifecycle_eval`, `git_ref_audit`, and the `ref_deleted` webhook through one edition deletion each and confirm the resulting state row carries `tombstone_reason='lifecycle_delete'`. DELETE a project via the public API and confirm `tombstone_reason='manual_delete'` on the project row.
- [ ] On an org with one tombstoned edition and one tombstoned project, fire each of `keeper_sync_run_discovery`, `keeper_sync_tier_main`, `keeper_sync_tier_discovery`, and `keeper_sync_tier_other` and confirm no `keeper_sync_project` child job is enqueued for either tombstoned resource. A non-tombstoned slug in the same org still enqueues as before.
- [ ] `GET /orgs/{org}/keeper-sync/tombstones` returns the org's tombstoned rows paginated by id, filterable by `resource_type` and `tombstone_reason`, with a derived `display_path` per row. Cursor pagination works across two pages.
- [ ] `DELETE /orgs/{org}/keeper-sync/tombstones/{state_id}` returns 204, clears the three tombstone columns on the matching state row, and revives a still-soft-deleted Docverse edition or project (clears `date_deleted`) in the same transaction. A subsequent `sync_edition` succeeds without crashing on the slug clash. Both endpoints require org-admin scope and emit one structured audit-log line with `org`, `resource_type`, `ltd_id`, `reason`, `actor`.
- [ ] On a project bound to a GitHub repo with `RefDeletedRule` configured, seed an LTD edition tracking a branch that no longer exists on GitHub and confirm `sync_project` writes a `lifecycle_preemptive` tombstone, does not fetch the LTD build, does not create a Docverse edition row, and does not copy any bytes into R2. The project's main edition still syncs.
- [ ] On the same project with `DraftInactivityRule(max_days_inactive=30)`, seed a draft whose LTD `date_rebuilt` is 60+ days old and confirm the proactive evaluator tombstones it the same way.
- [ ] On a project whose `BuildHistoryOrphanRule` is the only configured rule, confirm `sync_project` does NOT tombstone any LTD edition proactively (build_history_orphan is excluded from the proactive filter).
- [ ] Force a GitHub 500 / 404 on the matching-refs endpoint and confirm `sync_project` logs the failure and falls through to KEEP — editions sync normally and no proactive tombstones are written.
- [ ] On a project with a non-GitHub `doc_repo` (no binding resolves), confirm `sync_project` does not call any GitHub endpoints and editions sync normally.
- [ ] Across a `sync_project` invocation with multiple editions, confirm `git/matching-refs/heads` and `git/matching-refs/tags` are each hit exactly once for the project (per-project pre-fetch is shared across editions).

## References

- Closes #393
- Closes #394
- Closes #395
- Closes #396
- Closes #397
- Closes #398
- PRD: #332
- Jira: https://rubinobs.atlassian.net/browse/DM-54914
