### PR TITLE
DM-55123: Add git_ref-tracking edition lookup to EditionStore

### DIFF
--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -646,7 +646,16 @@ class KeeperSyncService:
 
         return EditionSyncOutcome(
             docverse_edition_id=edition.id,
-            docverse_slug=docverse_slug,
+            # Report the *persisted* edition's slug, not the keeper-derived
+            # ``docverse_slug``. When ``_ensure_edition`` adopts a
+            # differently-slugged native edition on the same git_ref (PRD
+            # #409: native ``tickets-DM-54686`` vs keeper ``DM-54686``), the
+            # two disagree. Both publish paths key off
+            # ``outcome.docverse_slug`` via ``get_by_slug``
+            # (publish_edition / _resolve_self_heal_target), so reporting the
+            # keeper slug would miss the row — the build would fail to
+            # publish (NotFoundError) or be silently skipped.
+            docverse_slug=edition.slug,
             docverse_project_id=project.id,
             docverse_project_slug=project.slug,
             build_outcome=build_outcome,

--- a/src/docverse/services/keeper_sync/service.py
+++ b/src/docverse/services/keeper_sync/service.py
@@ -674,6 +674,37 @@ class KeeperSyncService:
             )
             raise RuntimeError(msg)
         if edition is None:
+            # PRD #409: native auto-creation and keeper-sync derive an
+            # edition's slug from a branch differently, so the same
+            # ``git_ref`` can be slugged two ways (native
+            # ``tickets-DM-54686`` vs keeper-sync ``DM-54686``). After a
+            # slug miss, consult the shared git_ref lookup: if a
+            # differently-slugged edition already tracks this ref, adopt
+            # it — refresh its tracking and keep its slug — rather than
+            # insert a duplicate row on the same ref.
+            if tracking_mode == TrackingMode.git_ref:
+                adopted = (
+                    await self._edition_store.get_git_ref_tracking_edition(
+                        project_id=project_id,
+                        git_ref=tracking_params["git_ref"],
+                    )
+                )
+                if adopted is not None:
+                    await self._refresh_tracking(
+                        edition=adopted,
+                        tracking_mode=tracking_mode,
+                        tracking_params=tracking_params,
+                    )
+                    self._logger.info(
+                        "Adopted existing git_ref edition for keeper-sync"
+                        " import",
+                        project_id=project_id,
+                        git_ref=tracking_params["git_ref"],
+                        adopted_slug=adopted.slug,
+                        keeper_slug=docverse_slug,
+                        edition_id=adopted.id,
+                    )
+                    return adopted
             edition = await self._edition_store.create_internal(
                 project_id=project_id,
                 slug=docverse_slug,

--- a/src/docverse/storage/edition_store.py
+++ b/src/docverse/storage/edition_store.py
@@ -522,6 +522,51 @@ class EditionStore:
             for edition_row, build_public_id, build_git_ref in rows
         ]
 
