### PR TITLE
Run the stoker implement validation gate in the foreground

### DIFF
--- a/.agents/skills/project-mechanics/SKILL.md
+++ b/.agents/skills/project-mechanics/SKILL.md
@@ -18,7 +18,12 @@ Node/TypeScript). The named commands below target the primary
 ## Test commands
 
 - `focused_test`: `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test -- tests/path/to/file_test.py::test_name`
-- `complete_test`: `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test client_test`
+- `complete_test`: run only the suite(s) for the package(s) you changed,
+  per `## Monorepo selectors` — server change →
+  `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test`;
+  client change → `uv run --only-group=nox nox -s client_test`; both
+  changed → run both. The full cross-package suite is **not** the
+  in-iteration gate (see `## Final validation`).
 
 ## Lint
 
@@ -32,11 +37,19 @@ Node/TypeScript). The named commands below target the primary
 ## Final validation
 
 End-of-task validation runs `complete_test` + `lint_all` + `typing`
-in that order. Additional checks by component:
+in that order. Run the gate in the **foreground** and wait for it to
+finish — it may take a few minutes; keep going, don't background it.
+
+`complete_test` is **package-scoped**: run only the suite(s) for the
+package(s) you changed (see `## Monorepo selectors`). The full
+cross-package run (`nox -s test client_test`) and the multi-version
+compat suites (`client_test_compat`, `client_test_oldest`) are **CI's
+responsibility**, not the in-iteration gate — do not run them here.
+
+Additional checks by component:
 
 - Worker changes (`cloudflare-worker/`): `cd cloudflare-worker && npm run build && npm test` (run `npm ci` first if dependencies aren't installed).
 - deploy-worker changes (client deploy-worker code, which shells out to Node/npm): `uv run --only-group=nox nox -s deploy_worker_test`.
-- Client changes also run multi-version compat suites in CI: `uv run --only-group=nox nox -s client_test_compat client_test_oldest` (Python 3.12 + 3.13).
 
 ## Monorepo selectors
 

--- a/.agents/skills/stoker-implement/SKILL.md
+++ b/.agents/skills/stoker-implement/SKILL.md
@@ -2,7 +2,7 @@
 name: stoker-implement
 description: Drive a single pre-selected task through stoker-work's TDD cycle and commit/push/PR/close it (or stuck-mark it on failure). Use when invoked from the implement-phase prompt — the host has already picked the task and checked out its branch.
 ---
-<!-- stoker-managed: skills:.agents/skills/stoker-implement/SKILL.md:3ea7153b66cda0e2 -->
+<!-- stoker-managed: skills:.agents/skills/stoker-implement/SKILL.md:5822ab153beed9be -->
 
 # stoker-implement — drive one pre-selected stoker task to completion
 
@@ -46,6 +46,12 @@ If `stoker-work` Phase 4 cannot be made green within this iteration
 (e.g. pre-existing test failures, missing upstream dependency, or
 the project-mechanics file is missing), route to the stuck path
 (Phase 4 of *this* skill) — do not push broken state.
+
+**Turn-end invariant.** Your turn must not end until you have either
+(success) committed, pushed, opened/updated the PR, and closed the
+issue, or (failure) taken the stuck path. Never end your turn with a
+dirty working tree or with validation still running in the background —
+the host's next iteration will abort on the dirty tree.
 
 ## Phase 2: Commit (success path)
 

--- a/.agents/skills/stoker-work/SKILL.md
+++ b/.agents/skills/stoker-work/SKILL.md
@@ -2,7 +2,7 @@
 name: stoker-work
 description: The universal red/green/refactor TDD methodology building block — drives a unit of work through plan → failing test → minimal implementation → refactor → validation against this repo's project-mechanics. Use when invoked from `stoker-implement` (always delegates here for the dev cycle), from `stoker-fixup` or `stoker-rebase` when a finding or conflict warrants the full TDD discipline rather than an in-place apply-and-validate, or any time the user wants to drive a feature/bug-fix/refactor through plan → test → implement → validate.
 ---
-<!-- stoker-managed: skills:.agents/skills/stoker-work/SKILL.md:61b63b26db2bc01e -->
+<!-- stoker-managed: skills:.agents/skills/stoker-work/SKILL.md:6516b08d6df1db5b -->
 
 # stoker-work — Development Work Cycle
 
@@ -79,6 +79,14 @@ slice is scoped to one workspace package, follow that section's
 routing rules so the focused commands stay fast.
 
 ## Phase 4: Final validation
+
+Run every command in this phase in the **foreground** and wait for it
+to finish. Do **not** launch `<complete_test>` / `<lint_all>` /
+`<typing>` with `run_in_background` and then wait via `Monitor` or end
+your turn — under `stoker run` the agent is a single-shot headless
+session, so ending your turn terminates the run and any background work
+is killed before it reports. These commands may take several minutes;
+that wait is expected. Block on them.
 
 After all slices are complete, run the full suite to catch
 regressions and reach a clean fixpoint. Stoker's `stoker-implement`

--- a/.claude/skills/project-mechanics/SKILL.md
+++ b/.claude/skills/project-mechanics/SKILL.md
@@ -18,7 +18,12 @@ Node/TypeScript). The named commands below target the primary
 ## Test commands
 
 - `focused_test`: `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test -- tests/path/to/file_test.py::test_name`
