### PR TITLE
DM-55161: Rename the lifecycle-eval arq pool to maintenance

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "attribution": {
+    "commit": ""
+  },
   "permissions": {
     "allow": [
       "Bash(uv sync:*)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 2.0.0 (Unreleased)
 
+- Rename the dedicated lifecycle-eval arq worker pool to "maintenance" to reflect that it is now a catch-all for non-publishing periodic work (lifecycle evaluation, the git-ref audit, and the cross-subsystem reaper backstops) rather than lifecycle evaluation alone. `LifecycleEvalWorkerSettings` is now `MaintenanceWorkerSettings`, its queue binds `docverse:maintenance-queue` (via the new `docverse.worker.queues.MAINTENANCE_QUEUE_NAME`), the pool-wide timeout setting is `maintenance_job_timeout_seconds`, and the Sentry component is `worker-maintenance`. The lifecycle-evaluation domain (the `lifecycle_eval` job kind, worker functions, `lifecycle_eval_runs` table, and `lifecycle_reaper`) keeps its names. Operators must update the Phalanx worker Deployment to launch `docverse.worker.main.MaintenanceWorkerSettings` (and rename the timeout env override if set) in lock-step with this change.
 - Add support for testing mysql and postgres databases locally and in GitHub Actions.
 - Update to Flask 2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 2.0.0 (Unreleased)
 
 - Rename the dedicated lifecycle-eval arq worker pool to "maintenance" to reflect that it is now a catch-all for non-publishing periodic work (lifecycle evaluation, the git-ref audit, and the cross-subsystem reaper backstops) rather than lifecycle evaluation alone. `LifecycleEvalWorkerSettings` is now `MaintenanceWorkerSettings`, its queue binds `docverse:maintenance-queue` (via the new `docverse.worker.queues.MAINTENANCE_QUEUE_NAME`), the pool-wide timeout setting is `maintenance_job_timeout_seconds`, and the Sentry component is `worker-maintenance`. The lifecycle-evaluation domain (the `lifecycle_eval` job kind, worker functions, `lifecycle_eval_runs` table, and `lifecycle_reaper`) keeps its names. Operators must update the Phalanx worker Deployment to launch `docverse.worker.main.MaintenanceWorkerSettings` (and rename the timeout env override if set) in lock-step with this change.
+- Move the opportunistic `project_github_resolve` job off the default publishing queue onto the maintenance pool, so its installation-id resolution no longer contends with the live publishing flow. Creating or updating a project with a GitHub binding now enqueues the resolve onto `docverse:maintenance-queue`, and the job is registered on `MaintenanceWorkerSettings` rather than the default `WorkerSettings`.
 - Add support for testing mysql and postgres databases locally and in GitHub Actions.
 - Update to Flask 2.
 

--- a/src/docverse/config.py
+++ b/src/docverse/config.py
@@ -164,13 +164,14 @@ class Configuration(BaseSettings):
         ),
     )
 