+    async def get_git_ref_tracking_edition(
+        self, *, project_id: int, git_ref: str
+    ) -> Edition | None:
+        """Return the ``git_ref``-mode edition tracking ``git_ref``, if any.
+
+        The shared "is any ``git_ref``-mode edition already tracking this
+        ref?" lookup. keeper-sync consults it after a ``get_by_slug`` miss
+        so it adopts a differently-slugged existing edition rather than
+        inserting a duplicate that tracks the same ref (PRD #409): native
+        auto-creation and keeper-sync derive an edition's slug from a
+        branch differently, so the same branch can otherwise yield two
+        editions on one ``git_ref``.
+
+        The ``tracking_params->>'git_ref'`` equality is applied as a
+        server-side JSONB filter — non-matching rows never leave the
+        database — mirroring
+        :meth:`list_draft_editions_by_git_ref`. Unlike that method this
+        restricts to ``tracking_mode = git_ref`` (no ``alternate_git_ref``,
+        no ``kind``/``lifecycle_exempt`` filter) so it answers exactly
+        whether a literal-ref-tracking edition holds the ref. Soft-deleted
+        rows (``date_deleted IS NULL``) are ignored.
+
+        Returns the earliest-created match (``date_created``, then ``id``)
+        so adoption is deterministic and keeps the first-created slug when
+        a duplicate already exists; ``None`` when no edition tracks the
+        ref.
+        """
+        stmt = (
+            self._base_query()
+            .where(
+                SqlEdition.project_id == project_id,
+                SqlEdition.tracking_mode == TrackingMode.git_ref,
+                SqlEdition.date_deleted.is_(None),
+                SqlEdition.tracking_params["git_ref"].astext == git_ref,
+            )
+            .order_by(SqlEdition.date_created, SqlEdition.id)
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        row_tuple = result.first()
+        if row_tuple is None:
+            return None
+        edition_row, build_public_id, build_git_ref = row_tuple
+        return self._validate(edition_row, build_public_id, build_git_ref)
+
     async def find_matching_editions(
         self,
         *,

--- a/src/docverse/storage/edition_store.py
+++ b/src/docverse/storage/edition_store.py
@@ -540,9 +540,19 @@ class EditionStore:
         database — mirroring
         :meth:`list_draft_editions_by_git_ref`. Unlike that method this
         restricts to ``tracking_mode = git_ref`` (no ``alternate_git_ref``,
-        no ``kind``/``lifecycle_exempt`` filter) so it answers exactly
-        whether a literal-ref-tracking edition holds the ref. Soft-deleted
-        rows (``date_deleted IS NULL``) are ignored.
+        no ``lifecycle_exempt`` filter) so it answers exactly whether a
+        literal-ref-tracking edition holds the ref. Soft-deleted rows
+        (``date_deleted IS NULL``) are ignored.
+
+        The auto-created default ``__main`` edition (``kind = main``,
+        tracking ``{'git_ref': 'main'}``) is excluded: an imported LTD
+        edition that maps to ``git_ref = 'main'`` under a non-``main`` slug
+        (e.g. a manual edition pinned to a build built from ``main``, or a
+        ``git_refs`` edition tracking ``['main']`` under another slug) must
+        get its own row rather than adopt — and silently alias onto — the
+        project's default edition. An LTD edition actually slugged ``main``
+        folds to ``__main`` via ``derive_edition_slug`` and is updated
+        directly through ``get_by_slug``, never reaching this adoption path.
 
         Returns the earliest-created match (``date_created``, then ``id``)
         so adoption is deterministic and keeps the first-created slug when
@@ -554,6 +564,7 @@ class EditionStore:
             .where(
                 SqlEdition.project_id == project_id,
                 SqlEdition.tracking_mode == TrackingMode.git_ref,
+                SqlEdition.kind != EditionKind.main,
                 SqlEdition.date_deleted.is_(None),
                 SqlEdition.tracking_params["git_ref"].astext == git_ref,
             )

--- a/tests/services/keeper_sync/service_test.py
+++ b/tests/services/keeper_sync/service_test.py
@@ -26,8 +26,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.client.models import (
     BuildCreate,
     BuildStatus,
+    EditionCreate,
     EditionKind,
     OrganizationCreate,
+    ProjectCreate,
     TrackingMode,
 )
 from docverse.dbschema.build import SqlBuild
@@ -644,6 +646,132 @@ async def test_branch_edition_creates_new_draft_edition(
         )
         assert main is not None
         assert main.current_build_id is None
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_adopts_native_git_ref_edition(
+    db_session: AsyncSession,
+    http_client: httpx.AsyncClient,
+    mock_discovery: respx.Router,
+) -> None:
+    """keeper-sync adopts a differently-slugged native edition on one ref.
+
+    PRD #409: native auto-creation slugifies ``tickets/DM-54686`` to
+    ``tickets-DM-54686`` while keeper-sync imports LTD's own ``DM-54686``
+    slug. Both track the same ``git_ref``. After a ``get_by_slug`` miss,
+    keeper-sync must consult the shared git_ref lookup, adopt the
+    existing native edition (refresh its tracking, keep its slug), and
+    create no second row; the ``keeper_sync_state`` for the imported
+    edition points at the adopted edition's id.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+
+    logger = structlog.get_logger("test")
+    project_store = ProjectStore(session=db_session, logger=logger)
+    edition_store = EditionStore(session=db_session, logger=logger)
+
+    # A native auto-created edition already tracks ``tickets/DM-54686``
+    # under the slugified slug, before keeper-sync ever runs.
+    async with db_session.begin():
+        project = await project_store.create(
+            org_id=org_id,
+            data=ProjectCreate(
+                slug="pipelines",
+                title="LSST Science Pipelines",
+                source_url="https://example.com/lsst/pipelines",
+            ),
+        )
+        native_edition = await edition_store.create(
+            project_id=project.id,
+            data=EditionCreate(
+                slug="tickets-DM-54686",
+                title="DM-54686",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "tickets/DM-54686"},
+            ),
+        )
+    native_edition_id = native_edition.id
+
+    # LTD reports the same branch under its own ``DM-54686`` slug.
+    branch_edition = _load("edition_branch_git_refs.json")
+    branch_edition["slug"] = "DM-54686"
+    branch_edition["title"] = "DM-54686"
+    branch_edition["tracked_refs"] = ["tickets/DM-54686"]
+    branch_edition["build_url"] = f"{LTD_BASE}/builds/43"
+    branch_build = _load("build.json")
+    branch_build["self_url"] = f"{LTD_BASE}/builds/43"
+    branch_build["bucket_root_dir"] = "pipelines/builds/43"
+
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(200, json=_load("product_pipelines.json"))
+    )
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
+        return_value=httpx.Response(
+            200, json={"editions": [f"{LTD_BASE}/editions/2"]}
+        )
+    )
+    mock_discovery.get(f"{LTD_BASE}/editions/2").mock(
+        return_value=httpx.Response(200, json=branch_edition)
+    )
+    mock_discovery.get(f"{LTD_BASE}/builds/43").mock(
+        return_value=httpx.Response(200, json=branch_build)
+    )
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/43/index.html": b"<html>branch</html>",
+    }
+    service = _build_service(
+        db_session, http_client, object_store, source_objects
+    )
+
+    result = await service.sync_project(org_id=org_id, ltd_slug="pipelines")
+
+    # The adopted edition's id is returned even though the keeper slug
+    # differs from the native one.
+    assert len(result.edition_outcomes) == 1
+    assert result.edition_outcomes[0].docverse_edition_id == native_edition_id
+
+    state_store = KeeperSyncStateStore(
+        session=db_session, logger=structlog.get_logger("test")
+    )
+    async with db_session.begin():
+        # No second edition under the keeper-derived slug was created.
+        keeper_slugged = await edition_store.get_by_slug(
+            project_id=project.id, slug="DM-54686"
+        )
+        assert keeper_slugged is None
+
+        # The native edition survives, keeps its slug, and its tracking
+        # was refreshed to the imported git_ref.
+        adopted = await edition_store.get_by_slug(
+            project_id=project.id, slug="tickets-DM-54686"
+        )
+        assert adopted is not None
+        assert adopted.id == native_edition_id
+        assert adopted.tracking_mode == TrackingMode.git_ref
+        assert adopted.tracking_params == {"git_ref": "tickets/DM-54686"}
+
+        # Exactly one edition tracks the ref — no duplicate row.
+        all_editions = await edition_store.list_all_by_project(project.id)
+        on_ref = [
+            e
+            for e in all_editions
+            if (e.tracking_params or {}).get("git_ref") == "tickets/DM-54686"
+        ]
+        assert len(on_ref) == 1
+
+        # keeper_sync_state for the imported edition (ltd_id=2) points at
+        # the adopted edition's id.
+        state = await state_store.get(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+        )
+        assert state is not None
+        assert state.docverse_id == native_edition_id
 
 
 @pytest.mark.asyncio

--- a/tests/storage/edition_store_test.py
+++ b/tests/storage/edition_store_test.py
@@ -1768,3 +1768,143 @@ async def test_list_draft_editions_by_git_ref_scoped_to_project(
         )
         await db_session.commit()
     assert result == []
+
+
+# ── get_git_ref_tracking_edition ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_git_ref_tracking_edition_returns_match(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """The git_ref-mode edition tracking the ref is returned.
+
+    Pins the shared "is any git_ref-mode edition already tracking this
+    ref?" lookup that keeper-sync consults before creating an edition
+    (PRD #409). The server-side filter mirrors
+    :meth:`EditionStore.list_draft_editions_by_git_ref` but restricts to
+    ``tracking_mode = git_ref``.
+    """
+    async with db_session.begin():
+        project_id = await _create_project(db_session)
+        await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="tickets-DM-54686",
+                title="DM-54686",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "tickets/DM-54686"},
+            ),
+        )
+        found = await edition_store.get_git_ref_tracking_edition(
+            project_id=project_id, git_ref="tickets/DM-54686"
+        )
+        await db_session.commit()
+    assert found is not None
+    assert found.slug == "tickets-DM-54686"
+
+
+@pytest.mark.asyncio
+async def test_get_git_ref_tracking_edition_none_when_no_match(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """``None`` is returned when no edition tracks the ref."""
+    async with db_session.begin():
+        project_id = await _create_project(db_session)
+        found = await edition_store.get_git_ref_tracking_edition(
+            project_id=project_id, git_ref="tickets/DM-54686"
+        )
+        await db_session.commit()
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_get_git_ref_tracking_edition_excludes_other_ref(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """A git_ref-mode edition tracking a different ref is not returned."""
+    async with db_session.begin():
+        project_id = await _create_project(db_session)
+        await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="feature-y",
+                title="Feature Y",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "feature-y"},
+            ),
+        )
+        found = await edition_store.get_git_ref_tracking_edition(
+            project_id=project_id, git_ref="feature-x"
+        )
+        await db_session.commit()
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_get_git_ref_tracking_edition_excludes_soft_deleted(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """A soft-deleted edition on the ref is ignored (returns ``None``)."""
+    async with db_session.begin():
+        org_id, project_id = await _create_project_with_org(db_session)
+        await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="tickets-DM-1",
+                title="DM-1",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "tickets/DM-1"},
+            ),
+        )
+        await edition_store.soft_delete(
+            org_id=org_id,
+            project_id=project_id,
+            slug="tickets-DM-1",
+            reason=TombstoneReason.manual_delete,
+        )
+        found = await edition_store.get_git_ref_tracking_edition(
+            project_id=project_id, git_ref="tickets/DM-1"
+        )
+        await db_session.commit()
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_get_git_ref_tracking_edition_excludes_other_tracking_mode(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """A non-``git_ref``-mode edition on the same ref is not returned.
+
+    The lookup answers strictly "is any ``git_ref``-mode edition tracking
+    this ref?"; an ``alternate_git_ref`` edition that happens to carry the
+    same ``tracking_params->>'git_ref'`` must not satisfy it.
+    """
+    async with db_session.begin():
+        project_id = await _create_project(db_session)
+        await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="usdf-dev",
+                title="USDF Dev",
+                kind=EditionKind.alternate,
+                tracking_mode=TrackingMode.alternate_git_ref,
+                tracking_params={
+                    "git_ref": "tickets/DM-2",
+                    "alternate_name": "usdf-dev",
+                },
+            ),
+        )
+        found = await edition_store.get_git_ref_tracking_edition(
+            project_id=project_id, git_ref="tickets/DM-2"
+        )
+        await db_session.commit()
+    assert found is None

--- a/tests/storage/edition_store_test.py
+++ b/tests/storage/edition_store_test.py
@@ -1908,3 +1908,76 @@ async def test_get_git_ref_tracking_edition_excludes_other_tracking_mode(
         )
         await db_session.commit()
     assert found is None
+
+
+@pytest.mark.asyncio
+async def test_get_git_ref_tracking_edition_excludes_default_main(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """The auto-created default ``__main`` edition is never adopted.
+
+    A non-``main``-slugged LTD edition that maps to ``git_ref = 'main'``
+    (e.g. a manual edition pinned to a build built from ``main``) must get
+    its own row rather than fold onto — and silently alias — the project's
+    default edition. The lookup excludes ``kind = main`` so such an import
+    does not adopt ``__main``.
+    """
+    async with db_session.begin():
+        project_id = await _create_project(db_session)
+        # The reserved ``__main`` slug only goes through ``create_internal``
+        # (it does not conform to ``EditionCreate``'s user-facing pattern),
+        # matching how project creation seeds the default edition.
+        await edition_store.create_internal(
+            project_id=project_id,
+            slug="__main",
+            title="Main",
+            kind=EditionKind.main,
+            tracking_mode=TrackingMode.git_ref,
+            tracking_params={"git_ref": "main"},
+        )
+        found = await edition_store.get_git_ref_tracking_edition(
+            project_id=project_id, git_ref="main"
+        )
+        await db_session.commit()
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_get_git_ref_tracking_edition_returns_non_default_on_main(
+    db_session: AsyncSession,
+    edition_store: EditionStore,
+) -> None:
+    """A non-default edition tracking ``main`` is still returned.
+
+    Excluding the default ``__main`` edition must stay narrow: a genuine
+    draft edition that happens to track ``git_ref = 'main'`` under its own
+    slug remains adoptable for de-duplication even when the default edition
+    is present.
+    """
+    async with db_session.begin():
+        project_id = await _create_project(db_session)
+        await edition_store.create_internal(
+            project_id=project_id,
+            slug="__main",
+            title="Main",
+            kind=EditionKind.main,
+            tracking_mode=TrackingMode.git_ref,
+            tracking_params={"git_ref": "main"},
+        )
+        await edition_store.create(
+            project_id=project_id,
+            data=EditionCreate(
+                slug="stable",
+                title="Stable",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "main"},
+            ),
+        )
+        found = await edition_store.get_git_ref_tracking_edition(
+            project_id=project_id, git_ref="main"
+        )
+        await db_session.commit()
+    assert found is not None
+    assert found.slug == "stable"

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -34,10 +34,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import (
     BuildStatus,
+    EditionCreate,
+    EditionKind,
     JobKind,
     KeeperSyncConfig,
     KeeperSyncRunStatus,
     OrganizationCreate,
+    ProjectCreate,
+    TrackingMode,
 )
 from docverse.client.models.queue_enums import PublishStatus
 from docverse.dbschema.edition import SqlEdition
@@ -352,6 +356,142 @@ async def test_keeper_sync_project_runs_service_and_enqueues_publish(  # noqa: P
     # Build content actually landed in the destination object store.
     assert any(k.endswith("/index.html") for k in object_store.objects)
     assert any(k.endswith("/app.js") for k in object_store.objects)
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_project_publishes_adopted_edition_under_native_slug(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An adopted edition's publish carries the persisted native slug.
+
+    PRD #409: a native edition already tracks ``tickets/DM-54686`` under
+    the slugified ``tickets-DM-54686`` slug; keeper-sync imports LTD's own
+    ``DM-54686`` slug on the same ref and adopts the native edition. The
+    enqueued ``publish_edition`` job must carry the *persisted* slug
+    (``tickets-DM-54686``) — both publish paths resolve the edition via
+    ``get_by_slug``, so the keeper-derived ``DM-54686`` would miss the row
+    and the freshly-synced build would fail to publish.
+    """
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session)
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_project_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+        # A native auto-created edition already tracks the branch ref under
+        # the slugified slug, before keeper-sync ever runs.
+        project_store = ProjectStore(session=db_session, logger=_logger())
+        seed_project = await project_store.create(
+            org_id=org_id,
+            data=ProjectCreate(
+                slug="pipelines",
+                title="LSST Science Pipelines",
+                source_url="https://example.com/lsst/pipelines",
+            ),
+        )
+        edition_store = EditionStore(session=db_session, logger=_logger())
+        native_edition = await edition_store.create(
+            project_id=seed_project.id,
+            data=EditionCreate(
+                slug="tickets-DM-54686",
+                title="DM-54686",
+                kind=EditionKind.draft,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "tickets/DM-54686"},
+            ),
+        )
+    native_edition_id = native_edition.id
+
+    # LTD reports the same branch under its own ``DM-54686`` slug.
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(200, json=_load("product_pipelines.json"))
+    )
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines/editions/").mock(
+        return_value=httpx.Response(
+            200, json={"editions": [f"{LTD_BASE}/editions/2"]}
+        )
+    )
+    branch_edition = _load("edition_branch_git_refs.json")
+    branch_edition["slug"] = "DM-54686"
+    branch_edition["title"] = "DM-54686"
+    branch_edition["tracked_refs"] = ["tickets/DM-54686"]
+    branch_edition["build_url"] = f"{LTD_BASE}/builds/43"
+    mock_discovery.get(f"{LTD_BASE}/editions/2").mock(
+        return_value=httpx.Response(200, json=branch_edition)
+    )
+    branch_build = _load("build.json")
+    branch_build["self_url"] = f"{LTD_BASE}/builds/43"
+    branch_build["bucket_root_dir"] = "pipelines/builds/43"
+    mock_discovery.get(f"{LTD_BASE}/builds/43").mock(
+        return_value=httpx.Response(200, json=branch_build)
+    )
+
+    object_store = MockObjectStore()
+    source_objects = {
+        "pipelines/builds/43/index.html": b"<html>branch</html>",
+    }
+    _patch_factory_io(
+        monkeypatch,
+        object_store=object_store,
+        source_objects=source_objects,
+    )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
+
+    result = await keeper_sync_project(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "run_id": run_id,
+            "queue_job_id": queue_job_id,
+            "ltd_slug": "pipelines",
+            "ltd_base_url": LTD_BASE,
+        },
+    )
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    publish_jobs = get_jobs_by_name(
+        mock_arq, "publish_edition", queue_name="docverse:queue"
+    )
+    assert len(publish_jobs) == 1
+    publish_payload = publish_jobs[0].kwargs["payload"]
+    # The publish job must carry the persisted native slug so
+    # ``publish_edition``'s ``get_by_slug`` resolves the adopted edition;
+    # the keeper-derived ``DM-54686`` slug would miss the row entirely.
+    assert publish_payload["edition_slug"] == "tickets-DM-54686"
+    assert publish_payload["edition_id"] == native_edition_id
+
+    async for session in db_session_dependency():
+        async with session.begin():
+            project_store = ProjectStore(session=session, logger=_logger())
+            project = await project_store.get_by_slug(
+                org_id=org_id, slug="pipelines"
+            )
+            assert project is not None
+
+            edition_store = EditionStore(session=session, logger=_logger())
+            # The adopted edition got the synced build and a pending publish.
+            adopted = await edition_store.get_by_slug(
+                project_id=project.id, slug="tickets-DM-54686"
+            )
+            assert adopted is not None
+            assert adopted.id == native_edition_id
+            assert adopted.current_build_id is not None
+            assert adopted.publish_status == PublishStatus.pending
+
+            # No second row was created under the keeper-derived slug.
+            keeper_slugged = await edition_store.get_by_slug(
+                project_id=project.id, slug="DM-54686"
+            )
+            assert keeper_slugged is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add `EditionStore.get_git_ref_tracking_edition`, a shared server-side-filtered lookup that returns the single `git_ref`-mode edition already tracking a given `git_ref` for a project (or `None` when none does). It mirrors `list_draft_editions_by_git_ref`'s JSONB filter but restricts to `tracking_mode = git_ref`, answering exactly "is any git_ref-mode edition already tracking this ref?".
- Wire `KeeperSyncService._ensure_edition` to consult that lookup after a `get_by_slug` miss for `git_ref`-mode editions: when a differently-slugged edition already tracks the same `git_ref` (native `tickets-DM-54686` vs keeper-sync `DM-54686`), adopt it — refresh its tracking, keep its slug, and point `keeper_sync_state` at it — instead of inserting a duplicate row on the same ref (PRD #409).
- No-match and slug-hit paths are unchanged: a ref nothing tracks still creates an edition (LTD `main`→`__main` folding and the `DEFAULT_EDITION_SLUG`-missing guard intact), and a same-slug hit still takes the existing `_refresh_tracking` path.

## Validation steps

- In a REPL against a dev database, create two `git_ref`-mode editions tracking different refs plus one soft-deleted edition on a third ref, then call `get_git_ref_tracking_edition` and confirm it returns only the live edition tracking the queried ref, and `None` for a ref nothing tracks.
- Confirm an `alternate_git_ref` edition carrying the same `tracking_params->>'git_ref'` is **not** returned (the lookup is git_ref-mode only).
- With SQLAlchemy echo enabled, confirm the emitted SQL pushes both the `tracking_mode = 'git_ref'` predicate and the `tracking_params->>'git_ref'` equality to the database (no non-matching rows loaded into Python).
- Against a dev database, create a native `git_ref`-mode edition `tickets-DM-54686` tracking `tickets/DM-54686`, then run a keeper-sync import of an LTD edition slugged `DM-54686` on the same ref; confirm no second edition is created, the native edition keeps its slug with refreshed tracking, and `keeper_sync_state` for the imported edition points at the native edition's id.
- Run a keeper-sync import for a ref no edition yet tracks and confirm a new edition is still created (no regression), with LTD `main`→`__main` folding intact.
- Run a keeper-sync import where an edition with the matching keeper slug already exists and confirm it still takes the slug-hit `_refresh_tracking` path (the adopt-existing branch does not fire).

## References

- Closes #410
- Closes #411
- PRD: #409
- Jira: https://rubinobs.atlassian.net/browse/DM-55123