### PR TITLE
DM-55200: Add Sasquatch metrics foundation and core events

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,26 @@ make lint    # Run linters
 make typing  # Run type checking
 make run     # Start the development server on port 8080
 ```
+
+## Application metrics
+
+Docverse publishes Sasquatch application metrics (SQR-112) through a Safir
+`EventManager`. The metrics configuration is selected from the environment
+by `metrics_configuration_factory`:
+
+- `METRICS_APPLICATION` — application name reported on every event
+  (`docverse`).
+- `METRICS_ENABLED` / `METRICS_MOCK` — select the manager variant. In
+  production set `METRICS_ENABLED=true`. In tests set `METRICS_MOCK=true`
+  with `METRICS_ENABLED=false` to use an in-memory mock manager (this is
+  what the nox `test` session sets). With neither mock nor disabled
+  selected, the Kafka-backed manager is used.
+- `KAFKA_*` — Kafka connection settings (bootstrap servers, security
+  protocol, and any TLS material) used when metrics are enabled.
+- `SCHEMA_MANAGER_*` — the Confluent-compatible schema-registry URL used to
+  register and evolve the event Avro schemas.
+
+Events publish to the `lsst.square.metrics.events.docverse` topic. The
+`phalanx-docverse` deployment is responsible for supplying the `KAFKA_*` /
+`SCHEMA_MANAGER_*` values and for registering that topic in Sasquatch;
+that work is tracked separately from this repository.

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,6 +58,12 @@ def test(session: nox.Session) -> None:
                 "REPERTOIRE_BASE_URL": (
                     "https://roundtable.lsst.cloud/repertoire"
                 ),
+                # Resolve Configuration.metrics to a MockEventManager so
+                # the app/workers start without Kafka and tests can assert
+                # on published events.
+                "METRICS_APPLICATION": "docverse",
+                "METRICS_ENABLED": "false",
+                "METRICS_MOCK": "true",
             },
         )
 
@@ -153,6 +159,12 @@ def create_migration(session: nox.Session) -> None:
             "REPERTOIRE_BASE_URL": (
                 "https://roundtable.lsst.cloud/repertoire"
             ),
+            # ``alembic/env.py`` imports ``docverse.config``, whose
+            # ``metrics`` field resolves from these vars; the mock
+            # manager keeps migration autogeneration Kafka-free.
+            "METRICS_APPLICATION": "docverse",
+            "METRICS_ENABLED": "false",
+            "METRICS_MOCK": "true",
         }
         session.run("alembic", "upgrade", "head", env=env)
         session.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "base32-lib",
     "rubin-gafaelfawr",
     "rubin-repertoire",
-    "safir[db,arq]>=13",
+    "safir[db,arq,kafka]>=13",
     "uvicorn[standard]>=0.34",
 ]
 

--- a/server-changelog.d/20260609_120000_DM_55200.md
+++ b/server-changelog.d/20260609_120000_DM_55200.md
@@ -1,0 +1,7 @@
+### New features
+
+- Added the foundation for Sasquatch application metrics (SQR-112) and the high-signal core events. A new `docverse.metrics` package defines scalar-only `EventPayload` models, dedicated metrics enums, a single `DocverseEvents(EventMaker)` registry, and a `build_event_manager(config)` helper that the FastAPI lifespan and every arq worker `on_startup` use to stand up a Safir `EventManager`. The app threads `DocverseEvents` to handlers via `RequestContext.events` and to workers via `ctx["events"]`. Three events now publish: `build_uploaded` (the `PATCH …/builds/{build}` upload-complete handler, with uploader + build-annotation provenance), `build_processed` (the `build_processing` worker terminal, with success/object/size/edition counts, stale-skip flag, and elapsed), and `edition_published` (the `publish_edition` worker success terminal, with edition kind, trigger, and elapsed). Handlers and workers publish after their transaction commits and run best-effort (`raise_on_error=False`), so a metrics-backend outage never fails a request, build, or job.
+
+### Other changes
+
+- `Configuration` gained a `metrics` field, selected from the environment by Safir's `metrics_configuration_factory`. Deployments must supply the `METRICS_*` / `KAFKA_*` / `SCHEMA_MANAGER_*` settings (see the README "Application metrics" section), and the `phalanx-docverse` deployment must register the `lsst.square.metrics.events.docverse` topic in Sasquatch (tracked separately).

--- a/src/docverse/config.py
+++ b/src/docverse/config.py
@@ -327,6 +327,36 @@ class Configuration(BaseSettings):
         ),
     )
 
+    inventory_census_cron_hour: int = Field(
+        4,
+        title="UTC hour for the daily resource_inventory census cron",
+        description=(
+            "Hour (UTC) at which the daily ``inventory_census`` job runs"
+            " on the maintenance pool, publishing the SQR-112"
+            " ``resource_inventory`` gauge. Paired with"
+            " ``inventory_census_cron_minute``; the 04:47 default sits"
+            " in the quiet pre-dawn UTC window, ahead of the daily"
+            " ``git_ref_audit`` tick at 05:17, and its minute is"
+            " staggered off every maintenance-pool reaper slot so the"
+            " census never co-fires with them. Config-driven so an"
+            " operator can move the census without a code change."
+        ),
+    )
+
+    inventory_census_cron_minute: int = Field(
+        47,
+        title="UTC minute for the daily resource_inventory census cron",
+        description=(
+            "Minute of ``inventory_census_cron_hour`` (UTC) at which the"
+            " daily ``inventory_census`` job runs. The default 47 is"
+            " staggered off every maintenance-pool reaper minute slot"
+            " (``{0,30}`` / ``{3,18,33,48}`` / ``{6,36}`` / ``{12,42}``"
+            " / ``{24,54}``) and the five-minute ``arq_queue_stats``"
+            " cadence so a horizontally scaled maintenance pool never"
+            " fires the census on the same minute as another cron."
+        ),
+    )
+
     superadmin_usernames: Annotated[
         list[str], BeforeValidator(_parse_comma_separated)
     ] = Field(

--- a/src/docverse/config.py
+++ b/src/docverse/config.py
@@ -10,6 +10,7 @@ from pydantic import BeforeValidator, Field, HttpUrl, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.arq import ArqMode, build_arq_redis_settings
 from safir.logging import LogLevel, Profile
+from safir.metrics import MetricsConfiguration, metrics_configuration_factory
 from safir.pydantic import EnvRedisDsn
 
 __all__ = ["Configuration", "config"]
@@ -45,6 +46,30 @@ class Configuration(BaseSettings):
         None,
         title="Slack webhook for alerts",
         description="If set, alerts will be posted to this Slack webhook",
+    )
+
+    metrics: MetricsConfiguration = Field(
+        default_factory=metrics_configuration_factory,
+        title="Sasquatch application-metrics configuration",
+        description=(
+            "Configures Safir's ``EventManager`` for the Docverse"
+            " application-metrics pipeline (SQR-112). The concrete"
+            " variant is selected from the environment by"
+            " ``metrics_configuration_factory``:\n\n"
+            "- ``METRICS_APPLICATION`` (e.g. ``docverse``),"
+            " ``METRICS_ENABLED``, and ``METRICS_MOCK`` choose between"
+            " the mock, disabled, and Kafka-backed managers. Set"
+            " ``METRICS_MOCK=true`` (with ``METRICS_ENABLED=false``) for"
+            " tests; set ``METRICS_ENABLED=true`` in production.\n"
+            "- When enabled, ``KAFKA_*`` (bootstrap servers, security"
+            " protocol, and any TLS material) and ``SCHEMA_MANAGER_*``"
+            " (the Confluent-compatible schema-registry URL) connect the"
+            " manager to Sasquatch.\n\n"
+            "Events publish to the ``lsst.square.metrics.events.docverse``"
+            " topic, which the ``phalanx-docverse`` deployment must"
+            " register in Sasquatch (tracked separately from this"
+            " application)."
+        ),
     )
 
     github_app_id: int | None = Field(

--- a/src/docverse/dependencies/context.py
+++ b/src/docverse/dependencies/context.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from structlog.stdlib import BoundLogger
 
 from ..factory import HandlerFactory
+from ..metrics.events import DocverseEvents
 from ..services.credential_encryptor import CredentialEncryptor
 from ..storage.user_info_store import StubUserInfoStore, UserInfoStore
 
@@ -58,6 +59,13 @@ class RequestContext:
     factory: HandlerFactory
     """The component factory."""
 
+    events: DocverseEvents
+    """The Sasquatch metrics event publishers.
+
+    Handlers publish application metrics through this after committing
+    their transaction (e.g. ``context.events.build_uploaded.publish(...)``).
+    """
+
     def rebind_logger(self, **values: Any) -> None:
         """Add the given values to the logging context.
 
@@ -91,6 +99,7 @@ class ContextDependency:
         self._github_webhook_secret: SecretStr | None = None
         self._github_app_validated: bool = True
         self._github_app_html_url: str | None = None
+        self._events: DocverseEvents | None = None
 
     @property
     def github_app_enabled(self) -> bool:
@@ -128,11 +137,15 @@ class ContextDependency:
         if not self._initialized:
             msg = "ContextDependency not initialized"
             raise RuntimeError(msg)
+        if self._events is None:
+            msg = "ContextDependency events not initialized"
+            raise RuntimeError(msg)
         return RequestContext(
             request=request,
             response=response,
             logger=logger,
             session=session,
+            events=self._events,
             factory=HandlerFactory(
                 session=session,
                 logger=logger,
@@ -151,7 +164,7 @@ class ContextDependency:
             ),
         )
 
-    async def initialize(  # noqa: PLR0913
+    async def initialize(  # noqa: C901, PLR0913
         self,
         user_info_store: UserInfoStore | None = None,
         credential_encryptor: CredentialEncryptor | None = None,
@@ -162,9 +175,12 @@ class ContextDependency:
         github_app_id: int | None = None,
         github_app_private_key: SecretStr | None = None,
         github_webhook_secret: SecretStr | None = None,
+        events: DocverseEvents | None = None,
     ) -> None:
         """Initialize the process-wide shared context."""
         self._initialized = True
+        if events is not None:
+            self._events = events
         if user_info_store is not None:
             self._user_info_store = user_info_store
         if credential_encryptor is not None:

--- a/src/docverse/domain/inventory_census.py
+++ b/src/docverse/domain/inventory_census.py
@@ -1,0 +1,89 @@
+"""Domain models for the daily resource-inventory census (SQR-112).
+
+The census is a read-only snapshot of every organization's and
+non-deleted project's active resource counts, taken once a day by the
+``inventory_census`` worker and published as the ``resource_inventory``
+Sasquatch gauge. The models are deliberately flat scalar counters so the
+worker can map each row straight onto an event payload.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "InventoryCensus",
+    "OrgInventoryCensus",
+    "ProjectInventoryCensus",
+]
+
+
+class ProjectInventoryCensus(BaseModel):
+    """Active-resource counts for one non-deleted project.
+
+    Soft-deleted editions and builds are excluded from the counts, and a
+    project only produces one of these rows when it is itself
+    non-deleted, so a soft-deleted project's editions and builds never
+    appear anywhere in the census.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    org_id: int = Field(description="ID of the owning organization.")
+    org_slug: str = Field(description="Slug of the owning organization.")
+    project_id: int = Field(description="ID of the project.")
+    project_slug: str = Field(description="Slug of the project.")
+    edition_count: int = Field(
+        description="Number of non-deleted editions in the project."
+    )
+    build_count: int = Field(
+        description="Number of non-deleted builds in the project."
+    )
+    total_build_bytes: int = Field(
+        description=(
+            "Summed ``total_size_bytes`` of the project's non-deleted"
+            " builds; 0 when there are none or every size is unset."
+        )
+    )
+
+
+class OrgInventoryCensus(BaseModel):
+    """Active-resource counts for one organization.
+
+    Every organization yields exactly one of these rows, even one with no
+    projects (``project_count == 0``). The edition/build counts and byte
+    sum are the roll-up of the org's non-deleted projects.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    org_id: int = Field(description="ID of the organization.")
+    org_slug: str = Field(description="Slug of the organization.")
+    project_count: int = Field(
+        description="Number of non-deleted projects in the organization."
+    )
+    edition_count: int = Field(
+        description="Number of non-deleted editions across the org's projects."
+    )
+    build_count: int = Field(
+        description="Number of non-deleted builds across the org's projects."
+    )
+    total_build_bytes: int = Field(
+        description=(
+            "Summed ``total_size_bytes`` of every non-deleted build"
+            " across the org's projects."
+        )
+    )
+
+
+class InventoryCensus(BaseModel):
+    """A full census snapshot: one org row per org, one per live project."""
+
+    model_config = ConfigDict(frozen=True)
+
+    orgs: list[OrgInventoryCensus] = Field(
+        description="One census row per organization."
+    )
+    projects: list[ProjectInventoryCensus] = Field(
+        description="One census row per non-deleted project."
+    )

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -37,6 +37,7 @@ from .services.edition_tracking import (
     EditionTrackingService,
 )
 from .services.infrastructure import InfrastructureService
+from .services.inventory_census import InventoryCensusService
 from .services.keeper_sync import (
     BuildContentCopier,
     CopyResult,
@@ -69,6 +70,7 @@ from .storage.github import (
     GitHubAppNotConfiguredError,
     GitHubRefSetFetcher,
 )
+from .storage.inventory_census_store import InventoryCensusStore
 from .storage.keeper_sync import KeeperSyncStateStore
 from .storage.keeper_sync_run_store import KeeperSyncRunStore
 from .storage.lifecycle_eval_run_store import LifecycleEvalRunStore
@@ -202,6 +204,17 @@ class Factory:
     def create_git_ref_audit_run_store(self) -> GitRefAuditRunStore:
         """Create a :class:`GitRefAuditRunStore`."""
         return GitRefAuditRunStore(session=self._session, logger=self._logger)
+
+    def create_inventory_census_store(self) -> InventoryCensusStore:
+        """Create an :class:`InventoryCensusStore`."""
+        return InventoryCensusStore(session=self._session, logger=self._logger)
+
+    def create_inventory_census_service(self) -> InventoryCensusService:
+        """Create an :class:`InventoryCensusService`."""
+        return InventoryCensusService(
+            store=self.create_inventory_census_store(),
+            logger=self._logger,
+        )
 
     def create_github_ref_set_fetcher(self) -> GitHubRefSetFetcher:
         """Create a :class:`GitHubRefSetFetcher`.

--- a/src/docverse/handlers/orgs/builds.py
+++ b/src/docverse/handlers/orgs/builds.py
@@ -21,6 +21,7 @@ from docverse.handlers.params import (
     OrgSlugParam,
     ProjectSlugParam,
 )
+from docverse.metrics import BuildUploadedEvent
 from docverse.storage.pagination import (
     BUILD_CURSOR_TYPE,
     DEFAULT_PAGE_LIMIT,
@@ -175,6 +176,7 @@ async def patch_build(  # noqa: PLR0913
     user: Annotated[AuthenticatedUser, Depends(require_uploader)],  # noqa: ARG001
 ) -> Build:
     queue_url: str | None = None
+    upload_completed = False
     async with context.session.begin():
         service = context.factory.create_build_service()
 
@@ -190,6 +192,7 @@ async def patch_build(  # noqa: PLR0913
                     job=serialize_base32_id(queue_job.public_id),
                 )
             )
+            upload_completed = True
         else:
             # No-op update: just fetch the build
             build = await service.get_by_public_id(
@@ -199,6 +202,29 @@ async def patch_build(  # noqa: PLR0913
             )
 
         await context.session.commit()
+
+    # Emit the build_uploaded metric only for a real upload-complete
+    # transition, and only after the commit so the event reflects durably
+    # persisted state. Production runs raise_on_error=False, so a metrics
+    # backend outage cannot fail this request (no defensive try/except).
+    if upload_completed:
+        annotations = build.annotations
+        await context.events.build_uploaded.publish(
+            BuildUploadedEvent(
+                organization=org_slug,
+                project=project_slug,
+                uploader=build.uploader,
+                commit_sha=annotations.commit_sha if annotations else None,
+                github_repository=(
+                    annotations.github_repository if annotations else None
+                ),
+                github_run_id=(
+                    annotations.github_run_id if annotations else None
+                ),
+                github_actor=annotations.github_actor if annotations else None,
+                ci_platform=annotations.ci_platform if annotations else None,
+            )
+        )
 
     return Build.from_domain(
         build,

--- a/src/docverse/handlers/orgs/editions.py
+++ b/src/docverse/handlers/orgs/editions.py
@@ -28,6 +28,11 @@ from docverse.handlers.params import (
     OrgSlugParam,
     ProjectSlugParam,
 )
+from docverse.metrics import (
+    EditionLifecycleEvent,
+    LifecycleAction,
+    MetricsEditionKind,
+)
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_slug,
 )
@@ -131,6 +136,17 @@ async def post_edition(
             org_slug=org_slug, project_slug=project_slug, data=data
         )
         await context.session.commit()
+    # Emit after the commit so the event reflects durably persisted state.
+    # Production runs raise_on_error=False, so a metrics-backend outage
+    # cannot fail this request (no defensive try/except).
+    await context.events.edition_lifecycle.publish(
+        EditionLifecycleEvent(
+            organization=org_slug,
+            project=project_slug,
+            action=LifecycleAction.create,
+            edition_kind=MetricsEditionKind.from_api(edition.kind),
+        )
+    )
     await try_enqueue_dashboard_build_by_slug(
         factory=context.factory,
         session=context.session,
@@ -265,6 +281,15 @@ async def post_edition_rollback(  # noqa: PLR0913
             build_public_id=data.build,
         )
         await context.session.commit()
+    # Publish after the commit (best-effort; raise_on_error=False).
+    await context.events.edition_lifecycle.publish(
+        EditionLifecycleEvent(
+            organization=org_slug,
+            project=project_slug,
+            action=LifecycleAction.rollback,
+            edition_kind=MetricsEditionKind.from_api(edition.kind),
+        )
+    )
     await try_enqueue_dashboard_build_by_slug(
         factory=context.factory,
         session=context.session,
@@ -308,6 +333,15 @@ async def patch_edition(  # noqa: PLR0913
             data=data,
         )
         await context.session.commit()
+    # Publish after the commit (best-effort; raise_on_error=False).
+    await context.events.edition_lifecycle.publish(
+        EditionLifecycleEvent(
+            organization=org_slug,
+            project=project_slug,
+            action=LifecycleAction.update,
+            edition_kind=MetricsEditionKind.from_api(edition.kind),
+        )
+    )
     await try_enqueue_dashboard_build_by_slug(
         factory=context.factory,
         session=context.session,
@@ -408,4 +442,16 @@ async def delete_edition(
         logger=context.logger,
         org_slug=org_slug,
         project_slug=project_slug,
+    )
+    # Delete is multi-transaction (soft-delete commit + CDN unpublish);
+    # publish only after that final step succeeds, so the event signals a
+    # fully-completed delete (best-effort, raise_on_error=False). The
+    # ``edition`` domain object was read above and stays usable here.
+    await context.events.edition_lifecycle.publish(
+        EditionLifecycleEvent(
+            organization=org_slug,
+            project=project_slug,
+            action=LifecycleAction.delete,
+            edition_kind=MetricsEditionKind.from_api(edition.kind),
+        )
     )

--- a/src/docverse/handlers/orgs/members.py
+++ b/src/docverse/handlers/orgs/members.py
@@ -11,6 +11,12 @@ from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.exceptions import ConflictError, NotFoundError
 from docverse.handlers.params import MemberIdParam, OrgSlugParam
+from docverse.metrics import (
+    MembershipChangeAction,
+    MembershipChangedEvent,
+    MetricsOrgRole,
+    MetricsPrincipalType,
+)
 
 from .models import OrgMembership
 
@@ -82,6 +88,23 @@ async def post_member(
             raise ConflictError(msg)
         member = await store.create(org_id=user.org.id, data=data)
         await context.session.commit()
+    # Publish after the commit so the event reflects durably persisted
+    # state. Production runs raise_on_error=False, so a metrics-backend
+    # outage cannot fail this request (no defensive try/except). Mapped
+    # from the API enums at the emission site (SQR-112 D4); membership is
+    # org-scoped, so project is None.
+    await context.events.membership_changed.publish(
+        MembershipChangedEvent(
+            organization=org_slug,
+            project=None,
+            action=MembershipChangeAction.add,
+            role=MetricsOrgRole.from_api(member.role),
+            principal_type=MetricsPrincipalType.from_api(
+                member.principal_type
+            ),
+            principal=member.principal,
+        )
+    )
     return OrgMembership.from_domain(member, context.request, org_slug)
 
 
@@ -118,7 +141,7 @@ async def get_member(
     name="delete_member",
 )
 async def delete_member(
-    org_slug: OrgSlugParam,  # noqa: ARG001
+    org_slug: OrgSlugParam,
     member_id: MemberIdParam,
     context: Annotated[RequestContext, Depends(context_dependency)],
     user: Annotated[AuthenticatedUser, Depends(require_admin)],
@@ -126,12 +149,34 @@ async def delete_member(
     principal_type, principal = _parse_member_id(member_id)
     async with context.session.begin():
         store = context.factory.create_membership_store()
-        deleted = await store.delete(
+        # Capture the membership before deleting it so the removal event
+        # can carry the gone principal's role and identity.
+        member = await store.get_by_principal(
             org_id=user.org.id,
             principal_type=principal_type,
             principal=principal,
         )
-        if not deleted:
+        if member is None:
             msg = f"Member {member_id!r} not found"
             raise NotFoundError(msg)
+        await store.delete(
+            org_id=user.org.id,
+            principal_type=principal_type,
+            principal=principal,
+        )
         await context.session.commit()
+    # Publish after the commit (best-effort; raise_on_error=False). Mapped
+    # from the API enums at the emission site; membership is org-scoped,
+    # so project is None.
+    await context.events.membership_changed.publish(
+        MembershipChangedEvent(
+            organization=org_slug,
+            project=None,
+            action=MembershipChangeAction.remove,
+            role=MetricsOrgRole.from_api(member.role),
+            principal_type=MetricsPrincipalType.from_api(
+                member.principal_type
+            ),
+            principal=member.principal,
+        )
+    )

--- a/src/docverse/handlers/orgs/projects.py
+++ b/src/docverse/handlers/orgs/projects.py
@@ -14,6 +14,7 @@ from docverse.dependencies.auth import (
 )
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.handlers.params import OrgSlugParam, ProjectSlugParam
+from docverse.metrics import LifecycleAction, ProjectLifecycleEvent
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_slug,
 )
@@ -133,6 +134,16 @@ async def post_project(
             org_slug=org_slug, data=data
         )
         await context.session.commit()
+    # Emit after the commit so the event reflects durably persisted state.
+    # Production runs raise_on_error=False, so a metrics-backend outage
+    # cannot fail this request (no defensive try/except).
+    await context.events.project_lifecycle.publish(
+        ProjectLifecycleEvent(
+            organization=org_slug,
+            project=project.slug,
+            action=LifecycleAction.create,
+        )
+    )
     await try_enqueue_project_github_resolve_by_id(
         factory=context.factory,
         session=context.session,
@@ -195,6 +206,14 @@ async def patch_project(
         )
         default_edition = await service.get_default_edition(project.id)
         await context.session.commit()
+    # Publish after the commit (best-effort; raise_on_error=False).
+    await context.events.project_lifecycle.publish(
+        ProjectLifecycleEvent(
+            organization=org_slug,
+            project=project.slug,
+            action=LifecycleAction.update,
+        )
+    )
     await try_enqueue_dashboard_build_by_slug(
         factory=context.factory,
         session=context.session,
@@ -277,3 +296,14 @@ async def delete_project(
                     project_slug=project_slug,
                     edition_slug=edition_slug,
                 )
+    # Delete is multi-transaction (soft-delete commit + per-edition CDN
+    # unpublish); publish only after that final step succeeds, so the
+    # event signals a fully-completed delete (best-effort,
+    # raise_on_error=False).
+    await context.events.project_lifecycle.publish(
+        ProjectLifecycleEvent(
+            organization=org_slug,
+            project=project_slug,
+            action=LifecycleAction.delete,
+        )
+    )

--- a/src/docverse/main.py
+++ b/src/docverse/main.py
@@ -27,6 +27,7 @@ from .handlers.internal import internal_router
 from .handlers.orgs import orgs_router
 from .handlers.queue import queue_router
 from .handlers.webhooks import webhook_router
+from .metrics import build_event_manager
 from .sentry import initialize_sentry
 from .services.credential_encryptor import CredentialEncryptor
 from .storage.github import validate_github_app
@@ -94,6 +95,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
         logger=logger,
     )
 
+    event_manager, events = await build_event_manager(config, logger=logger)
+
     await context_dependency.initialize(
         credential_encryptor=encryptor,
         superadmin_usernames=config.superadmin_usernames,
@@ -104,6 +107,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
         github_app_id=config.github_app_id,
         github_app_private_key=config.github_app_private_key,
         github_webhook_secret=config.github_webhook_secret,
+        events=events,
     )
     github_app_html_url = await validate_github_app(
         state=context_dependency,
@@ -116,6 +120,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
     context_dependency.set_github_app_html_url(github_app_html_url)
     yield
     await context_dependency.aclose()
+    await event_manager.aclose()
     await http_client_dependency.aclose()
     await db_session_dependency.aclose()
 

--- a/src/docverse/metrics/__init__.py
+++ b/src/docverse/metrics/__init__.py
@@ -25,6 +25,7 @@ from .payloads import (
     LifecycleActionEvent,
     MembershipChangedEvent,
     ProjectLifecycleEvent,
+    ResourceInventoryEvent,
 )
 
 __all__ = [
@@ -47,5 +48,6 @@ __all__ = [
     "MetricsOrgRole",
     "MetricsPrincipalType",
     "ProjectLifecycleEvent",
+    "ResourceInventoryEvent",
     "build_event_manager",
 ]

--- a/src/docverse/metrics/__init__.py
+++ b/src/docverse/metrics/__init__.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from .enums import EditionPublishTrigger, MetricsEditionKind
+from .enums import EditionPublishTrigger, LifecycleAction, MetricsEditionKind
 from .events import DocverseEvents
 from .manager import build_event_manager
 from .payloads import (
     BuildProcessedEvent,
     BuildUploadedEvent,
     DocverseEventBase,
+    EditionLifecycleEvent,
     EditionPublishedEvent,
+    ProjectLifecycleEvent,
 )
 
 __all__ = [
@@ -17,8 +19,11 @@ __all__ = [
     "BuildUploadedEvent",
     "DocverseEventBase",
     "DocverseEvents",
+    "EditionLifecycleEvent",
     "EditionPublishTrigger",
     "EditionPublishedEvent",
+    "LifecycleAction",
     "MetricsEditionKind",
+    "ProjectLifecycleEvent",
     "build_event_manager",
 ]

--- a/src/docverse/metrics/__init__.py
+++ b/src/docverse/metrics/__init__.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from .enums import EditionPublishTrigger, LifecycleAction, MetricsEditionKind
+from .enums import (
+    EditionPublishTrigger,
+    LifecycleAction,
+    MembershipChangeAction,
+    MetricsEditionKind,
+    MetricsOrgRole,
+    MetricsPrincipalType,
+)
 from .events import DocverseEvents
 from .manager import build_event_manager
 from .payloads import (
@@ -11,6 +18,7 @@ from .payloads import (
     DocverseEventBase,
     EditionLifecycleEvent,
     EditionPublishedEvent,
+    MembershipChangedEvent,
     ProjectLifecycleEvent,
 )
 
@@ -23,7 +31,11 @@ __all__ = [
     "EditionPublishTrigger",
     "EditionPublishedEvent",
     "LifecycleAction",
+    "MembershipChangeAction",
+    "MembershipChangedEvent",
     "MetricsEditionKind",
+    "MetricsOrgRole",
+    "MetricsPrincipalType",
     "ProjectLifecycleEvent",
     "build_event_manager",
 ]

--- a/src/docverse/metrics/__init__.py
+++ b/src/docverse/metrics/__init__.py
@@ -1,0 +1,24 @@
+"""Sasquatch application metrics for Docverse (SQR-112)."""
+
+from __future__ import annotations
+
+from .enums import EditionPublishTrigger, MetricsEditionKind
+from .events import DocverseEvents
+from .manager import build_event_manager
+from .payloads import (
+    BuildProcessedEvent,
+    BuildUploadedEvent,
+    DocverseEventBase,
+    EditionPublishedEvent,
+)
+
+__all__ = [
+    "BuildProcessedEvent",
+    "BuildUploadedEvent",
+    "DocverseEventBase",
+    "DocverseEvents",
+    "EditionPublishTrigger",
+    "EditionPublishedEvent",
+    "MetricsEditionKind",
+    "build_event_manager",
+]

--- a/src/docverse/metrics/__init__.py
+++ b/src/docverse/metrics/__init__.py
@@ -15,9 +15,11 @@ from .manager import build_event_manager
 from .payloads import (
     BuildProcessedEvent,
     BuildUploadedEvent,
+    DashboardBuiltEvent,
     DocverseEventBase,
     EditionLifecycleEvent,
     EditionPublishedEvent,
+    KeeperSyncRunCompletedEvent,
     MembershipChangedEvent,
     ProjectLifecycleEvent,
 )
@@ -25,11 +27,13 @@ from .payloads import (
 __all__ = [
     "BuildProcessedEvent",
     "BuildUploadedEvent",
+    "DashboardBuiltEvent",
     "DocverseEventBase",
     "DocverseEvents",
     "EditionLifecycleEvent",
     "EditionPublishTrigger",
     "EditionPublishedEvent",
+    "KeeperSyncRunCompletedEvent",
     "LifecycleAction",
     "MembershipChangeAction",
     "MembershipChangedEvent",

--- a/src/docverse/metrics/__init__.py
+++ b/src/docverse/metrics/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from .enums import (
     EditionPublishTrigger,
     LifecycleAction,
+    LifecycleActionTrigger,
+    LifecycleReapAction,
     MembershipChangeAction,
     MetricsEditionKind,
     MetricsOrgRole,
@@ -20,6 +22,7 @@ from .payloads import (
     EditionLifecycleEvent,
     EditionPublishedEvent,
     KeeperSyncRunCompletedEvent,
+    LifecycleActionEvent,
     MembershipChangedEvent,
     ProjectLifecycleEvent,
 )
@@ -35,6 +38,9 @@ __all__ = [
     "EditionPublishedEvent",
     "KeeperSyncRunCompletedEvent",
     "LifecycleAction",
+    "LifecycleActionEvent",
+    "LifecycleActionTrigger",
+    "LifecycleReapAction",
     "MembershipChangeAction",
     "MembershipChangedEvent",
     "MetricsEditionKind",

--- a/src/docverse/metrics/enums.py
+++ b/src/docverse/metrics/enums.py
@@ -14,12 +14,15 @@ from enum import StrEnum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from docverse.client.models import EditionKind
+    from docverse.client.models import EditionKind, OrgRole, PrincipalType
 
 __all__ = [
     "EditionPublishTrigger",
     "LifecycleAction",
+    "MembershipChangeAction",
     "MetricsEditionKind",
+    "MetricsOrgRole",
+    "MetricsPrincipalType",
 ]
 
 
@@ -66,6 +69,65 @@ class LifecycleAction(StrEnum):
     update = "update"
     delete = "delete"
     rollback = "rollback"
+
+
+class MembershipChangeAction(StrEnum):
+    """The membership operation recorded on a ``membership_changed`` event.
+
+    Unlike the CRUD-shaped :class:`LifecycleAction`, an org membership is
+    only ever added or removed (an in-place role change is modelled as a
+    remove + add by the API), so this event carries a dedicated
+    add/remove verb. The emission site selects the action statically:
+    ``post_member`` emits ``add`` and ``delete_member`` emits ``remove``.
+    """
+
+    add = "add"
+    remove = "remove"
+
+
+class MetricsOrgRole(StrEnum):
+    """Org role recorded on a ``membership_changed`` event.
+
+    Mirrors :class:`docverse.client.models.OrgRole` value-for-value; the
+    emission site maps the API enum to this one so the metrics Avro
+    schema does not depend on the API model (SQR-112 D4).
+    """
+
+    reader = "reader"
+    uploader = "uploader"
+    admin = "admin"
+
+    @classmethod
+    def from_api(cls, role: OrgRole) -> MetricsOrgRole:
+        """Map the API :class:`~docverse.client.models.OrgRole`.
+
+        Values are identical, so this is a straight value lookup; keeping
+        the mapping explicit lets the metrics schema evolve independently
+        of the API model.
+        """
+        return cls(role.value)
+
+
+class MetricsPrincipalType(StrEnum):
+    """Principal type recorded on a ``membership_changed`` event.
+
+    Mirrors :class:`docverse.client.models.PrincipalType` value-for-value;
+    the emission site maps the API enum to this one so the metrics Avro
+    schema does not depend on the API model (SQR-112 D4).
+    """
+
+    user = "user"
+    group = "group"
+
+    @classmethod
+    def from_api(cls, principal_type: PrincipalType) -> MetricsPrincipalType:
+        """Map the API :class:`~docverse.client.models.PrincipalType`.
+
+        Values are identical, so this is a straight value lookup; keeping
+        the mapping explicit lets the metrics schema evolve independently
+        of the API model.
+        """
+        return cls(principal_type.value)
 
 
 class EditionPublishTrigger(StrEnum):

--- a/src/docverse/metrics/enums.py
+++ b/src/docverse/metrics/enums.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 __all__ = [
     "EditionPublishTrigger",
     "LifecycleAction",
+    "LifecycleActionTrigger",
+    "LifecycleReapAction",
     "MembershipChangeAction",
     "MetricsEditionKind",
     "MetricsOrgRole",
@@ -128,6 +130,49 @@ class MetricsPrincipalType(StrEnum):
         of the API model.
         """
         return cls(principal_type.value)
+
+
+class LifecycleActionTrigger(StrEnum):
+    """Which worker drove a ``lifecycle_action`` reap (SQR-112 D7).
+
+    ``lifecycle_action`` is emitted by two shared reaper workers that
+    both soft-delete resources; this enum records which one performed a
+    given reap. Each worker selects its trigger statically at the
+    emission site (``lifecycle_eval`` vs. ``git_ref_audit``).
+    """
+
+    lifecycle_eval = "lifecycle_eval"
+    git_ref_audit = "git_ref_audit"
+
+
+class LifecycleReapAction(StrEnum):
+    """The lifecycle rule that drove a reap on a ``lifecycle_action`` event.
+
+    Mirrors the lifecycle-rule ``type`` discriminators
+    (:class:`docverse.domain.lifecycle.LifecycleRule`) value-for-value;
+    the emission site maps the matched rule's ``type`` to this enum so the
+    metrics Avro schema evolves independently of the rule schema. The
+    ``lifecycle_eval`` worker emits ``draft_inactivity`` (editions) and
+    ``build_history_orphan`` (builds); ``git_ref_audit`` emits only
+    ``ref_deleted``.
+    """
+
+    draft_inactivity = "draft_inactivity"
+    build_history_orphan = "build_history_orphan"
+    ref_deleted = "ref_deleted"
+
+    @classmethod
+    def from_rule_type(cls, rule_type: str) -> LifecycleReapAction:
+        """Map a lifecycle-rule ``type`` discriminator to this enum.
+
+        Values are identical to the rule ``type`` strings, so this is a
+        straight value lookup; keeping the mapping explicit makes a rename
+        on either side a reviewable change rather than a silent schema
+        break. The reaper workers filter their rule sets to the kinds they
+        own before evaluation, so every ``rule_type`` reaching here is one
+        of this enum's members.
+        """
+        return cls(rule_type)
 
 
 class EditionPublishTrigger(StrEnum):

--- a/src/docverse/metrics/enums.py
+++ b/src/docverse/metrics/enums.py
@@ -1,0 +1,50 @@
+"""Dedicated string enums for Sasquatch metrics event payloads.
+
+These enums are intentionally separate from the API client enums in
+``docverse.client.models`` (SQR-112 D4/D7): the metrics schema is a
+published Avro contract consumed by Sasquatch and must be able to
+evolve independently of the HTTP API. Each enum is mapped from its
+API-side counterpart at the emission site, so a rename on either side
+is an explicit, reviewable change rather than a silent schema break.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = [
+    "EditionPublishTrigger",
+    "MetricsEditionKind",
+]
+
+
+class MetricsEditionKind(StrEnum):
+    """Kind of edition, as recorded on ``edition_published`` events.
+
+    Mirrors :class:`docverse.client.models.EditionKind` value-for-value;
+    the emission site maps the API enum to this one so the metrics Avro
+    schema does not depend on the API model.
+    """
+
+    main = "main"
+    release = "release"
+    draft = "draft"
+    major = "major"
+    minor = "minor"
+    alternate = "alternate"
+
+
+class EditionPublishTrigger(StrEnum):
+    """What caused a ``publish_edition`` job to run.
+
+    ``publish_edition`` is a shared worker reached from more than one
+    flow (SQR-112 D7), so the event records which one drove this
+    publish:
+
+    - ``build`` — a client-uploaded build's edition-tracking fan-out.
+    - ``keeper_sync`` — the LTD Keeper backfill (the publish job's
+      ``queue_jobs`` row carries a ``keeper_sync_run_id``).
+    """
+
+    build = "build"
+    keeper_sync = "keeper_sync"

--- a/src/docverse/metrics/enums.py
+++ b/src/docverse/metrics/enums.py
@@ -185,7 +185,16 @@ class EditionPublishTrigger(StrEnum):
     - ``build`` — a client-uploaded build's edition-tracking fan-out.
     - ``keeper_sync`` — the LTD Keeper backfill (the publish job's
       ``queue_jobs`` row carries a ``keeper_sync_run_id``).
+    - ``rollback`` — a user-initiated edition rollback (the rollback
+      handler enqueues a ``publish_edition`` job with no
+      ``keeper_sync_run_id``, tagging its payload ``trigger=rollback``
+      so it is not conflated with build fan-out).
+
+    ``build`` is the default: a publish with neither a
+    ``keeper_sync_run_id`` nor an explicit payload ``trigger`` is the
+    ordinary build-driven fan-out.
     """
 
     build = "build"
     keeper_sync = "keeper_sync"
+    rollback = "rollback"

--- a/src/docverse/metrics/enums.py
+++ b/src/docverse/metrics/enums.py
@@ -11,15 +11,20 @@ is an explicit, reviewable change rather than a silent schema break.
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from docverse.client.models import EditionKind
 
 __all__ = [
     "EditionPublishTrigger",
+    "LifecycleAction",
     "MetricsEditionKind",
 ]
 
 
 class MetricsEditionKind(StrEnum):
-    """Kind of edition, as recorded on ``edition_published`` events.
+    """Kind of edition, as recorded on edition metrics events.
 
     Mirrors :class:`docverse.client.models.EditionKind` value-for-value;
     the emission site maps the API enum to this one so the metrics Avro
@@ -32,6 +37,35 @@ class MetricsEditionKind(StrEnum):
     major = "major"
     minor = "minor"
     alternate = "alternate"
+
+    @classmethod
+    def from_api(cls, kind: EditionKind) -> MetricsEditionKind:
+        """Map the API :class:`~docverse.client.models.EditionKind`.
+
+        Values are identical, so this is a straight value lookup; keeping
+        the mapping explicit lets the metrics schema evolve independently
+        of the API model (SQR-112 D4).
+        """
+        return cls(kind.value)
+
+
+class LifecycleAction(StrEnum):
+    """The management operation recorded on a ``*_lifecycle`` event.
+
+    A single consolidated enum (SQR-112 D4) backs both
+    :class:`~docverse.metrics.payloads.ProjectLifecycleEvent` and
+    :class:`~docverse.metrics.payloads.EditionLifecycleEvent`: rather
+    than a distinct event type per CRUD verb, one ``project_lifecycle`` /
+    ``edition_lifecycle`` event carries the verb in this field. The
+    emission site selects the action statically (each handler knows its
+    own operation). ``rollback`` applies only to editions; projects emit
+    just ``create``/``update``/``delete``.
+    """
+
+    create = "create"
+    update = "update"
+    delete = "delete"
+    rollback = "rollback"
 
 
 class EditionPublishTrigger(StrEnum):

--- a/src/docverse/metrics/events.py
+++ b/src/docverse/metrics/events.py
@@ -15,7 +15,9 @@ from safir.metrics import EventManager, EventPublisher
 from .payloads import (
     BuildProcessedEvent,
     BuildUploadedEvent,
+    EditionLifecycleEvent,
     EditionPublishedEvent,
+    ProjectLifecycleEvent,
 )
 
 __all__ = ["DocverseEvents"]
@@ -33,6 +35,8 @@ class DocverseEvents(EventMaker):
     build_uploaded: EventPublisher[BuildUploadedEvent]
     build_processed: EventPublisher[BuildProcessedEvent]
     edition_published: EventPublisher[EditionPublishedEvent]
+    project_lifecycle: EventPublisher[ProjectLifecycleEvent]
+    edition_lifecycle: EventPublisher[EditionLifecycleEvent]
 
     async def initialize(self, manager: EventManager) -> None:
         """Register a publisher for every Docverse event type.
@@ -50,4 +54,10 @@ class DocverseEvents(EventMaker):
         )
         self.edition_published = await manager.create_publisher(
             "edition_published", EditionPublishedEvent
+        )
+        self.project_lifecycle = await manager.create_publisher(
+            "project_lifecycle", ProjectLifecycleEvent
+        )
+        self.edition_lifecycle = await manager.create_publisher(
+            "edition_lifecycle", EditionLifecycleEvent
         )

--- a/src/docverse/metrics/events.py
+++ b/src/docverse/metrics/events.py
@@ -15,8 +15,10 @@ from safir.metrics import EventManager, EventPublisher
 from .payloads import (
     BuildProcessedEvent,
     BuildUploadedEvent,
+    DashboardBuiltEvent,
     EditionLifecycleEvent,
     EditionPublishedEvent,
+    KeeperSyncRunCompletedEvent,
     MembershipChangedEvent,
     ProjectLifecycleEvent,
 )
@@ -35,10 +37,12 @@ class DocverseEvents(EventMaker):
 
     build_uploaded: EventPublisher[BuildUploadedEvent]
     build_processed: EventPublisher[BuildProcessedEvent]
+    dashboard_built: EventPublisher[DashboardBuiltEvent]
     edition_published: EventPublisher[EditionPublishedEvent]
     project_lifecycle: EventPublisher[ProjectLifecycleEvent]
     edition_lifecycle: EventPublisher[EditionLifecycleEvent]
     membership_changed: EventPublisher[MembershipChangedEvent]
+    keeper_sync_run_completed: EventPublisher[KeeperSyncRunCompletedEvent]
 
     async def initialize(self, manager: EventManager) -> None:
         """Register a publisher for every Docverse event type.
@@ -54,6 +58,9 @@ class DocverseEvents(EventMaker):
         self.build_processed = await manager.create_publisher(
             "build_processed", BuildProcessedEvent
         )
+        self.dashboard_built = await manager.create_publisher(
+            "dashboard_built", DashboardBuiltEvent
+        )
         self.edition_published = await manager.create_publisher(
             "edition_published", EditionPublishedEvent
         )
@@ -65,4 +72,7 @@ class DocverseEvents(EventMaker):
         )
         self.membership_changed = await manager.create_publisher(
             "membership_changed", MembershipChangedEvent
+        )
+        self.keeper_sync_run_completed = await manager.create_publisher(
+            "keeper_sync_run_completed", KeeperSyncRunCompletedEvent
         )

--- a/src/docverse/metrics/events.py
+++ b/src/docverse/metrics/events.py
@@ -1,0 +1,53 @@
+"""The Docverse application-metrics event registry.
+
+:class:`DocverseEvents` is the single :class:`safir.metrics.EventMaker`
+for the whole application. Its :meth:`~DocverseEvents.initialize` is
+called once per process — from the FastAPI lifespan and from each arq
+worker ``on_startup`` — to register one publisher per event type against
+the process-wide :class:`safir.metrics.EventManager`.
+"""
+
+from __future__ import annotations
+
+from safir.dependencies.metrics import EventMaker
+from safir.metrics import EventManager, EventPublisher
+
+from .payloads import (
+    BuildProcessedEvent,
+    BuildUploadedEvent,
+    EditionPublishedEvent,
+)
+
+__all__ = ["DocverseEvents"]
+
+
+class DocverseEvents(EventMaker):
+    """Container of every Docverse metrics event publisher.
+
+    The publisher attributes are assigned in :meth:`initialize`; until
+    that runs they are absent, so a process must initialize the maker
+    before publishing. The attribute names double as the Avro schema /
+    event names registered with the schema manager.
+    """
+
+    build_uploaded: EventPublisher[BuildUploadedEvent]
+    build_processed: EventPublisher[BuildProcessedEvent]
+    edition_published: EventPublisher[EditionPublishedEvent]
+
+    async def initialize(self, manager: EventManager) -> None:
+        """Register a publisher for every Docverse event type.
+
+        Parameters
+        ----------
+        manager
+            An initialized :class:`safir.metrics.EventManager`.
+        """
+        self.build_uploaded = await manager.create_publisher(
+            "build_uploaded", BuildUploadedEvent
+        )
+        self.build_processed = await manager.create_publisher(
+            "build_processed", BuildProcessedEvent
+        )
+        self.edition_published = await manager.create_publisher(
+            "edition_published", EditionPublishedEvent
+        )

--- a/src/docverse/metrics/events.py
+++ b/src/docverse/metrics/events.py
@@ -17,6 +17,7 @@ from .payloads import (
     BuildUploadedEvent,
     EditionLifecycleEvent,
     EditionPublishedEvent,
+    MembershipChangedEvent,
     ProjectLifecycleEvent,
 )
 
@@ -37,6 +38,7 @@ class DocverseEvents(EventMaker):
     edition_published: EventPublisher[EditionPublishedEvent]
     project_lifecycle: EventPublisher[ProjectLifecycleEvent]
     edition_lifecycle: EventPublisher[EditionLifecycleEvent]
+    membership_changed: EventPublisher[MembershipChangedEvent]
 
     async def initialize(self, manager: EventManager) -> None:
         """Register a publisher for every Docverse event type.
@@ -60,4 +62,7 @@ class DocverseEvents(EventMaker):
         )
         self.edition_lifecycle = await manager.create_publisher(
             "edition_lifecycle", EditionLifecycleEvent
+        )
+        self.membership_changed = await manager.create_publisher(
+            "membership_changed", MembershipChangedEvent
         )

--- a/src/docverse/metrics/events.py
+++ b/src/docverse/metrics/events.py
@@ -22,6 +22,7 @@ from .payloads import (
     LifecycleActionEvent,
     MembershipChangedEvent,
     ProjectLifecycleEvent,
+    ResourceInventoryEvent,
 )
 
 __all__ = ["DocverseEvents"]
@@ -45,6 +46,7 @@ class DocverseEvents(EventMaker):
     membership_changed: EventPublisher[MembershipChangedEvent]
     keeper_sync_run_completed: EventPublisher[KeeperSyncRunCompletedEvent]
     lifecycle_action: EventPublisher[LifecycleActionEvent]
+    resource_inventory: EventPublisher[ResourceInventoryEvent]
 
     async def initialize(self, manager: EventManager) -> None:
         """Register a publisher for every Docverse event type.
@@ -80,4 +82,7 @@ class DocverseEvents(EventMaker):
         )
         self.lifecycle_action = await manager.create_publisher(
             "lifecycle_action", LifecycleActionEvent
+        )
+        self.resource_inventory = await manager.create_publisher(
+            "resource_inventory", ResourceInventoryEvent
         )

--- a/src/docverse/metrics/events.py
+++ b/src/docverse/metrics/events.py
@@ -19,6 +19,7 @@ from .payloads import (
     EditionLifecycleEvent,
     EditionPublishedEvent,
     KeeperSyncRunCompletedEvent,
+    LifecycleActionEvent,
     MembershipChangedEvent,
     ProjectLifecycleEvent,
 )
@@ -43,6 +44,7 @@ class DocverseEvents(EventMaker):
     edition_lifecycle: EventPublisher[EditionLifecycleEvent]
     membership_changed: EventPublisher[MembershipChangedEvent]
     keeper_sync_run_completed: EventPublisher[KeeperSyncRunCompletedEvent]
+    lifecycle_action: EventPublisher[LifecycleActionEvent]
 
     async def initialize(self, manager: EventManager) -> None:
         """Register a publisher for every Docverse event type.
@@ -75,4 +77,7 @@ class DocverseEvents(EventMaker):
         )
         self.keeper_sync_run_completed = await manager.create_publisher(
             "keeper_sync_run_completed", KeeperSyncRunCompletedEvent
+        )
+        self.lifecycle_action = await manager.create_publisher(
+            "lifecycle_action", LifecycleActionEvent
         )

--- a/src/docverse/metrics/manager.py
+++ b/src/docverse/metrics/manager.py
@@ -1,0 +1,53 @@
+"""Construction of the Docverse metrics event manager.
+
+:func:`build_event_manager` is the single place that turns the
+application's :class:`~docverse.config.Configuration` into a started
+:class:`safir.metrics.EventManager` plus a registered
+:class:`~docverse.metrics.events.DocverseEvents`. Both the FastAPI
+lifespan and each arq worker ``on_startup`` call it so the wiring stays
+identical across every process that publishes events.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from safir.metrics import EventManager
+from structlog.stdlib import BoundLogger
+
+from .events import DocverseEvents
+
+if TYPE_CHECKING:
+    from ..config import Configuration
+
+__all__ = ["build_event_manager"]
+
+
+async def build_event_manager(
+    config: Configuration,
+    *,
+    logger: BoundLogger | None = None,
+) -> tuple[EventManager, DocverseEvents]:
+    """Build and initialize the event manager and the Docverse events.
+
+    Parameters
+    ----------
+    config
+        The application configuration. Its ``metrics`` field selects the
+        concrete manager (mock, disabled, or Kafka-backed).
+    logger
+        Logger for the manager's internal logging. Defaults to the
+        ``safir.metrics`` logger when omitted.
+
+    Returns
+    -------
+    tuple of (EventManager, DocverseEvents)
+        The started manager and the events maker with every publisher
+        registered. The caller owns the manager's lifetime and must
+        ``await manager.aclose()`` on shutdown.
+    """
+    manager = config.metrics.make_manager(logger=logger)
+    await manager.initialize()
+    events = DocverseEvents()
+    await events.initialize(manager)
+    return manager, events

--- a/src/docverse/metrics/payloads.py
+++ b/src/docverse/metrics/payloads.py
@@ -36,6 +36,7 @@ __all__ = [
     "LifecycleActionEvent",
     "MembershipChangedEvent",
     "ProjectLifecycleEvent",
+    "ResourceInventoryEvent",
 ]
 
 
@@ -232,6 +233,31 @@ class LifecycleActionEvent(DocverseEventBase):
 
     success: bool
     """Whether the reap committed successfully (always ``True`` today)."""
+
+
+class ResourceInventoryEvent(DocverseEventBase):
+    """A daily census snapshot of active resources (SQR-112 D8).
+
+    Emitted by the ``inventory_census`` worker once per org (org-scoped,
+    ``project=None``, ``project_count`` set) and once per non-deleted
+    project (project-scoped, ``project`` set, ``project_count=None``).
+    Every field is a self-contained absolute-count gauge queried
+    downstream with ``last()``: soft-deleted projects/editions/builds are
+    excluded and ``total_build_bytes`` is the summed footprint of exactly
+    the active builds counted by ``build_count``.
+    """
+
+    project_count: int | None
+    """Active projects in the org; ``None`` on a project-scoped row."""
+
+    edition_count: int
+    """Active editions in scope (org-wide on an org row, else the project)."""
+
+    build_count: int
+    """Active builds in scope (org-wide on an org row, else the project)."""
+
+    total_build_bytes: int
+    """Summed ``total_size_bytes`` of the active builds in scope."""
 
 
 class MembershipChangedEvent(DocverseEventBase):

--- a/src/docverse/metrics/payloads.py
+++ b/src/docverse/metrics/payloads.py
@@ -14,7 +14,14 @@ from datetime import timedelta
 
 from safir.metrics import EventPayload
 
-from .enums import EditionPublishTrigger, LifecycleAction, MetricsEditionKind
+from .enums import (
+    EditionPublishTrigger,
+    LifecycleAction,
+    MembershipChangeAction,
+    MetricsEditionKind,
+    MetricsOrgRole,
+    MetricsPrincipalType,
+)
 
 __all__ = [
     "BuildProcessedEvent",
@@ -22,6 +29,7 @@ __all__ = [
     "DocverseEventBase",
     "EditionLifecycleEvent",
     "EditionPublishedEvent",
+    "MembershipChangedEvent",
     "ProjectLifecycleEvent",
 ]
 
@@ -142,3 +150,26 @@ class EditionLifecycleEvent(DocverseEventBase):
 
     edition_kind: MetricsEditionKind
     """Kind of the edition the operation acted on."""
+
+
+class MembershipChangedEvent(DocverseEventBase):
+    """An organization member was added or removed.
+
+    Emitted from the members handler: ``post_member`` (``action=add``)
+    and ``delete_member`` (``action=remove``), each published after the
+    operation's commit. Membership is org-scoped, so ``project`` is
+    always ``None``; the principal's role and identity are carried as
+    dedicated metrics enums mapped from the API at the emission site.
+    """
+
+    action: MembershipChangeAction
+    """Whether the member was added or removed."""
+
+    role: MetricsOrgRole
+    """Role the membership grants (or granted, for a removal)."""
+
+    principal_type: MetricsPrincipalType
+    """Whether the principal is a user or a group."""
+
+    principal: str
+    """Username or group name the membership applies to."""

--- a/src/docverse/metrics/payloads.py
+++ b/src/docverse/metrics/payloads.py
@@ -17,6 +17,8 @@ from safir.metrics import EventPayload
 from .enums import (
     EditionPublishTrigger,
     LifecycleAction,
+    LifecycleActionTrigger,
+    LifecycleReapAction,
     MembershipChangeAction,
     MetricsEditionKind,
     MetricsOrgRole,
@@ -31,6 +33,7 @@ __all__ = [
     "EditionLifecycleEvent",
     "EditionPublishedEvent",
     "KeeperSyncRunCompletedEvent",
+    "LifecycleActionEvent",
     "MembershipChangedEvent",
     "ProjectLifecycleEvent",
 ]
@@ -204,6 +207,31 @@ class KeeperSyncRunCompletedEvent(DocverseEventBase):
 
     elapsed: timedelta
     """Wall-clock time from the run starting to its terminal transition."""
+
+
+class LifecycleActionEvent(DocverseEventBase):
+    """A lifecycle reaper soft-deleted a resource.
+
+    Emitted once per reap/deletion by the ``lifecycle_eval`` and
+    ``git_ref_audit`` workers (SQR-112 D7), published after the per-org
+    soft-delete transaction commits. ``action`` records which lifecycle
+    rule drove the reap and ``trigger`` records which worker performed it;
+    both are dedicated metrics enums mapped at the emission site. The
+    event is project-scoped — every reaped row belongs to a known project,
+    so ``project`` is always set. ``success`` is ``True`` because the
+    event is only published once the reap's atomic commit succeeds; it is
+    carried for schema uniformity with the other flow events (SQR-112 D3)
+    and leaves room for a future soft-failure reap path.
+    """
+
+    action: LifecycleReapAction
+    """Which lifecycle rule drove the reap."""
+
+    trigger: LifecycleActionTrigger
+    """Which worker performed the reap (lifecycle_eval vs. git_ref_audit)."""
+
+    success: bool
+    """Whether the reap committed successfully (always ``True`` today)."""
 
 
 class MembershipChangedEvent(DocverseEventBase):

--- a/src/docverse/metrics/payloads.py
+++ b/src/docverse/metrics/payloads.py
@@ -1,0 +1,115 @@
+"""Sasquatch metrics event payloads for Docverse.
+
+Every payload derives from :class:`DocverseEventBase`, which carries the
+two dimensions every Docverse metric is sliced by — ``organization`` and
+``project``. Payloads are deliberately **scalar-only** (the Avro/InfluxDB
+backing store rejects nested structures; see
+:meth:`safir.metrics.EventPayload.validate_structure`), and durations are
+expressed as :class:`datetime.timedelta`.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from safir.metrics import EventPayload
+
+from .enums import EditionPublishTrigger, MetricsEditionKind
+
+__all__ = [
+    "BuildProcessedEvent",
+    "BuildUploadedEvent",
+    "DocverseEventBase",
+    "EditionPublishedEvent",
+]
+
+
+class DocverseEventBase(EventPayload):
+    """Common dimensions shared by every Docverse metrics event.
+
+    Every Docverse metric is analysed per organization, and almost all
+    of them per project; carrying both on a shared base keeps the slice
+    dimensions consistent across the catalog. ``project`` is ``None`` for
+    org-scoped events (e.g. a future ``resource_inventory`` org row).
+    """
+
+    organization: str
+    """Slug of the organization the event belongs to."""
+
+    project: str | None
+    """Slug of the project, or ``None`` for org-scoped events."""
+
+
+class BuildUploadedEvent(DocverseEventBase):
+    """A client signalled that a build's upload is complete.
+
+    Emitted from the ``PATCH .../builds/{build}`` handler when the build
+    transitions ``pending -> processing``. The provenance fields are
+    copied from the build's annotations (``None`` where the uploader did
+    not annotate them) and give SQuaRE adoption/source signal.
+    """
+
+    uploader: str
+    """Principal (user or bot) that uploaded the build."""
+
+    commit_sha: str | None
+    """Git commit SHA the build was produced from, if annotated."""
+
+    github_repository: str | None
+    """``owner/repo`` that produced the build, if annotated."""
+
+    github_run_id: str | None
+    """GitHub Actions run ID, if annotated."""
+
+    github_actor: str | None
+    """GitHub user or app that triggered the run, if annotated."""
+
+    ci_platform: str | None
+    """CI platform that produced the build, if annotated."""
+
+
+class BuildProcessedEvent(DocverseEventBase):
+    """A build finished processing in the ``build_processing`` worker.
+
+    Covers all three terminal outcomes: a successful unpack+upload, a
+    failed one (``success=False``), and a stale build that was skipped
+    because a newer build for the same ``(project, git_ref)`` superseded
+    it (``stale_skipped=True``).
+    """
+
+    success: bool
+    """Whether processing completed without error."""
+
+    object_count: int | None
+    """Number of objects uploaded, or ``None`` when nothing was uploaded."""
+
+    total_size_bytes: int | None
+    """Total uploaded size in bytes, or ``None`` when nothing was uploaded."""
+
+    editions_updated: int
+    """Number of editions repointed at this build."""
+
+    editions_skipped: int
+    """Number of tracking editions left unchanged."""
+
+    stale_skipped: bool
+    """Whether this build was skipped as superseded by a newer build."""
+
+    elapsed: timedelta
+    """Wall-clock time the worker spent on this build."""
+
+
+class EditionPublishedEvent(DocverseEventBase):
+    """An edition's current build finished publishing to the CDN.
+
+    Emitted from the ``publish_edition`` worker's success terminal.
+    """
+
+    edition_kind: MetricsEditionKind
+    """Kind of the published edition."""
+
+    trigger: EditionPublishTrigger
+    """What flow drove this publish (build fan-out vs. keeper-sync)."""
+
+    elapsed: timedelta
+    """Wall-clock time the worker spent on this publish."""

--- a/src/docverse/metrics/payloads.py
+++ b/src/docverse/metrics/payloads.py
@@ -26,9 +26,11 @@ from .enums import (
 __all__ = [
     "BuildProcessedEvent",
     "BuildUploadedEvent",
+    "DashboardBuiltEvent",
     "DocverseEventBase",
     "EditionLifecycleEvent",
     "EditionPublishedEvent",
+    "KeeperSyncRunCompletedEvent",
     "MembershipChangedEvent",
     "ProjectLifecycleEvent",
 ]
@@ -109,6 +111,27 @@ class BuildProcessedEvent(DocverseEventBase):
     """Wall-clock time the worker spent on this build."""
 
 
+class DashboardBuiltEvent(DocverseEventBase):
+    """A dashboard finished building in the ``dashboard_build`` worker.
+
+    Covers both terminal outcomes: a successful render+upload and a
+    failed one (``success=False``). The object counters are ``None`` on
+    the failure path, where nothing was uploaded.
+    """
+
+    success: bool
+    """Whether the dashboard build completed without error."""
+
+    object_count: int | None
+    """Number of dashboard artifacts uploaded, or ``None`` on failure."""
+
+    total_size_bytes: int | None
+    """Total uploaded dashboard size in bytes, or ``None`` on failure."""
+
+    elapsed: timedelta
+    """Wall-clock time the worker spent on this dashboard build."""
+
+
 class EditionPublishedEvent(DocverseEventBase):
     """An edition's current build finished publishing to the CDN.
 
@@ -150,6 +173,37 @@ class EditionLifecycleEvent(DocverseEventBase):
 
     edition_kind: MetricsEditionKind
     """Kind of the edition the operation acted on."""
+
+
+class KeeperSyncRunCompletedEvent(DocverseEventBase):
+    """An LTD-keeper backfill run reached a terminal status.
+
+    Emitted when
+    :func:`docverse.services.keeper_sync_finalisation.maybe_finalise_run`
+    actually rolls a ``keeper_sync_runs`` row to a terminal status (from
+    any of the worker paths that finalise a run: ``keeper_sync_project``,
+    ``publish_edition``, or the keeper-sync reaper). A keeper-sync run
+    spans many projects, so it is org-scoped and ``project`` is always
+    ``None``. ``success`` is ``True`` only when every attributed child
+    job completed cleanly (run status ``succeeded``); a run with any
+    failed child finalises ``partial_failure`` and reports
+    ``success=False``.
+    """
+
+    success: bool
+    """Whether the run finalised with no failed child jobs."""
+
+    total_count: int
+    """Total number of queue jobs attributed to the run."""
+
+    succeeded_count: int
+    """Number of attributed jobs that completed cleanly."""
+
+    failed_count: int
+    """Number of attributed jobs that failed (or soft-failed)."""
+
+    elapsed: timedelta
+    """Wall-clock time from the run starting to its terminal transition."""
 
 
 class MembershipChangedEvent(DocverseEventBase):

--- a/src/docverse/metrics/payloads.py
+++ b/src/docverse/metrics/payloads.py
@@ -14,13 +14,15 @@ from datetime import timedelta
 
 from safir.metrics import EventPayload
 
-from .enums import EditionPublishTrigger, MetricsEditionKind
+from .enums import EditionPublishTrigger, LifecycleAction, MetricsEditionKind
 
 __all__ = [
     "BuildProcessedEvent",
     "BuildUploadedEvent",
     "DocverseEventBase",
+    "EditionLifecycleEvent",
     "EditionPublishedEvent",
+    "ProjectLifecycleEvent",
 ]
 
 
@@ -113,3 +115,30 @@ class EditionPublishedEvent(DocverseEventBase):
 
     elapsed: timedelta
     """Wall-clock time the worker spent on this publish."""
+
+
+class ProjectLifecycleEvent(DocverseEventBase):
+    """A project was created, updated, or deleted via the projects handler.
+
+    Consolidates the project management verbs into one event keyed by
+    ``action`` (SQR-112 D4). Published from the FastAPI projects handler
+    after the operation's final commit.
+    """
+
+    action: LifecycleAction
+    """Which management operation occurred (create/update/delete)."""
+
+
+class EditionLifecycleEvent(DocverseEventBase):
+    """An edition was created, updated, deleted, or rolled back.
+
+    Consolidates the edition management verbs into one event keyed by
+    ``action`` (SQR-112 D4). Published from the FastAPI editions handler
+    after the operation's final commit.
+    """
+
+    action: LifecycleAction
+    """Which management operation occurred (create/update/delete/rollback)."""
+
+    edition_kind: MetricsEditionKind
+    """Kind of the edition the operation acted on."""

--- a/src/docverse/services/edition.py
+++ b/src/docverse/services/edition.py
@@ -13,6 +13,7 @@ from docverse.domain.edition_build_history import EditionBuildHistoryWithBuild
 from docverse.domain.organization import Organization
 from docverse.domain.project import Project
 from docverse.exceptions import ConflictError, NotFoundError
+from docverse.metrics import EditionPublishTrigger
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -415,6 +416,10 @@ class EditionService:
                 "queue_job_public_id": serialize_base32_id(
                     child_job.public_id
                 ),
+                # Tag the publish so its edition_published metric reports
+                # trigger=rollback rather than the default build fan-out
+                # (the queue job carries no keeper_sync_run_id). SQR-112 D7.
+                "trigger": EditionPublishTrigger.rollback.value,
             },
         )
 

--- a/src/docverse/services/inventory_census.py
+++ b/src/docverse/services/inventory_census.py
@@ -1,0 +1,35 @@
+"""Service for the daily resource-inventory census (SQR-112)."""
+
+from __future__ import annotations
+
+import structlog
+
+from docverse.domain.inventory_census import InventoryCensus
+from docverse.storage.inventory_census_store import InventoryCensusStore
+
+__all__ = ["InventoryCensusService"]
+
+
+class InventoryCensusService:
+    """Take a read-only census of active Docverse resources.
+
+    A thin wrapper over :class:`InventoryCensusStore`, mirroring the
+    other read-only run services (e.g.
+    :class:`docverse.services.keeper_sync_run.KeeperSyncRunService`): the
+    store owns the grouped-aggregate SQL and this service is the
+    factory-wired entry point the daily ``inventory_census`` worker
+    calls.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: InventoryCensusStore,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._store = store
+        self._logger = logger
+
+    async def take_census(self) -> InventoryCensus:
+        """Return one census snapshot of active orgs/projects/resources."""
+        return await self._store.aggregate_inventory()

--- a/src/docverse/services/keeper_sync_finalisation.py
+++ b/src/docverse/services/keeper_sync_finalisation.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import sentry_sdk
+import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import KeeperSyncRunStatus
@@ -93,6 +95,7 @@ async def publish_run_completed(
     session: AsyncSession,
     org_store: OrganizationStore,
     completion: KeeperSyncRunWithActivity | None,
+    logger: structlog.stdlib.BoundLogger,
 ) -> None:
     """Emit one ``keeper_sync_run_completed`` metric for a finalised run.
 
@@ -102,33 +105,42 @@ async def publish_run_completed(
     A keeper-sync run spans many projects, so it is org-scoped and
     ``project`` is always ``None``; ``success`` is ``True`` only for a
     clean ``succeeded`` finalisation, ``False`` for ``partial_failure`` /
-    ``failed``. Best-effort: production runs ``raise_on_error=False`` so a
-    metrics-backend outage never disrupts run finalisation (no defensive
-    try/except at the call sites).
+    ``failed``.
+
+    Fully best-effort: callers invoke this *after* their finalisation
+    transaction has committed, so it swallows and logs any error — a
+    metrics-backend outage (already covered by ``raise_on_error=False``)
+    *or* a DB error during its own ``org_id`` resolution — rather than
+    letting it propagate and disrupt (or retry) an already-committed run
+    finalisation.
 
     The org slug is resolved from the run's ``org_id`` so a single helper
     serves every finaliser regardless of what its payload carried.
     """
     if events is None or completion is None:
         return
-    run = completion.run
-    activity = completion.activity
-    async with session.begin():
-        org = await org_store.get_by_id(run.org_id)
-    organization = org.slug if org is not None else str(run.org_id)
-    elapsed = (
-        run.date_finished - run.date_started
-        if run.date_finished is not None
-        else timedelta(0)
-    )
-    await events.keeper_sync_run_completed.publish(
-        KeeperSyncRunCompletedEvent(
-            organization=organization,
-            project=None,
-            success=run.status == KeeperSyncRunStatus.succeeded,
-            total_count=activity.total_count,
-            succeeded_count=activity.succeeded_count,
-            failed_count=activity.failed_count,
-            elapsed=elapsed,
+    try:
+        run = completion.run
+        activity = completion.activity
+        async with session.begin():
+            org = await org_store.get_by_id(run.org_id)
+        organization = org.slug if org is not None else str(run.org_id)
+        elapsed = (
+            run.date_finished - run.date_started
+            if run.date_finished is not None
+            else timedelta(0)
         )
-    )
+        await events.keeper_sync_run_completed.publish(
+            KeeperSyncRunCompletedEvent(
+                organization=organization,
+                project=None,
+                success=run.status == KeeperSyncRunStatus.succeeded,
+                total_count=activity.total_count,
+                succeeded_count=activity.succeeded_count,
+                failed_count=activity.failed_count,
+                elapsed=elapsed,
+            )
+        )
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
+        logger.exception("Failed to publish keeper_sync_run_completed metric")

--- a/src/docverse/services/keeper_sync_finalisation.py
+++ b/src/docverse/services/keeper_sync_finalisation.py
@@ -6,23 +6,52 @@ worker (after a publish job that was attributed to a keeper-sync run
 completes) need to roll the parent ``keeper_sync_runs`` row to a
 terminal status once every attributed child has reached terminal. The
 logic is the same in both places, so it lives here.
+
+When :func:`maybe_finalise_run` actually drives a run terminal it returns
+the finalised run paired with its child-job activity; callers publish the
+``keeper_sync_run_completed`` Sasquatch metric from that result via
+:func:`publish_run_completed`, after their transaction commits (SQR-112).
 """
 
 from __future__ import annotations
 
-from docverse.client.models import KeeperSyncRunStatus
-from docverse.exceptions import NotFoundError
-from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+from datetime import timedelta
 
-__all__ = ["maybe_finalise_run"]
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.client.models import KeeperSyncRunStatus
+from docverse.domain.keeper_sync_run import KeeperSyncRunWithActivity
+from docverse.exceptions import NotFoundError
+from docverse.metrics import KeeperSyncRunCompletedEvent
+from docverse.metrics.events import DocverseEvents
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
+from docverse.storage.organization_store import OrganizationStore
+
+__all__ = ["maybe_finalise_run", "publish_run_completed"]
+
+
+_TERMINAL_STATUSES = frozenset(
+    {
+        KeeperSyncRunStatus.succeeded,
+        KeeperSyncRunStatus.partial_failure,
+        KeeperSyncRunStatus.failed,
+    }
+)
 
 
 async def maybe_finalise_run(
     *,
     run_store: KeeperSyncRunStore,
     run_id: int,
-) -> None:
+) -> KeeperSyncRunWithActivity | None:
     """Transition the run to a terminal status once all children are terminal.
+
+    Returns the finalised run paired with the child-job activity it was
+    computed from when (and only when) this call actually drove the run
+    terminal; returns ``None`` otherwise (children still pending, no
+    attributed children, or the run was already terminal). Callers use
+    the return value to publish ``keeper_sync_run_completed`` after their
+    surrounding transaction commits.
 
     Idempotent re-entry on the same terminal status is handled by
     ``transition_status``'s same-status fast path. The explicit terminal
@@ -35,11 +64,12 @@ async def maybe_finalise_run(
     ``InvalidJobStateError``, which would roll back the surrounding
     ``session.begin()`` and undo that child's terminal transition. We
     swallow the conflict here so the loser of the race exits cleanly
-    and lets the winning terminal status stand.
+    (returning ``None``, so it publishes nothing) and lets the winning
+    terminal status stand.
     """
     activity = await run_store.aggregate_activity(run_id=run_id)
     if activity.total_count == 0 or activity.pending_count > 0:
-        return
+        return None
     new_status = (
         KeeperSyncRunStatus.partial_failure
         if activity.failed_count > 0
@@ -49,10 +79,56 @@ async def maybe_finalise_run(
     if run is None:
         msg = f"Keeper sync run {run_id} not found"
         raise NotFoundError(msg)
-    if run.status in {
-        KeeperSyncRunStatus.succeeded,
-        KeeperSyncRunStatus.partial_failure,
-        KeeperSyncRunStatus.failed,
-    }:
+    if run.status in _TERMINAL_STATUSES:
+        return None
+    finalised = await run_store.transition_status(
+        run_id=run_id, new_status=new_status
+    )
+    return KeeperSyncRunWithActivity(run=finalised, activity=activity)
+
+
+async def publish_run_completed(
+    *,
+    events: DocverseEvents | None,
+    session: AsyncSession,
+    org_store: OrganizationStore,
+    completion: KeeperSyncRunWithActivity | None,
+) -> None:
+    """Emit one ``keeper_sync_run_completed`` metric for a finalised run.
+
+    A no-op when ``events`` is unset (a worker ctx wired without metrics)
+    or ``completion`` is ``None`` (this caller did not actually finalise
+    the run — children still pending, or another finaliser won the race).
+    A keeper-sync run spans many projects, so it is org-scoped and
+    ``project`` is always ``None``; ``success`` is ``True`` only for a
+    clean ``succeeded`` finalisation, ``False`` for ``partial_failure`` /
+    ``failed``. Best-effort: production runs ``raise_on_error=False`` so a
+    metrics-backend outage never disrupts run finalisation (no defensive
+    try/except at the call sites).
+
+    The org slug is resolved from the run's ``org_id`` so a single helper
+    serves every finaliser regardless of what its payload carried.
+    """
+    if events is None or completion is None:
         return
-    await run_store.transition_status(run_id=run_id, new_status=new_status)
+    run = completion.run
+    activity = completion.activity
+    async with session.begin():
+        org = await org_store.get_by_id(run.org_id)
+    organization = org.slug if org is not None else str(run.org_id)
+    elapsed = (
+        run.date_finished - run.date_started
+        if run.date_finished is not None
+        else timedelta(0)
+    )
+    await events.keeper_sync_run_completed.publish(
+        KeeperSyncRunCompletedEvent(
+            organization=organization,
+            project=None,
+            success=run.status == KeeperSyncRunStatus.succeeded,
+            total_count=activity.total_count,
+            succeeded_count=activity.succeeded_count,
+            failed_count=activity.failed_count,
+            elapsed=elapsed,
+        )
+    )

--- a/src/docverse/storage/inventory_census_store.py
+++ b/src/docverse/storage/inventory_census_store.py
@@ -83,12 +83,16 @@ class InventoryCensusStore:
         # soft-deleted project are dropped below because that project
         # contributes no row to assemble them onto.
         edition_count_rows = (
-            await self._session.execute(
-                select(SqlEdition.project_id, func.count(SqlEdition.id))
-                .where(SqlEdition.date_deleted.is_(None))
-                .group_by(SqlEdition.project_id)
+            (
+                await self._session.execute(
+                    select(SqlEdition.project_id, func.count(SqlEdition.id))
+                    .where(SqlEdition.date_deleted.is_(None))
+                    .group_by(SqlEdition.project_id)
+                )
             )
-        ).all()
+            .tuples()
+            .all()
+        )
         edition_counts: dict[int, int] = dict(edition_count_rows)
 
         # Non-deleted build counts + byte sums per project. ``SUM`` skips

--- a/src/docverse/storage/inventory_census_store.py
+++ b/src/docverse/storage/inventory_census_store.py
@@ -1,0 +1,151 @@
+"""Read-only grouped-aggregate census of active Docverse resources.
+
+The store backs the daily ``inventory_census`` worker (SQR-112 D8). It
+runs only read-only grouped aggregates — ``COUNT`` of non-deleted
+projects/editions/builds and ``SUM`` of active-build ``total_size_bytes``
+— and takes no advisory locks, so a census pass never contends with the
+publishing or maintenance flows for row locks. Modelled on
+:meth:`docverse.storage.lifecycle_eval_run_store.LifecycleEvalRunStore.aggregate_activity`:
+one ``GROUP BY`` query per resource, assembled into per-project rows and
+rolled up to per-org rows in Python. The per-resource queries are kept
+separate so joining editions and builds onto projects in a single query
+cannot fan the build-byte ``SUM`` out across the edition rows.
+"""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.dbschema.build import SqlBuild
+from docverse.dbschema.edition import SqlEdition
+from docverse.dbschema.organization import SqlOrganization
+from docverse.dbschema.project import SqlProject
+from docverse.domain.inventory_census import (
+    InventoryCensus,
+    OrgInventoryCensus,
+    ProjectInventoryCensus,
+)
+
+__all__ = ["InventoryCensusStore"]
+
+
+class InventoryCensusStore:
+    """Read-only grouped-aggregate census of active resources."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._session = session
+        self._logger = logger
+
+    async def aggregate_inventory(self) -> InventoryCensus:
+        """Census active orgs/projects/editions/builds in one snapshot.
+
+        Every org yields one :class:`OrgInventoryCensus` row (even with
+        zero projects); every non-deleted project yields one
+        :class:`ProjectInventoryCensus` row. Soft-deleted
+        projects/editions/builds are excluded everywhere — and editions
+        and builds belonging to a soft-deleted project drop out by
+        virtue of that project not producing a row. All counts and the
+        byte sum are absolute gauges (SQR-112 D8), queried downstream
+        with ``last()``.
+        """
+        # Every org, including those with no projects, so each yields a
+        # census row.
+        org_rows = (
+            await self._session.execute(
+                select(SqlOrganization.id, SqlOrganization.slug).order_by(
+                    SqlOrganization.slug
+                )
+            )
+        ).all()
+
+        # Non-deleted projects with their owning org's slug.
+        project_rows = (
+            await self._session.execute(
+                select(
+                    SqlProject.id,
+                    SqlProject.slug,
+                    SqlProject.org_id,
+                    SqlOrganization.slug,
+                )
+                .join(SqlOrganization, SqlOrganization.id == SqlProject.org_id)
+                .where(SqlProject.date_deleted.is_(None))
+                .order_by(SqlProject.id)
+            )
+        ).all()
+
+        # Non-deleted edition counts per project. Editions of a
+        # soft-deleted project are dropped below because that project
+        # contributes no row to assemble them onto.
+        edition_count_rows = (
+            await self._session.execute(
+                select(SqlEdition.project_id, func.count(SqlEdition.id))
+                .where(SqlEdition.date_deleted.is_(None))
+                .group_by(SqlEdition.project_id)
+            )
+        ).all()
+        edition_counts: dict[int, int] = {
+            project_id: count for project_id, count in edition_count_rows
+        }
+
+        # Non-deleted build counts + byte sums per project. ``SUM`` skips
+        # NULL ``total_size_bytes`` (an unprocessed build still counts
+        # toward ``build_count`` but adds nothing to the footprint); the
+        # ``coalesce`` yields 0 for a project whose builds are all
+        # NULL-sized.
+        build_rows = (
+            await self._session.execute(
+                select(
+                    SqlBuild.project_id,
+                    func.count(SqlBuild.id),
+                    func.coalesce(func.sum(SqlBuild.total_size_bytes), 0),
+                )
+                .where(SqlBuild.date_deleted.is_(None))
+                .group_by(SqlBuild.project_id)
+            )
+        ).all()
+        build_stats: dict[int, tuple[int, int]] = {
+            project_id: (count, int(total_bytes))
+            for project_id, count, total_bytes in build_rows
+        }
+
+        projects: list[ProjectInventoryCensus] = []
+        projects_by_org: dict[int, list[ProjectInventoryCensus]] = {}
+        for project_id, project_slug, org_id, org_slug in project_rows:
+            build_count, total_build_bytes = build_stats.get(
+                project_id, (0, 0)
+            )
+            project = ProjectInventoryCensus(
+                org_id=org_id,
+                org_slug=org_slug,
+                project_id=project_id,
+                project_slug=project_slug,
+                edition_count=edition_counts.get(project_id, 0),
+                build_count=build_count,
+                total_build_bytes=total_build_bytes,
+            )
+            projects.append(project)
+            projects_by_org.setdefault(org_id, []).append(project)
+
+        orgs: list[OrgInventoryCensus] = []
+        for org_id, org_slug in org_rows:
+            org_projects = projects_by_org.get(org_id, [])
+            orgs.append(
+                OrgInventoryCensus(
+                    org_id=org_id,
+                    org_slug=org_slug,
+                    project_count=len(org_projects),
+                    edition_count=sum(p.edition_count for p in org_projects),
+                    build_count=sum(p.build_count for p in org_projects),
+                    total_build_bytes=sum(
+                        p.total_build_bytes for p in org_projects
+                    ),
+                )
+            )
+
+        return InventoryCensus(orgs=orgs, projects=projects)

--- a/src/docverse/storage/inventory_census_store.py
+++ b/src/docverse/storage/inventory_census_store.py
@@ -89,9 +89,7 @@ class InventoryCensusStore:
                 .group_by(SqlEdition.project_id)
             )
         ).all()
-        edition_counts: dict[int, int] = {
-            project_id: count for project_id, count in edition_count_rows
-        }
+        edition_counts: dict[int, int] = dict(edition_count_rows)
 
         # Non-deleted build counts + byte sums per project. ``SUM`` skips
         # NULL ``total_size_bytes`` (an unprocessed build still counts

--- a/src/docverse/worker/functions/__init__.py
+++ b/src/docverse/worker/functions/__init__.py
@@ -8,6 +8,7 @@ from .dashboard_sync import dashboard_sync
 from .dashboard_sync_reaper import dashboard_sync_reaper
 from .git_ref_audit import git_ref_audit
 from .git_ref_audit_discovery import git_ref_audit_discovery
+from .inventory_census import inventory_census
 from .keeper_sync import (
     keeper_sync_project,
     keeper_sync_reaper,
@@ -33,6 +34,7 @@ __all__ = [
     "dashboard_sync_reaper",
     "git_ref_audit",
     "git_ref_audit_discovery",
+    "inventory_census",
     "keeper_sync_project",
     "keeper_sync_reaper",
     "keeper_sync_run_discovery",

--- a/src/docverse/worker/functions/build_processing.py
+++ b/src/docverse/worker/functions/build_processing.py
@@ -11,6 +11,9 @@ import asyncio
 import io
 import mimetypes
 import tarfile
+import time
+from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 
 import sentry_sdk
@@ -29,6 +32,7 @@ from docverse.domain.build import Build
 from docverse.domain.edition_tracking import EditionTrackingResult
 from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
+from docverse.metrics import BuildProcessedEvent
 from docverse.services.lock_service import LockKey
 from docverse.services.publish_enqueue import enqueue_publish_for_edition
 from docverse.storage.build_store import BuildStore
@@ -38,6 +42,23 @@ from docverse.storage.queue_job_store import QueueJobStore
 
 #: Maximum number of concurrent upload tasks.
 _UPLOAD_CONCURRENCY = 50
+
+
+@dataclass(slots=True)
+class _BuildProcessedOutcome:
+    """Terminal metrics for one ``build_processing`` run.
+
+    Carried up from the per-path helpers so the top-level function can
+    emit a single ``build_processed`` event covering whichever of the
+    three terminal outcomes (success, failure, stale-skip) occurred.
+    """
+
+    success: bool
+    object_count: int | None
+    total_size_bytes: int | None
+    editions_updated: int
+    editions_skipped: int
+    stale_skipped: bool
 
 
 async def build_processing(
@@ -70,6 +91,7 @@ async def build_processing(
         build=build_public_id,
     )
 
+    started = time.monotonic()
     async for session in db_session_dependency():
         factory = ctx["factory_builder"](session=session, logger=logger)
         build_store = factory.create_build_store()
@@ -101,25 +123,73 @@ async def build_processing(
                 build_id=build_id,
                 logger=logger,
             ):
-                return "completed"
-            return await _process_build_locked(
-                session=session,
-                factory=factory,
-                org_slug=org_slug,
-                build_store=build_store,
-                org_store=org_store,
-                queue_job_store=queue_job_store,
-                ctx=ctx,
-                build=build,
-                org_id=org_id,
-                project_slug=project_slug,
-                build_id=build_id,
-                build_public_id=build_public_id,
-                logger=logger,
-            )
+                result = "completed"
+                outcome = _BuildProcessedOutcome(
+                    success=True,
+                    object_count=None,
+                    total_size_bytes=None,
+                    editions_updated=0,
+                    editions_skipped=0,
+                    stale_skipped=True,
+                )
+            else:
+                result, outcome = await _process_build_locked(
+                    session=session,
+                    factory=factory,
+                    org_slug=org_slug,
+                    build_store=build_store,
+                    org_store=org_store,
+                    queue_job_store=queue_job_store,
+                    ctx=ctx,
+                    build=build,
+                    org_id=org_id,
+                    project_slug=project_slug,
+                    build_id=build_id,
+                    build_public_id=build_public_id,
+                    logger=logger,
+                )
+
+        # Publish after releasing the lock and after the terminal DB
+        # transition has committed. Best-effort: production runs
+        # raise_on_error=False so a metrics outage never fails the build.
+        await _publish_build_processed(
+            ctx=ctx,
+            org_slug=org_slug,
+            project_slug=project_slug,
+            outcome=outcome,
+            started=started,
+        )
+        return result
 
     msg = "No database session available"
     raise RuntimeError(msg)
+
+
+async def _publish_build_processed(
+    *,
+    ctx: dict[str, Any],
+    org_slug: str,
+    project_slug: str,
+    outcome: _BuildProcessedOutcome,
+    started: float,
+) -> None:
+    """Emit one ``build_processed`` metric for a finished build run."""
+    events = ctx.get("events")
+    if events is None:
+        return
+    await events.build_processed.publish(
+        BuildProcessedEvent(
+            organization=org_slug,
+            project=project_slug,
+            success=outcome.success,
+            object_count=outcome.object_count,
+            total_size_bytes=outcome.total_size_bytes,
+            editions_updated=outcome.editions_updated,
+            editions_skipped=outcome.editions_skipped,
+            stale_skipped=outcome.stale_skipped,
+            elapsed=timedelta(seconds=time.monotonic() - started),
+        )
+    )
 
 
 async def _guard_stale_build(  # noqa: PLR0913
@@ -178,11 +248,14 @@ async def _process_build_locked(  # noqa: PLR0913
     build_id: int,
     build_public_id: str,
     logger: structlog.stdlib.BoundLogger,
-) -> str:
+) -> tuple[str, _BuildProcessedOutcome]:
     """Unpack, upload, and finalize a non-stale build under the lock.
 
     Assumes the caller holds the BUILD_PROCESSING advisory lock and has
     already confirmed this build is the latest for ``(project, git_ref)``.
+
+    Returns the arq status message paired with the terminal metrics for
+    the run so the caller can emit one ``build_processed`` event.
     """
     # Phase 1: Load metadata and mark QueueJob as in_progress
     async with session.begin():
@@ -234,9 +307,16 @@ async def _process_build_locked(  # noqa: PLR0913
             )
             if queue_job_id is not None:
                 await queue_job_store.fail(queue_job_id)
-        return "failed"
+        return "failed", _BuildProcessedOutcome(
+            success=False,
+            object_count=None,
+            total_size_bytes=None,
+            editions_updated=0,
+            editions_skipped=0,
+            stale_skipped=False,
+        )
     else:
-        await _finalize_success(
+        editions_updated, editions_skipped = await _finalize_success(
             session=session,
             factory=factory,
             build_store=build_store,
@@ -252,7 +332,14 @@ async def _process_build_locked(  # noqa: PLR0913
             total_size_bytes=total_size_bytes,
             logger=logger,
         )
-        return "completed"
+        return "completed", _BuildProcessedOutcome(
+            success=True,
+            object_count=object_count,
+            total_size_bytes=total_size_bytes,
+            editions_updated=editions_updated,
+            editions_skipped=editions_skipped,
+            stale_skipped=False,
+        )
 
 
 async def _mark_stale_skipped(  # noqa: PLR0913
@@ -365,10 +452,16 @@ async def _finalize_success(  # noqa: PLR0913
     object_count: int,
     total_size_bytes: int,
     logger: structlog.stdlib.BoundLogger,
-) -> None:
+) -> tuple[int, int]:
     """Run edition tracking and mark the queue job complete.
 
     Edition tracking failures are logged but do not fail the build.
+
+    Returns
+    -------
+    tuple of int, int
+        The number of editions updated and skipped (both ``0`` when
+        edition tracking failed), for the ``build_processed`` metric.
     """
     # Phase 3b: Edition tracking
     tracking_result = await _track_editions(
@@ -465,6 +558,10 @@ async def _finalize_success(  # noqa: PLR0913
             )
             await queue_job_store.complete(queue_job_id, has_errors=has_errors)
     logger.info("Build processing completed")
+
+    if tracking_result is None:
+        return 0, 0
+    return len(tracking_result.updated), len(tracking_result.skipped)
 
 
 async def _enqueue_publish_jobs(  # noqa: PLR0913

--- a/src/docverse/worker/functions/dashboard_build.py
+++ b/src/docverse/worker/functions/dashboard_build.py
@@ -6,8 +6,9 @@ MVP slice) and uploads them to the project's object store.
 
 from __future__ import annotations
 
+import time
 import traceback
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import sentry_sdk
@@ -15,6 +16,7 @@ import structlog
 from safir.dependencies.db_session import db_session_dependency
 
 from docverse.exceptions import NotFoundError
+from docverse.metrics import DashboardBuiltEvent
 from docverse.services.lock_service import LockKey
 
 
@@ -44,6 +46,7 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
     project_id: int = payload["project_id"]
     queue_job_id: int = payload["queue_job_id"]
 
+    started = time.monotonic()
     async for session in db_session_dependency():
         factory = ctx["factory_builder"](session=session, logger=logger)
         queue_job_store = factory.create_queue_job_store()
@@ -119,6 +122,18 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                             "traceback": traceback.format_exc(),
                         },
                     )
+                # Publish after the failed transition commits. Best-effort:
+                # production runs raise_on_error=False so a metrics outage
+                # never fails the build (no defensive try/except).
+                await _publish_dashboard_built(
+                    ctx=ctx,
+                    org_slug=payload["org_slug"],
+                    project_slug=payload["project_slug"],
+                    success=False,
+                    object_count=None,
+                    total_size_bytes=None,
+                    started=started,
+                )
                 return "failed"
 
             async with session.begin():
@@ -134,7 +149,44 @@ async def dashboard_build(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                 )
                 await queue_job_store.complete(queue_job_id)
             logger.info("Dashboard build completed")
+            # Publish after the terminal transition commits (same
+            # best-effort rationale as the failure branch above).
+            await _publish_dashboard_built(
+                ctx=ctx,
+                org_slug=payload["org_slug"],
+                project_slug=payload["project_slug"],
+                success=True,
+                object_count=progress.object_count,
+                total_size_bytes=progress.total_size_bytes,
+                started=started,
+            )
             return "completed"
 
     msg = "No database session available"
     raise RuntimeError(msg)
+
+
+async def _publish_dashboard_built(  # noqa: PLR0913
+    *,
+    ctx: dict[str, Any],
+    org_slug: str,
+    project_slug: str,
+    success: bool,
+    object_count: int | None,
+    total_size_bytes: int | None,
+    started: float,
+) -> None:
+    """Emit one ``dashboard_built`` metric for a finished dashboard build."""
+    events = ctx.get("events")
+    if events is None:
+        return
+    await events.dashboard_built.publish(
+        DashboardBuiltEvent(
+            organization=org_slug,
+            project=project_slug,
+            success=success,
+            object_count=object_count,
+            total_size_bytes=total_size_bytes,
+            elapsed=timedelta(seconds=time.monotonic() - started),
+        )
+    )

--- a/src/docverse/worker/functions/git_ref_audit.py
+++ b/src/docverse/worker/functions/git_ref_audit.py
@@ -42,6 +42,11 @@ from docverse.domain.edition import Edition
 from docverse.domain.lifecycle import LifecycleRuleSet, RefDeletedRule
 from docverse.domain.project import Project
 from docverse.factory import Factory
+from docverse.metrics import (
+    LifecycleActionEvent,
+    LifecycleActionTrigger,
+    LifecycleReapAction,
+)
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_slug,
 )
@@ -101,12 +106,20 @@ async def git_ref_audit(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
         async with session.begin():
             await queue_job_store.start(queue_job_id)
 
+        # Collected inside the soft-delete transaction and published only
+        # after it commits below: one (project_slug, action) per reaped
+        # edition. On the failure path ``_audit_org`` raises before its
+        # transaction commits, so the partially-filled list is discarded
+        # without ever being published (no phantom events for rolled-back
+        # reaps).
+        reaps: list[tuple[str, LifecycleReapAction]] = []
         try:
             had_failures = await _audit_org(
                 session=session,
                 factory=factory,
                 org_id=org_id,
                 org_slug=org_slug,
+                reaps=reaps,
                 logger=logger,
             )
         except Exception as exc:
@@ -136,18 +149,25 @@ async def git_ref_audit(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
             "Git ref audit completed for org",
             had_failures=had_failures,
         )
+        # Publish one lifecycle_action per reaped edition after the commit.
+        # Best-effort: production runs raise_on_error=False so a metrics
+        # outage never fails the audit (no defensive try/except).
+        await _publish_lifecycle_actions(
+            ctx=ctx, org_slug=org_slug, reaps=reaps
+        )
         return "completed_with_errors" if had_failures else "completed"
 
     msg = "No database session available"
     raise RuntimeError(msg)
 
 
-async def _audit_org(
+async def _audit_org(  # noqa: PLR0913
     *,
     session: AsyncSession,
     factory: Factory,
     org_id: int,
     org_slug: str,
+    reaps: list[tuple[str, LifecycleReapAction]],
     logger: structlog.stdlib.BoundLogger,
 ) -> bool:
     """Audit every GitHub-bound project for the org.
@@ -209,6 +229,7 @@ async def _audit_org(
         editions_by_project=editions_by_project,
         org_id=org_id,
         org_slug=org_slug,
+        reaps=reaps,
         logger=logger,
     )
     return had_failures
@@ -340,6 +361,7 @@ async def _apply_deletions(  # noqa: PLR0913
     editions_by_project: dict[int, list[Edition]],
     org_id: int,
     org_slug: str,
+    reaps: list[tuple[str, LifecycleReapAction]],
     logger: structlog.stdlib.BoundLogger,
 ) -> None:
     """Soft-delete every matched edition in one transaction per org.
@@ -375,6 +397,7 @@ async def _apply_deletions(  # noqa: PLR0913
                 if not deleted:
                     continue
                 deleted_count += 1
+                reaps.append((project.slug, LifecycleReapAction.ref_deleted))
                 await publishing_service.unpublish(
                     org_id=org_id,
                     project_slug=project.slug,
@@ -453,3 +476,32 @@ async def _load_org_state(
     for edition in editions:
         editions_by_project[edition.project_id].append(edition)
     return org.lifecycle_rules, projects, editions_by_project
+
+
+async def _publish_lifecycle_actions(
+    *,
+    ctx: dict[str, Any],
+    org_slug: str,
+    reaps: list[tuple[str, LifecycleReapAction]],
+) -> None:
+    """Emit one ``lifecycle_action`` metric per ref-deleted reap.
+
+    ``trigger`` is fixed to ``git_ref_audit`` (this worker) and ``action``
+    is always ``ref_deleted`` (the only rule this worker honours), and
+    ``success`` is ``True`` because each reap is published only after its
+    atomic soft-delete transaction committed. Skips silently when the
+    process has no event manager (tests that do not assert on metrics).
+    """
+    events = ctx.get("events")
+    if events is None:
+        return
+    for project_slug, action in reaps:
+        await events.lifecycle_action.publish(
+            LifecycleActionEvent(
+                organization=org_slug,
+                project=project_slug,
+                action=action,
+                trigger=LifecycleActionTrigger.git_ref_audit,
+                success=True,
+            )
+        )

--- a/src/docverse/worker/functions/inventory_census.py
+++ b/src/docverse/worker/functions/inventory_census.py
@@ -1,0 +1,81 @@
+"""arq cron worker that publishes the daily ``resource_inventory`` gauge.
+
+Daily cron entrypoint for the SQR-112 D8 resource-inventory census. Each
+firing takes one read-only snapshot of every org's and non-deleted
+project's active resource counts (via :class:`InventoryCensusService`,
+which runs grouped aggregates with no advisory locks) and publishes one
+org-scoped ``resource_inventory`` event per org plus one project-scoped
+event per project. The counts are self-contained absolute gauges queried
+downstream with ``last()``; the publish is best-effort — production runs
+``raise_on_error=False`` so a metrics-backend outage can never fail the
+job, and there is no defensive try/except at the call site.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from safir.dependencies.db_session import db_session_dependency
+
+from docverse.domain.inventory_census import InventoryCensus
+from docverse.metrics import ResourceInventoryEvent
+
+__all__ = ["inventory_census"]
+
+
+async def inventory_census(ctx: dict[str, Any]) -> str:
+    """Publish one ``resource_inventory`` gauge per org and per project."""
+    logger = structlog.get_logger("docverse.worker.inventory_census")
+
+    async for session in db_session_dependency():
+        factory = ctx["factory_builder"](session=session, logger=logger)
+        service = factory.create_inventory_census_service()
+        async with session.begin():
+            census = await service.take_census()
+        await _publish_resource_inventory(ctx=ctx, census=census)
+        logger.info(
+            "Inventory census completed",
+            org_count=len(census.orgs),
+            project_count=len(census.projects),
+        )
+        return "completed"
+
+    msg = "No database session available"
+    raise RuntimeError(msg)
+
+
+async def _publish_resource_inventory(
+    *, ctx: dict[str, Any], census: InventoryCensus
+) -> None:
+    """Emit one org-scoped row per org and one project-scoped row per project.
+
+    Published after the read transaction closes. Best-effort: production
+    runs ``raise_on_error=False`` so a metrics outage never fails the job
+    (no defensive try/except at the call site).
+    """
+    events = ctx.get("events")
+    if events is None:
+        return
+    for org in census.orgs:
+        await events.resource_inventory.publish(
+            ResourceInventoryEvent(
+                organization=org.org_slug,
+                project=None,
+                project_count=org.project_count,
+                edition_count=org.edition_count,
+                build_count=org.build_count,
+                total_build_bytes=org.total_build_bytes,
+            )
+        )
+    for project in census.projects:
+        await events.resource_inventory.publish(
+            ResourceInventoryEvent(
+                organization=project.org_slug,
+                project=project.project_slug,
+                project_count=None,
+                edition_count=project.edition_count,
+                build_count=project.build_count,
+                total_build_bytes=project.total_build_bytes,
+            )
+        )

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -197,6 +197,7 @@ async def keeper_sync_reaper(ctx: dict[str, Any]) -> str:
                 session=session,
                 org_store=org_store,
                 completion=completion,
+                logger=logger,
             )
 
         total_reaped = len(reaped) + len(tier_silent) + len(tier_orphans)
@@ -483,6 +484,7 @@ async def keeper_sync_project(
                 session=session,
                 org_store=org_store,
                 completion=completion,
+                logger=logger,
             )
             raise
 
@@ -498,6 +500,7 @@ async def keeper_sync_project(
             session=session,
             org_store=org_store,
             completion=completion,
+            logger=logger,
         )
         logger.info("Keeper-sync project completed")
         return "completed"

--- a/src/docverse/worker/functions/keeper_sync.py
+++ b/src/docverse/worker/functions/keeper_sync.py
@@ -47,6 +47,7 @@ from docverse.client.models import (
 )
 from docverse.config import config
 from docverse.domain.base32id import serialize_base32_id
+from docverse.domain.keeper_sync_run import KeeperSyncRunWithActivity
 from docverse.domain.organization import Organization
 from docverse.factory import Factory
 from docverse.services.keeper_sync.scheduler import (
@@ -69,7 +70,10 @@ from docverse.services.keeper_sync.service import (
     EditionSyncOutcome,
     ProjectSyncResult,
 )
-from docverse.services.keeper_sync_finalisation import maybe_finalise_run
+from docverse.services.keeper_sync_finalisation import (
+    maybe_finalise_run,
+    publish_run_completed,
+)
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.services.publish_enqueue import enqueue_publish_for_edition
 from docverse.storage.keeper_sync import KeeperSyncStateStore, ResourceType
@@ -161,7 +165,9 @@ async def keeper_sync_reaper(ctx: dict[str, Any]) -> str:
         factory = ctx["factory_builder"](session=session, logger=logger)
         queue_job_store = factory.create_queue_job_store()
         run_store = factory.create_keeper_sync_run_store()
+        org_store = factory.create_org_store()
 
+        completions: list[KeeperSyncRunWithActivity] = []
         async with session.begin():
             reaped = await queue_job_store.fail_silent_run_children(
                 idle_after=threshold
@@ -176,7 +182,22 @@ async def keeper_sync_reaper(ctx: dict[str, Any]) -> str:
             for run_id in run_ids:
                 if run_id is None:
                     continue
-                await maybe_finalise_run(run_store=run_store, run_id=run_id)
+                completion = await maybe_finalise_run(
+                    run_store=run_store, run_id=run_id
+                )
+                if completion is not None:
+                    completions.append(completion)
+
+        # Publish one keeper_sync_run_completed per run this sweep drove
+        # terminal, after the finalisation transaction commits.
+        events = ctx.get("events")
+        for completion in completions:
+            await publish_run_completed(
+                events=events,
+                session=session,
+                org_store=org_store,
+                completion=completion,
+            )
 
         total_reaped = len(reaped) + len(tier_silent) + len(tier_orphans)
         if total_reaped:
@@ -443,6 +464,7 @@ async def keeper_sync_project(
         except Exception as exc:
             sentry_sdk.capture_exception(exc)
             logger.exception("Keeper-sync project failed")
+            completion: KeeperSyncRunWithActivity | None = None
             async with session.begin():
                 await queue_job_store.fail(
                     queue_job_id,
@@ -453,15 +475,30 @@ async def keeper_sync_project(
                     },
                 )
                 if run_id is not None:
-                    await maybe_finalise_run(
+                    completion = await maybe_finalise_run(
                         run_store=run_store, run_id=run_id
                     )
+            await publish_run_completed(
+                events=ctx.get("events"),
+                session=session,
+                org_store=org_store,
+                completion=completion,
+            )
             raise
 
+        completion = None
         async with session.begin():
             await queue_job_store.complete(queue_job_id)
             if run_id is not None:
-                await maybe_finalise_run(run_store=run_store, run_id=run_id)
+                completion = await maybe_finalise_run(
+                    run_store=run_store, run_id=run_id
+                )
+        await publish_run_completed(
+            events=ctx.get("events"),
+            session=session,
+            org_store=org_store,
+            completion=completion,
+        )
         logger.info("Keeper-sync project completed")
         return "completed"
 

--- a/src/docverse/worker/functions/lifecycle_eval.py
+++ b/src/docverse/worker/functions/lifecycle_eval.py
@@ -43,6 +43,11 @@ from docverse.domain.lifecycle import (
 )
 from docverse.domain.project import Project
 from docverse.factory import Factory
+from docverse.metrics import (
+    LifecycleActionEvent,
+    LifecycleActionTrigger,
+    LifecycleReapAction,
+)
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_slug,
 )
@@ -113,12 +118,20 @@ async def lifecycle_eval(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
         async with session.begin():
             await queue_job_store.start(queue_job_id)
 
+        # Collected inside the soft-delete transaction and published only
+        # after it commits below: one (project_slug, action) per reaped
+        # row. On the failure path ``_evaluate_org`` raises before its
+        # transaction commits, so the partially-filled list is discarded
+        # without ever being published (no phantom events for rolled-back
+        # reaps).
+        reaps: list[tuple[str, LifecycleReapAction]] = []
         try:
             await _evaluate_org(
                 session=session,
                 factory=factory,
                 org_id=org_id,
                 org_slug=org_slug,
+                reaps=reaps,
                 logger=logger,
             )
         except Exception as exc:
@@ -143,18 +156,25 @@ async def lifecycle_eval(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                 run_store=run_store, run_id=run_id
             )
         logger.info("Lifecycle evaluation completed for org")
+        # Publish one lifecycle_action per reaped row after the commit.
+        # Best-effort: production runs raise_on_error=False so a metrics
+        # outage never fails the pass (no defensive try/except).
+        await _publish_lifecycle_actions(
+            ctx=ctx, org_slug=org_slug, reaps=reaps
+        )
         return "completed"
 
     msg = "No database session available"
     raise RuntimeError(msg)
 
 
-async def _evaluate_org(
+async def _evaluate_org(  # noqa: PLR0913
     *,
     session: AsyncSession,
     factory: Factory,
     org_id: int,
     org_slug: str,
+    reaps: list[tuple[str, LifecycleReapAction]],
     logger: structlog.stdlib.BoundLogger,
 ) -> None:
     """Load the org's state, evaluate per-project rules, and apply deletions.
@@ -238,6 +258,7 @@ async def _evaluate_org(
                 build_index=build_index,
                 org_id=org_id,
                 org_slug=org_slug,
+                reaps=reaps,
                 logger=logger,
             )
             if editions_deleted:
@@ -355,6 +376,7 @@ async def _apply_decision(  # noqa: PLR0913
     build_index: dict[int, Build],
     org_id: int,
     org_slug: str,
+    reaps: list[tuple[str, LifecycleReapAction]],
     logger: structlog.stdlib.BoundLogger,
 ) -> int:
     """Soft-delete every entity the decision matched and emit one log per row.
@@ -396,6 +418,9 @@ async def _apply_decision(  # noqa: PLR0913
         if not deleted:
             continue
         editions_deleted += 1
+        reaps.append(
+            (project.slug, LifecycleReapAction.from_rule_type(rule_type))
+        )
         # Remove the CDN pointer for the soft-deleted edition so the
         # public URL stops resolving. ``unpublish`` is idempotent and a
         # no-op when the org has no CDN configured, so this is safe to
@@ -430,6 +455,9 @@ async def _apply_decision(  # noqa: PLR0913
         deleted = await build_store.soft_delete(build_id=build.id)
         if not deleted:
             continue
+        reaps.append(
+            (project.slug, LifecycleReapAction.from_rule_type(rule_type))
+        )
         logger.info(
             "Soft-deleted entity by lifecycle rule",
             entity_type="build",
@@ -444,3 +472,31 @@ async def _apply_decision(  # noqa: PLR0913
             ),
         )
     return editions_deleted
+
+
+async def _publish_lifecycle_actions(
+    *,
+    ctx: dict[str, Any],
+    org_slug: str,
+    reaps: list[tuple[str, LifecycleReapAction]],
+) -> None:
+    """Emit one ``lifecycle_action`` metric per reaped row.
+
+    ``trigger`` is fixed to ``lifecycle_eval`` (this worker), and
+    ``success`` is ``True`` because each reap is published only after its
+    atomic soft-delete transaction committed. Skips silently when the
+    process has no event manager (tests that do not assert on metrics).
+    """
+    events = ctx.get("events")
+    if events is None:
+        return
+    for project_slug, action in reaps:
+        await events.lifecycle_action.publish(
+            LifecycleActionEvent(
+                organization=org_slug,
+                project=project_slug,
+                action=action,
+                trigger=LifecycleActionTrigger.lifecycle_eval,
+                success=True,
+            )
+        )

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -23,6 +23,7 @@ from docverse.client.models.queue_enums import PublishStatus
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
 from docverse.domain.edition_build_history import EditionBuildHistory
+from docverse.domain.keeper_sync_run import KeeperSyncRunWithActivity
 from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
 from docverse.metrics import (
@@ -33,7 +34,10 @@ from docverse.metrics import (
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_id,
 )
-from docverse.services.keeper_sync_finalisation import maybe_finalise_run
+from docverse.services.keeper_sync_finalisation import (
+    maybe_finalise_run,
+    publish_run_completed,
+)
 from docverse.services.lock_service import LockKey
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -132,6 +136,7 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
             except Exception as exc:
                 sentry_sdk.capture_exception(exc)
                 logger.exception("Edition publish failed")
+                completion: KeeperSyncRunWithActivity | None = None
                 async with session.begin():
                     await _mark_failed(
                         edition_store=edition_store,
@@ -141,13 +146,20 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                         queue_job_id=queue_job_id,
                         exc=exc,
                     )
-                    await _maybe_finalise_keeper_sync_run(
+                    completion = await _maybe_finalise_keeper_sync_run(
                         factory=factory, queue_job_id=queue_job_id
                     )
+                await publish_run_completed(
+                    events=ctx.get("events"),
+                    session=session,
+                    org_store=factory.create_org_store(),
+                    completion=completion,
+                )
                 return "failed"
+            completion = None
             async with session.begin():
                 await queue_job_store.complete(queue_job_id)
-                await _maybe_finalise_keeper_sync_run(
+                completion = await _maybe_finalise_keeper_sync_run(
                     factory=factory, queue_job_id=queue_job_id
                 )
             logger.info("Edition publish completed")
@@ -163,6 +175,12 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                 edition=resources.edition,
                 queue_job_id=queue_job_id,
                 started=started,
+            )
+            await publish_run_completed(
+                events=ctx.get("events"),
+                session=session,
+                org_store=factory.create_org_store(),
+                completion=completion,
             )
             await try_enqueue_dashboard_build_by_id(
                 factory=factory,
@@ -280,7 +298,7 @@ async def _maybe_finalise_keeper_sync_run(
     *,
     factory: Factory,
     queue_job_id: int,
-) -> None:
+) -> KeeperSyncRunWithActivity | None:
     """Roll up the parent keeper-sync run if this publish was attributed.
 
     Publish jobs enqueued by ``keeper_sync_project`` (via the shared
@@ -302,8 +320,8 @@ async def _maybe_finalise_keeper_sync_run(
     run_store = factory.create_keeper_sync_run_store()
     queue_job = await queue_job_store.get(queue_job_id)
     if queue_job is None or queue_job.keeper_sync_run_id is None:
-        return
-    await maybe_finalise_run(
+        return None
+    return await maybe_finalise_run(
         run_store=run_store, run_id=queue_job.keeper_sync_run_id
     )
 

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -8,20 +8,29 @@ work without external context (per SQR-112 user story 12).
 
 from __future__ import annotations
 
+import time
 import traceback
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Any
 
 import sentry_sdk
 import structlog
 from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from docverse.client.models import EditionKind
 from docverse.client.models.queue_enums import PublishStatus
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
 from docverse.domain.edition_build_history import EditionBuildHistory
 from docverse.exceptions import NotFoundError
 from docverse.factory import Factory
+from docverse.metrics import (
+    EditionPublishedEvent,
+    EditionPublishTrigger,
+    MetricsEditionKind,
+)
 from docverse.services.dashboard.enqueue import (
     try_enqueue_dashboard_build_by_id,
 )
@@ -70,6 +79,7 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
 
     queue_job_id: int = payload["queue_job_id"]
 
+    started = time.monotonic()
     async for session in db_session_dependency():
         factory = ctx["factory_builder"](session=session, logger=logger)
         edition_store = factory.create_edition_store()
@@ -142,6 +152,19 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                     factory=factory, queue_job_id=queue_job_id
                 )
             logger.info("Edition publish completed")
+            # Publish after the success transition commits. Best-effort:
+            # production runs raise_on_error=False so a metrics outage
+            # never fails the publish (no defensive try/except).
+            await _publish_edition_published(
+                ctx=ctx,
+                session=session,
+                factory=factory,
+                org_id=payload["org_id"],
+                project_slug=payload["project_slug"],
+                edition=resources.edition,
+                queue_job_id=queue_job_id,
+                started=started,
+            )
             await try_enqueue_dashboard_build_by_id(
                 factory=factory,
                 session=session,
@@ -283,4 +306,56 @@ async def _maybe_finalise_keeper_sync_run(
         return
     await maybe_finalise_run(
         run_store=run_store, run_id=queue_job.keeper_sync_run_id
+    )
+
+
+def _metrics_edition_kind(kind: EditionKind) -> MetricsEditionKind:
+    """Map the API ``EditionKind`` to the dedicated metrics enum.
+
+    Values are identical, so this is a straight value lookup; keeping
+    the mapping explicit lets the metrics schema evolve independently of
+    the API model (SQR-112 D4).
+    """
+    return MetricsEditionKind(kind.value)
+
+
+async def _publish_edition_published(  # noqa: PLR0913
+    *,
+    ctx: dict[str, Any],
+    session: AsyncSession,
+    factory: Factory,
+    org_id: int,
+    project_slug: str,
+    edition: Edition,
+    queue_job_id: int,
+    started: float,
+) -> None:
+    """Emit one ``edition_published`` metric for a successful publish.
+
+    The publish job's ``queue_jobs`` row carries a ``keeper_sync_run_id``
+    only when the LTD-keeper backfill drove it, so its presence
+    classifies the ``trigger``.
+    """
+    events = ctx.get("events")
+    if events is None:
+        return
+    org_store = factory.create_org_store()
+    queue_job_store = factory.create_queue_job_store()
+    async with session.begin():
+        org = await org_store.get_by_id(org_id)
+        queue_job = await queue_job_store.get(queue_job_id)
+    organization = org.slug if org is not None else str(org_id)
+    trigger = (
+        EditionPublishTrigger.keeper_sync
+        if queue_job is not None and queue_job.keeper_sync_run_id is not None
+        else EditionPublishTrigger.build
+    )
+    await events.edition_published.publish(
+        EditionPublishedEvent(
+            organization=organization,
+            project=project_slug,
+            edition_kind=_metrics_edition_kind(edition.kind),
+            trigger=trigger,
+            elapsed=timedelta(seconds=time.monotonic() - started),
+        )
     )

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -154,6 +154,7 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                     session=session,
                     org_store=factory.create_org_store(),
                     completion=completion,
+                    logger=logger,
                 )
                 return "failed"
             completion = None
@@ -163,13 +164,16 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                     factory=factory, queue_job_id=queue_job_id
                 )
             logger.info("Edition publish completed")
-            # Publish after the success transition commits. Best-effort:
-            # production runs raise_on_error=False so a metrics outage
-            # never fails the publish (no defensive try/except).
+            # Emit the post-commit metrics after the success transition
+            # commits. Both emitters are fully best-effort: they swallow
+            # and log any error (a metrics outage *or* a DB hiccup during
+            # their own post-commit reads), so neither can fail or retry
+            # an edition whose publish has already committed.
             await _publish_edition_published(
                 ctx=ctx,
                 session=session,
                 factory=factory,
+                logger=logger,
                 org_id=payload["org_id"],
                 project_slug=payload["project_slug"],
                 edition=resources.edition,
@@ -181,6 +185,7 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                 session=session,
                 org_store=factory.create_org_store(),
                 completion=completion,
+                logger=logger,
             )
             await try_enqueue_dashboard_build_by_id(
                 factory=factory,
@@ -331,6 +336,7 @@ async def _publish_edition_published(  # noqa: PLR0913
     ctx: dict[str, Any],
     session: AsyncSession,
     factory: Factory,
+    logger: structlog.stdlib.BoundLogger,
     org_id: int,
     project_slug: str,
     edition: Edition,
@@ -342,27 +348,38 @@ async def _publish_edition_published(  # noqa: PLR0913
     The publish job's ``queue_jobs`` row carries a ``keeper_sync_run_id``
     only when the LTD-keeper backfill drove it, so its presence
     classifies the ``trigger``.
+
+    Fully best-effort: this runs *after* the publish has committed, so it
+    swallows and logs any error — a metrics-backend outage (already
+    covered by ``raise_on_error=False``) *or* a DB error during its own
+    post-commit reads — rather than letting it propagate and retry an
+    edition that has already published.
     """
     events = ctx.get("events")
     if events is None:
         return
-    org_store = factory.create_org_store()
-    queue_job_store = factory.create_queue_job_store()
-    async with session.begin():
-        org = await org_store.get_by_id(org_id)
-        queue_job = await queue_job_store.get(queue_job_id)
-    organization = org.slug if org is not None else str(org_id)
-    trigger = (
-        EditionPublishTrigger.keeper_sync
-        if queue_job is not None and queue_job.keeper_sync_run_id is not None
-        else EditionPublishTrigger.build
-    )
-    await events.edition_published.publish(
-        EditionPublishedEvent(
-            organization=organization,
-            project=project_slug,
-            edition_kind=MetricsEditionKind.from_api(edition.kind),
-            trigger=trigger,
-            elapsed=timedelta(seconds=time.monotonic() - started),
+    try:
+        org_store = factory.create_org_store()
+        queue_job_store = factory.create_queue_job_store()
+        async with session.begin():
+            org = await org_store.get_by_id(org_id)
+            queue_job = await queue_job_store.get(queue_job_id)
+        organization = org.slug if org is not None else str(org_id)
+        trigger = (
+            EditionPublishTrigger.keeper_sync
+            if queue_job is not None
+            and queue_job.keeper_sync_run_id is not None
+            else EditionPublishTrigger.build
         )
-    )
+        await events.edition_published.publish(
+            EditionPublishedEvent(
+                organization=organization,
+                project=project_slug,
+                edition_kind=MetricsEditionKind.from_api(edition.kind),
+                trigger=trigger,
+                elapsed=timedelta(seconds=time.monotonic() - started),
+            )
+        )
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
+        logger.exception("Failed to publish edition_published metric")

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -19,7 +19,6 @@ import structlog
 from safir.dependencies.db_session import db_session_dependency
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from docverse.client.models import EditionKind
 from docverse.client.models.queue_enums import PublishStatus
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
@@ -309,16 +308,6 @@ async def _maybe_finalise_keeper_sync_run(
     )
 
 
-def _metrics_edition_kind(kind: EditionKind) -> MetricsEditionKind:
-    """Map the API ``EditionKind`` to the dedicated metrics enum.
-
-    Values are identical, so this is a straight value lookup; keeping
-    the mapping explicit lets the metrics schema evolve independently of
-    the API model (SQR-112 D4).
-    """
-    return MetricsEditionKind(kind.value)
-
-
 async def _publish_edition_published(  # noqa: PLR0913
     *,
     ctx: dict[str, Any],
@@ -354,7 +343,7 @@ async def _publish_edition_published(  # noqa: PLR0913
         EditionPublishedEvent(
             organization=organization,
             project=project_slug,
-            edition_kind=_metrics_edition_kind(edition.kind),
+            edition_kind=MetricsEditionKind.from_api(edition.kind),
             trigger=trigger,
             elapsed=timedelta(seconds=time.monotonic() - started),
         )

--- a/src/docverse/worker/functions/publish_edition.py
+++ b/src/docverse/worker/functions/publish_edition.py
@@ -179,6 +179,7 @@ async def publish_edition(ctx: dict[str, Any], payload: dict[str, Any]) -> str:
                 edition=resources.edition,
                 queue_job_id=queue_job_id,
                 started=started,
+                trigger_override=payload.get("trigger"),
             )
             await publish_run_completed(
                 events=ctx.get("events"),
@@ -342,12 +343,17 @@ async def _publish_edition_published(  # noqa: PLR0913
     edition: Edition,
     queue_job_id: int,
     started: float,
+    trigger_override: str | None = None,
 ) -> None:
     """Emit one ``edition_published`` metric for a successful publish.
 
-    The publish job's ``queue_jobs`` row carries a ``keeper_sync_run_id``
-    only when the LTD-keeper backfill drove it, so its presence
-    classifies the ``trigger``.
+    The ``trigger`` is classified, in order:
+
+    * ``keeper_sync`` when the publish job's ``queue_jobs`` row carries a
+      ``keeper_sync_run_id`` (only the LTD-keeper backfill sets it);
+    * otherwise the explicit ``trigger_override`` from the job payload
+      (the rollback handler tags ``trigger=rollback``);
+    * otherwise ``build`` — the ordinary client-upload fan-out.
 
     Fully best-effort: this runs *after* the publish has committed, so it
     swallows and logs any error — a metrics-backend outage (already
@@ -365,12 +371,12 @@ async def _publish_edition_published(  # noqa: PLR0913
             org = await org_store.get_by_id(org_id)
             queue_job = await queue_job_store.get(queue_job_id)
         organization = org.slug if org is not None else str(org_id)
-        trigger = (
-            EditionPublishTrigger.keeper_sync
-            if queue_job is not None
-            and queue_job.keeper_sync_run_id is not None
-            else EditionPublishTrigger.build
-        )
+        if queue_job is not None and queue_job.keeper_sync_run_id is not None:
+            trigger = EditionPublishTrigger.keeper_sync
+        elif trigger_override is not None:
+            trigger = EditionPublishTrigger(trigger_override)
+        else:
+            trigger = EditionPublishTrigger.build
         await events.edition_published.publish(
             EditionPublishedEvent(
                 organization=organization,

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.config import Configuration
 from docverse.database import get_current_revision
 from docverse.factory import Factory
+from docverse.metrics import build_event_manager
 from docverse.sentry import (
     DocverseSentryComponent,
     initialize_sentry,
@@ -266,6 +267,13 @@ async def _startup(
     )
     ctx["factory_builder"] = factory_builder
 
+    # The metrics event manager is process-lifetime like the factory
+    # builder; ``shutdown`` owns ``event_manager`` teardown. Worker
+    # functions publish through ``ctx["events"]``.
+    event_manager, events = await build_event_manager(config, logger=logger)
+    ctx["event_manager"] = event_manager
+    ctx["events"] = events
+
     logger.info("Worker startup complete")
 
 
@@ -299,6 +307,9 @@ async def shutdown(ctx: dict[str, Any]) -> None:
         # Private-attribute access until safir adds a public shutdown API;
         # see https://github.com/lsst-sqre/safir/issues/522
         await arq_queue._pool.aclose()  # noqa: SLF001
+    event_manager = ctx.get("event_manager")
+    if event_manager is not None:
+        await event_manager.aclose()
     await ctx["http_client"].aclose()
     await db_session_dependency.aclose()
     logger = structlog.get_logger("docverse.worker")

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -53,6 +53,7 @@ from .functions import (
     dashboard_sync_reaper,
     git_ref_audit,
     git_ref_audit_discovery,
+    inventory_census,
     keeper_sync_project,
     keeper_sync_reaper,
     keeper_sync_run_discovery,
@@ -541,6 +542,17 @@ class MaintenanceWorkerSettings:
             timeout=config.maintenance_job_timeout_seconds,
             max_tries=1,
         ),
+        # The daily ``inventory_census`` cron (SQR-112 D8) publishes the
+        # ``resource_inventory`` gauge. Wrapped like the dispatchers with
+        # the maintenance per-job ``timeout`` and ``max_tries=1``: the
+        # census is the pool's primary cron work (not a backstop), and a
+        # single attempt avoids arq's default retry republishing the
+        # gauge — duplicates are harmless under ``last()`` but pointless.
+        func(
+            instrument_arq_task(inventory_census),
+            timeout=config.maintenance_job_timeout_seconds,
+            max_tries=1,
+        ),
         instrument_arq_task(lifecycle_reaper),
         instrument_arq_task(dashboard_build_reaper),
         instrument_arq_task(publish_edition_reaper),
@@ -573,6 +585,20 @@ class MaintenanceWorkerSettings:
             instrument_arq_task(git_ref_audit_discovery),
             hour={5},
             minute={17},
+        ),
+        # Daily ``inventory_census`` tick (SQR-112 D8) at the
+        # config-driven UTC ``inventory_census_cron_hour`` /
+        # ``inventory_census_cron_minute`` (04:47 by default). The hour
+        # sits in the quiet pre-dawn UTC window ahead of the
+        # ``git_ref_audit`` tick, and the minute is staggered off every
+        # maintenance-pool reaper slot and the five-minute queue-stats
+        # cadence so the census never co-fires with another cron on a
+        # horizontally scaled pool — the same contention-avoidance
+        # precedent as ``git_ref_audit_discovery`` at minute 17.
+        cron(
+            instrument_arq_task(inventory_census),
+            hour={config.inventory_census_cron_hour},
+            minute={config.inventory_census_cron_minute},
         ),
         cron(
             instrument_arq_task(lifecycle_reaper),

--- a/src/docverse/worker/main.py
+++ b/src/docverse/worker/main.py
@@ -18,6 +18,12 @@ from safir.arq import ArqQueue, RedisArqQueue
 from safir.database import create_database_engine, is_database_current
 from safir.dependencies.db_session import db_session_dependency
 from safir.logging import configure_logging
+from safir.metrics.arq import (
+    ARQ_EVENTS_CONTEXT_KEY,
+    initialize_arq_metrics,
+    make_on_job_start,
+    publish_queue_stats,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.config import Configuration
@@ -93,6 +99,34 @@ def _cron_minutes_for_tier_interval(interval: timedelta) -> set[int]:
         raise ValueError(msg)
     minutes = seconds // 60
     return set(range(0, 60, minutes))
+
+
+_QUEUE_STATS_CRON_MINUTES = set(range(0, 60, 5))
+"""Five-minute cadence for the ``arq_queue_stats`` gauge.
+
+Queue depth is a Sasquatch product-analytics gauge (SQR-112),
+deliberately distinct from operational telemetry, so a five-minute
+resolution is ample; the coarser cadence also limits the per-tick Redis
+pool that Safir's :func:`safir.metrics.arq.publish_queue_stats` opens.
+"""
+
+
+async def publish_queue_stats_cron(
+    ctx: dict[Any, Any], *args: Any, **kwargs: Any
+) -> None:
+    """Publish this pool's queue-depth ``arq_queue_stats`` gauge (SQR-112).
+
+    Registered as a per-pool cron on every ``WorkerSettings``. The pool's
+    queue name, Redis settings, and the generic arq publishers are all
+    read from the job ``ctx`` that :func:`_startup` populated, so one
+    coroutine serves all three pools and each publishes stats for the
+    queue its own worker process serves.
+    """
+    await publish_queue_stats(
+        ctx["queue_name"],
+        ctx["redis_settings"],
+        ctx[ARQ_EVENTS_CONTEXT_KEY],
+    )
 
 
 class WorkerFactoryBuilder:
@@ -274,6 +308,17 @@ async def _startup(
     ctx["event_manager"] = event_manager
     ctx["events"] = events
 
+    # Generic Safir arq-queue metrics (SQR-112): ``arq_job_run`` for every
+    # job (via ``make_on_job_start`` on each WorkerSettings) and
+    # ``arq_queue_stats`` per pool (via the ``publish_queue_stats_cron``
+    # cron). ``initialize_arq_metrics`` populates
+    # ``ctx[ARQ_EVENTS_CONTEXT_KEY]``; the stats cron also reads this
+    # pool's ``queue_name`` and the ``redis_settings`` (validated non-None
+    # above) back from ``ctx``.
+    await initialize_arq_metrics(event_manager, ctx)
+    ctx["queue_name"] = queue_name
+    ctx["redis_settings"] = config.arq_redis_settings
+
     logger.info("Worker startup complete")
 
 
@@ -326,9 +371,18 @@ class WorkerSettings:
         instrument_arq_task(ping),
         instrument_arq_task(publish_edition),
     ]
+    # Generic arq-queue metrics (SQR-112): publish ``arq_job_run`` for
+    # every job and an ``arq_queue_stats`` gauge for this pool's queue.
+    cron_jobs = [
+        cron(
+            instrument_arq_task(publish_queue_stats_cron),
+            minute=_QUEUE_STATS_CRON_MINUTES,
+        ),
+    ]
     redis_settings = config.arq_redis_settings
     queue_name = config.arq_queue_name
     on_startup = startup_default
+    on_job_start = make_on_job_start(config.arq_queue_name)
     on_shutdown = shutdown
 
 
@@ -400,10 +454,17 @@ class KeeperSyncWorkerSettings:
             instrument_arq_task(keeper_sync_tier_other),
             minute=_cron_minutes_for_tier_interval(TIER_OTHER_CRON_INTERVAL),
         ),
+        # Generic arq-queue metrics (SQR-112): per-pool ``arq_queue_stats``
+        # gauge for the keeper-sync queue.
+        cron(
+            instrument_arq_task(publish_queue_stats_cron),
+            minute=_QUEUE_STATS_CRON_MINUTES,
+        ),
     ]
     redis_settings = config.arq_redis_settings
     queue_name = KEEPER_SYNC_QUEUE_NAME
     on_startup = startup_keeper_sync
+    on_job_start = make_on_job_start(KEEPER_SYNC_QUEUE_NAME)
     on_shutdown = shutdown
 
 
@@ -572,8 +633,17 @@ class MaintenanceWorkerSettings:
             instrument_arq_task(dashboard_sync_reaper),
             minute={24, 54},
         ),
+        # Generic arq-queue metrics (SQR-112): per-pool ``arq_queue_stats``
+        # gauge for the maintenance queue. Queue-depth stats only touch
+        # Redis and Kafka, so the five-minute cadence is free to overlap
+        # the Postgres-bound reaper slots above without contention.
+        cron(
+            instrument_arq_task(publish_queue_stats_cron),
+            minute=_QUEUE_STATS_CRON_MINUTES,
+        ),
     ]
     redis_settings = config.arq_redis_settings
     queue_name = MAINTENANCE_QUEUE_NAME
     on_startup = startup_maintenance
+    on_job_start = make_on_job_start(MAINTENANCE_QUEUE_NAME)
     on_shutdown = shutdown

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,8 @@ from docverse.dbschema import Base
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.domain.base32id import serialize_base32_id
 from docverse.main import app as docverse_app
+from docverse.metrics import build_event_manager
+from docverse.metrics.events import DocverseEvents
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.storage.build_store import BuildStore
 from docverse.storage.membership_store import OrgMembershipStore
@@ -127,6 +129,21 @@ async def discovery_client() -> AsyncGenerator[DiscoveryClient]:
     """Return a ``DiscoveryClient`` backed by the autouse respx mock."""
     async with httpx.AsyncClient() as http_client:
         yield DiscoveryClient(http_client)
+
+
+@pytest_asyncio.fixture
+async def mock_events() -> AsyncGenerator[DocverseEvents]:
+    """Build an initialized ``DocverseEvents`` over a ``MockEventManager``.
+
+    Mirrors what the FastAPI lifespan and worker startup build, for unit
+    tests that construct a ``ContextDependency`` or worker ``ctx``
+    directly and therefore need to supply the metrics events themselves.
+    """
+    manager, events = await build_event_manager(config)
+    try:
+        yield events
+    finally:
+        await manager.aclose()
 
 
 @pytest_asyncio.fixture

--- a/tests/dependencies/context_test.py
+++ b/tests/dependencies/context_test.py
@@ -13,6 +13,7 @@ from safir.arq import MockArqQueue
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.dependencies.context import ContextDependency
+from docverse.metrics.events import DocverseEvents
 from docverse.storage.github import (
     GitHubAppClient,
     GitHubAppNotConfiguredError,
@@ -28,6 +29,7 @@ def _logger() -> structlog.stdlib.BoundLogger:
 async def test_request_context_creates_github_app_client_when_configured(
     db_session: AsyncSession,
     mock_github: GitHubMock,
+    mock_events: DocverseEvents,
 ) -> None:
     """With all three secrets set, the factory builds a GitHubAppClient."""
     dep = ContextDependency()
@@ -37,6 +39,7 @@ async def test_request_context_creates_github_app_client_when_configured(
             github_app_id=mock_github.app_id,
             github_app_private_key=SecretStr(mock_github.private_key_pem),
             github_webhook_secret=SecretStr("webhook-secret"),
+            events=mock_events,
         )
         context = await dep(
             request=Mock(spec=Request),
@@ -54,6 +57,7 @@ async def test_request_context_creates_github_app_client_when_configured(
 async def test_request_context_raises_when_github_secret_missing(
     db_session: AsyncSession,
     mock_github: GitHubMock,
+    mock_events: DocverseEvents,
 ) -> None:
     """A single missing secret makes ``create_github_app_client`` raise."""
     dep = ContextDependency()
@@ -63,6 +67,7 @@ async def test_request_context_raises_when_github_secret_missing(
             github_app_id=mock_github.app_id,
             github_app_private_key=SecretStr(mock_github.private_key_pem),
             # github_webhook_secret intentionally unset
+            events=mock_events,
         )
         context = await dep(
             request=Mock(spec=Request),
@@ -79,6 +84,7 @@ async def test_request_context_raises_when_github_secret_missing(
 async def test_set_github_app_validated_disables_feature(
     db_session: AsyncSession,
     mock_github: GitHubMock,
+    mock_events: DocverseEvents,
 ) -> None:
     """``set_github_app_validated(False)`` makes the gate raise.
 
@@ -93,6 +99,7 @@ async def test_set_github_app_validated_disables_feature(
             github_app_id=mock_github.app_id,
             github_app_private_key=SecretStr(mock_github.private_key_pem),
             github_webhook_secret=SecretStr("webhook-secret"),
+            events=mock_events,
         )
         # Sanity check: the feature is enabled out of the gate.
         context = await dep(
@@ -139,6 +146,7 @@ async def test_github_app_enabled_property_tracks_secret_presence(
 async def test_set_github_secrets_resets_validated_flag(
     db_session: AsyncSession,
     mock_github: GitHubMock,
+    mock_events: DocverseEvents,
 ) -> None:
     """A new secret bundle clears the prior ``validated=False`` decision.
 
@@ -153,6 +161,7 @@ async def test_set_github_secrets_resets_validated_flag(
             github_app_id=mock_github.app_id,
             github_app_private_key=SecretStr(mock_github.private_key_pem),
             github_webhook_secret=SecretStr("webhook-secret"),
+            events=mock_events,
         )
         dep.set_github_app_validated(value=False)
         dep.set_github_secrets(
@@ -176,11 +185,12 @@ async def test_set_github_secrets_resets_validated_flag(
 async def test_set_github_secrets_overrides_three_fields(
     db_session: AsyncSession,
     mock_github: GitHubMock,
+    mock_events: DocverseEvents,
 ) -> None:
     """``set_github_secrets`` updates the three GitHub-App secret slots."""
     dep = ContextDependency()
     async with httpx.AsyncClient() as http_client:
-        await dep.initialize(http_client=http_client)
+        await dep.initialize(http_client=http_client, events=mock_events)
         # No secrets yet.
         context = await dep(
             request=Mock(spec=Request),

--- a/tests/handlers/builds_test.py
+++ b/tests/handlers/builds_test.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import pytest
 from httpx import AsyncClient
+from safir.metrics import MockEventPublisher
 
 from docverse.client.models import BuildAnnotations
+from docverse.dependencies.context import context_dependency
 from tests.conftest import seed_build, seed_org_with_admin
 
 CONTENT_HASH = (
@@ -120,6 +122,69 @@ async def test_patch_build_upload_complete(client: AsyncClient) -> None:
     data = response.json()
     assert data["status"] == "processing"
     assert data["queue_url"] is not None
+
+
+@pytest.mark.asyncio
+async def test_patch_build_publishes_build_uploaded(
+    client: AsyncClient,
+) -> None:
+    """PATCH status=uploaded emits one build_uploaded with provenance."""
+    await _setup(client)
+    build_id = await seed_build(
+        "build-org",
+        "build-proj",
+        uploader="ci-bot",
+        annotations=BuildAnnotations.model_validate(
+            {
+                "commit_sha": "abc123",
+                "github_run_id": "42",
+                "ci_platform": "github-actions",
+            }
+        ),
+    )
+    response = await client.patch(
+        f"/docverse/orgs/build-org/projects/build-proj/builds/{build_id}",
+        json={"status": "uploaded"},
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 200
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.build_uploaded
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == "build-org"
+    assert event.project == "build-proj"
+    assert event.uploader == "ci-bot"
+    assert event.commit_sha == "abc123"
+    assert event.github_run_id == "42"
+    assert event.ci_platform == "github-actions"
+    # Provenance fields the uploader did not annotate are null.
+    assert event.github_repository is None
+    assert event.github_actor is None
+
+
+@pytest.mark.asyncio
+async def test_patch_build_noop_does_not_publish_build_uploaded(
+    client: AsyncClient,
+) -> None:
+    """A non-uploaded PATCH must not emit a build_uploaded event."""
+    await _setup(client)
+    build_id = await seed_build("build-org", "build-proj")
+    response = await client.patch(
+        f"/docverse/orgs/build-org/projects/build-proj/builds/{build_id}",
+        json={"status": "pending"},
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 200
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.build_uploaded
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/edition_rollback_test.py
+++ b/tests/handlers/edition_rollback_test.py
@@ -370,6 +370,9 @@ async def test_rollback_enqueues_publish_edition_arq_job(
     assert "org_id" in payload
     assert "edition_id" in payload
     assert "queue_job_id" in payload
+    # The rollback path tags its publish so the edition_published metric
+    # reports trigger=rollback rather than the default build fan-out.
+    assert payload["trigger"] == "rollback"
 
     logger = structlog.get_logger("docverse")
     async with db_session.begin():

--- a/tests/handlers/edition_rollback_test.py
+++ b/tests/handlers/edition_rollback_test.py
@@ -7,13 +7,16 @@ import structlog
 from httpx import AsyncClient
 from safir.arq import MockArqQueue
 from safir.dependencies.arq import arq_dependency
+from safir.metrics import MockEventPublisher
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import BuildCreate
 from docverse.client.models.queue_enums import JobKind, PublishStatus
 from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.dependencies.context import context_dependency
 from docverse.domain.base32id import serialize_base32_id
+from docverse.metrics import LifecycleAction, MetricsEditionKind
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -374,6 +377,40 @@ async def test_rollback_enqueues_publish_edition_arq_job(
         child = await qjs.get(payload["queue_job_id"])
         assert child is not None
         assert child.kind == JobKind.publish_edition
+
+
+@pytest.mark.asyncio
+async def test_rollback_publishes_edition_lifecycle(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Rollback emits one edition_lifecycle (rollback) with edition_kind."""
+    await _setup(client)
+    async with db_session.begin():
+        builds = await _create_builds_with_history(db_session, n_builds=2)
+        await db_session.commit()
+
+    target_public_id = serialize_base32_id(builds[0][1])
+    response = await client.post(
+        "/docverse/orgs/rb-org/projects/rb-proj/editions/__main/rollback",
+        json={"build": target_public_id},
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 200
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.edition_lifecycle
+    assert isinstance(publisher, MockEventPublisher)
+    rollback_events = [
+        e for e in publisher.published if e.action == LifecycleAction.rollback
+    ]
+    assert len(rollback_events) == 1
+    event = rollback_events[0]
+    assert event.organization == "rb-org"
+    assert event.project == "rb-proj"
+    # __main is the project's default edition (kind=main).
+    assert event.edition_kind == MetricsEditionKind.main
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -8,14 +8,17 @@ import pytest
 import structlog
 from httpx import AsyncClient
 from safir.dependencies.db_session import db_session_dependency
+from safir.metrics import MockEventPublisher
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import BuildCreate
 from docverse.client.models.builds import BuildAnnotations
 from docverse.dbschema.organization import SqlOrganization
+from docverse.dependencies.context import context_dependency
 from docverse.domain.base32id import serialize_base32_id
 from docverse.factory import Factory
+from docverse.metrics import LifecycleAction, MetricsEditionKind
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -185,6 +188,112 @@ async def test_delete_edition(client: AsyncClient) -> None:
         headers={"X-Auth-Request-User": "testuser"},
     )
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_post_edition_publishes_edition_lifecycle(
+    client: AsyncClient,
+) -> None:
+    """POST edition emits one edition_lifecycle (create) with edition_kind."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "lc-create-ed",
+            "title": "Lifecycle Create",
+            "kind": "release",
+            "tracking_mode": "git_ref",
+            "tracking_params": {"git_ref": "main"},
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.edition_lifecycle
+    assert isinstance(publisher, MockEventPublisher)
+    create_events = [
+        e for e in publisher.published if e.action == LifecycleAction.create
+    ]
+    assert len(create_events) == 1
+    event = create_events[0]
+    assert event.organization == "ed-org"
+    assert event.project == "ed-proj"
+    assert event.edition_kind == MetricsEditionKind.release
+
+
+@pytest.mark.asyncio
+async def test_patch_edition_publishes_edition_lifecycle(
+    client: AsyncClient,
+) -> None:
+    """PATCH edition emits one edition_lifecycle (update) with edition_kind."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "lc-update-ed",
+            "title": "Original",
+            "kind": "draft",
+            "tracking_mode": "git_ref",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    response = await client.patch(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions/lc-update-ed",
+        json={"title": "Updated"},
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 200
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.edition_lifecycle
+    assert isinstance(publisher, MockEventPublisher)
+    update_events = [
+        e for e in publisher.published if e.action == LifecycleAction.update
+    ]
+    assert len(update_events) == 1
+    event = update_events[0]
+    assert event.organization == "ed-org"
+    assert event.project == "ed-proj"
+    assert event.edition_kind == MetricsEditionKind.draft
+
+
+@pytest.mark.asyncio
+async def test_delete_edition_publishes_edition_lifecycle(
+    client: AsyncClient,
+) -> None:
+    """DELETE edition emits one edition_lifecycle (delete) + edition_kind."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions",
+        json={
+            "slug": "lc-delete-ed",
+            "title": "Delete Me",
+            "kind": "draft",
+            "tracking_mode": "git_ref",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    response = await client.delete(
+        "/docverse/orgs/ed-org/projects/ed-proj/editions/lc-delete-ed",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 204
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.edition_lifecycle
+    assert isinstance(publisher, MockEventPublisher)
+    delete_events = [
+        e for e in publisher.published if e.action == LifecycleAction.delete
+    ]
+    assert len(delete_events) == 1
+    event = delete_events[0]
+    assert event.organization == "ed-org"
+    assert event.project == "ed-proj"
+    assert event.edition_kind == MetricsEditionKind.draft
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/members_test.py
+++ b/tests/handlers/members_test.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 import pytest
 from httpx import AsyncClient
+from safir.metrics import MockEventPublisher
 
+from docverse.dependencies.context import context_dependency
+from docverse.metrics import (
+    MembershipChangeAction,
+    MetricsOrgRole,
+    MetricsPrincipalType,
+)
 from tests.conftest import seed_org_with_admin
 
 
@@ -89,6 +96,76 @@ async def test_delete_member(client: AsyncClient) -> None:
         headers={"X-Auth-Request-User": "admin-user"},
     )
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_post_member_publishes_membership_changed(
+    client: AsyncClient,
+) -> None:
+    """POST member emits one membership_changed with action=add."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/mem-org/members",
+        json={
+            "principal": "jdoe",
+            "principal_type": "user",
+            "role": "uploader",
+        },
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert response.status_code == 201
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.membership_changed
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == "mem-org"
+    assert event.project is None
+    assert event.action == MembershipChangeAction.add
+    assert event.role == MetricsOrgRole.uploader
+    assert event.principal_type == MetricsPrincipalType.user
+    assert event.principal == "jdoe"
+
+
+@pytest.mark.asyncio
+async def test_delete_member_publishes_membership_changed(
+    client: AsyncClient,
+) -> None:
+    """DELETE member emits one membership_changed with action=remove."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/mem-org/members",
+        json={
+            "principal": "g_spherex",
+            "principal_type": "group",
+            "role": "admin",
+        },
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    response = await client.delete(
+        "/docverse/orgs/mem-org/members/group:g_spherex",
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert response.status_code == 204
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.membership_changed
+    assert isinstance(publisher, MockEventPublisher)
+    remove_events = [
+        e
+        for e in publisher.published
+        if e.action == MembershipChangeAction.remove
+    ]
+    assert len(remove_events) == 1
+    event = remove_events[0]
+    assert event.organization == "mem-org"
+    assert event.project is None
+    assert event.role == MetricsOrgRole.admin
+    assert event.principal_type == MetricsPrincipalType.group
+    assert event.principal == "g_spherex"
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/projects_test.py
+++ b/tests/handlers/projects_test.py
@@ -8,12 +8,14 @@ import pytest
 import structlog
 from httpx import AsyncClient
 from safir.dependencies.db_session import db_session_dependency
+from safir.metrics import MockEventPublisher
 from sqlalchemy import select, update
 
 from docverse.dbschema.organization import SqlOrganization
 from docverse.dbschema.project import SqlProject
 from docverse.dependencies.context import context_dependency
 from docverse.factory import Factory
+from docverse.metrics import LifecycleAction
 from docverse.storage.editionpublisher import (
     EditionPublisher,
     MockEditionPublisher,
@@ -1302,3 +1304,100 @@ async def test_project_github_installed_status_and_app_url(
     assert binding["installation_id"] == 42
     assert binding["installation_status"] == "installed"
     assert binding["app_url"] == "https://github.com/apps/docverse"
+
+
+@pytest.mark.asyncio
+async def test_post_project_publishes_project_lifecycle(
+    client: AsyncClient,
+) -> None:
+    """POST project emits one project_lifecycle with action=create."""
+    await _setup(client)
+    response = await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "lifecycle-create-proj",
+            "title": "Lifecycle Create",
+            "source_url": "https://example.com/example/lc-create",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.project_lifecycle
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == "proj-org"
+    assert event.project == "lifecycle-create-proj"
+    assert event.action == LifecycleAction.create
+
+
+@pytest.mark.asyncio
+async def test_patch_project_publishes_project_lifecycle(
+    client: AsyncClient,
+) -> None:
+    """PATCH project emits one project_lifecycle with action=update."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "lifecycle-update-proj",
+            "title": "Original",
+            "source_url": "https://example.com/example/lc-update",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    response = await client.patch(
+        "/docverse/orgs/proj-org/projects/lifecycle-update-proj",
+        json={"title": "Updated"},
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 200
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.project_lifecycle
+    assert isinstance(publisher, MockEventPublisher)
+    update_events = [
+        e for e in publisher.published if e.action == LifecycleAction.update
+    ]
+    assert len(update_events) == 1
+    event = update_events[0]
+    assert event.organization == "proj-org"
+    assert event.project == "lifecycle-update-proj"
+
+
+@pytest.mark.asyncio
+async def test_delete_project_publishes_project_lifecycle(
+    client: AsyncClient,
+) -> None:
+    """DELETE project emits one project_lifecycle with action=delete."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/proj-org/projects",
+        json={
+            "slug": "lifecycle-delete-proj",
+            "title": "Delete Me",
+            "source_url": "https://example.com/example/lc-delete",
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    response = await client.delete(
+        "/docverse/orgs/proj-org/projects/lifecycle-delete-proj",
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 204
+
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.project_lifecycle
+    assert isinstance(publisher, MockEventPublisher)
+    delete_events = [
+        e for e in publisher.published if e.action == LifecycleAction.delete
+    ]
+    assert len(delete_events) == 1
+    event = delete_events[0]
+    assert event.organization == "proj-org"
+    assert event.project == "lifecycle-delete-proj"

--- a/tests/metrics/manager_test.py
+++ b/tests/metrics/manager_test.py
@@ -47,6 +47,7 @@ async def test_build_event_manager_registers_every_publisher() -> None:
     assert isinstance(events.edition_published, MockEventPublisher)
     assert isinstance(events.project_lifecycle, MockEventPublisher)
     assert isinstance(events.edition_lifecycle, MockEventPublisher)
+    assert isinstance(events.membership_changed, MockEventPublisher)
 
     await manager.aclose()
 

--- a/tests/metrics/manager_test.py
+++ b/tests/metrics/manager_test.py
@@ -50,6 +50,7 @@ async def test_build_event_manager_registers_every_publisher() -> None:
     assert isinstance(events.edition_lifecycle, MockEventPublisher)
     assert isinstance(events.membership_changed, MockEventPublisher)
     assert isinstance(events.keeper_sync_run_completed, MockEventPublisher)
+    assert isinstance(events.lifecycle_action, MockEventPublisher)
 
     await manager.aclose()
 

--- a/tests/metrics/manager_test.py
+++ b/tests/metrics/manager_test.py
@@ -45,6 +45,8 @@ async def test_build_event_manager_registers_every_publisher() -> None:
     assert isinstance(events.build_uploaded, MockEventPublisher)
     assert isinstance(events.build_processed, MockEventPublisher)
     assert isinstance(events.edition_published, MockEventPublisher)
+    assert isinstance(events.project_lifecycle, MockEventPublisher)
+    assert isinstance(events.edition_lifecycle, MockEventPublisher)
 
     await manager.aclose()
 

--- a/tests/metrics/manager_test.py
+++ b/tests/metrics/manager_test.py
@@ -51,6 +51,7 @@ async def test_build_event_manager_registers_every_publisher() -> None:
     assert isinstance(events.membership_changed, MockEventPublisher)
     assert isinstance(events.keeper_sync_run_completed, MockEventPublisher)
     assert isinstance(events.lifecycle_action, MockEventPublisher)
+    assert isinstance(events.resource_inventory, MockEventPublisher)
 
     await manager.aclose()
 

--- a/tests/metrics/manager_test.py
+++ b/tests/metrics/manager_test.py
@@ -44,10 +44,12 @@ async def test_build_event_manager_registers_every_publisher() -> None:
     # Every declared publisher is registered and recording.
     assert isinstance(events.build_uploaded, MockEventPublisher)
     assert isinstance(events.build_processed, MockEventPublisher)
+    assert isinstance(events.dashboard_built, MockEventPublisher)
     assert isinstance(events.edition_published, MockEventPublisher)
     assert isinstance(events.project_lifecycle, MockEventPublisher)
     assert isinstance(events.edition_lifecycle, MockEventPublisher)
     assert isinstance(events.membership_changed, MockEventPublisher)
+    assert isinstance(events.keeper_sync_run_completed, MockEventPublisher)
 
     await manager.aclose()
 

--- a/tests/metrics/manager_test.py
+++ b/tests/metrics/manager_test.py
@@ -1,0 +1,165 @@
+"""Foundation tests for the Docverse metrics event manager.
+
+These tests do not touch the database: they build the event manager
+straight from configuration (resolved to a ``MockEventManager`` by the
+``METRICS_MOCK=true`` test environment) and exercise the swallow posture
+that production relies on (``raise_on_error=False``).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+import structlog
+from safir.metrics import (
+    KafkaEventManager,
+    MockEventManager,
+    MockEventPublisher,
+)
+from safir.metrics._event_manager import _State
+from structlog.testing import capture_logs
+
+from docverse.config import Configuration
+from docverse.metrics import (
+    BuildProcessedEvent,
+    BuildUploadedEvent,
+    DocverseEvents,
+    EditionPublishedEvent,
+    EditionPublishTrigger,
+    MetricsEditionKind,
+    build_event_manager,
+)
+
+
+@pytest.mark.asyncio
+async def test_build_event_manager_registers_every_publisher() -> None:
+    """The mock config builds a MockEventManager with all publishers."""
+    config = Configuration()
+    manager, events = await build_event_manager(config)
+
+    assert isinstance(manager, MockEventManager)
+    assert isinstance(events, DocverseEvents)
+    # Every declared publisher is registered and recording.
+    assert isinstance(events.build_uploaded, MockEventPublisher)
+    assert isinstance(events.build_processed, MockEventPublisher)
+    assert isinstance(events.edition_published, MockEventPublisher)
+
+    await manager.aclose()
+
+
+@pytest.mark.asyncio
+async def test_publishers_record_payloads() -> None:
+    """Publishing a payload through each publisher records it for asserts."""
+    config = Configuration()
+    manager, events = await build_event_manager(config)
+
+    build_uploaded = events.build_uploaded
+    build_processed = events.build_processed
+    edition_published = events.edition_published
+    assert isinstance(build_uploaded, MockEventPublisher)
+    assert isinstance(build_processed, MockEventPublisher)
+    assert isinstance(edition_published, MockEventPublisher)
+
+    await build_uploaded.publish(
+        BuildUploadedEvent(
+            organization="org",
+            project="proj",
+            uploader="testuser",
+            commit_sha=None,
+            github_repository=None,
+            github_run_id=None,
+            github_actor=None,
+            ci_platform=None,
+        )
+    )
+    await build_processed.publish(
+        BuildProcessedEvent(
+            organization="org",
+            project="proj",
+            success=True,
+            object_count=3,
+            total_size_bytes=99,
+            editions_updated=1,
+            editions_skipped=0,
+            stale_skipped=False,
+            elapsed=timedelta(seconds=1),
+        )
+    )
+    await edition_published.publish(
+        EditionPublishedEvent(
+            organization="org",
+            project="proj",
+            edition_kind=MetricsEditionKind.release,
+            trigger=EditionPublishTrigger.build,
+            elapsed=timedelta(seconds=2),
+        )
+    )
+
+    build_uploaded.published.assert_published_all(
+        [
+            {
+                "organization": "org",
+                "project": "proj",
+                "uploader": "testuser",
+                "commit_sha": None,
+                "github_repository": None,
+                "github_run_id": None,
+                "github_actor": None,
+                "ci_platform": None,
+            }
+        ]
+    )
+    assert len(build_processed.published) == 1
+    assert len(edition_published.published) == 1
+
+    await manager.aclose()
+
+
+@pytest.mark.asyncio
+async def test_publish_failure_is_swallowed_when_not_raising() -> None:
+    """With raise_on_error=False a failing publish is swallowed and logged.
+
+    Production runs the Kafka-backed manager with ``raise_on_error=False``
+    so a Kafka/schema-registry outage can never fail a request, build, or
+    job. Docverse call sites therefore publish with no defensive
+    try/except; this test pins that swallow behaviour at the Safir
+    boundary the call sites depend on.
+    """
+    logger = structlog.get_logger("docverse.test")
+    manager = KafkaEventManager(
+        application="docverse",
+        topic_prefix="lsst.square.metrics.events",
+        kafka_broker=Mock(),
+        kafka_admin_client=Mock(),
+        schema_manager=AsyncMock(),
+        raise_on_error=False,
+        logger=logger,
+    )
+    # Drive the manager into a publishable state without a live Kafka.
+    manager._state = _State.ready_to_publish
+
+    failing_publisher = Mock()
+    failing_publisher.publish = AsyncMock(
+        side_effect=RuntimeError("kafka down")
+    )
+    failing_publisher.topic = "lsst.square.metrics.events.docverse"
+
+    payload = BuildUploadedEvent(
+        organization="org",
+        project="proj",
+        uploader="testuser",
+        commit_sha=None,
+        github_repository=None,
+        github_run_id=None,
+        github_actor=None,
+        ci_platform=None,
+    )
+
+    # The failing publish is swallowed: ``manager.publish`` returns (its
+    # abandonable wrapper turns the error into a no-op) instead of raising.
+    with capture_logs() as captured:
+        await manager.publish(payload, failing_publisher, None)
+
+    assert any(record.get("log_level") == "error" for record in captured)

--- a/tests/storage/inventory_census_store_test.py
+++ b/tests/storage/inventory_census_store_test.py
@@ -1,0 +1,221 @@
+"""Tests for :class:`InventoryCensusStore`.
+
+Seeds orgs, projects, editions, and builds — including soft-deleted rows
+and a soft-deleted project — and asserts the read-only grouped aggregate
+excludes everything deleted, rolls projects up to their org, and emits a
+row for an org with no projects.
+"""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import func
+
+from docverse.client.models import (
+    BuildCreate,
+    EditionKind,
+    OrganizationCreate,
+    ProjectCreate,
+    TrackingMode,
+)
+from docverse.dbschema.build import SqlBuild
+from docverse.dbschema.edition import SqlEdition
+from docverse.dbschema.project import SqlProject
+from docverse.storage.build_store import BuildStore
+from docverse.storage.edition_store import EditionStore
+from docverse.storage.inventory_census_store import InventoryCensusStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+
+_CONTENT_HASH = (
+    "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+)
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _make_build(
+    db_session: AsyncSession,
+    *,
+    project_id: int,
+    project_slug: str,
+    git_ref: str,
+    total_size_bytes: int | None,
+    deleted: bool = False,
+) -> None:
+    """Create one build with an explicit size, optionally soft-deleted."""
+    build_store = BuildStore(session=db_session, logger=_logger())
+    build = await build_store.create(
+        project_id=project_id,
+        project_slug=project_slug,
+        data=BuildCreate(git_ref=git_ref, content_hash=_CONTENT_HASH),
+        uploader="testuser",
+    )
+    row = await db_session.get(SqlBuild, build.id)
+    assert row is not None
+    row.total_size_bytes = total_size_bytes
+    if deleted:
+        row.date_deleted = func.now()
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_aggregate_inventory_excludes_deleted_and_rolls_up(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """Census counts active rows only, rolled up per org and per project."""
+    logger = _logger()
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+    edition_store = EditionStore(session=db_session, logger=logger)
+
+    async with db_session.begin():
+        alpha = await org_store.create(
+            OrganizationCreate(
+                slug="alpha",
+                title="Alpha",
+                base_domain="alpha.example.com",
+            )
+        )
+        # ``beta`` deliberately has no projects: it must still yield one
+        # org census row with project_count == 0.
+        await org_store.create(
+            OrganizationCreate(
+                slug="beta",
+                title="Beta",
+                base_domain="beta.example.com",
+            )
+        )
+
+        p_one = await proj_store.create(
+            org_id=alpha.id,
+            data=ProjectCreate(
+                slug="p-one",
+                title="Project One",
+                source_url="https://example.com/example/one",
+            ),
+        )
+        await proj_store.create(
+            org_id=alpha.id,
+            data=ProjectCreate(
+                slug="p-two",
+                title="Project Two",
+                source_url="https://example.com/example/two",
+            ),
+        )
+        p_gone = await proj_store.create(
+            org_id=alpha.id,
+            data=ProjectCreate(
+                slug="p-gone",
+                title="Project Gone",
+                source_url="https://example.com/example/gone",
+            ),
+        )
+
+        # p-one: 2 active editions + 1 soft-deleted edition.
+        for slug in ("__main", "v1"):
+            await edition_store.create_internal(
+                project_id=p_one.id,
+                slug=slug,
+                title=slug,
+                kind=EditionKind.main
+                if slug == "__main"
+                else EditionKind.release,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "main"},
+            )
+        dead_edition = await edition_store.create_internal(
+            project_id=p_one.id,
+            slug="v0",
+            title="v0",
+            kind=EditionKind.release,
+            tracking_mode=TrackingMode.git_ref,
+            tracking_params={"git_ref": "v0"},
+        )
+        dead_edition_row = await db_session.get(SqlEdition, dead_edition.id)
+        assert dead_edition_row is not None
+        dead_edition_row.date_deleted = func.now()
+
+        # p-one: 2 sized active builds + 1 NULL-sized active build + 1
+        # soft-deleted build. total_build_bytes == 100 + 200 == 300,
+        # build_count == 3 (the NULL-sized build still counts).
+        await _make_build(
+            db_session,
+            project_id=p_one.id,
+            project_slug=p_one.slug,
+            git_ref="a",
+            total_size_bytes=100,
+        )
+        await _make_build(
+            db_session,
+            project_id=p_one.id,
+            project_slug=p_one.slug,
+            git_ref="b",
+            total_size_bytes=200,
+        )
+        await _make_build(
+            db_session,
+            project_id=p_one.id,
+            project_slug=p_one.slug,
+            git_ref="c",
+            total_size_bytes=None,
+        )
+        await _make_build(
+            db_session,
+            project_id=p_one.id,
+            project_slug=p_one.slug,
+            git_ref="d",
+            total_size_bytes=999,
+            deleted=True,
+        )
+
+        # p-gone is soft-deleted but still carries an active edition and
+        # an active build — both must be excluded from the census.
+        await edition_store.create_internal(
+            project_id=p_gone.id,
+            slug="__main",
+            title="main",
+            kind=EditionKind.main,
+            tracking_mode=TrackingMode.git_ref,
+            tracking_params={"git_ref": "main"},
+        )
+        await _make_build(
+            db_session,
+            project_id=p_gone.id,
+            project_slug=p_gone.slug,
+            git_ref="x",
+            total_size_bytes=500,
+        )
+        gone_row = await db_session.get(SqlProject, p_gone.id)
+        assert gone_row is not None
+        gone_row.date_deleted = func.now()
+
+    store = InventoryCensusStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        census = await store.aggregate_inventory()
+
+    orgs = {o.org_slug: o for o in census.orgs}
+    assert set(orgs) == {"alpha", "beta"}
+    assert orgs["alpha"].project_count == 2
+    assert orgs["alpha"].edition_count == 2
+    assert orgs["alpha"].build_count == 3
+    assert orgs["alpha"].total_build_bytes == 300
+    assert orgs["beta"].project_count == 0
+    assert orgs["beta"].edition_count == 0
+    assert orgs["beta"].build_count == 0
+    assert orgs["beta"].total_build_bytes == 0
+
+    projects = {p.project_slug: p for p in census.projects}
+    assert set(projects) == {"p-one", "p-two"}
+    assert projects["p-one"].org_slug == "alpha"
+    assert projects["p-one"].edition_count == 2
+    assert projects["p-one"].build_count == 3
+    assert projects["p-one"].total_build_bytes == 300
+    assert projects["p-two"].edition_count == 0
+    assert projects["p-two"].build_count == 0
+    assert projects["p-two"].total_build_bytes == 0

--- a/tests/worker/arq_metrics_test.py
+++ b/tests/worker/arq_metrics_test.py
@@ -1,0 +1,160 @@
+"""Tests for the generic Safir arq-queue metrics wiring (SQR-112).
+
+Each of the three worker pools (default, keeper-sync, maintenance)
+publishes ``arq_job_run`` for every job it runs (via ``on_job_start``)
+and ``arq_queue_stats`` for its own queue (via a per-pool cron). These
+tests drive both hooks against a ``MockEventManager`` so they assert the
+events fire with the right queue name without a live Redis or Kafka.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from arq.cron import CronJob
+from safir.metrics import EventManager, MockEventPublisher
+from safir.metrics.arq import ARQ_EVENTS_CONTEXT_KEY, initialize_arq_metrics
+
+from docverse.config import Configuration
+from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
+from docverse.worker.main import (
+    KeeperSyncWorkerSettings,
+    MaintenanceWorkerSettings,
+    WorkerSettings,
+    publish_queue_stats_cron,
+)
+from docverse.worker.queues import MAINTENANCE_QUEUE_NAME
+
+_config = Configuration()
+
+# Five-minute resolution is ample for the Sasquatch product-analytics
+# queue-depth gauge (deliberately distinct from operational telemetry)
+# and limits the per-tick Redis pool that Safir's helper opens.
+_QUEUE_STATS_MINUTES = set(range(0, 60, 5))
+
+# (WorkerSettings class, the queue name that pool binds to). The class
+# is typed ``Any`` so mypy does not flag the arbitrary ``on_job_start`` /
+# ``cron_jobs`` attribute access across the three parametrized pools.
+_POOLS: list[tuple[Any, str]] = [
+    (WorkerSettings, _config.arq_queue_name),
+    (KeeperSyncWorkerSettings, KEEPER_SYNC_QUEUE_NAME),
+    (MaintenanceWorkerSettings, MAINTENANCE_QUEUE_NAME),
+]
+
+_POOL_IDS = ["default", "keeper_sync", "maintenance"]
+
+
+async def _make_arq_metrics_ctx() -> tuple[EventManager, dict[str, Any]]:
+    """Build a started ``MockEventManager`` and a ctx with arq publishers.
+
+    Mirrors what production's ``_startup`` does: build the event manager
+    and run ``initialize_arq_metrics`` so ``ctx[ARQ_EVENTS_CONTEXT_KEY]``
+    carries the generic arq publishers the hooks read back.
+    """
+    manager = _config.metrics.make_manager()
+    await manager.initialize()
+    ctx: dict[str, Any] = {}
+    await initialize_arq_metrics(manager, ctx)
+    return manager, ctx
+
+
+def _underlying(coroutine: Any) -> Any:
+    """Peel the one ``instrument_arq_task`` layer off a registered task.
+
+    :func:`docverse.sentry.instrument_arq_task` wraps with
+    :func:`functools.wraps`, exposing the original coroutine via
+    ``__wrapped__`` — so identity comparisons can target the unwrapped
+    ``publish_queue_stats_cron``.
+    """
+    return getattr(coroutine, "__wrapped__", coroutine)
+
+
+def _queue_stats_cron(settings_cls: Any) -> CronJob:
+    crons = [
+        job
+        for job in getattr(settings_cls, "cron_jobs", [])
+        if isinstance(job, CronJob)
+        and _underlying(job.coroutine) is publish_queue_stats_cron
+    ]
+    assert len(crons) == 1
+    return crons[0]
+
+
+@pytest.mark.parametrize(
+    ("settings_cls", "expected_queue"), _POOLS, ids=_POOL_IDS
+)
+@pytest.mark.asyncio
+async def test_on_job_start_publishes_arq_job_run(
+    settings_cls: Any, expected_queue: str
+) -> None:
+    """Every job run on a pool publishes ``arq_job_run`` for its queue."""
+    manager, ctx = await _make_arq_metrics_ctx()
+    # arq sets ``score`` to the epoch-millisecond instant the job should
+    # ideally have started; five seconds in the past yields a positive
+    # ``time_in_queue``.
+    ideal_start = datetime.now(tz=UTC) - timedelta(seconds=5)
+    ctx["score"] = int(ideal_start.timestamp() * 1000)
+
+    await settings_cls.on_job_start(ctx)
+
+    publisher = ctx[ARQ_EVENTS_CONTEXT_KEY].arq_queue_job_event
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.queue == expected_queue
+    assert event.time_in_queue >= timedelta(seconds=4)
+
+    await manager.aclose()
+
+
+@pytest.mark.parametrize(
+    "settings_cls",
+    [WorkerSettings, KeeperSyncWorkerSettings, MaintenanceWorkerSettings],
+    ids=_POOL_IDS,
+)
+def test_pool_registers_one_queue_stats_cron(settings_cls: Any) -> None:
+    """Each pool registers exactly one five-minute queue-stats cron."""
+    cron_job = _queue_stats_cron(settings_cls)
+    assert cron_job.minute == _QUEUE_STATS_MINUTES
+
+
+@pytest.mark.parametrize(
+    ("settings_cls", "expected_queue"), _POOLS, ids=_POOL_IDS
+)
+@pytest.mark.asyncio
+async def test_queue_stats_cron_publishes_arq_queue_stats(
+    settings_cls: Any,
+    expected_queue: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The queue-stats cron publishes ``arq_queue_stats`` with the depth."""
+    manager, ctx = await _make_arq_metrics_ctx()
+    # The cron reads the pool's queue name from ctx, exactly as
+    # ``_startup`` sets it per pool. ``redis_settings`` is opaque here:
+    # Safir's ``publish_queue_stats`` only forwards it to ``create_pool``,
+    # which the test mocks out.
+    ctx["queue_name"] = expected_queue
+    ctx["redis_settings"] = object()
+
+    class _FakeRedis:
+        async def zcard(self, _queue: str) -> int:
+            return 7
+
+    async def _fake_create_pool(settings: Any) -> _FakeRedis:
+        return _FakeRedis()
+
+    monkeypatch.setattr("safir.metrics.arq.create_pool", _fake_create_pool)
+
+    cron_job = _queue_stats_cron(settings_cls)
+    await cron_job.coroutine(ctx)
+
+    publisher = ctx[ARQ_EVENTS_CONTEXT_KEY].arq_queue_stats
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.queue == expected_queue
+    assert event.num_queued == 7
+
+    await manager.aclose()

--- a/tests/worker/build_processing_test.py
+++ b/tests/worker/build_processing_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import tarfile
 import time
+from datetime import timedelta
 from typing import Any
 
 import httpx
@@ -14,6 +15,7 @@ import structlog
 from rubin.repertoire import DiscoveryClient, register_mock_discovery
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
+from safir.metrics import MockEventPublisher
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -35,6 +37,7 @@ from docverse.domain.api_urls import edition_url, queue_job_url
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.queue import JobKind, JobStatus
 from docverse.factory import Factory
+from docverse.metrics import build_event_manager
 from docverse.services.edition_tracking import EditionTrackingService
 from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.build_store import BuildStore
@@ -270,6 +273,77 @@ async def test_build_processing_updates_edition(
             assert len(job.progress["editions_updated"]) == 1
             assert job.progress["editions_updated"][0]["slug"] == "main"
             assert job.progress["editions_updated"][0]["action"] == "created"
+
+
+@pytest.mark.asyncio
+async def test_build_processing_publishes_build_processed(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A processed build emits one ``build_processed`` metric event."""
+    logger = _logger()
+    mock_store = MockObjectStore()
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        org, project = await _setup_org_and_project(db_session)
+        build = await _create_build_in_processing(
+            db_session, project.id, git_ref="main"
+        )
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        await queue_job_store.create(
+            kind=JobKind.build_processing,
+            org_id=org.id,
+            project_id=project.id,
+            build_id=build.id,
+            backend_job_id="test-arq-metrics",
+        )
+
+    file_body = b"<html>hello</html>"
+    tarball = _make_tarball({"index.html": file_body})
+    await mock_store.upload_object(
+        key=build.staging_key,
+        data=tarball,
+        content_type="application/gzip",
+    )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_objectstore_for_org",
+        _mock_create_objectstore(mock_store),
+    )
+
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-arq-metrics",
+        events=events,
+    )
+    payload: dict[str, Any] = {
+        "org_id": org.id,
+        "org_slug": org.slug,
+        "project_slug": project.slug,
+        "build_id": build.id,
+        "build_public_id": serialize_base32_id(build.public_id),
+    }
+
+    result = await build_processing(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    publisher = events.build_processed
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == org.slug
+    assert event.project == project.slug
+    assert event.success is True
+    assert event.object_count == 1
+    assert event.total_size_bytes == len(file_body)
+    assert event.editions_updated == 1
+    assert event.editions_skipped == 0
+    assert event.stale_skipped is False
+    assert event.elapsed >= timedelta(0)
 
 
 @pytest.mark.asyncio

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -19,6 +19,7 @@ from rubin.repertoire import DiscoveryClient
 from safir.arq import MockArqQueue
 
 from docverse.config import Configuration
+from docverse.metrics.events import DocverseEvents
 from docverse.services.credential_encryptor import CredentialEncryptor
 from docverse.worker.main import WorkerFactoryBuilder
 
@@ -38,13 +39,18 @@ def make_worker_ctx(
     github_app_id: int | None = None,
     github_app_private_key: SecretStr | None = None,
     github_webhook_secret: SecretStr | None = None,
+    events: DocverseEvents | None = None,
 ) -> dict[str, Any]:
     """Build a worker ctx dict that mirrors ``worker.main.startup``.
 
     Defaults are filled in for every dep so individual tests only need
     to override the ones that drive their assertion (e.g.,
     ``arq_queue=mock_arq`` to read enqueued jobs back, or the GitHub-App
-    secrets when exercising ``dashboard_sync``).
+    secrets when exercising ``dashboard_sync``). Pass ``events`` (an
+    initialized :class:`~docverse.metrics.events.DocverseEvents`) when a
+    test asserts on published metrics; production's ``_startup`` always
+    sets ``ctx["events"]``, but tests that do not care about metrics may
+    leave it unset and the emitting worker simply skips publication.
     """
     if encryptor is None:
         encryptor = CredentialEncryptor(
@@ -71,4 +77,6 @@ def make_worker_ctx(
     }
     if job_id is not None:
         ctx["job_id"] = job_id
+    if events is not None:
+        ctx["events"] = events
     return ctx

--- a/tests/worker/dashboard_build_test.py
+++ b/tests/worker/dashboard_build_test.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import time
+from datetime import timedelta
 from typing import Any
 
 import httpx
 import pytest
 import structlog
 from safir.dependencies.db_session import db_session_dependency
+from safir.metrics import MockEventPublisher
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog.testing import capture_logs
@@ -19,10 +21,12 @@ from docverse.client.models import (
     ProjectCreate,
     TrackingMode,
 )
+from docverse.config import Configuration
 from docverse.dbschema.organization import SqlOrganization
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.queue import JobKind, JobStatus
 from docverse.factory import Factory
+from docverse.metrics import build_event_manager
 from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingCreate,
@@ -239,6 +243,132 @@ async def test_dashboard_build_marks_failed_on_render_exception(
             assert job.status == JobStatus.failed
             assert job.errors is not None
             assert "Simulated objectstore" in job.errors["message"]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_build_publishes_dashboard_built(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completed dashboard_build emits one ``dashboard_built`` event."""
+    logger = _logger()
+    mock_store = MockObjectStore()
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        org, project = await _setup_org_and_project(db_session)
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        queue_job = await queue_job_store.create(
+            kind=JobKind.dashboard_build,
+            org_id=org.id,
+            project_id=project.id,
+            backend_job_id="test-arq-dash-event",
+        )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_objectstore_for_org",
+        _mock_create_objectstore(mock_store),
+    )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(
+        http_client=http_client,
+        job_id="test-arq-dash-event",
+        events=events,
+    )
+    payload: dict[str, Any] = {
+        "org_id": org.id,
+        "org_slug": org.slug,
+        "project_id": project.id,
+        "project_slug": project.slug,
+        "queue_job_id": queue_job.id,
+        "queue_job_public_id": serialize_base32_id(queue_job.public_id),
+    }
+
+    result = await dashboard_build(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    publisher = events.dashboard_built
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == org.slug
+    assert event.project == project.slug
+    assert event.success is True
+    # Four MVP artifacts uploaded (matches the phase-transition test).
+    assert event.object_count == 4
+    assert event.total_size_bytes is not None
+    assert event.total_size_bytes > 0
+    assert event.elapsed >= timedelta(0)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_build_publishes_dashboard_built_on_failure(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed dashboard_build emits dashboard_built with success=False."""
+    logger = _logger()
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        org, project = await _setup_org_and_project(db_session)
+        queue_job_store = QueueJobStore(session=db_session, logger=logger)
+        queue_job = await queue_job_store.create(
+            kind=JobKind.dashboard_build,
+            org_id=org.id,
+            project_id=project.id,
+            backend_job_id="test-arq-dash-event-fail",
+        )
+
+    async def _broken_create_objectstore(
+        self: Factory,
+        *,
+        org_id: int,
+        service_label: str,
+    ) -> MockObjectStore:
+        msg = "Simulated objectstore resolution failure"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        Factory,
+        "create_objectstore_for_org",
+        _broken_create_objectstore,
+    )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(
+        http_client=http_client,
+        job_id="test-arq-dash-event-fail",
+        events=events,
+    )
+    payload: dict[str, Any] = {
+        "org_id": org.id,
+        "org_slug": org.slug,
+        "project_id": project.id,
+        "project_slug": project.slug,
+        "queue_job_id": queue_job.id,
+        "queue_job_public_id": serialize_base32_id(queue_job.public_id),
+    }
+
+    result = await dashboard_build(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "failed"
+
+    publisher = events.dashboard_built
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == org.slug
+    assert event.project == project.slug
+    assert event.success is False
+    assert event.object_count is None
+    assert event.total_size_bytes is None
+    assert event.elapsed >= timedelta(0)
 
 
 class _RecordingMockObjectStore(MockObjectStore):

--- a/tests/worker/git_ref_audit_test.py
+++ b/tests/worker/git_ref_audit_test.py
@@ -419,7 +419,7 @@ async def test_git_ref_audit_publishes_lifecycle_action(
     ``action=ref_deleted``, ``trigger=git_ref_audit``, and
     ``success=True``.
     """
-    _manager, events = await build_event_manager(Configuration())
+    manager, events = await build_event_manager(Configuration())
 
     async with db_session.begin():
         org_id, org_slug = await _seed_org(db_session, slug="gra-event-org")
@@ -483,6 +483,7 @@ async def test_git_ref_audit_publishes_lifecycle_action(
     assert event.action is LifecycleReapAction.ref_deleted
     assert event.trigger is LifecycleActionTrigger.git_ref_audit
     assert event.success is True
+    await manager.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/worker/git_ref_audit_test.py
+++ b/tests/worker/git_ref_audit_test.py
@@ -18,6 +18,7 @@ import respx
 import structlog
 from pydantic import SecretStr
 from safir.dependencies.db_session import db_session_dependency
+from safir.metrics import MockEventPublisher
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,6 +31,7 @@ from docverse.client.models import (
     TrackingMode,
 )
 from docverse.client.models.projects import ProjectGitHubBindingCreate
+from docverse.config import Configuration
 from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.project import SqlProject
 from docverse.dbschema.queue_job import SqlQueueJob
@@ -40,6 +42,12 @@ from docverse.domain.lifecycle import (
     RefDeletedRule,
 )
 from docverse.domain.queue import JobStatus
+from docverse.metrics import (
+    DocverseEvents,
+    LifecycleActionTrigger,
+    LifecycleReapAction,
+    build_event_manager,
+)
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.git_ref_audit_run_store import GitRefAuditRunStore
 from docverse.storage.github import GITHUB_API_BASE_URL
@@ -224,13 +232,17 @@ def _seed_refs_500(router: respx.Router, *, owner: str, repo: str) -> None:
 
 
 def _make_ctx(
-    *, http_client: httpx.AsyncClient, mock_github: GitHubMock
+    *,
+    http_client: httpx.AsyncClient,
+    mock_github: GitHubMock,
+    events: DocverseEvents | None = None,
 ) -> dict[str, object]:
     return make_worker_ctx(
         http_client=http_client,
         github_app_id=mock_github.app_id,
         github_app_private_key=SecretStr(mock_github.private_key_pem),
         github_webhook_secret=SecretStr("webhook-secret"),
+        events=events,
     )
 
 
@@ -390,6 +402,87 @@ async def test_git_ref_audit_soft_deletes_missing_refs_only(
             run = await run_store.get(run_id)
             assert run is not None
             assert run.status is GitRefAuditRunStatus.succeeded
+
+
+@pytest.mark.asyncio
+async def test_git_ref_audit_publishes_lifecycle_action(
+    app: None,
+    db_session: AsyncSession,
+    mock_github: GitHubMock,
+) -> None:
+    """Each ref-deleted reap publishes ``lifecycle_action`` (trigger=audit).
+
+    Seeds one GitHub-bound project with a draft tracking a live branch
+    (kept) and a draft tracking a branch absent from GitHub (reaped),
+    runs the worker with an initialized event manager, and asserts a
+    single ``lifecycle_action`` event for the reaped edition carrying
+    ``action=ref_deleted``, ``trigger=git_ref_audit``, and
+    ``success=True``.
+    """
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session, slug="gra-event-org")
+        installation_id = mock_github.seed_installation(
+            "acme", "evented", installation_id=71, owner_id=333
+        )
+        project_id = await _seed_github_project(
+            db_session,
+            org_id=org_id,
+            slug="acme-evented",
+            owner="acme",
+            repo="evented",
+            installation_id=installation_id,
+        )
+        await _seed_draft_edition(
+            db_session,
+            project_id=project_id,
+            slug="kept-branch",
+            git_ref="main",
+        )
+        await _seed_draft_edition(
+            db_session,
+            project_id=project_id,
+            slug="deleted-branch",
+            git_ref="tickets/DM-gone",
+        )
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id, org_slug=org_slug
+        )
+
+    _seed_refs(
+        mock_github.router,
+        owner="acme",
+        repo="evented",
+        branches=["main"],
+        tags=[],
+    )
+
+    async with httpx.AsyncClient() as http_client:
+        ctx = _make_ctx(
+            http_client=http_client, mock_github=mock_github, events=events
+        )
+        result = await git_ref_audit(
+            ctx,
+            {
+                "org_id": org_id,
+                "org_slug": org_slug,
+                "git_ref_audit_run_id": run_id,
+                "queue_job_id": queue_job_id,
+            },
+        )
+
+    assert result == "completed"
+
+    publisher = events.lifecycle_action
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == org_slug
+    assert event.project == "acme-evented"
+    assert event.action is LifecycleReapAction.ref_deleted
+    assert event.trigger is LifecycleActionTrigger.git_ref_audit
+    assert event.success is True
 
 
 @pytest.mark.asyncio

--- a/tests/worker/inventory_census_test.py
+++ b/tests/worker/inventory_census_test.py
@@ -1,0 +1,206 @@
+"""Integration tests for the ``inventory_census`` worker function.
+
+Seeds orgs, projects, editions, and builds — including soft-deleted rows
+and a soft-deleted project — and asserts the worker publishes one
+org-scoped ``resource_inventory`` row per org plus one project-scoped row
+per non-deleted project, excluding everything deleted.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import structlog
+from safir.metrics import MockEventPublisher
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import func
+
+from docverse.client.models import (
+    BuildCreate,
+    EditionKind,
+    OrganizationCreate,
+    ProjectCreate,
+    TrackingMode,
+)
+from docverse.config import Configuration
+from docverse.dbschema.build import SqlBuild
+from docverse.dbschema.edition import SqlEdition
+from docverse.dbschema.project import SqlProject
+from docverse.metrics import build_event_manager
+from docverse.storage.build_store import BuildStore
+from docverse.storage.edition_store import EditionStore
+from docverse.storage.organization_store import OrganizationStore
+from docverse.storage.project_store import ProjectStore
+from docverse.worker.functions.inventory_census import inventory_census
+from tests.worker.conftest import make_worker_ctx
+
+_CONTENT_HASH = (
+    "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+)
+
+
+def _logger() -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger("docverse")  # type: ignore[no-any-return]
+
+
+async def _make_build(
+    db_session: AsyncSession,
+    *,
+    project_id: int,
+    project_slug: str,
+    git_ref: str,
+    total_size_bytes: int,
+    deleted: bool = False,
+) -> None:
+    build_store = BuildStore(session=db_session, logger=_logger())
+    build = await build_store.create(
+        project_id=project_id,
+        project_slug=project_slug,
+        data=BuildCreate(git_ref=git_ref, content_hash=_CONTENT_HASH),
+        uploader="testuser",
+    )
+    row = await db_session.get(SqlBuild, build.id)
+    assert row is not None
+    row.total_size_bytes = total_size_bytes
+    if deleted:
+        row.date_deleted = func.now()
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_inventory_census_publishes_org_and_project_rows(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """The census emits one org row + one row per live project, no deleted."""
+    logger = _logger()
+    _manager, events = await build_event_manager(Configuration())
+
+    org_store = OrganizationStore(session=db_session, logger=logger)
+    proj_store = ProjectStore(session=db_session, logger=logger)
+    edition_store = EditionStore(session=db_session, logger=logger)
+
+    async with db_session.begin():
+        org = await org_store.create(
+            OrganizationCreate(
+                slug="census-org",
+                title="Census Org",
+                base_domain="census.example.com",
+            )
+        )
+        kept = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug="kept",
+                title="Kept",
+                source_url="https://example.com/example/kept",
+            ),
+        )
+        removed = await proj_store.create(
+            org_id=org.id,
+            data=ProjectCreate(
+                slug="removed",
+                title="Removed",
+                source_url="https://example.com/example/removed",
+            ),
+        )
+
+        # kept: 2 active editions + 1 soft-deleted edition.
+        for slug, kind in (
+            ("__main", EditionKind.main),
+            ("v1", EditionKind.release),
+        ):
+            await edition_store.create_internal(
+                project_id=kept.id,
+                slug=slug,
+                title=slug,
+                kind=kind,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "main"},
+            )
+        dead_edition = await edition_store.create_internal(
+            project_id=kept.id,
+            slug="v0",
+            title="v0",
+            kind=EditionKind.release,
+            tracking_mode=TrackingMode.git_ref,
+            tracking_params={"git_ref": "v0"},
+        )
+        dead_edition_row = await db_session.get(SqlEdition, dead_edition.id)
+        assert dead_edition_row is not None
+        dead_edition_row.date_deleted = func.now()
+
+        # kept: 2 active builds (10 + 20) + 1 soft-deleted build (99).
+        await _make_build(
+            db_session,
+            project_id=kept.id,
+            project_slug=kept.slug,
+            git_ref="a",
+            total_size_bytes=10,
+        )
+        await _make_build(
+            db_session,
+            project_id=kept.id,
+            project_slug=kept.slug,
+            git_ref="b",
+            total_size_bytes=20,
+        )
+        await _make_build(
+            db_session,
+            project_id=kept.id,
+            project_slug=kept.slug,
+            git_ref="c",
+            total_size_bytes=99,
+            deleted=True,
+        )
+
+        # removed is soft-deleted but carries an active edition + build,
+        # both of which must be excluded from the census.
+        await edition_store.create_internal(
+            project_id=removed.id,
+            slug="__main",
+            title="main",
+            kind=EditionKind.main,
+            tracking_mode=TrackingMode.git_ref,
+            tracking_params={"git_ref": "main"},
+        )
+        await _make_build(
+            db_session,
+            project_id=removed.id,
+            project_slug=removed.slug,
+            git_ref="x",
+            total_size_bytes=500,
+        )
+        removed_row = await db_session.get(SqlProject, removed.id)
+        assert removed_row is not None
+        removed_row.date_deleted = func.now()
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client, events=events)
+
+    result = await inventory_census(ctx)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    publisher = events.resource_inventory
+    assert isinstance(publisher, MockEventPublisher)
+
+    org_rows = [e for e in publisher.published if e.project is None]
+    project_rows = [e for e in publisher.published if e.project is not None]
+
+    assert len(org_rows) == 1
+    org_event = org_rows[0]
+    assert org_event.organization == "census-org"
+    assert org_event.project_count == 1
+    assert org_event.edition_count == 2
+    assert org_event.build_count == 2
+    assert org_event.total_build_bytes == 30
+
+    assert len(project_rows) == 1
+    project_event = project_rows[0]
+    assert project_event.organization == "census-org"
+    assert project_event.project == "kept"
+    assert project_event.project_count is None
+    assert project_event.edition_count == 2
+    assert project_event.build_count == 2
+    assert project_event.total_build_bytes == 30

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -12,6 +12,7 @@ failing paths — without depending on real S3 or R2.
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 from types import TracebackType
@@ -24,6 +25,7 @@ import sentry_sdk
 import structlog
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
+from safir.metrics import MockEventPublisher
 from safir.testing.sentry import (
     TestTransport,
     capture_events_fixture,
@@ -44,12 +46,14 @@ from docverse.client.models import (
     TrackingMode,
 )
 from docverse.client.models.queue_enums import PublishStatus
+from docverse.config import Configuration
 from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.organization import SqlOrganization
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.queue import JobStatus
 from docverse.factory import Factory
+from docverse.metrics import build_event_manager
 from docverse.sentry import initialize_sentry
 from docverse.services.dashboard.enqueue import DashboardBuildEnqueuer
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
@@ -761,6 +765,68 @@ async def test_keeper_sync_project_failure_marks_queue_job_and_finalises_run(
 
     # Nothing was copied to the destination on the failure path.
     assert object_store.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_keeper_sync_project_publishes_run_completed(
+    app: None,
+    db_session: AsyncSession,
+    mock_discovery: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Finalising a run publishes one ``keeper_sync_run_completed`` event."""
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(db_session)
+        run_id = await _seed_run(db_session, org_id=org_id)
+        queue_job_id = await _seed_project_queue_job(
+            db_session, org_id=org_id, run_id=run_id
+        )
+
+    # LTD 404 → the run's single attributed child fails, so the run
+    # finalises as partial_failure (success=False).
+    mock_discovery.get(f"{LTD_BASE}/products/pipelines").mock(
+        return_value=httpx.Response(404)
+    )
+    object_store = MockObjectStore()
+    _patch_factory_io(
+        monkeypatch, object_store=object_store, source_objects={}
+    )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(
+        http_client=http_client, arq_queue=mock_arq, events=events
+    )
+
+    with pytest.raises(LtdNotFoundError):
+        await keeper_sync_project(
+            ctx,
+            {
+                "org_id": org_id,
+                "org_slug": org_slug,
+                "run_id": run_id,
+                "queue_job_id": queue_job_id,
+                "ltd_slug": "pipelines",
+                "ltd_base_url": LTD_BASE,
+            },
+        )
+    await ctx["http_client"].aclose()
+
+    publisher = events.keeper_sync_run_completed
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == org_slug
+    # A keeper-sync run is org-scoped, so the event carries no project.
+    assert event.project is None
+    assert event.success is False
+    assert event.total_count == 1
+    assert event.succeeded_count == 0
+    assert event.failed_count == 1
+    assert event.elapsed >= timedelta(0)
 
 
 @pytest.mark.asyncio

--- a/tests/worker/keeper_sync_reaper_test.py
+++ b/tests/worker/keeper_sync_reaper_test.py
@@ -17,6 +17,7 @@ import pytest
 import structlog
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
+from safir.metrics import MockEventPublisher
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import (
@@ -24,9 +25,11 @@ from docverse.client.models import (
     KeeperSyncRunStatus,
     OrganizationCreate,
 )
+from docverse.config import Configuration
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.queue import JobStatus
+from docverse.metrics import build_event_manager
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
 from docverse.storage.organization_store import OrganizationStore
@@ -131,6 +134,56 @@ async def test_reaper_fails_stuck_child_and_finalises_run(
             assert run is not None
             assert run.status == KeeperSyncRunStatus.partial_failure
             assert run.date_finished is not None
+
+
+@pytest.mark.asyncio
+async def test_reaper_publishes_run_completed(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """The reaper finalising a run emits one ``keeper_sync_run_completed``.
+
+    Covers the reaper's ``publish_run_completed`` wiring (untested by the
+    keeper_sync_project path): a stuck child is failed, the parent run
+    reaches ``partial_failure``, and the sweep publishes one org-scoped
+    run-completed event with ``success=False`` after the finalisation
+    transaction commits.
+    """
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        org_id = await _seed_org(db_session, slug="ks-reaper-evt")
+        run_id = await _seed_run(db_session, org_id=org_id)
+        await _seed_stuck_child(
+            db_session,
+            org_id=org_id,
+            run_id=run_id,
+            backend_job_id="arq-stuck-evt",
+            started_minutes_ago=600,
+        )
+
+    http_client = httpx.AsyncClient()
+    mock_arq = MockArqQueue(default_queue_name="docverse:queue")
+    register_queue(mock_arq, KEEPER_SYNC_QUEUE_NAME)
+    ctx = make_worker_ctx(
+        http_client=http_client, arq_queue=mock_arq, events=events
+    )
+    try:
+        await keeper_sync_reaper(ctx)
+    finally:
+        await ctx["http_client"].aclose()
+
+    publisher = events.keeper_sync_run_completed
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == "ks-reaper-evt"
+    # A keeper-sync run is org-scoped, so it carries no project.
+    assert event.project is None
+    assert event.success is False
+    assert event.total_count == 1
+    assert event.failed_count == 1
+    assert event.elapsed >= timedelta(0)
 
 
 @pytest.mark.asyncio

--- a/tests/worker/lifecycle_eval_test.py
+++ b/tests/worker/lifecycle_eval_test.py
@@ -1080,7 +1080,7 @@ async def test_lifecycle_eval_publishes_lifecycle_action(
     project_b_rules = LifecycleRuleSet(
         root=[BuildHistoryOrphanRule(min_position=1, min_age_days=30)]
     )
-    _manager, events = await build_event_manager(Configuration())
+    manager, events = await build_event_manager(Configuration())
 
     async with db_session.begin():
         org_id, org_slug = await _seed_org(
@@ -1153,6 +1153,7 @@ async def test_lifecycle_eval_publishes_lifecycle_action(
         ("event-project-a", LifecycleReapAction.draft_inactivity),
         ("event-project-b", LifecycleReapAction.build_history_orphan),
     }
+    await manager.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/worker/lifecycle_eval_test.py
+++ b/tests/worker/lifecycle_eval_test.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 import structlog
 from safir.dependencies.db_session import db_session_dependency
+from safir.metrics import MockEventPublisher
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import select, update
 
@@ -28,6 +29,7 @@ from docverse.client.models import (
     TrackingMode,
 )
 from docverse.client.models.queue_enums import JobKind, JobStatus
+from docverse.config import Configuration
 from docverse.dbschema.build import SqlBuild
 from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.edition_build_history import SqlEditionBuildHistory
@@ -41,6 +43,11 @@ from docverse.domain.lifecycle import (
     RefDeletedRule,
 )
 from docverse.factory import Factory
+from docverse.metrics import (
+    LifecycleActionTrigger,
+    LifecycleReapAction,
+    build_event_manager,
+)
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
@@ -1051,6 +1058,101 @@ async def test_lifecycle_eval_unpublishes_each_soft_deleted_edition(
     assert recorded_slugs == ["stale-a", "stale-b"]
     for call in mock_publisher.unpublish_calls:
         assert call.project_slug == "unpub-proj"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_eval_publishes_lifecycle_action(
+    app: None,
+    db_session: AsyncSession,
+) -> None:
+    """Each reap publishes one ``lifecycle_action`` (trigger=lifecycle_eval).
+
+    Seeds an edition reaped by ``draft_inactivity`` (project-a, inherited
+    org rule) and an orphan build reaped by ``build_history_orphan``
+    (project-b, project rule), runs the worker with an initialized event
+    manager, and asserts one ``lifecycle_action`` event per soft-deleted
+    row carrying the matching ``action`` enum, ``trigger=lifecycle_eval``,
+    and ``success=True``.
+    """
+    org_rules = LifecycleRuleSet(
+        root=[DraftInactivityRule(max_days_inactive=30)]
+    )
+    project_b_rules = LifecycleRuleSet(
+        root=[BuildHistoryOrphanRule(min_position=1, min_age_days=30)]
+    )
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        org_id, org_slug = await _seed_org(
+            db_session, slug="lce-event-org", lifecycle_rules=org_rules
+        )
+        project_a_id = await _seed_project(
+            db_session, org_id=org_id, slug="event-project-a"
+        )
+        project_b_id = await _seed_project(
+            db_session,
+            org_id=org_id,
+            slug="event-project-b",
+            lifecycle_rules=project_b_rules,
+        )
+        await _seed_edition(
+            db_session,
+            project_id=project_a_id,
+            slug="stale-draft",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+        )
+        current_build_id = await _seed_build(
+            db_session,
+            project_id=project_b_id,
+            project_slug="event-project-b",
+            date_completed=NOW - timedelta(days=40),
+        )
+        await _seed_build(
+            db_session,
+            project_id=project_b_id,
+            project_slug="event-project-b",
+            date_completed=NOW - timedelta(days=40),
+        )
+        await _seed_edition(
+            db_session,
+            project_id=project_b_id,
+            slug="main",
+            kind=EditionKind.draft,
+            date_updated=NOW - timedelta(days=60),
+            current_build_id=current_build_id,
+        )
+        run_id, queue_job_id = await _seed_run_and_queue_job(
+            db_session, org_id=org_id, org_slug=org_slug
+        )
+
+    http_client = httpx.AsyncClient()
+    ctx = make_worker_ctx(http_client=http_client, events=events)
+    result = await lifecycle_eval(
+        ctx,
+        {
+            "org_id": org_id,
+            "org_slug": org_slug,
+            "lifecycle_eval_run_id": run_id,
+            "queue_job_id": queue_job_id,
+        },
+    )
+    await http_client.aclose()
+    assert result == "completed"
+
+    publisher = events.lifecycle_action
+    assert isinstance(publisher, MockEventPublisher)
+    published = publisher.published
+    assert len(published) == 2
+    for event in published:
+        assert event.organization == org_slug
+        assert event.trigger is LifecycleActionTrigger.lifecycle_eval
+        assert event.success is True
+    by_project = {(event.project, event.action) for event in published}
+    assert by_project == {
+        ("event-project-a", LifecycleReapAction.draft_inactivity),
+        ("event-project-b", LifecycleReapAction.build_history_orphan),
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/worker/maintenance_worker_settings_test.py
+++ b/tests/worker/maintenance_worker_settings_test.py
@@ -18,6 +18,7 @@ from docverse.worker.functions import (
     build_processing_reaper,
     dashboard_build_reaper,
     dashboard_sync_reaper,
+    inventory_census,
     lifecycle_eval,
     lifecycle_eval_dispatcher,
     lifecycle_reaper,
@@ -115,6 +116,75 @@ def test_lifecycle_eval_dispatcher_runs_hourly() -> None:
     ]
     assert len(dispatcher_crons) == 1
     assert dispatcher_crons[0].minute == {0}
+
+
+def test_inventory_census_registered_as_function() -> None:
+    """The daily census is registered single-attempt with the pool timeout.
+
+    Unlike the cron-only reapers, ``inventory_census`` is the pool's
+    primary cron work, so it is wrapped with :func:`arq.func` carrying
+    the configured per-job ``timeout`` (a runaway aggregate is cancelled
+    by arq) and ``max_tries=1`` so arq's default retry never republishes
+    the gauge — mirroring how the dispatchers are registered.
+    """
+    census = _function_by_coroutine(inventory_census)
+    assert census.timeout_s == float(_config.maintenance_job_timeout_seconds)
+    assert census.max_tries == 1
+
+
+def test_inventory_census_runs_daily_at_configured_time() -> None:
+    """The census cron fires once a day at the config-driven hour/minute.
+
+    The schedule is sourced from ``inventory_census_cron_hour`` /
+    ``inventory_census_cron_minute`` so operators can move the census
+    without a code change; the defaults (04:47 UTC) sit in the quiet
+    pre-dawn window and are staggered off every maintenance-pool reaper
+    slot.
+    """
+    cron_jobs = list(getattr(MaintenanceWorkerSettings, "cron_jobs", []))
+    census_crons = [
+        job
+        for job in cron_jobs
+        if isinstance(job, CronJob)
+        and _underlying(job.coroutine) is inventory_census
+    ]
+    assert len(census_crons) == 1
+    assert census_crons[0].hour == {_config.inventory_census_cron_hour}
+    assert census_crons[0].minute == {_config.inventory_census_cron_minute}
+
+
+def test_inventory_census_cron_minute_does_not_collide_with_reapers() -> None:
+    """The census minute is staggered off every maintenance-pool reaper.
+
+    On a horizontally scaled maintenance pool a shared firing minute
+    would make the census race the reapers for the same Postgres
+    connection-pool slots, so the default cadence keeps the census on
+    its own minute. Pins the invariant so a future config-default tweak
+    cannot silently re-collide the schedule.
+    """
+    reaper_minutes = {0, 30, 3, 18, 33, 48, 6, 36, 12, 42, 24, 54}
+    assert _config.inventory_census_cron_minute not in reaper_minutes
+
+
+def test_default_worker_does_not_register_inventory_census() -> None:
+    """The default queue stays free of the census cron.
+
+    The census lives exclusively on the maintenance pool so its daily
+    aggregate never contends with the default pool's publishing jobs.
+    """
+    default_underlying = {
+        _underlying(entry.coroutine if isinstance(entry, Function) else entry)
+        for entry in WorkerSettings.functions
+    }
+    assert inventory_census not in default_underlying
+
+    cron_jobs = list(getattr(WorkerSettings, "cron_jobs", []) or [])
+    coroutines = {
+        _underlying(job.coroutine)
+        for job in cron_jobs
+        if isinstance(job, CronJob)
+    }
+    assert inventory_census not in coroutines
 
 
 def test_lifecycle_reaper_registered_as_function() -> None:

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from datetime import timedelta
 from types import TracebackType
 from typing import Any, Self
 
@@ -11,6 +12,7 @@ import pytest
 import structlog
 from safir.arq import MockArqQueue
 from safir.dependencies.db_session import db_session_dependency
+from safir.metrics import MockEventPublisher
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from structlog.testing import capture_logs
@@ -36,6 +38,11 @@ from docverse.domain.organization import Organization
 from docverse.domain.project import Project
 from docverse.domain.queue import JobKind, JobStatus, QueueJob
 from docverse.factory import Factory
+from docverse.metrics import (
+    EditionPublishTrigger,
+    MetricsEditionKind,
+    build_event_manager,
+)
 from docverse.services.lock_service import LockClass, LockKey
 from docverse.storage.build_store import BuildStore
 from docverse.storage.edition_build_history_store import (
@@ -310,6 +317,68 @@ async def test_publish_edition_success_lifecycle(
             assert job.date_started is not None
             assert job.date_completed is not None
             _ = history_entry
+
+
+@pytest.mark.asyncio
+async def test_publish_edition_publishes_edition_published(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful publish emits one ``edition_published`` metric event."""
+    mock_publisher = MockEditionPublisher()
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        (
+            org,
+            project,
+            edition,
+            build,
+            _history_entry,
+            queue_job,
+        ) = await _setup_publish_scenario(
+            db_session,
+            org_slug="pub-metrics-org",
+            cdn_service_label="cdn-prod",
+            backend_job_id="test-publish-arq-metrics",
+        )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_edition_publisher_for_org",
+        _mock_create_edition_publisher(mock_publisher),
+    )
+
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-publish-arq-metrics",
+        events=events,
+    )
+    payload = _make_payload(
+        org=org,
+        project=project,
+        edition=edition,
+        build=build,
+        queue_job=queue_job,
+    )
+
+    result = await publish_edition(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    publisher = events.edition_published
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    assert event.organization == org.slug
+    assert event.project == project.slug
+    # The scenario edition is ``EditionKind.release``; the worker maps it
+    # to the dedicated metrics enum.
+    assert event.edition_kind == MetricsEditionKind.release
+    # No keeper_sync_run_id on the queue job => a build-driven publish.
+    assert event.trigger == EditionPublishTrigger.build
+    assert event.elapsed >= timedelta(0)
 
 
 @pytest.mark.asyncio

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -215,8 +215,9 @@ def _make_payload(
     edition: Edition,
     build: Build,
     queue_job: QueueJob,
+    trigger: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    payload: dict[str, Any] = {
         "org_id": org.id,
         "project_slug": project.slug,
         "edition_id": edition.id,
@@ -226,6 +227,9 @@ def _make_payload(
         "queue_job_id": queue_job.id,
         "queue_job_public_id": serialize_base32_id(queue_job.public_id),
     }
+    if trigger is not None:
+        payload["trigger"] = trigger
+    return payload
 
 
 @pytest.mark.asyncio
@@ -379,6 +383,67 @@ async def test_publish_edition_publishes_edition_published(
     # No keeper_sync_run_id on the queue job => a build-driven publish.
     assert event.trigger == EditionPublishTrigger.build
     assert event.elapsed >= timedelta(0)
+
+
+@pytest.mark.asyncio
+async def test_publish_edition_rollback_trigger(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rollback-driven publish reports ``trigger=rollback``.
+
+    The rollback handler enqueues ``publish_edition`` with no
+    ``keeper_sync_run_id`` but tags its payload ``trigger=rollback``
+    (SQR-112 D7), so the ``edition_published`` metric must distinguish it
+    from the ordinary build fan-out.
+    """
+    mock_publisher = MockEditionPublisher()
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        (
+            org,
+            project,
+            edition,
+            build,
+            _history_entry,
+            queue_job,
+        ) = await _setup_publish_scenario(
+            db_session,
+            org_slug="pub-rollback-org",
+            cdn_service_label="cdn-prod",
+            backend_job_id="test-publish-arq-rollback",
+        )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_edition_publisher_for_org",
+        _mock_create_edition_publisher(mock_publisher),
+    )
+
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-publish-arq-rollback",
+        events=events,
+    )
+    payload = _make_payload(
+        org=org,
+        project=project,
+        edition=edition,
+        build=build,
+        queue_job=queue_job,
+        trigger=EditionPublishTrigger.rollback.value,
+    )
+
+    result = await publish_edition(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    publisher = events.edition_published
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    assert publisher.published[0].trigger == EditionPublishTrigger.rollback
 
 
 @pytest.mark.asyncio

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -22,12 +22,14 @@ from docverse.client.models import (
     BuildStatus,
     EditionCreate,
     EditionKind,
+    KeeperSyncRunStatus,
     OrganizationCreate,
     ProjectCreate,
     TrackingMode,
 )
 from docverse.client.models.queue_enums import PublishStatus
 from docverse.config import Configuration
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.organization import SqlOrganization
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.base32id import serialize_base32_id
@@ -53,6 +55,7 @@ from docverse.storage.editionpublisher import (
     EditionPublisher,
     MockEditionPublisher,
 )
+from docverse.storage.keeper_sync_run_store import KeeperSyncRunStore
 from docverse.storage.organization_store import OrganizationStore
 from docverse.storage.project_store import ProjectStore
 from docverse.storage.queue_job_store import QueueJobStore
@@ -131,6 +134,7 @@ async def _setup_publish_scenario(
     org_slug: str,
     cdn_service_label: str | None,
     backend_job_id: str,
+    keeper_sync_run_id: int | None = None,
 ) -> tuple[
     Organization,
     Project,
@@ -139,7 +143,12 @@ async def _setup_publish_scenario(
     EditionBuildHistory,
     QueueJob,
 ]:
-    """Create org, project, edition, build, history entry, and queue job."""
+    """Create org, project, edition, build, history entry, and queue job.
+
+    When ``keeper_sync_run_id`` is supplied the publish ``QueueJob`` is
+    attributed to that keeper-sync run (mirroring the backfill path), so
+    completing the publish drives the run terminal.
+    """
     logger = _logger()
     org_store = OrganizationStore(session=db_session, logger=logger)
     proj_store = ProjectStore(session=db_session, logger=logger)
@@ -204,6 +213,7 @@ async def _setup_publish_scenario(
         build_id=refreshed_build.id,
         edition_id=edition.id,
         backend_job_id=backend_job_id,
+        keeper_sync_run_id=keeper_sync_run_id,
     )
     return org, project, edition, refreshed_build, history_entry, queue_job
 
@@ -230,6 +240,19 @@ def _make_payload(
     if trigger is not None:
         payload["trigger"] = trigger
     return payload
+
+
+async def _seed_keeper_sync_run(
+    db_session: AsyncSession, *, org_id: int
+) -> int:
+    """Seed an ``in_progress`` keeper-sync run to attribute a publish to."""
+    row = SqlKeeperSyncRun(
+        org_id=org_id, kind="backfill", status="in_progress"
+    )
+    db_session.add(row)
+    await db_session.flush()
+    await db_session.refresh(row)
+    return row.id
 
 
 @pytest.mark.asyncio
@@ -444,6 +467,95 @@ async def test_publish_edition_rollback_trigger(
     assert isinstance(publisher, MockEventPublisher)
     assert len(publisher.published) == 1
     assert publisher.published[0].trigger == EditionPublishTrigger.rollback
+
+
+@pytest.mark.asyncio
+async def test_publish_edition_finalises_keeper_sync_run_succeeded(
+    app: None,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run's last publish completing emits ``success=True`` run-completed.
+
+    Attributes the publish job to a keeper-sync run as its only child, so
+    completing the publish drives the run to ``succeeded`` and the worker
+    publishes one ``keeper_sync_run_completed`` with ``success=True`` —
+    covering the ``publish_edition`` finaliser wiring and the clean
+    success branch (the keeper_sync_project test only covers
+    ``partial_failure``).
+    """
+    mock_publisher = MockEditionPublisher()
+    _manager, events = await build_event_manager(Configuration())
+
+    async with db_session.begin():
+        org_store = OrganizationStore(session=db_session, logger=_logger())
+        org_seed = await org_store.create(
+            OrganizationCreate(
+                slug="pub-run-org",
+                title="Run Org",
+                base_domain="pub-run-org.example.com",
+            )
+        )
+        run_id = await _seed_keeper_sync_run(db_session, org_id=org_seed.id)
+
+    async with db_session.begin():
+        (
+            org,
+            project,
+            edition,
+            build,
+            _history_entry,
+            queue_job,
+        ) = await _setup_publish_scenario(
+            db_session,
+            org_slug="pub-run-attrib-org",
+            cdn_service_label="cdn-prod",
+            backend_job_id="test-publish-arq-run",
+            keeper_sync_run_id=run_id,
+        )
+
+    monkeypatch.setattr(
+        Factory,
+        "create_edition_publisher_for_org",
+        _mock_create_edition_publisher(mock_publisher),
+    )
+
+    ctx = make_worker_ctx(
+        http_client=httpx.AsyncClient(),
+        job_id="test-publish-arq-run",
+        events=events,
+    )
+    payload = _make_payload(
+        org=org,
+        project=project,
+        edition=edition,
+        build=build,
+        queue_job=queue_job,
+    )
+
+    result = await publish_edition(ctx, payload)
+    await ctx["http_client"].aclose()
+    assert result == "completed"
+
+    publisher = events.keeper_sync_run_completed
+    assert isinstance(publisher, MockEventPublisher)
+    assert len(publisher.published) == 1
+    event = publisher.published[0]
+    # A keeper-sync run is org-scoped, so it carries no project.
+    assert event.project is None
+    assert event.success is True
+    assert event.total_count == 1
+    assert event.succeeded_count == 1
+    assert event.failed_count == 0
+    assert event.elapsed >= timedelta(0)
+
+    # The run row itself reached the terminal succeeded status.
+    async for session in db_session_dependency():
+        async with session.begin():
+            run_store = KeeperSyncRunStore(session=session, logger=_logger())
+            run = await run_store.get(run_id)
+            assert run is not None
+            assert run.status == KeeperSyncRunStatus.succeeded
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -130,6 +130,31 @@ wheels = [
 ]
 
 [[package]]
+name = "aiokafka"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/5f/dfc1180fd22d1acdc91949ec36e97199c43742dacb057cb8efed3679ed04/aiokafka-0.14.0.tar.gz", hash = "sha256:8ffdc945798ba4d3d132b705d4244d0a1f493925efb57c637a2ca88ee82794e1", size = 601374, upload-time = "2026-04-29T10:43:03.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/b0/c9384541b2e4cc52a16402fc53fb9d44af0d78d37954cf8c7271c376ad47/aiokafka-0.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:db16e43fac4c1c5006131046c1bf370c580d6ac4495a10ac7778245710943179", size = 345859, upload-time = "2026-04-29T10:42:45.449Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d1/fc266d9f4ffba4f197356c6ffdfbb0fe32e7cb874e240f299935d058ac06/aiokafka-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:32a8e91d88cf3ccf0778927715610d6579888c5f4748db4c2022cda25d628a48", size = 348284, upload-time = "2026-04-29T10:42:47.104Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8e/0c4c270786dac79f3fca74c6166c3a25b61b0d26132be0d69f0d7f206f0a/aiokafka-0.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aad4a575a506e7784e25e430f27026fe2f4378560b21b7f4e8c9a54f0d06eaee", size = 1117867, upload-time = "2026-04-29T10:42:48.394Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7f/3b89fbd0a3be9edfd5b51e20bb5cd695c851219b63c501c051cf84367fa9/aiokafka-0.14.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75e4a003502c9c3b5c705fa7c00d634ba146bf38fa5d525b80bb6ff6e3e779fe", size = 1108860, upload-time = "2026-04-29T10:42:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/59/849aba75cff93277bf6bf8b630de79e902949ff7ec48e4b12a64e6e32cae/aiokafka-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a128e213cbc2bce0ea3db65a68920e52cebeeb8209bf001ac7aa022a8bd54d7d", size = 310889, upload-time = "2026-04-29T10:42:52.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e5/52eab8f8515d23da7b5d90e2c5ba10eab9494a0314f749e3f73e003f4a50/aiokafka-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:d6fa16bef3544be87bd1a7a8317b9d85e3da59f3202326d9ff22735ed052746e", size = 329470, upload-time = "2026-04-29T10:42:53.536Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9d/984803315fe2b883ea6e08b1d9c8a752bd5c16e966d8714bacc67c72c417/aiokafka-0.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5d70615d1530ad19d0c4da8d87abaec0a12b9fdaabffdcd4e400efa0c50ef80c", size = 346672, upload-time = "2026-04-29T10:42:55.267Z" },
+    { url = "https://files.pythonhosted.org/packages/49/df/da314966b7f3c3117bd78b082563cb03dbe3007848cb8f4b0932faf390a0/aiokafka-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7e2392360c370b1ba6564c57d2889e154ecdb43157a8f7b7d7afe5e3c02fcc1a", size = 349594, upload-time = "2026-04-29T10:42:56.565Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7a/160516944ea0e0f68ea78e38f944c52f5248c7c7df26cba22a40b9f25709/aiokafka-0.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:201e38ecc595f9f65a945f1ef9085157ddf28f25cd2e482fd9efa1fcf4638213", size = 1114112, upload-time = "2026-04-29T10:42:57.869Z" },
+    { url = "https://files.pythonhosted.org/packages/68/c4/9841118a2157e913e8ebfbc0a2b58f7b60f1f7202040c3e1df8925ed1184/aiokafka-0.14.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cd651e1f56571baae306fdd0b5509047ab9625797a24cd75902e139c5a20318", size = 1098571, upload-time = "2026-04-29T10:42:59.356Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a1/0af8a37849a4108ae227f46c4c62f6beab31863cf66ba318fb73b0be5b26/aiokafka-0.14.0-cp314-cp314-win32.whl", hash = "sha256:128127eb96dab98150b636bb5f480c80e15f02f82a118eec206a521c8cf7cf7c", size = 314107, upload-time = "2026-04-29T10:43:01.111Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/fb46c65f758900c71d0f1c73b7802720f99cabcb1f4a11676573f9bc1b8f/aiokafka-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:aa385039aa9b235359319bbdcf48c9c86a75d81c9c547d645056d00361238903", size = 333320, upload-time = "2026-04-29T10:43:02.424Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -265,6 +290,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -338,6 +372,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
+name = "casefy"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/50/f5991618899c42d0c6339bd83fed5f694f56b204dfb3f2a052f0d586d4c5/casefy-1.0.0.tar.gz", hash = "sha256:bc99428475c2089c5f6a21297b4cfe4e83dff132cf3bb06655ddcb90632af1ed", size = 123432, upload-time = "2024-11-30T10:00:59.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/b6/797c17fe4804896836ef33b447f0a2641d59a8d1d63e63834fb3fbc87cd8/casefy-1.0.0-py3-none-any.whl", hash = "sha256:c89f96fb0fbd13691073b7a65c1e668e81453247d647479a3db105e86d7b0df9", size = 6299, upload-time = "2024-11-30T10:00:33.134Z" },
 ]
 
 [[package]]
@@ -616,6 +659,32 @@ wheels = [
 ]
 
 [[package]]
+name = "dacite"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/a0/7ca79796e799a3e782045d29bf052b5cde7439a2bbb17f15ff44f7aacc63/dacite-1.9.2.tar.gz", hash = "sha256:6ccc3b299727c7aa17582f0021f6ae14d5de47c7227932c47fec4cdfefd26f09", size = 22420, upload-time = "2025-02-05T09:27:29.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/35/386550fd60316d1e37eccdda609b074113298f23cef5bddb2049823fe666/dacite-1.9.2-py3-none-any.whl", hash = "sha256:053f7c3f5128ca2e9aceb66892b1a3c8936d02c686e707bee96e19deef4bc4a0", size = 16600, upload-time = "2025-02-05T09:27:24.345Z" },
+]
+
+[[package]]
+name = "dataclasses-avroschema"
+version = "0.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "casefy" },
+    { name = "dacite" },
+    { name = "fastavro" },
+    { name = "inflection" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/75/3aaf3217c0eb8b886020ac3e0531b146c943303eaf1dd9bd57e07c9cd5d3/dataclasses_avroschema-0.70.0.tar.gz", hash = "sha256:ed0686eec199d2f1f6487112c4ff9f42e6c8f373effde36496a257c046d51e3f", size = 46193, upload-time = "2026-05-18T15:01:56.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/2f/c7c0d6c015123eff625a43dae8f3709167c0dec54399dc8adc08c35aae88/dataclasses_avroschema-0.70.0-py3-none-any.whl", hash = "sha256:30820d24e8209f1ba65befd5e8f90b7bb45269f7bd8c1aae77f381e298e5ca9f", size = 56969, upload-time = "2026-05-18T15:01:58.125Z" },
+]
+
+[[package]]
 name = "dependency-groups"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -666,7 +735,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "rubin-gafaelfawr" },
     { name = "rubin-repertoire" },
-    { name = "safir", extra = ["arq", "db"] },
+    { name = "safir", extra = ["arq", "db", "kafka"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -708,7 +777,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2" },
     { name = "rubin-gafaelfawr" },
     { name = "rubin-repertoire" },
-    { name = "safir", extras = ["arq", "db"], specifier = ">=13" },
+    { name = "safir", extras = ["arq", "db", "kafka"], specifier = ">=13" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
 
@@ -767,6 +836,24 @@ dev = [
 ]
 
 [[package]]
+name = "fast-depends"
+version = "3.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/6d/787a21ca8043a8fdb737cf28f645e94a46fc30b44a31de54573299156bad/fast_depends-3.0.8.tar.gz", hash = "sha256:896b16f79a512b6ea1df721b0aa1708a192a06f964be6597e01fcf5412559101", size = 18382, upload-time = "2026-03-02T19:54:28.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/1d/e4843e4eeb65f51447b8c22d200d12d8f94f27c97e77bb7162515cc8d61f/fast_depends-3.0.8-py3-none-any.whl", hash = "sha256:4c52c8a3907bca46d43e70e4364d6d016872d9a3aae4bc0c1c85e72e0a6a21c7", size = 25507, upload-time = "2026-03-02T19:54:27.594Z" },
+]
+
+[package.optional-dependencies]
+pydantic = [
+    { name = "pydantic" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
@@ -780,6 +867,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+]
+
+[[package]]
+name = "fastavro"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/5b/ccb338db71f347e3bc031d268bf6dc41e5ead63b6997b8e72af92f05e18e/fastavro-1.12.2.tar.gz", hash = "sha256:3c79502d56cf6b76210032e1c53494ddfbc73c140bccf2ef4092b3f0825323ab", size = 1030127, upload-time = "2026-04-24T14:36:01.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/39/f489a441d41cc9c0a8449fb1325d7a9c9eb57a5634e6ab19dfb0a1105324/fastavro-1.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:57bb6b908cb2e05baab63b04c3a31be3b4545a10bfab9748b8763016b5256704", size = 958566, upload-time = "2026-04-24T14:36:45.49Z" },
+    { url = "https://files.pythonhosted.org/packages/31/69/776cc025aee2d02acacb734cf690d2fbc295eaadde1b5d47caf8c77a6a2b/fastavro-1.12.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a007f95cc682f56e6d83f1d17c29c00bf719d6fe8e003282b535af3a1ba09c0", size = 3276390, upload-time = "2026-04-24T14:36:47.875Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bc/b7e15fa788f42cbe65827af2ec06c9ad91bb9f72c213110dbef61b53a5b0/fastavro-1.12.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e90460b0cd21f62be3cb26087e706e2cebb7b3fcef9e05b4473b61bb0415b5e", size = 3372779, upload-time = "2026-04-24T14:36:50.122Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c2/98993ca810231fc1397212f48c3d46626983722a24bbaaa5c27ee0963751/fastavro-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ccd15966b8218d41b06ec3e7c2556be89a8a693026c771e6564d2e40bbaf8ea", size = 3187591, upload-time = "2026-04-24T14:36:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/c180f340eba6478f1b20deccdd17e2b4a4d5074dafd812e3c4254fd035f7/fastavro-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06b6971d3dae10cb34353b857d16ad21ebd6f0ea394e86c96abdcad109005d6e", size = 3320589, upload-time = "2026-04-24T14:36:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/e9/aca0456216b5b8992e7b0a8542711b66799c05bfe24c8e32ef6f56e7eb93/fastavro-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:98dfcdfaf1498ae2f0e2fafe900a82e8320cc81d8ae5a95b8b8879eaa3298c39", size = 440883, upload-time = "2026-04-24T14:36:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7e/984896e716af504927be71b80a1e9661aa96c6f9e1e777d52823aacb99f2/fastavro-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:3888ef7a51adc77cdf07251bc762566a1be36211e1cff689f13980f3776a2f36", size = 377536, upload-time = "2026-04-24T14:36:58.274Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/42/09a1e1f8d9998d73848a6ff0aad6713ae6abf0dbf99918776f8ef33344a7/fastavro-1.12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:283dcd3129b632021894425974bedd0eb6db3bbf5994e448ccad10db4d803d31", size = 1049506, upload-time = "2026-04-24T14:36:59.797Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ef/80cc16f43919d532f25a707f34b275cccc09dca87a05b000fbbfc8e8f255/fastavro-1.12.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d125e210d5a0a1f701f12c0ecad9a03f1b04b5eddbce6ca36a1fc217da977ef", size = 3495899, upload-time = "2026-04-24T14:37:02.306Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/54/a0817d1d0236e9e0233f5c996f450cc795b056b8e06edb531f24b9df82ed/fastavro-1.12.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d4d66afad78e8f47feaa307728a6b71fe3effc63ba2b9eeb109ee687c9bd397", size = 3399232, upload-time = "2026-04-24T14:37:04.837Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0a/650f256c15f5875b6081544b9ba7ed8254329213e7e49e3db0aec68b5bee/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2328ec07925c04c89719e3971c9068a165c7fd474ea87675b1204de0440e71ff", size = 3320222, upload-time = "2026-04-24T14:37:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/8351d388f94fbb0870e8cffaae41d3cc607acc8d6a8a6a217e2794829593/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55dea7e74b834d4b70467fc19c5b9ccb5509fe39abc4d26891187c1b22176423", size = 3337096, upload-time = "2026-04-24T14:37:09.452Z" },
+    { url = "https://files.pythonhosted.org/packages/da/eb/b36ba9a88826e8c272df02e2f8b5da717e88b6eb508fddca3ca450043731/fastavro-1.12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8d37c87826ae7195cfbd20fcd448801f2f563bb38f2691ec6574e39cb9eca6c8", size = 963119, upload-time = "2026-04-24T14:37:11.557Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/3d7f540fb26ba4ea1f4ebd2783c586614da9ac00906a3092e92fd3f104a2/fastavro-1.12.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c463a3701f293e30d3d62e71e1989f112028d07f87432baf4507eeb57ec3831", size = 3266238, upload-time = "2026-04-24T14:37:13.84Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0b/b77be56c5109da0fc7dcfd7e6b6752fe0a61d0a5c58c6a65e38b4501946a/fastavro-1.12.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f604ba83498e209fff4c7ecc5063a39421dc538dace694bc592f9f338254f3dc", size = 3324020, upload-time = "2026-04-24T14:37:16.096Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/6e/951d41f244107e91bf2f59245b71783c03eaab4bdbc960d58316c19652bb/fastavro-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bfac2dada8ddc002e8b7d8289d6fad4f070bc1fec20371cec684a7d10d932e96", size = 3170160, upload-time = "2026-04-24T14:37:18.168Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6f/2adb571fda448d4afd2466e1cef2963fefdc6b37847da05249983e415f17/fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c", size = 3281842, upload-time = "2026-04-24T14:37:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/17/07/4bad2e96c4c6bae40253be2573cc09c1e5b9ccf821e1ff74e0d33b64bf90/fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f", size = 450903, upload-time = "2026-04-24T14:37:23.059Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b7/180f67ba9a46ba23a1ff6432f48d3087d4f2048579ecc262b00426cb1c63/fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a", size = 391076, upload-time = "2026-04-24T14:37:24.756Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/18f60329b627d2118a4a2b19e8741fbd807d60bf0470554e1bbfb7f1bca3/fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b", size = 1055430, upload-time = "2026-05-09T21:53:14.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ac/a1fa1fc29df0efc89d4946a743b09bdc9500591b5b92083eaf8e93664916/fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa", size = 3503075, upload-time = "2026-04-24T14:37:26.826Z" },
+    { url = "https://files.pythonhosted.org/packages/82/bf/4f669e10b6bc38a731ee3400aed1a1e2d0a3e3cf411e72f6b320d3af0eaf/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282", size = 3410900, upload-time = "2026-04-24T14:37:29.233Z" },
+    { url = "https://files.pythonhosted.org/packages/10/39/ecb19fdae4158a7730b5963fbf1b6d38d74678392d73083be518642af0c1/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370", size = 3335637, upload-time = "2026-04-24T14:37:31.472Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/f21bd5319113e89ceceed2df840df21e9c5150d181db74b6ba80400f9f48/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:afede7324822800e4f90e96b9514188a237a60f35e8e7a10b2129c10c78f6e4d", size = 3356664, upload-time = "2026-04-24T14:37:34.231Z" },
+]
+
+[[package]]
+name = "faststream"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "fast-depends", extra = ["pydantic"] },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/7b/d02c069be0bc671b2eb8f805a1f824d2bfbe1852c9c3f4ad719a7ad3710b/faststream-0.6.7.tar.gz", hash = "sha256:c732eaf861c4cbddd9c7f9098608486a9f05dff67a72335686c3044039045346", size = 306185, upload-time = "2026-03-01T08:20:27.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/23/9d51f352fbb656f5345030f57e20737b1c88167f0eac354ac548d577808b/faststream-0.6.7-py3-none-any.whl", hash = "sha256:a904a4b1e3babeaa244a9460821f5b05dd71b00c959c816360b2acbbe267cd5c", size = 513454, upload-time = "2026-03-01T08:20:26.423Z" },
 ]
 
 [[package]]
@@ -1075,6 +1208,15 @@ wheels = [
 ]
 
 [[package]]
+name = "inflection"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/7e/691d061b7329bc8d54edbf0ec22fbfb2afe61facb681f9aaa9bff7a27d04/inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417", size = 15091, upload-time = "2020-08-22T08:16:29.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2", size = 9454, upload-time = "2020-08-22T08:16:27.816Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1102,6 +1244,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1708,6 +1877,21 @@ wheels = [
 ]
 
 [[package]]
+name = "python-schema-registry-client"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "fastavro" },
+    { name = "httpx" },
+    { name = "jsonschema" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/4c/3b10063174780ee1ad97bca6c100cf9634aaba9559f03a588d721403567b/python_schema_registry_client-2.6.1.tar.gz", hash = "sha256:017fd45a36a4517d9c87c03c992393cce2c437c5ffa8fe1c9dfde1664caa89c9", size = 21360, upload-time = "2025-04-04T15:07:51.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/c1/abd18fc3c23dbe09321fcd812091320d4dc954046f95cb431ef2926cb11c/python_schema_registry_client-2.6.1-py3-none-any.whl", hash = "sha256:05950ca8f9a3409247514bef3fdb421839d6e1ae544b32dfd3b7b16237673303", size = 23095, upload-time = "2025-04-04T15:07:49.592Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -1774,6 +1958,19 @@ hiredis = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1798,6 +1995,101 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
 ]
 
 [[package]]
@@ -1894,6 +2186,12 @@ db = [
     { name = "alembic", extra = ["tz"] },
     { name = "asyncpg" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+]
+kafka = [
+    { name = "aiokafka" },
+    { name = "dataclasses-avroschema" },
+    { name = "faststream" },
+    { name = "python-schema-registry-client" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Stand up the SQR-112 Sasquatch application-metrics pipeline: a new `docverse.metrics` package with scalar-only `EventPayload` models, dedicated metrics enums, a single `DocverseEvents(EventMaker)` registry, and a `build_event_manager(config)` helper wired into the FastAPI lifespan and every arq worker `on_startup`.
- Emit the high-signal core three events — `build_uploaded` (PATCH builds handler, with uploader + annotation provenance), `build_processed` (`build_processing` worker terminal), and `edition_published` (`publish_edition` worker success terminal) — published after the owning transaction commits and threaded to handlers via `RequestContext.events` and to workers via `ctx["events"]`.
- Add `Configuration.metrics` (selected from `METRICS_*`/`KAFKA_*`/`SCHEMA_MANAGER_*`), run best-effort (`raise_on_error=False`) so a metrics outage never fails a request/build/job, and document the env values plus the `lsst.square.metrics.events.docverse` Sasquatch topic the `phalanx-docverse` deployment must register.
- Enable Safir's built-in generic arq-queue metrics on all three worker pools (default, keeper-sync, maintenance): every job publishes `arq_job_run` (with `queue` and `time_in_queue`) via `make_on_job_start`, and a per-pool five-minute cron publishes the `arq_queue_stats` queue-depth gauge (`num_queued`).
- Emit the `project_lifecycle` (create/update/delete) and `edition_lifecycle` (create/update/delete/rollback) flow events from the FastAPI projects and editions handlers, each published after the operation's final commit with a consolidated `LifecycleAction` verb (and `edition_kind` for editions).
- Emit the `membership_changed` flow event from the FastAPI members handler: `post_member` publishes `action=add` and `delete_member` publishes `action=remove`, each after the operation's commit, carrying the org-scoped principal's `role`, `principal_type`, and `principal` as dedicated metrics enums mapped from the API.
- Emit the two worker terminal-transition events: `dashboard_built` from the `dashboard_build` worker (`success`, `object_count`, `total_size_bytes`, `elapsed`) and `keeper_sync_run_completed` when a keeper-sync run is finalised (`success` plus run-stat counts and `elapsed`), the latter published from every `maybe_finalise_run` path (`keeper_sync_project`, the keeper-sync reaper, and `publish_edition`).
- Emit the `lifecycle_action` flow event once per reap/deletion from the `lifecycle_eval` and `git_ref_audit` reaper workers (SQR-112 D7): each soft-deleted row publishes one event carrying `organization`/`project`, an `action` enum (`draft_inactivity`/`build_history_orphan` from `lifecycle_eval`, `ref_deleted` from `git_ref_audit`), a `trigger` enum naming the worker, and `success`, published after the per-org soft-delete transaction commits.
- Emit the daily `resource_inventory` census gauge (SQR-112 D8): a new config-scheduled `inventory_census` maintenance cron takes a read-only grouped-aggregate snapshot of every org's and non-deleted project's active resource counts and publishes one org-scoped `resource_inventory` (with `project_count`) per org plus one project-scoped row per project; soft-deleted projects/editions/builds are excluded and `total_build_bytes` is the summed active-build footprint.

## Validation steps

- With `METRICS_MOCK=true`, start the app and each of the three worker pools and confirm the `EventManager` builds and every `DocverseEvents` publisher registers with no errors.
- `PATCH …/builds/{build}` with `status: uploaded` and confirm exactly one `build_uploaded` fires with the correct `organization`, `project`, `uploader`, and provenance fields (null where the build was not annotated).
- Process a build and confirm `build_processed` carries `success`, `object_count`, `total_size_bytes`, `editions_updated`, `editions_skipped`, `stale_skipped`, and `elapsed`.
- Publish an edition and confirm `edition_published` carries `edition_kind`, `trigger`, and `elapsed`.
- Simulate a publish failure (Kafka/registry outage) and confirm it is logged and swallowed (`raise_on_error=False`) without failing the request, build, or job.
- With metrics enabled, run a job on each of the default, keeper-sync, and maintenance pools and confirm each publishes an `arq_job_run` carrying its own `queue` and a non-negative `time_in_queue`.
- Confirm each pool's five-minute `publish_queue_stats` cron emits an `arq_queue_stats` with `num_queued` for the queue that pool serves.
- Confirm the README "Application metrics" section and the `Configuration.metrics` field document `METRICS_*`/`KAFKA_*`/`SCHEMA_MANAGER_*` and the `lsst.square.metrics.events.docverse` topic.
- Create, update, and delete a project and confirm each publishes exactly one `project_lifecycle` carrying the correct `action` (create/update/delete) plus `organization`/`project`.
- Create, update, delete, and roll back an edition and confirm each publishes exactly one `edition_lifecycle` carrying the correct `action` (create/update/delete/rollback) and `edition_kind`.
- Add an org member and confirm exactly one `membership_changed` fires with `action=add` and the correct `role`, `principal_type`, and `principal`.
- Remove an org member and confirm exactly one `membership_changed` fires with `action=remove` carrying the removed principal's `role`, `principal_type`, and `principal`.
- Run a dashboard build to completion and confirm exactly one `dashboard_built` fires with `success=true`, the `object_count`/`total_size_bytes` of the uploaded artifacts, and a non-negative `elapsed`; force the build to fail and confirm one `dashboard_built` fires with `success=false` and null counters.
- Finalise a keeper-sync run (let its last attributed child reach terminal, or let the reaper sweep it) and confirm exactly one `keeper_sync_run_completed` fires with org-scoped `organization`, `project=null`, `success` reflecting whether any child failed, and the `total_count`/`succeeded_count`/`failed_count` run stats.
- Run a `lifecycle_eval` pass that reaps a stale draft and an orphan build and confirm one `lifecycle_action` fires per reaped row with `trigger=lifecycle_eval` and `action=draft_inactivity` / `build_history_orphan`.
- Run a `git_ref_audit` pass that reaps an edition whose tracked git ref is gone and confirm one `lifecycle_action` fires with `trigger=git_ref_audit` and `action=ref_deleted`; confirm each event carries `organization`/`project` and `success=true`.
- Seed orgs, projects, editions, and builds — including soft-deleted rows and a soft-deleted project — run the `inventory_census` job, and confirm it publishes one org-scoped `resource_inventory` (with `project_count`, including a row for an org with zero projects) per org plus one project-scoped row per non-deleted project.
- Confirm soft-deleted projects/editions/builds are excluded from every census count and that `total_build_bytes` equals the summed `total_size_bytes` of the active builds (a NULL-sized active build counts toward `build_count` but adds nothing to the byte total).

## References

- Closes #432
- Closes #433
- Closes #434
- Closes #435
- Closes #436
- Closes #437
- Closes #438
- PRD: #431
- Jira: https://rubinobs.atlassian.net/browse/DM-55200