-    lifecycle_eval_job_timeout_seconds: int = Field(
+    maintenance_job_timeout_seconds: int = Field(
         3600,
-        title="Lifecycle-eval per-job timeout, in seconds",
+        title="Maintenance per-job timeout, in seconds",
         description=(
-            "Wraps the ``lifecycle_eval_dispatcher`` and per-org"
-            " ``lifecycle_eval`` arq functions on"
-            " ``LifecycleEvalWorkerSettings``: arq cancels a job that"
+            "Wraps all four maintenance-pool arq functions"
+            " (``lifecycle_eval_dispatcher`` / ``lifecycle_eval`` and"
+            " ``git_ref_audit_discovery`` / ``git_ref_audit``) on"
+            " ``MaintenanceWorkerSettings``: arq cancels a job that"
             " runs past this. The cron-driven ``lifecycle_reaper`` is"
             " the second backstop (covers OOM-killed workers / arq"
             " losing a job), so this should sit well below"

--- a/src/docverse/sentry.py
+++ b/src/docverse/sentry.py
@@ -21,7 +21,7 @@ __all__ = [
 
 
 DocverseSentryComponent = Literal[
-    "api", "worker", "worker-keeper-sync", "worker-lifecycle-eval", "cli"
+    "api", "worker", "worker-keeper-sync", "worker-maintenance", "cli"
 ]
 """Tag values for the ``component`` Sentry global tag.
 

--- a/src/docverse/services/project_github_resolve_enqueue.py
+++ b/src/docverse/services/project_github_resolve_enqueue.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING
 import sentry_sdk
 import structlog
 
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
+
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -56,9 +58,13 @@ async def try_enqueue_project_github_resolve_by_id(
             ):
                 return
             queue_backend = factory.create_queue_backend()
+            # Route onto the dedicated maintenance pool (PRD #419): the
+            # resolve's installation-id lookup is opportunistic and must
+            # not contend with the default pool's live publishing flow.
             await queue_backend.enqueue(
                 "project_github_resolve",
                 {"project_id": project_id},
+                queue_name=MAINTENANCE_QUEUE_NAME,
             )
             await session.commit()
     except Exception as exc:

--- a/src/docverse/worker/functions/git_ref_audit_discovery.py
+++ b/src/docverse/worker/functions/git_ref_audit_discovery.py
@@ -61,8 +61,7 @@ from docverse.domain.queue import QueueJob
 from docverse.factory import Factory
 from docverse.storage.git_ref_audit_run_store import GitRefAuditRunStore
 from docverse.storage.queue_job_store import QueueJobStore
-
-from .lifecycle_eval_dispatcher import LIFECYCLE_EVAL_QUEUE_NAME
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
 
 __all__ = ["git_ref_audit_discovery"]
 
@@ -239,7 +238,7 @@ async def _enqueue_arq_jobs(  # noqa: PLR0913
     enqueue and the ``backend_job_id`` write leaves an orphan-queued
     row (``backend_job_id IS NULL``) which ``lifecycle_reaper`` sweeps
     via :meth:`QueueJobStore.fail_orphaned_git_ref_audit_jobs`. The
-    audit shares the lifecycle-eval worker pool's queue so audit and
+    audit shares the maintenance worker pool's queue so audit and
     lifecycle-eval ticks can never crowd each other off the worker
     fleet.
     """
@@ -247,7 +246,7 @@ async def _enqueue_arq_jobs(  # noqa: PLR0913
     for org, queue_job in zip(orgs, queue_jobs, strict=True):
         metadata = await arq_queue.enqueue(
             "git_ref_audit",
-            _queue_name=LIFECYCLE_EVAL_QUEUE_NAME,
+            _queue_name=MAINTENANCE_QUEUE_NAME,
             payload={
                 "org_id": org.id,
                 "org_slug": org.slug,

--- a/src/docverse/worker/functions/lifecycle_eval_dispatcher.py
+++ b/src/docverse/worker/functions/lifecycle_eval_dispatcher.py
@@ -34,7 +34,7 @@ job. On each firing the dispatcher:
    orphan-tail window — row committed, ``backend_job_id IS NULL`` —
    is the responsibility of ``lifecycle_reaper``, the second
    durability backstop. The per-job arq ``timeout`` configured on
-   ``LifecycleEvalWorkerSettings`` is the first backstop (cancels a
+   ``MaintenanceWorkerSettings`` is the first backstop (cancels a
    runaway evaluator long before the reaper window).
 """
 
@@ -54,20 +54,9 @@ from docverse.domain.queue import QueueJob
 from docverse.factory import Factory
 from docverse.storage.lifecycle_eval_run_store import LifecycleEvalRunStore
 from docverse.storage.queue_job_store import QueueJobStore
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
 
-__all__ = ["LIFECYCLE_EVAL_QUEUE_NAME", "lifecycle_eval_dispatcher"]
-
-
-LIFECYCLE_EVAL_QUEUE_NAME = "docverse:lifecycle-queue"
-"""arq queue name dedicated to ``lifecycle_eval`` work.
-
-The queue is isolated from the default ``docverse:queue`` and the
-``docverse:sync-queue`` so a slow lifecycle pass cannot starve
-``build_processing`` / ``publish_edition`` or keeper-sync jobs. The
-PRD calls for "a new dedicated arq worker pool (the third pool,
-alongside the default and keeper-sync pools)" — this constant is the
-queue name those pools bind to.
-"""
+__all__ = ["lifecycle_eval_dispatcher"]
 
 
 async def lifecycle_eval_dispatcher(ctx: dict[str, Any]) -> str:
@@ -252,7 +241,7 @@ async def _enqueue_arq_jobs(  # noqa: PLR0913
     for org, queue_job in zip(orgs, queue_jobs, strict=True):
         metadata = await arq_queue.enqueue(
             "lifecycle_eval",
-            _queue_name=LIFECYCLE_EVAL_QUEUE_NAME,
+            _queue_name=MAINTENANCE_QUEUE_NAME,
             payload={
                 "org_id": org.id,
                 "org_slug": org.slug,

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -175,7 +175,10 @@ class WorkerFactoryBuilder:
 
 
 async def _startup(
-    ctx: dict[str, Any], *, component: DocverseSentryComponent
+    ctx: dict[str, Any],
+    *,
+    component: DocverseSentryComponent,
+    queue_name: str,
 ) -> None:
     """Initialize resources for the arq worker process.
 
@@ -205,6 +208,7 @@ async def _startup(
         "Docverse worker startup",
         app_version=version("docverse"),
         db_revision=db_revision,
+        queue_name=queue_name,
     )
 
     await db_session_dependency.initialize(
@@ -267,17 +271,25 @@ async def _startup(
 
 async def startup_default(ctx: dict[str, Any]) -> None:
     """on_startup for the default Docverse arq queue."""
-    await _startup(ctx, component="worker")
+    await _startup(ctx, component="worker", queue_name=config.arq_queue_name)
 
 
 async def startup_keeper_sync(ctx: dict[str, Any]) -> None:
     """on_startup for the dedicated keeper-sync arq queue."""
-    await _startup(ctx, component="worker-keeper-sync")
+    await _startup(
+        ctx,
+        component="worker-keeper-sync",
+        queue_name=KEEPER_SYNC_QUEUE_NAME,
+    )
 
 
 async def startup_maintenance(ctx: dict[str, Any]) -> None:
     """on_startup for the dedicated maintenance arq queue."""
-    await _startup(ctx, component="worker-maintenance")
+    await _startup(
+        ctx,
+        component="worker-maintenance",
+        queue_name=MAINTENANCE_QUEUE_NAME,
+    )
 
 
 async def shutdown(ctx: dict[str, Any]) -> None:

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -301,7 +301,6 @@ class WorkerSettings:
         instrument_arq_task(dashboard_build),
         instrument_arq_task(dashboard_sync),
         instrument_arq_task(ping),
-        instrument_arq_task(project_github_resolve),
         instrument_arq_task(publish_edition),
     ]
     redis_settings = config.arq_redis_settings
@@ -427,6 +426,14 @@ class MaintenanceWorkerSettings:
     rebuilds for worker capacity. The maintenance name reflects that
     the pool is the shared home for this non-publishing periodic work,
     no longer scoped to lifecycle evaluation alone.
+
+    The opportunistic ``project_github_resolve`` job (PRD #346) also
+    runs here: PRD #419 moves it off the default publishing pool because
+    its installation-id resolution is not time-sensitive and should not
+    contend with the live publishing flow. It is the one event-driven
+    (rather than cron-driven) function on the pool and is registered
+    plainly — no ``func`` timeout wrapper — exactly as it was on the
+    default pool.
     """
 
     functions = [
@@ -455,6 +462,14 @@ class MaintenanceWorkerSettings:
         instrument_arq_task(publish_edition_reaper),
         instrument_arq_task(build_processing_reaper),
         instrument_arq_task(dashboard_sync_reaper),
+        # ``project_github_resolve`` is the opportunistic GitHub-id
+        # resolve (PRD #346). PRD #419 moves it off the default
+        # publishing pool onto this maintenance pool: its work is not
+        # time-sensitive and must not contend with the live publishing
+        # flow. Registered plainly (no ``func`` timeout wrapper, arq's
+        # default retry policy) exactly as it was on the default pool,
+        # so the move changes only which pool runs it.
+        instrument_arq_task(project_github_resolve),
     ]
     cron_jobs = [
         cron(

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -60,7 +60,7 @@ from .functions import (
     publish_edition,
     publish_edition_reaper,
 )
-from .functions.lifecycle_eval_dispatcher import LIFECYCLE_EVAL_QUEUE_NAME
+from .queues import MAINTENANCE_QUEUE_NAME
 
 config = Configuration()
 
@@ -275,9 +275,9 @@ async def startup_keeper_sync(ctx: dict[str, Any]) -> None:
     await _startup(ctx, component="worker-keeper-sync")
 
 
-async def startup_lifecycle_eval(ctx: dict[str, Any]) -> None:
-    """on_startup for the dedicated lifecycle-eval arq queue."""
-    await _startup(ctx, component="worker-lifecycle-eval")
+async def startup_maintenance(ctx: dict[str, Any]) -> None:
+    """on_startup for the dedicated maintenance arq queue."""
+    await _startup(ctx, component="worker-maintenance")
 
 
 async def shutdown(ctx: dict[str, Any]) -> None:
@@ -385,16 +385,17 @@ class KeeperSyncWorkerSettings:
     on_shutdown = shutdown
 
 
-class LifecycleEvalWorkerSettings:
-    """arq WorkerSettings for the dedicated lifecycle queue.
+class MaintenanceWorkerSettings:
+    """arq WorkerSettings for the dedicated maintenance queue.
 
-    Bound to ``docverse:lifecycle-queue`` (see
-    :data:`LIFECYCLE_EVAL_QUEUE_NAME`) so a slow lifecycle pass cannot
+    Bound to ``docverse:maintenance-queue`` (see
+    :data:`MAINTENANCE_QUEUE_NAME`) so a slow maintenance pass cannot
     starve the default queue's ``build_processing`` and
     ``publish_edition`` jobs or the keeper-sync queue's
-    ``keeper_sync_project`` jobs. The PRD §"Orchestration" specifies a
-    third pool alongside the default and keeper-sync pools; this
-    class is the binding.
+    ``keeper_sync_project`` jobs. This is the third pool alongside the
+    default and keeper-sync pools — a catch-all for non-publishing
+    periodic work rather than lifecycle evaluation alone; this class
+    is the binding.
 
     Both the hourly ``lifecycle_eval`` (dispatcher + per-org worker)
     and the daily ``git_ref_audit`` (discovery + per-org worker) live
@@ -406,7 +407,7 @@ class LifecycleEvalWorkerSettings:
 
     All four functions are wrapped with :func:`arq.func` so the
     dedicated queue inherits a per-job ``timeout`` (sourced from
-    ``Config.lifecycle_eval_job_timeout_seconds``) and a
+    ``Config.maintenance_job_timeout_seconds``) and a
     single-attempt policy. A failure must surface promptly so the
     per-org worker's ``except Exception`` block can route to
     ``queue_job_store.fail()`` and the parent run finalises via the
@@ -423,31 +424,30 @@ class LifecycleEvalWorkerSettings:
     ``publish_edition_reaper``, ``build_processing_reaper``, and
     ``dashboard_sync_reaper`` run here (PRD #367) so reaper sweeps
     never compete with build processing or user-triggered dashboard
-    rebuilds for worker capacity. The pool name retains its
-    lifecycle-eval lineage but is no longer scoped to lifecycle work
-    alone; a rename to a maintenance-style identifier is tracked
-    separately.
+    rebuilds for worker capacity. The maintenance name reflects that
+    the pool is the shared home for this non-publishing periodic work,
+    no longer scoped to lifecycle evaluation alone.
     """
 
     functions = [
         func(
             instrument_arq_task(lifecycle_eval_dispatcher),
-            timeout=config.lifecycle_eval_job_timeout_seconds,
+            timeout=config.maintenance_job_timeout_seconds,
             max_tries=1,
         ),
         func(
             instrument_arq_task(lifecycle_eval),
-            timeout=config.lifecycle_eval_job_timeout_seconds,
+            timeout=config.maintenance_job_timeout_seconds,
             max_tries=1,
         ),
         func(
             instrument_arq_task(git_ref_audit_discovery),
-            timeout=config.lifecycle_eval_job_timeout_seconds,
+            timeout=config.maintenance_job_timeout_seconds,
             max_tries=1,
         ),
         func(
             instrument_arq_task(git_ref_audit),
-            timeout=config.lifecycle_eval_job_timeout_seconds,
+            timeout=config.maintenance_job_timeout_seconds,
             max_tries=1,
         ),
         instrument_arq_task(lifecycle_reaper),
@@ -536,6 +536,6 @@ class LifecycleEvalWorkerSettings:
         ),
     ]
     redis_settings = config.arq_redis_settings
-    queue_name = LIFECYCLE_EVAL_QUEUE_NAME
-    on_startup = startup_lifecycle_eval
+    queue_name = MAINTENANCE_QUEUE_NAME
+    on_startup = startup_maintenance
     on_shutdown = shutdown

--- a/src/docverse/worker/queues.py
+++ b/src/docverse/worker/queues.py
@@ -1,0 +1,24 @@
+"""arq queue-name constants for Docverse's dedicated worker pools.
+
+A neutral home for the dedicated-pool queue names, decoupled from any
+one worker function. ``KEEPER_SYNC_QUEUE_NAME`` lives next to its
+keeper-sync service for historical reasons; new pool queue names land
+here so a function module never has to own a pool-wide constant.
+"""
+
+from __future__ import annotations
+
+__all__ = ["MAINTENANCE_QUEUE_NAME"]
+
+
+MAINTENANCE_QUEUE_NAME = "docverse:maintenance-queue"
+"""arq queue name for the dedicated maintenance worker pool.
+
+The pool is a catch-all for non-publishing periodic work — lifecycle
+evaluation, the git-ref audit, and the cross-subsystem reaper
+backstops — so its queue is isolated from the default ``docverse:queue``
+and the ``docverse:sync-queue`` and one of those slow passes can never
+starve ``build_processing`` / ``publish_edition`` or keeper-sync jobs.
+``MaintenanceWorkerSettings`` binds this name; the dispatchers enqueue
+their fan-out jobs onto it.
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ from docverse.storage.membership_store import OrgMembershipStore
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from docverse.storage.user_info_store import StubUserInfoStore
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
 
 from .support.arq_testing import register_queue
 from .support.github_mock import GitHubMock, make_rsa_pem
@@ -150,12 +151,15 @@ async def app() -> AsyncGenerator[FastAPI]:
         context_dependency._superadmin_usernames = ["superadmin"]
         # Replace the MockArqQueue with one that uses the configured
         # queue name so ArqQueueBackend can enqueue to the right queue.
-        # Register the dedicated keeper-sync queue too — MockArqQueue
-        # only auto-creates the slot for its ``default_queue_name``,
-        # so the ``POST /orgs/{org}/keeper-sync/runs`` enqueue would
-        # otherwise hit ``KeyError`` on first use.
+        # Register the dedicated keeper-sync and maintenance queues too —
+        # MockArqQueue only auto-creates the slot for its
+        # ``default_queue_name``, so the ``POST /orgs/{org}/keeper-sync/
+        # runs`` enqueue and the project_github_resolve enqueue onto the
+        # maintenance pool (PRD #419) would otherwise hit ``KeyError`` on
+        # first use.
         arq_queue = MockArqQueue(default_queue_name=config.arq_queue_name)
         register_queue(arq_queue, KEEPER_SYNC_QUEUE_NAME)
+        register_queue(arq_queue, MAINTENANCE_QUEUE_NAME)
         arq_dependency._arq_queue = arq_queue
         yield docverse_app
 

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -283,11 +283,11 @@ _JOB_STATE_CASES: list[
     (
         "run-not-found",
         lambda: InvalidJobStateError(
-            queue_name="docverse:lifecycle-queue",
+            queue_name="docverse:maintenance-queue",
             message="Lifecycle eval run 99 not found",
         ),
         {
-            "queue_name": "docverse:lifecycle-queue",
+            "queue_name": "docverse:maintenance-queue",
         },
     ),
 ]

--- a/tests/handlers/project_github_resolve_enqueue_test.py
+++ b/tests/handlers/project_github_resolve_enqueue_test.py
@@ -5,6 +5,10 @@ one ``project_github_resolve`` arq job (PRD #346 user story 12 /
 acceptance criterion 1). Projects without a GitHub binding must not
 generate a no-op enqueue: the worker would just skip them, and the
 queue noise would obscure real enqueues.
+
+PRD #419 routes the resolve onto the dedicated ``maintenance`` pool
+rather than the default publishing queue, so it never contends with the
+live publishing flow; the POST test pins that queue target explicitly.
 """
 
 from __future__ import annotations
@@ -14,8 +18,12 @@ from httpx import AsyncClient
 from safir.arq import MockArqQueue
 from safir.dependencies.arq import arq_dependency
 
+from docverse.config import Configuration
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
 from tests.conftest import seed_org_with_admin
 from tests.support.arq_testing import count_jobs_by_name, get_jobs_by_name
+
+_config = Configuration()
 
 
 async def _setup(client: AsyncClient) -> None:
@@ -23,11 +31,18 @@ async def _setup(client: AsyncClient) -> None:
     await seed_org_with_admin(client, "pgr-org", "testuser")
 
 
-def _resolve_count() -> int:
-    """Count enqueued ``project_github_resolve`` arq jobs."""
+def _resolve_count(*, queue_name: str | None = None) -> int:
+    """Count enqueued ``project_github_resolve`` arq jobs.
+
+    With ``queue_name`` given, restrict the count to that one queue;
+    with ``None`` (the default) union the count across every queue the
+    mock has touched (see :func:`count_jobs_by_name`).
+    """
     mock_arq = arq_dependency._arq_queue
     assert isinstance(mock_arq, MockArqQueue)
-    return count_jobs_by_name(mock_arq, "project_github_resolve")
+    return count_jobs_by_name(
+        mock_arq, "project_github_resolve", queue_name=queue_name
+    )
 
 
 def _resolve_payloads() -> list[dict[str, object]]:
@@ -50,16 +65,19 @@ def _resolve_payloads() -> list[dict[str, object]]:
 async def test_post_project_with_github_enqueues_resolve(
     client: AsyncClient,
 ) -> None:
-    """POST with ``github`` enqueues one ``project_github_resolve`` job.
+    """POST with ``github`` enqueues one resolve onto the maintenance queue.
 
     Reproduces the post-create steady state of user story 12: an admin
     creates a project with structured GitHub coordinates, and the
     handler fires off the asynchronous installation-id resolution so
     the operator does not have to know the installation id at create
-    time.
+    time. PRD #419 routes that resolve onto the dedicated maintenance
+    pool, so this pins the enqueue to ``docverse:maintenance-queue`` and
+    asserts it does not land on the default publishing queue.
     """
     await _setup(client)
-    before = _resolve_count()
+    before_maintenance = _resolve_count(queue_name=MAINTENANCE_QUEUE_NAME)
+    before_default = _resolve_count(queue_name=_config.arq_queue_name)
 
     response = await client.post(
         "/docverse/orgs/pgr-org/projects",
@@ -72,8 +90,13 @@ async def test_post_project_with_github_enqueues_resolve(
     )
     assert response.status_code == 201
 
-    after = _resolve_count()
-    assert after - before == 1
+    assert (
+        _resolve_count(queue_name=MAINTENANCE_QUEUE_NAME) - before_maintenance
+        == 1
+    )
+    assert (
+        _resolve_count(queue_name=_config.arq_queue_name) - before_default == 0
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/worker/git_ref_audit_discovery_test.py
+++ b/tests/worker/git_ref_audit_discovery_test.py
@@ -34,9 +34,7 @@ from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.git_ref_audit_discovery import (
     git_ref_audit_discovery,
 )
-from docverse.worker.functions.lifecycle_eval_dispatcher import (
-    LIFECYCLE_EVAL_QUEUE_NAME,
-)
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
 from tests.support.arq_testing import get_jobs_by_name, register_queue
 from tests.worker.conftest import make_worker_ctx
 
@@ -141,7 +139,7 @@ async def test_discovery_fans_out_per_in_scope_org(
 
     http_client = httpx.AsyncClient()
     mock_arq = MockArqQueue(default_queue_name="docverse:queue")
-    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    register_queue(mock_arq, MAINTENANCE_QUEUE_NAME)
     ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
 
     result = await git_ref_audit_discovery(ctx)
@@ -149,7 +147,7 @@ async def test_discovery_fans_out_per_in_scope_org(
     assert result == "completed"
 
     audit_jobs = get_jobs_by_name(
-        mock_arq, "git_ref_audit", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+        mock_arq, "git_ref_audit", queue_name=MAINTENANCE_QUEUE_NAME
     )
     assert len(audit_jobs) == 1
     payload_slugs = {job.kwargs["payload"]["org_slug"] for job in audit_jobs}
@@ -197,7 +195,7 @@ async def test_discovery_with_no_in_scope_orgs_terminates_run_succeeded(
 
     http_client = httpx.AsyncClient()
     mock_arq = MockArqQueue(default_queue_name="docverse:queue")
-    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    register_queue(mock_arq, MAINTENANCE_QUEUE_NAME)
     ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
 
     result = await git_ref_audit_discovery(ctx)
@@ -205,7 +203,7 @@ async def test_discovery_with_no_in_scope_orgs_terminates_run_succeeded(
     assert result == "completed"
 
     audit_jobs = get_jobs_by_name(
-        mock_arq, "git_ref_audit", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+        mock_arq, "git_ref_audit", queue_name=MAINTENANCE_QUEUE_NAME
     )
     assert audit_jobs == []
 
@@ -260,7 +258,7 @@ async def test_discovery_skips_tick_when_prior_run_in_flight(
 
     http_client = httpx.AsyncClient()
     mock_arq = MockArqQueue(default_queue_name="docverse:queue")
-    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    register_queue(mock_arq, MAINTENANCE_QUEUE_NAME)
     ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
 
     result = await git_ref_audit_discovery(ctx)
@@ -268,7 +266,7 @@ async def test_discovery_skips_tick_when_prior_run_in_flight(
     assert result == "skipped"
 
     audit_jobs = get_jobs_by_name(
-        mock_arq, "git_ref_audit", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+        mock_arq, "git_ref_audit", queue_name=MAINTENANCE_QUEUE_NAME
     )
     assert audit_jobs == []
 
@@ -311,7 +309,7 @@ async def test_discovery_disabled_by_feature_flag(
 
     http_client = httpx.AsyncClient()
     mock_arq = MockArqQueue(default_queue_name="docverse:queue")
-    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    register_queue(mock_arq, MAINTENANCE_QUEUE_NAME)
     ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
 
     result = await git_ref_audit_discovery(ctx)

--- a/tests/worker/lifecycle_eval_dispatcher_test.py
+++ b/tests/worker/lifecycle_eval_dispatcher_test.py
@@ -31,10 +31,10 @@ from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
 from docverse.worker.functions.lifecycle_eval_dispatcher import (
-    LIFECYCLE_EVAL_QUEUE_NAME,
     _create_run_with_children,
     lifecycle_eval_dispatcher,
 )
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
 from tests.support.arq_testing import get_jobs_by_name, register_queue
 from tests.worker.conftest import make_worker_ctx
 
@@ -131,7 +131,7 @@ async def test_dispatcher_fans_out_per_in_scope_org(
 
     http_client = httpx.AsyncClient()
     mock_arq = MockArqQueue(default_queue_name="docverse:queue")
-    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    register_queue(mock_arq, MAINTENANCE_QUEUE_NAME)
     ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
 
     result = await lifecycle_eval_dispatcher(ctx)
@@ -141,7 +141,7 @@ async def test_dispatcher_fans_out_per_in_scope_org(
     # Two child ``lifecycle_eval`` jobs were enqueued on the dedicated
     # queue — one per in-scope org — and zero on the default queue.
     eval_jobs = get_jobs_by_name(
-        mock_arq, "lifecycle_eval", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+        mock_arq, "lifecycle_eval", queue_name=MAINTENANCE_QUEUE_NAME
     )
     assert len(eval_jobs) == 2
     default_jobs = get_jobs_by_name(
@@ -210,7 +210,7 @@ async def test_dispatcher_with_no_in_scope_orgs_terminates_run_succeeded(
 
     http_client = httpx.AsyncClient()
     mock_arq = MockArqQueue(default_queue_name="docverse:queue")
-    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    register_queue(mock_arq, MAINTENANCE_QUEUE_NAME)
     ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
 
     result = await lifecycle_eval_dispatcher(ctx)
@@ -218,7 +218,7 @@ async def test_dispatcher_with_no_in_scope_orgs_terminates_run_succeeded(
     assert result == "completed"
 
     eval_jobs = get_jobs_by_name(
-        mock_arq, "lifecycle_eval", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+        mock_arq, "lifecycle_eval", queue_name=MAINTENANCE_QUEUE_NAME
     )
     assert eval_jobs == []
 
@@ -292,7 +292,7 @@ async def test_dispatcher_skips_when_create_loses_race(
 
     http_client = httpx.AsyncClient()
     mock_arq = MockArqQueue(default_queue_name="docverse:queue")
-    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    register_queue(mock_arq, MAINTENANCE_QUEUE_NAME)
     ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
 
     result = await lifecycle_eval_dispatcher(ctx)
@@ -300,7 +300,7 @@ async def test_dispatcher_skips_when_create_loses_race(
     assert result == "skipped"
 
     eval_jobs = get_jobs_by_name(
-        mock_arq, "lifecycle_eval", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+        mock_arq, "lifecycle_eval", queue_name=MAINTENANCE_QUEUE_NAME
     )
     assert eval_jobs == []
 
@@ -344,7 +344,7 @@ async def test_dispatcher_skips_tick_when_prior_run_in_flight(
 
     http_client = httpx.AsyncClient()
     mock_arq = MockArqQueue(default_queue_name="docverse:queue")
-    register_queue(mock_arq, LIFECYCLE_EVAL_QUEUE_NAME)
+    register_queue(mock_arq, MAINTENANCE_QUEUE_NAME)
     ctx = make_worker_ctx(http_client=http_client, arq_queue=mock_arq)
 
     result = await lifecycle_eval_dispatcher(ctx)
@@ -352,7 +352,7 @@ async def test_dispatcher_skips_tick_when_prior_run_in_flight(
     assert result == "skipped"
 
     eval_jobs = get_jobs_by_name(
-        mock_arq, "lifecycle_eval", queue_name=LIFECYCLE_EVAL_QUEUE_NAME
+        mock_arq, "lifecycle_eval", queue_name=MAINTENANCE_QUEUE_NAME
     )
     assert eval_jobs == []
 

--- a/tests/worker/maintenance_worker_settings_test.py
+++ b/tests/worker/maintenance_worker_settings_test.py
@@ -21,6 +21,7 @@ from docverse.worker.functions import (
     lifecycle_eval,
     lifecycle_eval_dispatcher,
     lifecycle_reaper,
+    project_github_resolve,
     publish_edition_reaper,
 )
 from docverse.worker.main import (
@@ -439,6 +440,35 @@ def test_default_worker_does_not_register_dashboard_sync_reaper() -> None:
         if isinstance(job, CronJob)
     }
     assert dashboard_sync_reaper not in coroutines
+
+
+def test_project_github_resolve_registered_on_maintenance_pool() -> None:
+    """``project_github_resolve`` is registered on the maintenance pool.
+
+    PRD #419 moves the opportunistic GitHub-id resolve off the default
+    publishing queue and onto the maintenance pool: its work is not
+    time-sensitive and must not contend with the live publishing flow.
+    """
+    underlying = {
+        _underlying(entry.coroutine if isinstance(entry, Function) else entry)
+        for entry in MaintenanceWorkerSettings.functions
+    }
+    assert project_github_resolve in underlying
+
+
+def test_default_worker_does_not_register_project_github_resolve() -> None:
+    """The default queue no longer registers ``project_github_resolve``.
+
+    PRD #419 relocates the resolve onto the maintenance pool, so the
+    default publishing pool must not also register it — otherwise a
+    default-pool worker could pick the job up and defeat the isolation
+    the move exists to provide.
+    """
+    default_underlying = {
+        _underlying(entry.coroutine if isinstance(entry, Function) else entry)
+        for entry in WorkerSettings.functions
+    }
+    assert project_github_resolve not in default_underlying
 
 
 def test_default_worker_does_not_register_lifecycle_functions() -> None:

--- a/tests/worker/maintenance_worker_settings_test.py
+++ b/tests/worker/maintenance_worker_settings_test.py
@@ -1,6 +1,6 @@
-"""Tests for the ``LifecycleEvalWorkerSettings`` arq config.
+"""Tests for the ``MaintenanceWorkerSettings`` arq config.
 
-Pins the contract operators rely on: the lifecycle queue is isolated
+Pins the contract operators rely on: the maintenance queue is isolated
 from both the default queue and the keeper-sync queue, the dispatcher
 fires on an hourly cron, and the per-org worker is registered on the
 same dedicated pool so the dispatcher's enqueues actually run.
@@ -23,16 +23,14 @@ from docverse.worker.functions import (
     lifecycle_reaper,
     publish_edition_reaper,
 )
-from docverse.worker.functions.lifecycle_eval_dispatcher import (
-    LIFECYCLE_EVAL_QUEUE_NAME,
-)
 from docverse.worker.main import (
     KeeperSyncWorkerSettings,
-    LifecycleEvalWorkerSettings,
+    MaintenanceWorkerSettings,
     WorkerSettings,
     shutdown,
-    startup_lifecycle_eval,
+    startup_maintenance,
 )
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
 
 _config = Configuration()
 
@@ -52,7 +50,7 @@ def _underlying(coroutine: Any) -> Any:
 
 
 def _function_by_coroutine(coro: object) -> Function:
-    for entry in LifecycleEvalWorkerSettings.functions:
+    for entry in MaintenanceWorkerSettings.functions:
         if (
             isinstance(entry, Function)
             and _underlying(entry.coroutine) is coro
@@ -62,17 +60,17 @@ def _function_by_coroutine(coro: object) -> Function:
     raise AssertionError(msg)
 
 
-def test_lifecycle_eval_worker_settings_uses_dedicated_queue() -> None:
-    """The lifecycle queue is isolated from default and sync queues."""
-    assert LifecycleEvalWorkerSettings.queue_name == LIFECYCLE_EVAL_QUEUE_NAME
-    assert LifecycleEvalWorkerSettings.queue_name != WorkerSettings.queue_name
+def test_maintenance_worker_settings_uses_dedicated_queue() -> None:
+    """The maintenance queue is isolated from default and sync queues."""
+    assert MaintenanceWorkerSettings.queue_name == MAINTENANCE_QUEUE_NAME
+    assert MaintenanceWorkerSettings.queue_name != WorkerSettings.queue_name
     assert (
-        LifecycleEvalWorkerSettings.queue_name
+        MaintenanceWorkerSettings.queue_name
         != KeeperSyncWorkerSettings.queue_name
     )
 
 
-def test_lifecycle_eval_worker_settings_registers_functions() -> None:
+def test_maintenance_worker_settings_registers_functions() -> None:
     """Dispatcher and per-org worker are both registered, single-attempt.
 
     Both are wrapped with :func:`arq.func` carrying the configured
@@ -83,31 +81,31 @@ def test_lifecycle_eval_worker_settings_registers_functions() -> None:
     """
     dispatcher = _function_by_coroutine(lifecycle_eval_dispatcher)
     per_org = _function_by_coroutine(lifecycle_eval)
-    expected_timeout = float(_config.lifecycle_eval_job_timeout_seconds)
+    expected_timeout = float(_config.maintenance_job_timeout_seconds)
     assert dispatcher.timeout_s == expected_timeout
     assert per_org.timeout_s == expected_timeout
     assert dispatcher.max_tries == 1
     assert per_org.max_tries == 1
 
 
-def test_lifecycle_eval_worker_settings_share_lifecycle_hooks() -> None:
-    """Lifecycle queue has its own ``on_startup`` (per-component Sentry tag).
+def test_maintenance_worker_settings_share_lifecycle_hooks() -> None:
+    """Maintenance queue has its own ``on_startup`` (per-component Sentry tag).
 
-    The lifecycle wrapper funnels through the same ``_startup`` body as
+    The maintenance wrapper funnels through the same ``_startup`` body as
     the default and keeper-sync queues so the factory-builder shape stays
     uniform; the only intentional divergence is the Sentry ``component``
-    tag (``worker-lifecycle-eval``). ``on_shutdown`` is fully shared.
+    tag (``worker-maintenance``). ``on_shutdown`` is fully shared.
     """
-    assert LifecycleEvalWorkerSettings.on_startup is startup_lifecycle_eval
+    assert MaintenanceWorkerSettings.on_startup is startup_maintenance
     assert (
-        LifecycleEvalWorkerSettings.on_startup is not WorkerSettings.on_startup
+        MaintenanceWorkerSettings.on_startup is not WorkerSettings.on_startup
     )
-    assert LifecycleEvalWorkerSettings.on_shutdown is shutdown
+    assert MaintenanceWorkerSettings.on_shutdown is shutdown
 
 
 def test_lifecycle_eval_dispatcher_runs_hourly() -> None:
     """The dispatcher cron fires at minute 0 of every hour."""
-    cron_jobs = list(getattr(LifecycleEvalWorkerSettings, "cron_jobs", []))
+    cron_jobs = list(getattr(MaintenanceWorkerSettings, "cron_jobs", []))
     dispatcher_crons = [
         job
         for job in cron_jobs
@@ -119,7 +117,7 @@ def test_lifecycle_eval_dispatcher_runs_hourly() -> None:
 
 
 def test_lifecycle_reaper_registered_as_function() -> None:
-    """The reaper is registered as a plain coroutine on the lifecycle pool.
+    """The reaper is registered as a plain coroutine on the maintenance pool.
 
     Unlike the dispatcher and per-org worker, the reaper is not wrapped
     in :func:`arq.func` — it is a cron-only backstop with no per-job
@@ -132,7 +130,7 @@ def test_lifecycle_reaper_registered_as_function() -> None:
     """
     underlying = {
         _underlying(entry.coroutine if isinstance(entry, Function) else entry)
-        for entry in LifecycleEvalWorkerSettings.functions
+        for entry in MaintenanceWorkerSettings.functions
     }
     assert lifecycle_reaper in underlying
 
@@ -144,11 +142,11 @@ def test_lifecycle_reaper_runs_every_thirty_minutes() -> None:
     ``lifecycle_reaper_threshold_seconds`` see prompt finalisation,
     infrequent enough that production with the 6 h default rarely
     sees no-work-to-do log spam. The ``lifecycle_reaper`` keeps the
-    canonical ``{0, 30}`` slot; the other reapers on the lifecycle
+    canonical ``{0, 30}`` slot; the other reapers on the maintenance
     pool are staggered off it so a horizontally scaled pool never
     fires two reapers on the same minute.
     """
-    cron_jobs = list(getattr(LifecycleEvalWorkerSettings, "cron_jobs", []))
+    cron_jobs = list(getattr(MaintenanceWorkerSettings, "cron_jobs", []))
     reaper_crons = [
         job
         for job in cron_jobs
@@ -160,16 +158,16 @@ def test_lifecycle_reaper_runs_every_thirty_minutes() -> None:
 
 
 def test_dashboard_build_reaper_registered_as_function() -> None:
-    """``dashboard_build_reaper`` is registered on the lifecycle pool.
+    """``dashboard_build_reaper`` is registered on the maintenance pool.
 
     Per PRD #367 §"Pool placement" the four main-pool kind reapers
-    register on the existing :class:`LifecycleEvalWorkerSettings` arq
+    register on the existing :class:`MaintenanceWorkerSettings` arq
     pool so reaper sweeps never compete with build processing or
     user-triggered dashboard rebuilds for worker capacity.
     """
     underlying = {
         _underlying(entry.coroutine if isinstance(entry, Function) else entry)
-        for entry in LifecycleEvalWorkerSettings.functions
+        for entry in MaintenanceWorkerSettings.functions
     }
     assert dashboard_build_reaper in underlying
 
@@ -183,9 +181,9 @@ def test_dashboard_build_reaper_runs_every_fifteen_minutes() -> None:
     wall-clock recovery time stays under ~45 minutes from the moment
     a worker silently dies. The slots are offset off the canonical
     quarter-hours (``{3, 18, 33, 48}``) so this reaper never
-    co-fires with the lifecycle pool's other reapers.
+    co-fires with the maintenance pool's other reapers.
     """
-    cron_jobs = list(getattr(LifecycleEvalWorkerSettings, "cron_jobs", []))
+    cron_jobs = list(getattr(MaintenanceWorkerSettings, "cron_jobs", []))
     reaper_crons = [
         job
         for job in cron_jobs
@@ -199,7 +197,7 @@ def test_dashboard_build_reaper_runs_every_fifteen_minutes() -> None:
 def test_default_worker_does_not_register_dashboard_build_reaper() -> None:
     """The default queue stays free of the dashboard_build reaper.
 
-    The reaper lives exclusively on the lifecycle pool so cron-driven
+    The reaper lives exclusively on the maintenance pool so cron-driven
     maintenance work never contends with the operator-triggered
     ``dashboard_build`` job itself on the default pool.
     """
@@ -219,16 +217,16 @@ def test_default_worker_does_not_register_dashboard_build_reaper() -> None:
 
 
 def test_publish_edition_reaper_registered_as_function() -> None:
-    """``publish_edition_reaper`` is registered on the lifecycle pool.
+    """``publish_edition_reaper`` is registered on the maintenance pool.
 
     Per PRD #367 §"Pool placement" the four main-pool kind reapers
-    register on the existing :class:`LifecycleEvalWorkerSettings` arq
+    register on the existing :class:`MaintenanceWorkerSettings` arq
     pool so reaper sweeps never compete with build processing or
     user-triggered ``publish_edition`` jobs for worker capacity.
     """
     underlying = {
         _underlying(entry.coroutine if isinstance(entry, Function) else entry)
-        for entry in LifecycleEvalWorkerSettings.functions
+        for entry in MaintenanceWorkerSettings.functions
     }
     assert publish_edition_reaper in underlying
 
@@ -241,9 +239,9 @@ def test_publish_edition_reaper_runs_every_thirty_minutes() -> None:
     rather than the dashboard_build reaper's tighter 15-minute
     schedule. The slot is offset off the lifecycle reaper's
     ``{0, 30}`` so the two reapers never query ``queue_jobs`` at
-    the same instant on a horizontally scaled lifecycle pool.
+    the same instant on a horizontally scaled maintenance pool.
     """
-    cron_jobs = list(getattr(LifecycleEvalWorkerSettings, "cron_jobs", []))
+    cron_jobs = list(getattr(MaintenanceWorkerSettings, "cron_jobs", []))
     reaper_crons = [
         job
         for job in cron_jobs
@@ -257,7 +255,7 @@ def test_publish_edition_reaper_runs_every_thirty_minutes() -> None:
 def test_default_worker_does_not_register_publish_edition_reaper() -> None:
     """The default queue stays free of the publish_edition reaper.
 
-    The reaper lives exclusively on the lifecycle pool so cron-driven
+    The reaper lives exclusively on the maintenance pool so cron-driven
     maintenance work never contends with the operator-triggered
     ``publish_edition`` job itself on the default pool.
     """
@@ -277,16 +275,16 @@ def test_default_worker_does_not_register_publish_edition_reaper() -> None:
 
 
 def test_build_processing_reaper_registered_as_function() -> None:
-    """``build_processing_reaper`` is registered on the lifecycle pool.
+    """``build_processing_reaper`` is registered on the maintenance pool.
 
     Per PRD #367 §"Pool placement" the four main-pool kind reapers
-    register on the existing :class:`LifecycleEvalWorkerSettings` arq
+    register on the existing :class:`MaintenanceWorkerSettings` arq
     pool so reaper sweeps never compete with build processing or
     user-triggered ``build_processing`` jobs for worker capacity.
     """
     underlying = {
         _underlying(entry.coroutine if isinstance(entry, Function) else entry)
-        for entry in LifecycleEvalWorkerSettings.functions
+        for entry in MaintenanceWorkerSettings.functions
     }
     assert build_processing_reaper in underlying
 
@@ -299,11 +297,11 @@ def test_build_processing_reaper_runs_every_thirty_minutes() -> None:
     rather than the dashboard_build reaper's tighter 15-minute
     schedule. The slot is offset off the lifecycle reaper's
     ``{0, 30}`` so the two reapers never query ``queue_jobs`` at
-    the same instant on a horizontally scaled lifecycle pool. The
+    the same instant on a horizontally scaled maintenance pool. The
     8-hour threshold is what keeps real multi-hour uploads safe
     from false reaping — cadence is independent of threshold.
     """
-    cron_jobs = list(getattr(LifecycleEvalWorkerSettings, "cron_jobs", []))
+    cron_jobs = list(getattr(MaintenanceWorkerSettings, "cron_jobs", []))
     reaper_crons = [
         job
         for job in cron_jobs
@@ -317,7 +315,7 @@ def test_build_processing_reaper_runs_every_thirty_minutes() -> None:
 def test_default_worker_does_not_register_build_processing_reaper() -> None:
     """The default queue stays free of the build_processing reaper.
 
-    The reaper lives exclusively on the lifecycle pool so cron-driven
+    The reaper lives exclusively on the maintenance pool so cron-driven
     maintenance work never contends with the operator-triggered
     ``build_processing`` job itself on the default pool.
     """
@@ -337,16 +335,16 @@ def test_default_worker_does_not_register_build_processing_reaper() -> None:
 
 
 def test_dashboard_sync_reaper_registered_as_function() -> None:
-    """``dashboard_sync_reaper`` is registered on the lifecycle pool.
+    """``dashboard_sync_reaper`` is registered on the maintenance pool.
 
     Per PRD #367 §"Pool placement" the four main-pool kind reapers
-    register on the existing :class:`LifecycleEvalWorkerSettings` arq
+    register on the existing :class:`MaintenanceWorkerSettings` arq
     pool so reaper sweeps never compete with build processing or
     user-triggered ``dashboard_sync`` jobs for worker capacity.
     """
     underlying = {
         _underlying(entry.coroutine if isinstance(entry, Function) else entry)
-        for entry in LifecycleEvalWorkerSettings.functions
+        for entry in MaintenanceWorkerSettings.functions
     }
     assert dashboard_sync_reaper in underlying
 
@@ -359,11 +357,11 @@ def test_dashboard_sync_reaper_runs_every_thirty_minutes() -> None:
     rather than the dashboard_build reaper's tighter 15-minute
     schedule. The slot is offset off the lifecycle reaper's
     ``{0, 30}`` so the two reapers never query ``queue_jobs`` at
-    the same instant on a horizontally scaled lifecycle pool. The
+    the same instant on a horizontally scaled maintenance pool. The
     6-hour threshold is what gives an operator-triggered GitHub
     fetch + fanout room — cadence is independent of threshold.
     """
-    cron_jobs = list(getattr(LifecycleEvalWorkerSettings, "cron_jobs", []))
+    cron_jobs = list(getattr(MaintenanceWorkerSettings, "cron_jobs", []))
     reaper_crons = [
         job
         for job in cron_jobs
@@ -374,11 +372,11 @@ def test_dashboard_sync_reaper_runs_every_thirty_minutes() -> None:
     assert reaper_crons[0].minute == {24, 54}
 
 
-def test_lifecycle_pool_reaper_crons_are_staggered() -> None:
-    """No two reapers on the lifecycle pool share a firing minute.
+def test_maintenance_pool_reaper_crons_are_staggered() -> None:
+    """No two reapers on the maintenance pool share a firing minute.
 
-    Today's single-worker lifecycle pool runs cron jobs sequentially,
-    so co-fires are harmless. The lifecycle pool is explicitly
+    Today's single-worker maintenance pool runs cron jobs sequentially,
+    so co-fires are harmless. The maintenance pool is explicitly
     designed to scale horizontally, however, and on a multi-worker
     pool every reaper that fires on the same minute would race for
     the same Postgres connection-pool slots and ``queue_jobs`` heap
@@ -396,7 +394,7 @@ def test_lifecycle_pool_reaper_crons_are_staggered() -> None:
         dashboard_sync_reaper,
         dashboard_build_reaper,
     }
-    cron_jobs = list(getattr(LifecycleEvalWorkerSettings, "cron_jobs", []))
+    cron_jobs = list(getattr(MaintenanceWorkerSettings, "cron_jobs", []))
     seen: dict[int, str] = {}
     for job in cron_jobs:
         if not isinstance(job, CronJob):
@@ -405,7 +403,7 @@ def test_lifecycle_pool_reaper_crons_are_staggered() -> None:
         if coro not in reaper_coros:
             continue
         # ``CronJob.minute`` is typed ``set[int] | int`` (arq accepts
-        # either form); every lifecycle-pool reaper uses the set form,
+        # either form); every maintenance-pool reaper uses the set form,
         # but normalise here so the invariant test does not have to
         # care about that shape.
         raw = job.minute
@@ -415,7 +413,7 @@ def test_lifecycle_pool_reaper_crons_are_staggered() -> None:
         for minute in minutes:
             assert minute not in seen, (
                 f"minute {minute} is shared by {seen[minute]!r} and "
-                f"{coro.__name__!r} — reaper crons on the lifecycle "
+                f"{coro.__name__!r} — reaper crons on the maintenance "
                 "pool must be staggered"
             )
             seen[minute] = coro.__name__
@@ -424,7 +422,7 @@ def test_lifecycle_pool_reaper_crons_are_staggered() -> None:
 def test_default_worker_does_not_register_dashboard_sync_reaper() -> None:
     """The default queue stays free of the dashboard_sync reaper.
 
-    The reaper lives exclusively on the lifecycle pool so cron-driven
+    The reaper lives exclusively on the maintenance pool so cron-driven
     maintenance work never contends with the operator-triggered
     ``dashboard_sync`` job itself on the default pool.
     """

--- a/tests/worker/sentry_arq_test.py
+++ b/tests/worker/sentry_arq_test.py
@@ -38,8 +38,9 @@ from safir.testing.sentry import (
 from docverse.sentry import initialize_sentry, instrument_arq_task
 from docverse.worker.main import (
     KeeperSyncWorkerSettings,
-    LifecycleEvalWorkerSettings,
+    MaintenanceWorkerSettings,
     WorkerSettings,
+    startup_maintenance,
 )
 
 
@@ -94,7 +95,7 @@ def test_instrument_arq_task_keeps_arq_func_registration_name() -> None:
     Direct end-to-end check that the ``functools.wraps`` contract above
     survives :func:`arq.func`'s ``coroutine.__qualname__`` fallback,
     which is the actual registration path used by the production
-    :class:`KeeperSyncWorkerSettings` / :class:`LifecycleEvalWorkerSettings`
+    :class:`KeeperSyncWorkerSettings` / :class:`MaintenanceWorkerSettings`
     classes.
     """
     registered = func(instrument_arq_task(_example_task))
@@ -178,7 +179,7 @@ def test_worker_settings_registers_tasks_under_original_names() -> None:
     Backstop against a future regression where someone adds a task or
     cron job to :class:`WorkerSettings`,
     :class:`KeeperSyncWorkerSettings`, or
-    :class:`LifecycleEvalWorkerSettings` and forgets to wrap it with
+    :class:`MaintenanceWorkerSettings` and forgets to wrap it with
     :func:`instrument_arq_task` (which would leave it producing
     ``transaction: "unknown arq task"`` alerts) -- or wraps it with
     something that breaks :func:`functools.wraps` and silently renames
@@ -193,7 +194,7 @@ def test_worker_settings_registers_tasks_under_original_names() -> None:
     settings_classes = (
         WorkerSettings,
         KeeperSyncWorkerSettings,
-        LifecycleEvalWorkerSettings,
+        MaintenanceWorkerSettings,
     )
     for settings in settings_classes:
         # ``functions`` may hold raw coroutines or ``arq.Function``
@@ -222,3 +223,28 @@ def test_worker_settings_registers_tasks_under_original_names() -> None:
                 f"{settings.__name__}: task {entry.name!r} is not wrapped"
                 " with instrument_arq_task"
             )
+
+
+@pytest.mark.asyncio
+async def test_startup_maintenance_uses_worker_maintenance_component(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The maintenance startup tags Sentry events with ``worker-maintenance``.
+
+    ``MaintenanceWorkerSettings.on_startup`` funnels through the shared
+    ``_startup`` body (DB / Redis init) that every pool reuses; the only
+    intentional divergence is the Sentry ``component`` tag that lets the
+    maintenance pool's events be filtered apart from the default and
+    keeper-sync pools. Rather than stand up the full worker environment,
+    patch ``_startup`` and assert the maintenance wrapper forwards
+    ``component="worker-maintenance"`` — the one value that
+    distinguishes this pool.
+    """
+    captured: dict[str, Any] = {}
+
+    async def fake_startup(ctx: dict[str, Any], *, component: str) -> None:
+        captured["component"] = component
+
+    monkeypatch.setattr("docverse.worker.main._startup", fake_startup)
+    await startup_maintenance({})
+    assert captured["component"] == "worker-maintenance"

--- a/tests/worker/sentry_arq_test.py
+++ b/tests/worker/sentry_arq_test.py
@@ -42,6 +42,7 @@ from docverse.worker.main import (
     WorkerSettings,
     startup_maintenance,
 )
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
 
 
 def _patch_sentry_init_with_test_transport(
@@ -242,9 +243,13 @@ async def test_startup_maintenance_uses_worker_maintenance_component(
     """
     captured: dict[str, Any] = {}
 
-    async def fake_startup(ctx: dict[str, Any], *, component: str) -> None:
+    async def fake_startup(
+        ctx: dict[str, Any], *, component: str, queue_name: str
+    ) -> None:
         captured["component"] = component
+        captured["queue_name"] = queue_name
 
     monkeypatch.setattr("docverse.worker.main._startup", fake_startup)
     await startup_maintenance({})
     assert captured["component"] == "worker-maintenance"
+    assert captured["queue_name"] == MAINTENANCE_QUEUE_NAME


### PR DESCRIPTION
## Summary

- Rename the dedicated arq worker pool's wrapper surfaces from *lifecycle-eval* to *maintenance*, reflecting that the pool is a catch-all for non-publishing periodic work (lifecycle evaluation, the git-ref audit, and the cross-subsystem reaper backstops) rather than lifecycle evaluation alone.
- Add a neutral `docverse.worker.queues.MAINTENANCE_QUEUE_NAME = "docverse:maintenance-queue"` and bind it on the renamed `MaintenanceWorkerSettings`; rename the pool-wide timeout setting to `maintenance_job_timeout_seconds`, the startup hook to `startup_maintenance`, and the Sentry component to `worker-maintenance`.
- Move the opportunistic `project_github_resolve` job off the default publishing queue onto the maintenance pool, so its installation-id resolution no longer contends with the live publishing flow: the enqueue now targets `docverse:maintenance-queue` and the job is registered on `MaintenanceWorkerSettings` rather than the default `WorkerSettings`.
- The lifecycle-evaluation **domain** (the `lifecycle_eval` job kind / functions, the `lifecycle_eval_runs` table, `lifecycle_reaper`, and `lifecycle_reaper_threshold_seconds`) keeps its names, so no Alembic migration is generated.

## Validation steps

- Launch `arq docverse.worker.main.MaintenanceWorkerSettings` and confirm it boots and binds the `docverse:maintenance-queue` queue (`MaintenanceWorkerSettings.queue_name == "docverse:maintenance-queue"`).
- `git grep` for `LifecycleEvalWorkerSettings` and `LIFECYCLE_EVAL_QUEUE_NAME` and confirm the symbols no longer exist anywhere in the tree.
- Confirm `lifecycle_eval_dispatcher` and `git_ref_audit_discovery` enqueue their fan-out jobs onto `docverse:maintenance-queue`.
- Confirm `project_github_resolve` is registered on `MaintenanceWorkerSettings.functions` and absent from `WorkerSettings.functions`.
- Create or update a project with a GitHub binding and confirm the resolve enqueues onto `docverse:maintenance-queue` rather than the default publishing queue.
- Confirm the maintenance worker reports to Sentry under component `worker-maintenance`.
- Confirm the pool-wide timeout is sourced from `maintenance_job_timeout_seconds`, and `lifecycle_reaper_threshold_seconds` plus the four other `*_reaper_threshold_seconds` keys are unchanged.
- Confirm `lifecycle_reaper`, `JobKind.lifecycle_eval`, the `lifecycle_eval_runs` table, and the lifecycle services are unchanged — no Alembic migration is generated.
- **[DEPLOY GATE]** The companion Phalanx worker Deployment must point at `docverse.worker.main.MaintenanceWorkerSettings` (and rename the timeout env override to `maintenance_job_timeout_seconds` if set) and deploy in lock-step, or the worker fails to launch on the renamed class path.

## References

- Closes #420
- Closes #421
- PRD: #419
- Jira: https://rubinobs.atlassian.net/browse/DM-55161