-- `complete_test`: `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test client_test`
+- `complete_test`: run only the suite(s) for the package(s) you changed,
+  per `## Monorepo selectors` — server change →
+  `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test`;
+  client change → `uv run --only-group=nox nox -s client_test`; both
+  changed → run both. The full cross-package suite is **not** the
+  in-iteration gate (see `## Final validation`).
 
 ## Lint
 
@@ -32,11 +37,19 @@ Node/TypeScript). The named commands below target the primary
 ## Final validation
 
 End-of-task validation runs `complete_test` + `lint_all` + `typing`
-in that order. Additional checks by component:
+in that order. Run the gate in the **foreground** and wait for it to
+finish — it may take a few minutes; keep going, don't background it.
+
+`complete_test` is **package-scoped**: run only the suite(s) for the
+package(s) you changed (see `## Monorepo selectors`). The full
+cross-package run (`nox -s test client_test`) and the multi-version
+compat suites (`client_test_compat`, `client_test_oldest`) are **CI's
+responsibility**, not the in-iteration gate — do not run them here.
+
+Additional checks by component:
 
 - Worker changes (`cloudflare-worker/`): `cd cloudflare-worker && npm run build && npm test` (run `npm ci` first if dependencies aren't installed).
 - deploy-worker changes (client deploy-worker code, which shells out to Node/npm): `uv run --only-group=nox nox -s deploy_worker_test`.
-- Client changes also run multi-version compat suites in CI: `uv run --only-group=nox nox -s client_test_compat client_test_oldest` (Python 3.12 + 3.13).
 
 ## Monorepo selectors
 

--- a/.claude/skills/stoker-implement/SKILL.md
+++ b/.claude/skills/stoker-implement/SKILL.md
@@ -2,7 +2,7 @@
 name: stoker-implement
 description: Drive a single pre-selected task through stoker-work's TDD cycle and commit/push/PR/close it (or stuck-mark it on failure). Use when invoked from the implement-phase prompt — the host has already picked the task and checked out its branch.
 ---
-<!-- stoker-managed: skills:.claude/skills/stoker-implement/SKILL.md:3ea7153b66cda0e2 -->
+<!-- stoker-managed: skills:.claude/skills/stoker-implement/SKILL.md:5822ab153beed9be -->
 
 # stoker-implement — drive one pre-selected stoker task to completion
 

--- a/.claude/skills/stoker-implement/SKILL.md
+++ b/.claude/skills/stoker-implement/SKILL.md
@@ -47,6 +47,12 @@ If `stoker-work` Phase 4 cannot be made green within this iteration
 the project-mechanics file is missing), route to the stuck path
 (Phase 4 of *this* skill) — do not push broken state.
 
