### PR TITLE
DM-55493: Auto-configure testcontainers for Colima in noxfile

### DIFF
--- a/.agents/skills/project-mechanics/SKILL.md
+++ b/.agents/skills/project-mechanics/SKILL.md
@@ -17,10 +17,10 @@ Node/TypeScript). The named commands below target the primary
 
 ## Test commands
 
-- `focused_test`: `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test -- tests/path/to/file_test.py::test_name`
+- `focused_test`: `uv run --only-group=nox nox -s test -- tests/path/to/file_test.py::test_name`
 - `complete_test`: run only the suite(s) for the package(s) you changed,
   per `## Monorepo selectors` — server change →
-  `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test`;
+  `uv run --only-group=nox nox -s test`;
   client change → `uv run --only-group=nox nox -s client_test`; both
   changed → run both. The full cross-package suite is **not** the
   in-iteration gate (see `## Final validation`).
@@ -55,7 +55,7 @@ Additional checks by component:
 
 Scope test/lint commands to the package you changed:
 
-- **Server** (`src/docverse/`, `tests/`, `alembic/`, `noxfile.py`): `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test -- tests/...`
+- **Server** (`src/docverse/`, `tests/`, `alembic/`, `noxfile.py`): `uv run --only-group=nox nox -s test -- tests/...`
 - **Client** (`client/`): `uv run --only-group=nox nox -s client_test -- client/tests/...`
 - **Cloudflare worker** (`cloudflare-worker/`): `cd cloudflare-worker && npm run build && npm test`
 - Lint and typing are repo-wide regardless of which package changed (`lint_all` / `typing` above cover all components).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,6 @@
       "Bash(uv sync:*)",
       "Bash(uv run nox:*)",
       "Bash(uv run --only-group=nox nox:*)",
-      "Bash(TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox:*)",
       "Bash(npm test:*)",
       "Bash(npm run:*)",
       "Bash(npx vitest:*)",

--- a/.claude/skills/project-mechanics/SKILL.md
+++ b/.claude/skills/project-mechanics/SKILL.md
@@ -17,10 +17,10 @@ Node/TypeScript). The named commands below target the primary
 
 ## Test commands
 
-- `focused_test`: `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test -- tests/path/to/file_test.py::test_name`
+- `focused_test`: `uv run --only-group=nox nox -s test -- tests/path/to/file_test.py::test_name`
 - `complete_test`: run only the suite(s) for the package(s) you changed,
   per `## Monorepo selectors` — server change →
-  `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test`;
+  `uv run --only-group=nox nox -s test`;
   client change → `uv run --only-group=nox nox -s client_test`; both
   changed → run both. The full cross-package suite is **not** the
   in-iteration gate (see `## Final validation`).
@@ -55,7 +55,7 @@ Additional checks by component:
 
 Scope test/lint commands to the package you changed:
 
-- **Server** (`src/docverse/`, `tests/`, `alembic/`, `noxfile.py`): `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test -- tests/...`
+- **Server** (`src/docverse/`, `tests/`, `alembic/`, `noxfile.py`): `uv run --only-group=nox nox -s test -- tests/...`
 - **Client** (`client/`): `uv run --only-group=nox nox -s client_test -- client/tests/...`
 - **Cloudflare worker** (`cloudflare-worker/`): `cd cloudflare-worker && npm run build && npm test`
 - Lint and typing are repo-wide regardless of which package changed (`lint_all` / `typing` above cover all components).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This repository was originally created for LTD Keeper. During the codebase migra
 - **Lint a specific file**: `uv run --only-group=lint ruff check path/to/file.py`
 - **Format a specific file**: `uv run --only-group=lint ruff format path/to/file.py`
 - **Type checking**: `uv run --only-group=nox nox -s typing`
-- **Server tests**: `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true uv run --only-group=nox nox -s test`
+- **Server tests**: `uv run --only-group=nox nox -s test`
 - **Client tests**: `uv run --only-group=nox nox -s client_test`
 - **Running specific tests**: pass pytest args after `--`, e.g. `uv run --only-group=nox nox -s test -- tests/path/to/file_test.py`
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,10 +1,60 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
 import nox
 from nox_uv import session
-from testcontainers.postgres import PostgresContainer
+
+if TYPE_CHECKING:
+    from testcontainers.postgres import PostgresContainer
 
 nox.needs_version = ">=2024.4.15"
 nox.options.default_venv_backend = "uv"
 nox.options.sessions = ["lint", "typing", "test", "client_test"]