+**Turn-end invariant.** Your turn must not end until you have either
+(success) committed, pushed, opened/updated the PR, and closed the
+issue, or (failure) taken the stuck path. Never end your turn with a
+dirty working tree or with validation still running in the background —
+the host's next iteration will abort on the dirty tree.
+
 ## Phase 2: Commit (success path)
 
 `stoker-work` Phase 4 already left the working tree at a fixpoint with

--- a/.claude/skills/stoker-work/SKILL.md
+++ b/.claude/skills/stoker-work/SKILL.md
@@ -2,7 +2,7 @@
 name: stoker-work
 description: The universal red/green/refactor TDD methodology building block — drives a unit of work through plan → failing test → minimal implementation → refactor → validation against this repo's project-mechanics. Use when invoked from `stoker-implement` (always delegates here for the dev cycle), from `stoker-fixup` or `stoker-rebase` when a finding or conflict warrants the full TDD discipline rather than an in-place apply-and-validate, or any time the user wants to drive a feature/bug-fix/refactor through plan → test → implement → validate.
 ---
-<!-- stoker-managed: skills:.claude/skills/stoker-work/SKILL.md:61b63b26db2bc01e -->
+<!-- stoker-managed: skills:.claude/skills/stoker-work/SKILL.md:6516b08d6df1db5b -->
 
 # stoker-work — Development Work Cycle
 

--- a/.claude/skills/stoker-work/SKILL.md
+++ b/.claude/skills/stoker-work/SKILL.md
@@ -80,6 +80,14 @@ routing rules so the focused commands stay fast.
 
 ## Phase 4: Final validation
 
+Run every command in this phase in the **foreground** and wait for it
+to finish. Do **not** launch `<complete_test>` / `<lint_all>` /
+`<typing>` with `run_in_background` and then wait via `Monitor` or end
+your turn — under `stoker run` the agent is a single-shot headless
+session, so ending your turn terminates the run and any background work
+is killed before it reports. These commands may take several minutes;
+that wait is expected. Block on them.
+
 After all slices are complete, run the full suite to catch
 regressions and reach a clean fixpoint. Stoker's `stoker-implement`
 expects the working tree to be in a known good state when this phase


### PR DESCRIPTION
## Summary

A `stoker run` against this repo aborted after a single successful
implement iteration with `DIRTY TREE — aborting run`. Root cause: the
implement agent reached Phase 4 final validation, found `complete_test`
ran the entire cross-package suite (~1686 testcontainer-backed tests),
launched it with `run_in_background: true`, waited via `Monitor`, and
then ended its turn. Under stoker's single-shot headless session,
ending the turn ends the session — the background suite was
force-terminated, nothing was committed, and the tree was left dirty.
The next iteration's start-of-iter dirty-tree guard then aborted the
run.

This updates the stoker skill copies in this repo to make the
validation gate **blocking and cheap**:

- **`stoker-work` Phase 4** — run the gate in the foreground; never
  background `complete_test` / `lint_all` / `typing` and wait via
  `Monitor` or end the turn.
- **`stoker-implement`** — add a turn-end invariant: the turn must not
  end with a dirty tree or background validation still running.
- **`project-mechanics`** — `complete_test` is now package-scoped via
  the monorepo selectors (server change → `nox -s test`, client change
  → `nox -s client_test`). The full cross-package run and the
  multi-version compat suites (`client_test_compat`,
  `client_test_oldest`) are declared CI's responsibility, not the
  in-iteration gate.

Both the `.claude/skills` and `.agents/skills` copies are updated, and
the `stoker-managed` markers re-synced from the upstream profile
(jsickcodes/stoker#226, which carries the same discipline in stoker's
builtin default profile so future onboards inherit it).

## Validation

- Dry-confirmed the new package-scoped server gate from a clean tree:
  `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test`
  ran 1679 tests to green in ~5m21s entirely in the foreground — a
  comfortable blocking gate versus the full cross-package suite that
  provoked the backgrounding.

## References

- Upstream profile change: jsickcodes/stoker#226