+
+
+def _setup_testcontainers_env() -> None:
+    """Configure testcontainers environment variables for Colima on macOS.
+
+    This must be called before any containers are started to ensure the
+    Reaper can connect properly when using Colima as the Docker runtime.
+    """
+    # Set testcontainers host override for Colima on macOS
+    # This fixes "nodename nor servname provided, or not known" errors
+    docker_host = os.getenv("DOCKER_HOST", "")
+    m = re.search(r"\.colima/(?P<profile>[^/]+)/docker\.sock$", docker_host)
+    if m:
+        # Extract the Colima VM IP address for the active profile.
+        # colima ls -j emits one JSON object per line (one per profile).
+        try:
+            result = subprocess.run(
+                ["colima", "ls", "-j"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            for line in result.stdout.splitlines():
+                if not line.strip():
+                    continue
+                colima_info = json.loads(line)
+                if colima_info.get("name") == m["profile"] and colima_info.get(
+                    "address"
+                ):
+                    os.environ["TESTCONTAINERS_HOST_OVERRIDE"] = colima_info[
+                        "address"
+                    ]
+                    break
+        except (
+            subprocess.CalledProcessError,
+            json.JSONDecodeError,
+            KeyError,
+        ):
+            # If we can't get the Colima address, don't set override
+            pass
 
 
 def _install_pg_extensions(postgres: PostgresContainer) -> None:
@@ -39,6 +89,11 @@ def typing(session: nox.Session) -> None:
 
 @session(uv_groups=["dev"])
 def test(session: nox.Session) -> None:
+    _setup_testcontainers_env()
+
+    # Import after setting environment variables so config is read correctly
+    from testcontainers.postgres import PostgresContainer  # noqa: PLC0415
+
     with PostgresContainer("postgres:17") as postgres:
         _install_pg_extensions(postgres)
         url = postgres.get_connection_url(driver="asyncpg")
@@ -145,6 +200,11 @@ def create_migration(session: nox.Session) -> None:
         )
 
     message = session.posargs[0]
+
+    _setup_testcontainers_env()
+
+    # Import after setting environment variables so config is read correctly
+    from testcontainers.postgres import PostgresContainer  # noqa: PLC0415
 
     with PostgresContainer("postgres:17") as postgres:
         _install_pg_extensions(postgres)


### PR DESCRIPTION
## Summary

- Add a `_setup_testcontainers_env()` helper (ported from [lsst-sqre/ook](https://github.com/lsst-sqre/ook/blob/main/noxfile.py)) that detects a Colima `DOCKER_HOST`, looks up that profile's VM address via `colima ls -j`, and sets `TESTCONTAINERS_HOST_OVERRIDE` before any container starts. This fixes the `socket.gaierror: [Errno 8] nodename nor servname provided, or not known` failure when Ryuk tries to connect under Colima on macOS, **without** disabling Ryuk — so orphaned containers still get reaped.
- Call the helper at the top of the two sessions that start containers (`test` and `create-migration`), and move the `testcontainers` import inside those sessions so the environment is configured before testcontainers reads its config.
- Drop the now-unnecessary `TC_HOST=localhost TESTCONTAINERS_RYUK_DISABLED=true` prefixes from the documented commands in `CLAUDE.md`, the `project-mechanics` skill, and the `.claude/settings.json` permission allowlist. (`TC_HOST` takes precedence over `TESTCONTAINERS_HOST_OVERRIDE`, so a leftover prefix would defeat the fix.)

The helper is a no-op when `DOCKER_HOST` doesn't point at a Colima socket, so Docker Desktop and CI are unaffected.

## Validation steps

- On macOS with Colima as the Docker runtime, run `uv run --only-group=nox nox -s test` with **no** env prefixes and confirm the suite runs to completion. Verified locally: 1740 passed in 4:41, with Ryuk enabled.
- Confirm the multi-profile case resolves correctly — with both a `default` and a second (stopped) Colima profile present, the helper picks the address of the profile named in `DOCKER_HOST`.
- Run `uv run --only-group=nox nox -s create-migration -- "test message"` to confirm the migration session also starts its container cleanly (discard the generated revision).
- On Docker Desktop (or any non-Colima runtime), confirm `nox -s test` still works and `TESTCONTAINERS_HOST_OVERRIDE` is left unset.

## References

- Closes #440
- Jira: https://rubinobs.atlassian.net/browse/DM-55493