### PR TITLE
DM-55549: Time-ordered Crockford Base32 resource IDs

### DIFF
--- a/alembic/versions/20260528_0000_c7d8e9f0a1b2_keeper_sync_runs_public_id.py
+++ b/alembic/versions/20260528_0000_c7d8e9f0a1b2_keeper_sync_runs_public_id.py
@@ -1,0 +1,86 @@
+"""Add a public Base32 ``public_id`` to ``keeper_sync_runs``.
+
+Part of the time-ordered resource-ID work (PRD #448 / DM-55549). Every
+externally-addressable resource gets a stable Crockford Base32
+``public_id`` so the API never leaks the raw integer primary key.
+Keeper-sync runs are next: this migration adds the ``BIGINT`` column and
+backfills it, and the following slice switches the API surface over.
+
+The column mirrors the shape already on ``builds`` and ``queue_jobs`` —
+``BIGINT``, unique, not-null, ``autoincrement=False`` — because the value
+is minted in application code (or, here, by this backfill), never by a
+sequence.
+
+Backfill story
+--------------
+The PRD names ``date_created`` as the backfill source, but
+``keeper_sync_runs`` has no such column; its creation timestamp is
+``date_started`` (NOT NULL, defaulted to ``now()``). Existing rows are
+therefore re-minted from ``date_started`` in ascending order via
+``mint_time_ordered_resource_ids``, which yields strictly increasing IDs
+that sort in creation order even when several rows share a millisecond.
+Run IDs appear in no object-store keys, so re-assigning them to existing
+rows is safe — nothing downstream is keyed off the value.
+
+The column is added nullable, backfilled, then the unique constraint is
+created and the column flipped to ``NOT NULL``, so the migration succeeds
+against a populated table without a two-phase deploy.
+
+Revision ID: c7d8e9f0a1b2
+Revises: b6c7d8e9f0a1
+Create Date: 2026-05-28 00:00:00.000000+00:00
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from docverse.domain.base32id import mint_time_ordered_resource_ids
+
+# revision identifiers, used by Alembic.
+revision: str = "c7d8e9f0a1b2"
+down_revision: str | None = "b6c7d8e9f0a1"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "keeper_sync_runs",
+        sa.Column(
+            "public_id", sa.BigInteger(), autoincrement=False, nullable=True
+        ),
+    )
+
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, date_started FROM keeper_sync_runs"
+            " ORDER BY date_started ASC, id ASC"
+        )
+    ).all()
+    if rows:
+        public_ids = mint_time_ordered_resource_ids(
+            [row.date_started for row in rows]
+        )
+        for row, public_id in zip(rows, public_ids, strict=True):
+            bind.execute(
+                sa.text(
+                    "UPDATE keeper_sync_runs SET public_id = :public_id"
+                    " WHERE id = :id"
+                ),
+                {"public_id": public_id, "id": row.id},
+            )
+
+    op.create_unique_constraint(
+        "keeper_sync_runs_public_id_key", "keeper_sync_runs", ["public_id"]
+    )
+    op.alter_column("keeper_sync_runs", "public_id", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "keeper_sync_runs_public_id_key",
+        "keeper_sync_runs",
+        type_="unique",
+    )
+    op.drop_column("keeper_sync_runs", "public_id")

--- a/alembic/versions/20260529_0000_d8e9f0a1b2c3_keeper_sync_state_public_id.py
+++ b/alembic/versions/20260529_0000_d8e9f0a1b2c3_keeper_sync_state_public_id.py
@@ -1,0 +1,94 @@
+"""Add a public Base32 ``public_id`` to ``keeper_sync_state``.
+
+Part of the time-ordered resource-ID work (PRD #448 / DM-55549). Every
+externally-addressable resource gets a stable Crockford Base32
+``public_id`` so the API never leaks the raw integer primary key.
+Keeper-sync state rows — the rows that back tombstones — are next: this
+migration adds the ``BIGINT`` column and backfills it, and the following
+slice switches the tombstone API surface over to addressing rows by this
+public id instead of the raw primary key.
+
+The column mirrors the shape already on ``builds``, ``queue_jobs``, and
+``keeper_sync_runs`` — ``BIGINT``, unique, not-null,
+``autoincrement=False`` — because the value is minted in application code
+(or, here, by this backfill), never by a sequence.
+
+Backfill story
+--------------
+The PRD names ``date_created`` as the backfill source, but
+``keeper_sync_state`` has no creation timestamp at all — only the
+nullable ``date_last_synced``, ``date_rebuilt_seen``, and
+``date_tombstoned``. Existing rows are therefore re-minted from
+``COALESCE(date_tombstoned, date_last_synced, now())`` in ascending order
+via ``mint_time_ordered_resource_ids``, which yields strictly increasing
+IDs that sort in that order even when several rows share a millisecond.
+Rows where every timestamp is NULL fall back to ``now()`` and simply
+order last, receiving strictly increasing IDs among themselves. State IDs
+appear in no object-store keys, so re-assigning them to existing rows is
+safe — nothing downstream is keyed off the value.
+
+The column is added nullable, backfilled, then the unique constraint is
+created and the column flipped to ``NOT NULL``, so the migration succeeds
+against a populated table without a two-phase deploy.
+
+Revision ID: d8e9f0a1b2c3
+Revises: c7d8e9f0a1b2
+Create Date: 2026-05-29 00:00:00.000000+00:00
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from docverse.domain.base32id import mint_time_ordered_resource_ids
+
+# revision identifiers, used by Alembic.
+revision: str = "d8e9f0a1b2c3"
+down_revision: str | None = "c7d8e9f0a1b2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "keeper_sync_state",
+        sa.Column(
+            "public_id", sa.BigInteger(), autoincrement=False, nullable=True
+        ),
+    )
+
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT id,"
+            " COALESCE(date_tombstoned, date_last_synced, now()) AS sort_ts"
+            " FROM keeper_sync_state"
+            " ORDER BY COALESCE(date_tombstoned, date_last_synced, now())"
+            " ASC, id ASC"
+        )
+    ).all()
+    if rows:
+        public_ids = mint_time_ordered_resource_ids(
+            [row.sort_ts for row in rows]
+        )
+        for row, public_id in zip(rows, public_ids, strict=True):
+            bind.execute(
+                sa.text(
+                    "UPDATE keeper_sync_state SET public_id = :public_id"
+                    " WHERE id = :id"
+                ),
+                {"public_id": public_id, "id": row.id},
+            )
+
+    op.create_unique_constraint(
+        "keeper_sync_state_public_id_key", "keeper_sync_state", ["public_id"]
+    )
+    op.alter_column("keeper_sync_state", "public_id", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "keeper_sync_state_public_id_key",
+        "keeper_sync_state",
+        type_="unique",
+    )
+    op.drop_column("keeper_sync_state", "public_id")

--- a/client/src/docverse/client/models/keeper_sync.py
+++ b/client/src/docverse/client/models/keeper_sync.py
@@ -103,7 +103,9 @@ class KeeperSyncRun(BaseModel):
         )
     )
 
-    id: int = Field(description="Numeric identifier for the run.")
+    id: str = Field(
+        description="Public Crockford Base32 identifier for the run."
+    )
 
     kind: KeeperSyncRunKind = Field(description="Kind of run.")
 

--- a/client/src/docverse/client/models/keeper_sync.py
+++ b/client/src/docverse/client/models/keeper_sync.py
@@ -515,7 +515,7 @@ class KeeperSyncTombstone(BaseModel):
     """One tombstoned ``keeper_sync_state`` row.
 
     Returned by ``GET /orgs/{org}/keeper-sync/tombstones`` and
-    ``DELETE /orgs/{org}/keeper-sync/tombstones/{state_id}`` (the
+    ``DELETE /orgs/{org}/keeper-sync/tombstones/{tombstone}`` (the
     DELETE returns 204 with no body, so this model only appears on
     list responses today; keeping it as a sibling of the list-entry
     shape lets a future "get one tombstone" endpoint reuse it).
@@ -533,11 +533,11 @@ class KeeperSyncTombstone(BaseModel):
         )
     )
 
-    state_id: int = Field(
+    id: str = Field(
         description=(
-            "Primary key of the underlying ``keeper_sync_state`` row."
-            " Use this id with the DELETE endpoint to clear the"
-            " tombstone."
+            "Public Crockford Base32 identifier for the tombstoned"
+            " ``keeper_sync_state`` row. Use this id with the DELETE"
+            " endpoint to clear the tombstone."
         )
     )
 

--- a/client/src/docverse/client/models/queue.py
+++ b/client/src/docverse/client/models/queue.py
@@ -198,11 +198,11 @@ class QueueJob(BaseModel):
 
     status: JobStatus = Field(description="Current status of the job.")
 
-    keeper_sync_run_id: int | None = Field(
+    keeper_sync_run_id: str | None = Field(
         default=None,
         description=(
-            "Identifier of the keeper-sync run this job is attributed to,"
-            " or ``null`` for jobs not part of a run."
+            "Public Crockford Base32 identifier of the keeper-sync run this"
+            " job is attributed to, or ``null`` for jobs not part of a run."
         ),
     )
 

--- a/client/tests/keeper_sync_model_test.py
+++ b/client/tests/keeper_sync_model_test.py
@@ -7,7 +7,11 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import ValidationError
 
-from docverse.client.models import KeeperSyncConfig, KeeperSyncRun
+from docverse.client.models import (
+    KeeperSyncConfig,
+    KeeperSyncRun,
+    KeeperSyncTombstone,
+)
 
 
 def test_default_is_disabled_with_default_url_and_empty_allowlist() -> None:
@@ -84,6 +88,35 @@ def test_keeper_sync_run_id_is_base32_string() -> None:
     assert run.id == "AAAA-BBBB-CCCC-05"
 
     restored = KeeperSyncRun.model_validate(run.model_dump(mode="json"))
+    assert restored.id == "AAAA-BBBB-CCCC-05"
+
+
+def test_keeper_sync_tombstone_id_is_base32_string() -> None:
+    """``KeeperSyncTombstone.id`` carries the Base32 public id as a string.
+
+    Locks the API contract change from the raw ``keeper_sync_state``
+    primary key (``state_id``) to the row's Base32 public identifier;
+    the value round-trips unchanged through
+    ``model_dump``/``model_validate``.
+    """
+    tombstone = KeeperSyncTombstone(
+        self_url=(
+            "https://docverse.example/orgs/o/keeper-sync/tombstones/"
+            "AAAA-BBBB-CCCC-05"
+        ),
+        id="AAAA-BBBB-CCCC-05",
+        resource_type="edition",
+        ltd_slug="v1.0",
+        ltd_id=42,
+        date_tombstoned=datetime(2026, 1, 1, tzinfo=UTC),
+        tombstone_reason="manual_delete",
+        display_path="proj/v1.0",
+    )
+    assert tombstone.id == "AAAA-BBBB-CCCC-05"
+
+    restored = KeeperSyncTombstone.model_validate(
+        tombstone.model_dump(mode="json")
+    )
     assert restored.id == "AAAA-BBBB-CCCC-05"
 
 

--- a/client/tests/keeper_sync_model_test.py
+++ b/client/tests/keeper_sync_model_test.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 from pydantic import ValidationError
 
-from docverse.client.models import KeeperSyncConfig
+from docverse.client.models import KeeperSyncConfig, KeeperSyncRun
 
 
 def test_default_is_disabled_with_default_url_and_empty_allowlist() -> None:
@@ -56,6 +58,33 @@ def test_rejects_invalid_url() -> None:
             ltd_base_url="not-a-url",  # type: ignore[arg-type]
             project_slugs=[],
         )
+
+
+def test_keeper_sync_run_id_is_base32_string() -> None:
+    """``KeeperSyncRun.id`` carries the Base32 public id as a string.
+
+    Locks the API contract change from an integer primary key to the
+    run's Base32 public identifier; the value round-trips unchanged
+    through ``model_dump``/``model_validate``.
+    """
+    run = KeeperSyncRun(
+        self_url="https://docverse.example/orgs/o/keeper-sync/runs/AAAA-BBBB",
+        jobs_url=(
+            "https://docverse.example/orgs/o/keeper-sync/runs/AAAA-BBBB/jobs"
+        ),
+        id="AAAA-BBBB-CCCC-05",
+        kind="backfill",
+        status="pending",
+        pending_count=0,
+        succeeded_count=0,
+        failed_count=0,
+        total_count=0,
+        date_started=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    assert run.id == "AAAA-BBBB-CCCC-05"
+
+    restored = KeeperSyncRun.model_validate(run.model_dump(mode="json"))
+    assert restored.id == "AAAA-BBBB-CCCC-05"
 
 
 def test_extra_fields_forbidden() -> None:

--- a/client/tests/queue_model_test.py
+++ b/client/tests/queue_model_test.py
@@ -206,6 +206,24 @@ def test_queue_job_subject_back_reference_fields_default_none() -> None:
         assert name in QueueJob.model_fields
 
 
+def test_queue_job_keeper_sync_run_id_is_base32_string() -> None:
+    """``keeper_sync_run_id`` carries the run's Base32 public id as a string.
+
+    Locks the API contract change from an integer FK to the run's Base32
+    public identifier; the value round-trips through validate/dump and
+    defaults to ``None`` for jobs not attributed to a run.
+    """
+    job = QueueJob.model_validate(
+        _queue_job(keeper_sync_run_id="AAAA-BBBB-CCCC-05")
+    )
+    assert job.keeper_sync_run_id == "AAAA-BBBB-CCCC-05"
+    dumped = job.model_dump(mode="json")
+    assert dumped["keeper_sync_run_id"] == "AAAA-BBBB-CCCC-05"
+
+    unattributed = QueueJob.model_validate(_queue_job())
+    assert unattributed.keeper_sync_run_id is None
+
+
 def test_queue_job_subject_back_reference_fields_round_trip() -> None:
     """The back-reference URLs survive a validate round-trip."""
     build = "https://example.com/orgs/o/projects/p/builds/0000-0000-0000-05"

--- a/src/docverse/dbschema/keeper_sync_run.py
+++ b/src/docverse/dbschema/keeper_sync_run.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any
 
 from sqlalchemy import (
+    BigInteger,
     CheckConstraint,
     DateTime,
     ForeignKey,
@@ -37,6 +38,10 @@ class SqlKeeperSyncRun(Base):
 
     id: Mapped[int] = mapped_column(
         Integer, primary_key=True, autoincrement=True
+    )
+
+    public_id: Mapped[int] = mapped_column(
+        BigInteger, unique=True, nullable=False, autoincrement=False
     )
 
     org_id: Mapped[int] = mapped_column(

--- a/src/docverse/dbschema/keeper_sync_state.py
+++ b/src/docverse/dbschema/keeper_sync_state.py
@@ -38,6 +38,10 @@ class SqlKeeperSyncState(Base):
         Integer, primary_key=True, autoincrement=True
     )
 
+    public_id: Mapped[int] = mapped_column(
+        BigInteger, unique=True, nullable=False, autoincrement=False
+    )
+
     org_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("organizations.id", ondelete="CASCADE"),

--- a/src/docverse/domain/base32id.py
+++ b/src/docverse/domain/base32id.py
@@ -13,6 +13,9 @@ References
 
 from __future__ import annotations
 
+import secrets
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any, TypeAlias
 
 import base32_lib
@@ -21,8 +24,14 @@ from pydantic import PlainSerializer, PlainValidator
 __all__ = [
     "BASE32_ID_LENGTH",
     "BASE32_ID_SPLIT_EVERY",
+    "RESOURCE_ID_EPOCH",
+    "RESOURCE_ID_RANDOM_BITS",
+    "RESOURCE_ID_TIMESTAMP_BITS",
     "Base32Id",
     "generate_base32_id",
+    "generate_resource_id",
+    "mint_resource_id_for_timestamp",
+    "mint_time_ordered_resource_ids",
     "serialize_base32_id",
     "validate_base32_id",
 ]
@@ -32,6 +41,31 @@ BASE32_ID_LENGTH = 12
 
 BASE32_ID_SPLIT_EVERY = 4
 """Default number of characters between hyphens for Base32Id."""
+
+RESOURCE_ID_EPOCH = datetime(2010, 1, 1, tzinfo=UTC)
+"""Fixed epoch (2010-01-01T00:00:00Z) for time-ordered resource IDs.
+
+This epoch is deliberately fixed for all time and is **not** configurable. It
+predates Rubin Observatory project records, so any table ported to this ID
+scheme can re-mint IDs from each row's ``date_created`` without ever hitting a
+pre-epoch timestamp. A single org-wide constant also avoids the silent
+misordering that per-service epoch configuration would invite.
+"""
+
+RESOURCE_ID_TIMESTAMP_BITS = 43
+"""High-order bits encoding milliseconds since `RESOURCE_ID_EPOCH`.
+
+43 bits of milliseconds gives roughly 278 years of runway from the epoch
+(to roughly the year 2288).
+"""
+
+RESOURCE_ID_RANDOM_BITS = 17
+"""Low-order random bits (~131k distinct values per millisecond).
+
+`RESOURCE_ID_TIMESTAMP_BITS` + `RESOURCE_ID_RANDOM_BITS` == 60, which is the
+Crockford Base32 envelope (12 characters at 5 bits each) that `Base32Id`
+serializes.
+"""
 
 
 def validate_base32_id(value: Any) -> int:
@@ -120,6 +154,109 @@ def generate_base32_id(*, length: int = 12, split_every: int = 4) -> str:
         length=length + 2, split_every=split_every, checksum=True
     )
     return result
+
+
+def mint_resource_id_for_timestamp(timestamp: datetime) -> int:
+    """Mint a time-ordered resource ID for a specific timestamp.
+
+    The ID is a Snowflake-style integer inside the 60-bit Crockford Base32
+    envelope: the high `RESOURCE_ID_TIMESTAMP_BITS` bits hold milliseconds
+    since `RESOURCE_ID_EPOCH` and the low `RESOURCE_ID_RANDOM_BITS` bits are
+    random. IDs minted for later timestamps therefore sort after earlier ones
+    under plain integer (and thus Base32 keyset) ordering. This is
+    deliberately *not* a truncated UUIDv7 (a 60-bit envelope cannot hold one,
+    and its 1970-anchored 48-bit timestamp would leave only 12 random bits).
+
+    Parameters
+    ----------
+    timestamp
+        A timezone-aware timestamp at or after `RESOURCE_ID_EPOCH`. The
+        re-mint migration reuses this helper to derive IDs from a row's
+        ``date_created``.
+
+    Returns
+    -------
+    int
+        An integer that fits the 60-bit envelope, suitable for the
+        ``public_id`` column and round-trippable through
+        `serialize_base32_id` / `validate_base32_id`.
+
+    Raises
+    ------
+    ValueError
+        If the timestamp is timezone-naive, precedes `RESOURCE_ID_EPOCH`, or
+        is far enough in the future to overflow the timestamp bits.
+    """
+    if timestamp.tzinfo is None:
+        msg = "timestamp must be timezone-aware"
+        raise ValueError(msg)
+
+    milliseconds = (timestamp - RESOURCE_ID_EPOCH) // timedelta(milliseconds=1)
+    if milliseconds < 0:
+        msg = (
+            "timestamp must not precede the resource ID epoch "
+            f"({RESOURCE_ID_EPOCH.isoformat()})"
+        )
+        raise ValueError(msg)
+    if milliseconds >= (1 << RESOURCE_ID_TIMESTAMP_BITS):
+        msg = "timestamp exceeds the 60-bit resource ID timestamp envelope"
+        raise ValueError(msg)
+
+    random_bits = secrets.randbits(RESOURCE_ID_RANDOM_BITS)
+    return (milliseconds << RESOURCE_ID_RANDOM_BITS) | random_bits
+
+
+def mint_time_ordered_resource_ids(
+    timestamps: Sequence[datetime],
+) -> list[int]:
+    """Mint strictly increasing, time-ordered IDs for a timestamp sequence.
+
+    Each ID is derived from its timestamp with
+    `mint_resource_id_for_timestamp`, so the sequence tracks wall-clock order.
+    When consecutive timestamps fall in the same millisecond (or the random
+    low bits would otherwise regress), the ID is bumped to ``previous + 1`` so
+    the returned sequence is *strictly* increasing regardless of tie density.
+    This is the generator a one-time backfill migration uses to reassign
+    ``public_id`` values in ``date_created`` order.
+
+    Parameters
+    ----------
+    timestamps
+        Timezone-aware timestamps in ascending order (typically each row's
+        ``date_created``). Ties are resolved by the caller's ordering.
+
+    Returns
+    -------
+    list[int]
+        One strictly increasing integer ID per input timestamp, each within
+        the 60-bit Crockford Base32 envelope.
+
+    Raises
+    ------
+    ValueError
+        If any timestamp is rejected by `mint_resource_id_for_timestamp`.
+    """
+    ids: list[int] = []
+    previous: int | None = None
+    for timestamp in timestamps:
+        candidate = mint_resource_id_for_timestamp(timestamp)
+        if previous is not None and candidate <= previous:
+            candidate = previous + 1
+        ids.append(candidate)
+        previous = candidate
+    return ids
+
+
+def generate_resource_id() -> int:
+    """Mint a time-ordered resource ID for the current time.
+
+    Returns
+    -------
+    int
+        A time-ordered integer for a ``public_id`` column. See
+        `mint_resource_id_for_timestamp` for the bit layout.
+    """
+    return mint_resource_id_for_timestamp(datetime.now(tz=UTC))
 
 
 Base32Id: TypeAlias = Annotated[

--- a/src/docverse/domain/keeper_sync_run.py
+++ b/src/docverse/domain/keeper_sync_run.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from docverse.client.models import KeeperSyncRunKind, KeeperSyncRunStatus
 
+from .base32id import Base32Id
+
 __all__ = [
     "KeeperSyncRun",
     "KeeperSyncRunActivity",
@@ -23,6 +25,9 @@ class KeeperSyncRun(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int = Field(description="Primary key for the run.")
+    public_id: Base32Id = Field(
+        description="Time-ordered Base32 public identifier for the run."
+    )
     org_id: int = Field(description="Organization that owns the run.")
     kind: KeeperSyncRunKind = Field(description="Kind of run.")
     status: KeeperSyncRunStatus = Field(description="Lifecycle status.")

--- a/src/docverse/handlers/orgs/dashboard_template.py
+++ b/src/docverse/handlers/orgs/dashboard_template.py
@@ -147,7 +147,7 @@ async def sync_org_dashboard_template(
         queue_job = await enqueuer.enqueue(binding.id)
         await context.session.commit()
     return DashboardTemplateSyncEnqueuedResponse.from_queue_job(
-        binding.id, queue_job, context.request
+        queue_job, context.request
     )
 
 
@@ -263,5 +263,5 @@ async def sync_project_dashboard_template(
         queue_job = await enqueuer.enqueue(binding.id)
         await context.session.commit()
     return DashboardTemplateSyncEnqueuedResponse.from_queue_job(
-        binding.id, queue_job, context.request
+        queue_job, context.request
     )

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -402,8 +402,16 @@ async def get_org_keeper_sync_run_jobs(
             cursor=parsed_cursor,
             limit=limit,
         )
+        # Every job in the page belongs to the same run, so memoize the
+        # run FK -> public-id resolution to collapse an N+1 run-store query.
+        run_public_id_cache: dict[int, str | None] = {}
         jobs = [
-            await QueueJob.from_domain(job, context.request, context.factory)
+            await QueueJob.from_domain(
+                job,
+                context.request,
+                context.factory,
+                run_public_id_cache=run_public_id_cache,
+            )
             for job in result.entries
         ]
     context.response.headers["Link"] = result.link_header(context.request.url)

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -15,7 +15,7 @@ from docverse.client.models import (
 )
 from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
-from docverse.handlers.params import OrgSlugParam, RunIdParam
+from docverse.handlers.params import OrgSlugParam, RunIdParam, TombstoneIdParam
 from docverse.handlers.queue.models import QueueJob
 from docverse.storage.keeper_sync import ResourceType, TombstoneReason
 from docverse.storage.pagination import (
@@ -499,7 +499,7 @@ async def get_org_keeper_sync_tombstones(
 
 
 @router.delete(
-    "/orgs/{org}/keeper-sync/tombstones/{state_id}",
+    "/orgs/{org}/keeper-sync/tombstones/{tombstone}",
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,
     summary="Clear a sync tombstone",
@@ -509,20 +509,18 @@ async def delete_org_keeper_sync_tombstone(
     org_slug: OrgSlugParam,
     context: Annotated[RequestContext, Depends(context_dependency)],
     user: Annotated[AuthenticatedUser, Depends(require_admin)],
-    state_id: Annotated[
-        int,
-        Path(description="Primary key of the keeper_sync_state row."),
-    ],
+    tombstone_id: TombstoneIdParam,
 ) -> Response:
+    public_id = parse_base32_id(tombstone_id, resource="tombstone")
     context.rebind_logger(actor=user.username)
     async with context.session.begin():
         service = context.factory.create_keeper_sync_tombstone_service()
-        cleared = await service.clear(state_id=state_id, org_id=user.org.id)
+        cleared = await service.clear(public_id=public_id, org_id=user.org.id)
         await context.session.commit()
     context.logger.info(
         "Cleared sync tombstone",
         org=org_slug,
-        state_id=state_id,
+        tombstone_id=tombstone_id,
         resource_type=cleared.state.resource_type,
         ltd_id=cleared.state.ltd_id,
         ltd_slug=cleared.state.ltd_slug,

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -15,7 +15,7 @@ from docverse.client.models import (
 )
 from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
-from docverse.handlers.params import OrgSlugParam
+from docverse.handlers.params import OrgSlugParam, RunIdParam
 from docverse.handlers.queue.models import QueueJob
 from docverse.storage.keeper_sync import ResourceType, TombstoneReason
 from docverse.storage.pagination import (
@@ -27,6 +27,7 @@ from docverse.storage.pagination import (
     MAX_PAGE_LIMIT,
     QUEUE_JOB_CURSOR_TYPE,
 )
+from docverse.validation import parse_base32_id
 
 from .keeper_sync_models import (
     KeeperSyncEditionStatus,
@@ -335,7 +336,7 @@ async def get_org_keeper_sync_runs(
 
 
 @router.get(
-    "/orgs/{org}/keeper-sync/runs/{run_id}",
+    "/orgs/{org}/keeper-sync/runs/{run}",
     response_model=KeeperSyncRun,
     summary="Get an LTD Keeper sync run with aggregate counters",
     name="get_org_keeper_sync_run",
@@ -344,20 +345,19 @@ async def get_org_keeper_sync_run(
     org_slug: OrgSlugParam,
     context: Annotated[RequestContext, Depends(context_dependency)],
     user: Annotated[AuthenticatedUser, Depends(require_admin)],
-    run_id: Annotated[
-        int, Path(description="Numeric identifier for the run.")
-    ],
+    run_id: RunIdParam,
 ) -> KeeperSyncRun:
+    public_id = parse_base32_id(run_id, resource="run")
     async with context.session.begin():
         service = context.factory.create_keeper_sync_run_service()
-        result = await service.get_run(org_slug=org_slug, run_id=run_id)
+        result = await service.get_run(org_slug=org_slug, public_id=public_id)
     return KeeperSyncRun.from_domain(
         result.run, result.activity, context.request, org_slug
     )
 
 
 @router.get(
-    "/orgs/{org}/keeper-sync/runs/{run_id}/jobs",
+    "/orgs/{org}/keeper-sync/runs/{run}/jobs",
     response_model=list[QueueJob],
     summary="List child queue jobs for an LTD Keeper sync run",
     name="get_org_keeper_sync_run_jobs",
@@ -366,9 +366,7 @@ async def get_org_keeper_sync_run_jobs(
     org_slug: OrgSlugParam,
     context: Annotated[RequestContext, Depends(context_dependency)],
     user: Annotated[AuthenticatedUser, Depends(require_admin)],
-    run_id: Annotated[
-        int, Path(description="Numeric identifier for the run.")
-    ],
+    run_id: RunIdParam,
     cursor: Annotated[
         str | None,
         Query(
@@ -391,6 +389,7 @@ async def get_org_keeper_sync_run_jobs(
         Query(alias="status", description="Filter jobs by status."),
     ] = None,
 ) -> list[QueueJob]:
+    public_id = parse_base32_id(run_id, resource="run")
     parsed_cursor = (
         QUEUE_JOB_CURSOR_TYPE.from_str(cursor) if cursor is not None else None
     )
@@ -398,7 +397,7 @@ async def get_org_keeper_sync_run_jobs(
         service = context.factory.create_keeper_sync_run_service()
         result = await service.list_run_jobs(
             org_slug=org_slug,
-            run_id=run_id,
+            public_id=public_id,
             status=status_filter,
             cursor=parsed_cursor,
             limit=limit,

--- a/src/docverse/handlers/orgs/keeper_sync_models.py
+++ b/src/docverse/handlers/orgs/keeper_sync_models.py
@@ -274,20 +274,21 @@ class KeeperSyncTombstone(_KeeperSyncTombstoneBase):
         if state.date_tombstoned is None or state.tombstone_reason is None:
             msg = (
                 "KeeperSyncTombstone.from_domain requires a tombstoned "
-                f"state row; state_id={state.id} has no tombstone"
+                f"state row; public_id={state.public_id} has no tombstone"
             )
             raise KeeperSyncInvariantError(msg)
+        tombstone_public_id = serialize_base32_id(state.public_id)
         return cls(
             self_url=HttpUrl(
                 str(
                     request.url_for(
                         "delete_org_keeper_sync_tombstone",
                         org=org_slug,
-                        state_id=state.id,
+                        tombstone=tombstone_public_id,
                     )
                 )
             ),
-            state_id=state.id,
+            id=tombstone_public_id,
             resource_type=KeeperSyncResourceType(state.resource_type),
             ltd_slug=state.ltd_slug,
             ltd_id=state.ltd_id,

--- a/src/docverse/handlers/orgs/keeper_sync_models.py
+++ b/src/docverse/handlers/orgs/keeper_sync_models.py
@@ -64,13 +64,14 @@ class KeeperSyncRun(_KeeperSyncRunBase):
         org_slug: str,
     ) -> Self:
         """Compose the response from a run plus its derived activity."""
+        run_public_id = serialize_base32_id(run.public_id)
         return cls(
             self_url=HttpUrl(
                 str(
                     request.url_for(
                         "get_org_keeper_sync_run",
                         org=org_slug,
-                        run_id=run.id,
+                        run=run_public_id,
                     )
                 )
             ),
@@ -79,11 +80,11 @@ class KeeperSyncRun(_KeeperSyncRunBase):
                     request.url_for(
                         "get_org_keeper_sync_run_jobs",
                         org=org_slug,
-                        run_id=run.id,
+                        run=run_public_id,
                     )
                 )
             ),
-            id=run.id,
+            id=run_public_id,
             kind=KeeperSyncRunKind(run.kind),
             status=KeeperSyncRunStatus(run.status),
             pending_count=activity.pending_count,

--- a/src/docverse/handlers/orgs/models.py
+++ b/src/docverse/handlers/orgs/models.py
@@ -489,7 +489,6 @@ class OrgDashboardRebuildEntry(_OrgDashboardRebuildEntryBase):
 class DashboardTemplateSyncEnqueuedResponse(BaseModel):
     """Response body for the dashboard-template force-sync endpoints."""
 
-    binding_id: int = Field(description="ID of the binding that was synced.")
     queue_job_id: str = Field(
         description="Base32 public ID of the enqueued ``dashboard_sync`` job."
     )
@@ -500,14 +499,12 @@ class DashboardTemplateSyncEnqueuedResponse(BaseModel):
     @classmethod
     def from_queue_job(
         cls,
-        binding_id: int,
         queue_job: QueueJobDomain,
         request: Request,
     ) -> Self:
-        """Create from a binding id + queue job, attaching the URL."""
+        """Create from a queue job, attaching the URL."""
         queue_job_id = serialize_base32_id(queue_job.public_id)
         return cls(
-            binding_id=binding_id,
             queue_job_id=queue_job_id,
             queue_job_url=str(
                 request.url_for("get_queue_job", job=queue_job_id)

--- a/src/docverse/handlers/params.py
+++ b/src/docverse/handlers/params.py
@@ -14,6 +14,7 @@ __all__ = [
     "MemberIdParam",
     "OrgSlugParam",
     "ProjectSlugParam",
+    "RunIdParam",
     "ServiceLabelParam",
 ]
 
@@ -48,6 +49,12 @@ MemberIdParam = Annotated[
 JobIdParam = Annotated[
     str,
     Path(alias="job", description="Base32-encoded queue job identifier."),
+]
+RunIdParam = Annotated[
+    str,
+    Path(
+        alias="run", description="Base32-encoded keeper-sync run identifier."
+    ),
 ]
 ServiceLabelParam = Annotated[
     str,

--- a/src/docverse/handlers/params.py
+++ b/src/docverse/handlers/params.py
@@ -16,6 +16,7 @@ __all__ = [
     "ProjectSlugParam",
     "RunIdParam",
     "ServiceLabelParam",
+    "TombstoneIdParam",
 ]
 
 CredentialLabelParam = Annotated[
@@ -59,4 +60,11 @@ RunIdParam = Annotated[
 ServiceLabelParam = Annotated[
     str,
     Path(alias="service", description="Service label."),
+]
+TombstoneIdParam = Annotated[
+    str,
+    Path(
+        alias="tombstone",
+        description="Base32-encoded keeper-sync tombstone identifier.",
+    ),
 ]

--- a/src/docverse/handlers/queue/models.py
+++ b/src/docverse/handlers/queue/models.py
@@ -24,6 +24,8 @@ class QueueJob(_QueueJobBase):
         domain: QueueJobDomain,
         request: Request,
         factory: Factory,
+        *,
+        run_public_id_cache: dict[int, str | None] | None = None,
     ) -> Self:
         """Create from a domain object, adding the HATEOAS URLs.
 
@@ -32,6 +34,12 @@ class QueueJob(_QueueJobBase):
         stores; each is ``None`` when the job targets no such resource or
         it could not be resolved (best-effort back-reference). Must be
         called inside an open session — it issues store reads.
+
+        ``run_public_id_cache`` is an optional caller-owned dict, keyed by the
+        integer keeper-sync run FK, used to memoize run public-id lookups
+        across a page of jobs. List endpoints where many jobs share a run
+        (e.g. the run-scoped jobs listing) pass one in to avoid an N+1
+        run-store query per job; single-job callers omit it.
         """
         job_id_str = serialize_base32_id(domain.public_id)
         # JSONB progress is stored untyped; validate it into the typed
@@ -45,7 +53,7 @@ class QueueJob(_QueueJobBase):
             domain, request, factory
         )
         keeper_sync_run_id = await _resolve_keeper_sync_run_public_id(
-            domain, factory
+            domain, factory, cache=run_public_id_cache
         )
         return cls(
             self_url=str(request.url_for("get_queue_job", job=job_id_str)),
@@ -69,21 +77,29 @@ class QueueJob(_QueueJobBase):
 async def _resolve_keeper_sync_run_public_id(
     domain: QueueJobDomain,
     factory: Factory,
+    *,
+    cache: dict[int, str | None] | None = None,
 ) -> str | None:
     """Resolve a job's keeper-sync run FK to the run's Base32 public id.
 
     Returns ``None`` for jobs not attributed to a run, or when the
     attributed run row cannot be resolved (best-effort back-reference).
     The raw integer FK is never surfaced in the API.
+
+    When ``cache`` is supplied it memoizes the FK-to-public-id resolution:
+    the run store is queried at most once per distinct run across a page of
+    jobs, collapsing the otherwise N+1 lookup on the run-scoped jobs listing.
     """
-    if domain.keeper_sync_run_id is None:
+    run_fk = domain.keeper_sync_run_id
+    if run_fk is None:
         return None
-    run = await factory.create_keeper_sync_run_store().get(
-        domain.keeper_sync_run_id
-    )
-    if run is None:
-        return None
-    return serialize_base32_id(run.public_id)
+    if cache is not None and run_fk in cache:
+        return cache[run_fk]
+    run = await factory.create_keeper_sync_run_store().get(run_fk)
+    resolved = serialize_base32_id(run.public_id) if run is not None else None
+    if cache is not None:
+        cache[run_fk] = resolved
+    return resolved
 
 
 async def _resolve_subject_urls(

--- a/src/docverse/handlers/queue/models.py
+++ b/src/docverse/handlers/queue/models.py
@@ -44,12 +44,15 @@ class QueueJob(_QueueJobBase):
         build_url, edition_url, subject_url = await _resolve_subject_urls(
             domain, request, factory
         )
+        keeper_sync_run_id = await _resolve_keeper_sync_run_public_id(
+            domain, factory
+        )
         return cls(
             self_url=str(request.url_for("get_queue_job", job=job_id_str)),
             id=job_id_str,
             kind=domain.kind,
             status=domain.status,
-            keeper_sync_run_id=domain.keeper_sync_run_id,
+            keeper_sync_run_id=keeper_sync_run_id,
             subject_label=domain.subject_label,
             subject_url=subject_url,
             build_url=build_url,
@@ -61,6 +64,26 @@ class QueueJob(_QueueJobBase):
             date_started=domain.date_started,
             date_completed=domain.date_completed,
         )
+
+
+async def _resolve_keeper_sync_run_public_id(
+    domain: QueueJobDomain,
+    factory: Factory,
+) -> str | None:
+    """Resolve a job's keeper-sync run FK to the run's Base32 public id.
+
+    Returns ``None`` for jobs not attributed to a run, or when the
+    attributed run row cannot be resolved (best-effort back-reference).
+    The raw integer FK is never surfaced in the API.
+    """
+    if domain.keeper_sync_run_id is None:
+        return None
+    run = await factory.create_keeper_sync_run_store().get(
+        domain.keeper_sync_run_id
+    )
+    if run is None:
+        return None
+    return serialize_base32_id(run.public_id)
 
 
 async def _resolve_subject_urls(

--- a/src/docverse/services/keeper_sync_run.py
+++ b/src/docverse/services/keeper_sync_run.py
@@ -243,14 +243,14 @@ class KeeperSyncRunService:
         self,
         *,
         org_slug: str,
-        run_id: int,
+        public_id: int,
     ) -> KeeperSyncRunWithActivity:
-        """Fetch a run by id, with derived ``queue_jobs`` activity."""
+        """Fetch a run by public id, with derived ``queue_jobs`` activity."""
         org = await self._require_org(org_slug)
-        run = await self._run_store.get(run_id)
+        run = await self._run_store.get_by_public_id(public_id)
         if run is None or run.org_id != org.id:
             msg = (
-                f"Keeper sync run {run_id} not found for organization "
+                f"Keeper sync run {public_id} not found for organization "
                 f"{org_slug!r}"
             )
             raise NotFoundError(msg)
@@ -278,7 +278,7 @@ class KeeperSyncRunService:
         self,
         *,
         org_slug: str,
-        run_id: int,
+        public_id: int,
         status: JobStatus | None = None,
         cursor: QueueJobDateCreatedCursor | None = None,
         limit: int,
@@ -291,10 +291,10 @@ class KeeperSyncRunService:
         single-run ``GET`` handler.
         """
         org = await self._require_org(org_slug)
-        run = await self._run_store.get(run_id)
+        run = await self._run_store.get_by_public_id(public_id)
         if run is None or run.org_id != org.id:
             msg = (
-                f"Keeper sync run {run_id} not found for organization "
+                f"Keeper sync run {public_id} not found for organization "
                 f"{org_slug!r}"
             )
             raise NotFoundError(msg)

--- a/src/docverse/services/keeper_sync_tombstone.py
+++ b/src/docverse/services/keeper_sync_tombstone.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
 from docverse.dbschema.project import SqlProject
+from docverse.storage._public_id import insert_with_time_ordered_public_id
 from docverse.storage.keeper_sync import (
     KeeperSyncState,
     KeeperSyncStateStore,
@@ -131,21 +132,31 @@ class KeeperSyncTombstoneService:
         if row is None:
             # Lifecycle-preemptive path: no Docverse row exists yet, so
             # synthesise a state row carrying only the tombstone fields.
-            row = SqlKeeperSyncState(
-                org_id=org_id,
-                resource_type=resource_type.value,
-                ltd_id=ltd_id,
-                ltd_slug=ltd_slug if ltd_slug is not None else str(ltd_id),
-                date_tombstoned=now,
-                tombstone_reason=reason.value,
-                tombstone_note=note,
+            # Every state row carries a time-ordered ``public_id``, minted
+            # here with the same collision-retry helper the state store's
+            # upsert uses.
+            resolved_slug = ltd_slug if ltd_slug is not None else str(ltd_id)
+
+            def _make_row(public_id: int) -> SqlKeeperSyncState:
+                return SqlKeeperSyncState(
+                    public_id=public_id,
+                    org_id=org_id,
+                    resource_type=resource_type.value,
+                    ltd_id=ltd_id,
+                    ltd_slug=resolved_slug,
+                    date_tombstoned=now,
+                    tombstone_reason=reason.value,
+                    tombstone_note=note,
+                )
+
+            row = await insert_with_time_ordered_public_id(
+                self._session, _make_row
             )
-            self._session.add(row)
         else:
             row.date_tombstoned = now
             row.tombstone_reason = reason.value
             row.tombstone_note = note
-        await self._session.flush()
+            await self._session.flush()
         await self._session.refresh(row)
         self._logger.info(
             "Sync tombstone recorded",

--- a/src/docverse/services/keeper_sync_tombstone.py
+++ b/src/docverse/services/keeper_sync_tombstone.py
@@ -270,21 +270,21 @@ class KeeperSyncTombstoneService:
     async def clear(
         self,
         *,
-        state_id: int,
+        public_id: int,
         org_id: int,
     ) -> ClearedTombstone:
         """Clear the tombstone on a state row, reviving its Docverse row.
 
-        Backs ``DELETE /orgs/{org}/keeper-sync/tombstones/{state_id}``.
-        Looks up the state row by ``(state_id, org_id)`` so a guessed
-        id from another org is invisible. The state row's
-        ``date_tombstoned`` / ``tombstone_reason`` / ``tombstone_note``
-        are cleared in-place. When the row carries a non-null
-        ``docverse_id`` and the matching ``editions`` / ``projects``
-        row is still soft-deleted, that row's ``date_deleted`` is
-        cleared in the *same* transaction — otherwise the next sync
-        iteration would crash on the slug clash because the
-        soft-deleted row still occupies the
+        Backs ``DELETE /orgs/{org}/keeper-sync/tombstones/{tombstone}``.
+        Looks up the state row by ``(public_id, org_id)`` — its Base32
+        public id scoped to the org — so a guessed id from another org
+        is invisible. The state row's ``date_tombstoned`` /
+        ``tombstone_reason`` / ``tombstone_note`` are cleared in-place.
+        When the row carries a non-null ``docverse_id`` and the
+        matching ``editions`` / ``projects`` row is still soft-deleted,
+        that row's ``date_deleted`` is cleared in the *same*
+        transaction — otherwise the next sync iteration would crash on
+        the slug clash because the soft-deleted row still occupies the
         ``uq_editions_project_lower_slug`` index slot. Soft-delete on
         builds is not modelled in this codebase, so the build branch
         only clears the tombstone fields.
@@ -292,7 +292,7 @@ class KeeperSyncTombstoneService:
         Raises
         ------
         NotFoundError
-            When no row matches ``(state_id, org_id)`` *or* the
+            When no row matches ``(public_id, org_id)`` *or* the
             matched row is not tombstoned. (Clearing an already-clear
             row is treated as "no such tombstone" — the admin URL is
             meaningful only on a tombstoned row.)
@@ -302,12 +302,13 @@ class KeeperSyncTombstoneService:
             NotFoundError,
         )
 
-        state = await self._state_store.get_by_id_for_org(
-            state_id=state_id, org_id=org_id
+        state = await self._state_store.get_by_public_id_for_org(
+            public_id=public_id, org_id=org_id
         )
         if state is None or state.date_tombstoned is None:
-            msg = f"No tombstone found for state_id={state_id}"
+            msg = f"No tombstone found for public_id={public_id}"
             raise NotFoundError(msg)
+        state_id = state.id
 
         await self._session.execute(
             update(SqlKeeperSyncState)

--- a/src/docverse/storage/_public_id.py
+++ b/src/docverse/storage/_public_id.py
@@ -1,0 +1,102 @@
+"""Collision-safe insertion of rows carrying a time-ordered ``public_id``.
+
+Time-ordered resource IDs (see :mod:`docverse.domain.base32id`) reserve only
+`~17` random low bits, so two rows minted in the same millisecond can collide
+on the ``public_id`` unique constraint. A naive ``session.flush()`` that hits
+that collision raises ``IntegrityError`` and — because per ``CLAUDE.md`` the
+request handler owns the surrounding ``session.begin()`` transaction — would
+poison that outer transaction, surfacing a collision as a 500 rather than a
+re-mint.
+
+`insert_with_time_ordered_public_id` isolates each insert attempt inside a
+SAVEPOINT (``session.begin_nested()``). A ``public_id`` collision rolls back
+only the savepoint, leaving the outer transaction intact, and the helper
+re-mints and retries. Any other integrity violation is a genuine error and is
+re-raised untouched.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from docverse.domain.base32id import generate_resource_id
+
+__all__ = ["insert_with_time_ordered_public_id"]
+
+MAX_PUBLIC_ID_ATTEMPTS = 5
+"""Bound on re-mint attempts before giving up.
+
+Same-millisecond collisions across ~131k random values are astronomically
+unlikely to recur even once; five attempts is a generous safety margin whose
+exhaustion signals a real problem rather than an unlucky draw.
+"""
+
+
+async def insert_with_time_ordered_public_id[Row](
+    session: AsyncSession,
+    make_row: Callable[[int], Row],
+    *,
+    max_attempts: int = MAX_PUBLIC_ID_ATTEMPTS,
+) -> Row:
+    """Insert a row minted with a time-ordered ``public_id``, retrying on
+    a ``public_id`` collision.
+
+    Parameters
+    ----------
+    session
+        The active session. Its surrounding transaction (owned by the
+        handler) is left intact on a collision because each attempt runs
+        inside its own SAVEPOINT.
+    make_row
+        Callable that, given a freshly minted integer ``public_id``, returns
+        the ORM row to insert. It is called once per attempt so any derived
+        values (e.g. object-store keys embedding the ID) are recomputed for
+        the retried ID.
+    max_attempts
+        Maximum number of mint-and-insert attempts before raising.
+
+    Returns
+    -------
+    Row
+        The successfully inserted (and flushed) ORM row.
+
+    Raises
+    ------
+    RuntimeError
+        If ``max_attempts`` consecutive ``public_id`` collisions occur.
+    """
+    last_error: IntegrityError | None = None
+    for _ in range(max_attempts):
+        row = make_row(generate_resource_id())
+        try:
+            async with session.begin_nested():
+                session.add(row)
+                await session.flush()
+        except IntegrityError as exc:
+            if not _is_public_id_conflict(exc):
+                raise
+            last_error = exc
+            continue
+        else:
+            return row
+    msg = (
+        f"Exhausted {max_attempts} attempts minting a unique public_id "
+        "for a time-ordered resource"
+    )
+    raise RuntimeError(msg) from last_error
+
+
+def _is_public_id_conflict(exc: IntegrityError) -> bool:
+    """Return True when ``exc`` is a ``public_id`` unique-constraint violation.
+
+    The retry loop only re-mints for ``public_id`` collisions; any other
+    integrity violation (a real bug or a different constraint) must propagate.
+    """
+    for candidate in (exc.orig, getattr(exc.orig, "__cause__", None)):
+        name = getattr(candidate, "constraint_name", None)
+        if name is not None:
+            return "public_id" in name
+    return "public_id" in str(exc.orig)

--- a/src/docverse/storage/_public_id.py
+++ b/src/docverse/storage/_public_id.py
@@ -34,6 +34,15 @@ unlikely to recur even once; five attempts is a generous safety margin whose
 exhaustion signals a real problem rather than an unlucky draw.
 """
 
+_UNIQUE_VIOLATION_SQLSTATE = "23505"
+"""Postgres SQLSTATE for ``unique_violation``.
+
+Only a genuine unique-constraint violation is a re-mintable ``public_id``
+collision. Gating on this code stops a *different* integrity error that merely
+mentions ``public_id`` (e.g. a NOT NULL violation, SQLSTATE ``23502``) from
+being silently retried and masked as an "exhausted attempts" error.
+"""
+
 
 async def insert_with_time_ordered_public_id[Row](
     session: AsyncSession,
@@ -92,11 +101,37 @@ async def insert_with_time_ordered_public_id[Row](
 def _is_public_id_conflict(exc: IntegrityError) -> bool:
     """Return True when ``exc`` is a ``public_id`` unique-constraint violation.
 
-    The retry loop only re-mints for ``public_id`` collisions; any other
-    integrity violation (a real bug or a different constraint) must propagate.
+    The retry loop only re-mints for ``public_id`` *unique* collisions; any
+    other integrity violation (a real bug or a different constraint) must
+    propagate. Two conditions must both hold: the error is a Postgres
+    ``unique_violation`` (SQLSTATE ``23505``), and the offending constraint
+    names ``public_id``. Requiring the unique-violation code stops a
+    non-unique integrity error that merely mentions ``public_id`` — e.g. a
+    NOT NULL violation if a future ``make_row`` callback forgets to set it —
+    from being silently retried and surfaced as an "exhausted attempts"
+    :class:`RuntimeError` that masks the real bug.
     """
+    if not _is_unique_violation(exc):
+        return False
     for candidate in (exc.orig, getattr(exc.orig, "__cause__", None)):
         name = getattr(candidate, "constraint_name", None)
         if name is not None:
             return "public_id" in name
     return "public_id" in str(exc.orig)
+
+
+def _is_unique_violation(exc: IntegrityError) -> bool:
+    """Return True when ``exc`` wraps a Postgres ``unique_violation``.
+
+    Checks the SQLSTATE on the driver exception (asyncpg exposes it as
+    ``sqlstate``; other DBAPIs as ``pgcode``) against ``23505``. Walks both
+    ``exc.orig`` and its ``__cause__`` because the driver exception may be
+    wrapped.
+    """
+    for candidate in (exc.orig, getattr(exc.orig, "__cause__", None)):
+        sqlstate = getattr(candidate, "sqlstate", None) or getattr(
+            candidate, "pgcode", None
+        )
+        if sqlstate == _UNIQUE_VIOLATION_SQLSTATE:
+            return True
+    return False

--- a/src/docverse/storage/build_store.py
+++ b/src/docverse/storage/build_store.py
@@ -12,13 +12,10 @@ from sqlalchemy.sql import func
 
 from docverse.client.models import BuildCreate, BuildStatus
 from docverse.dbschema.build import SqlBuild
-from docverse.domain.base32id import (
-    generate_base32_id,
-    serialize_base32_id,
-    validate_base32_id,
-)
+from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.build import Build
 from docverse.exceptions import InvalidBuildStateError
+from docverse.storage._public_id import insert_with_time_ordered_public_id
 from docverse.storage.pagination import BuildDateCreatedCursor
 
 # Valid status transitions
@@ -47,29 +44,37 @@ class BuildStore:
         data: BuildCreate,
         uploader: str,
     ) -> Build:
-        """Insert a new build row with status=pending."""
-        public_id = validate_base32_id(generate_base32_id())
-        base32_str = serialize_base32_id(public_id)
-        staging_key = f"__staging/{base32_str}.tar.gz"
-        storage_prefix = f"{project_slug}/__builds/{base32_str}/"
-        row = SqlBuild(
-            public_id=public_id,
-            project_id=project_id,
-            git_ref=data.git_ref,
-            alternate_name=data.alternate_name,
-            content_hash=data.content_hash,
-            status=BuildStatus.pending,
-            staging_key=staging_key,
-            storage_prefix=storage_prefix,
-            uploader=uploader,
-            annotations=(
-                data.annotations.model_dump(mode="json", exclude_none=True)
-                if data.annotations is not None
-                else None
-            ),
+        """Insert a new build row with status=pending.
+
+        The ``public_id`` is a time-ordered Crockford Base32 resource ID
+        minted at insert time. Because that ID is embedded in ``staging_key``
+        and ``storage_prefix``, the object-store keys are recomputed for each
+        mint attempt inside :func:`insert_with_time_ordered_public_id`, which
+        re-mints on the (rare) same-millisecond ``public_id`` collision.
+        """
+
+        def _make_row(public_id: int) -> SqlBuild:
+            base32_str = serialize_base32_id(public_id)
+            return SqlBuild(
+                public_id=public_id,
+                project_id=project_id,
+                git_ref=data.git_ref,
+                alternate_name=data.alternate_name,
+                content_hash=data.content_hash,
+                status=BuildStatus.pending,
+                staging_key=f"__staging/{base32_str}.tar.gz",
+                storage_prefix=f"{project_slug}/__builds/{base32_str}/",
+                uploader=uploader,
+                annotations=(
+                    data.annotations.model_dump(mode="json", exclude_none=True)
+                    if data.annotations is not None
+                    else None
+                ),
+            )
+
+        row = await insert_with_time_ordered_public_id(
+            self._session, _make_row
         )
-        self._session.add(row)
-        await self._session.flush()
         await self._session.refresh(row)
         return Build.model_validate(row)
 

--- a/src/docverse/storage/keeper_sync/state_store.py
+++ b/src/docverse/storage/keeper_sync/state_store.py
@@ -96,6 +96,7 @@ class KeeperSyncState(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
+    public_id: int
     org_id: int
     resource_type: str
     ltd_id: int | None = None
@@ -396,6 +397,32 @@ class KeeperSyncStateStore:
         """
         stmt = select(SqlKeeperSyncState).where(
             SqlKeeperSyncState.id == state_id,
+            SqlKeeperSyncState.org_id == org_id,
+        )
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return KeeperSyncState.model_validate(row)
+
+    async def get_by_public_id_for_org(
+        self,
+        *,
+        public_id: int,
+        org_id: int,
+    ) -> KeeperSyncState | None:
+        """Fetch a state row by its Base32 ``public_id``, scoped to an org.
+
+        The admin tombstones DELETE endpoint addresses rows by their
+        Base32 ``public_id``; scoping to ``org_id`` keeps the lookup
+        org-isolated so a guessed id from a different org returns
+        ``None`` (404) rather than the wrong row. Tombstoned rows are
+        visible to this lookup — the admin clear path is the only
+        caller and must be able to see the row it is about to
+        un-tombstone.
+        """
+        stmt = select(SqlKeeperSyncState).where(
+            SqlKeeperSyncState.public_id == public_id,
             SqlKeeperSyncState.org_id == org_id,
         )
         result = await self._session.execute(stmt)

--- a/src/docverse/storage/keeper_sync/state_store.py
+++ b/src/docverse/storage/keeper_sync/state_store.py
@@ -23,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import ColumnElement
 
 from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
+from docverse.storage._public_id import insert_with_time_ordered_public_id
 
 if TYPE_CHECKING:
     from docverse.storage.pagination import (
@@ -423,6 +424,12 @@ class KeeperSyncStateStore:
         ``(org_id, resource_type, ltd_id)`` for editions / builds. On
         update, only non-``None`` fields overwrite the existing row;
         ``None`` arguments preserve whatever value is already stored.
+
+        A newly inserted row is minted a time-ordered Base32 ``public_id``
+        via :func:`insert_with_time_ordered_public_id`, which re-mints on
+        the (rare) same-millisecond collision. Every state row carries a
+        public id, not just tombstoned ones — a tombstone is simply a
+        state row with ``date_tombstoned`` set.
         """
         clauses = _key_clauses(
             org_id=org_id,
@@ -435,19 +442,27 @@ class KeeperSyncStateStore:
         )
         row = existing.scalar_one_or_none()
         if row is None:
-            row = SqlKeeperSyncState(
-                org_id=org_id,
-                resource_type=resource_type.value,
-                ltd_id=ltd_id,
-                ltd_slug=ltd_slug,
-                docverse_id=docverse_id,
-                date_last_synced=date_last_synced,
-                date_rebuilt_seen=date_rebuilt_seen,
-                last_seen_etag=last_seen_etag,
-                content_hash=content_hash,
-                annotations=annotations,
+
+            def _make_row(public_id: int) -> SqlKeeperSyncState:
+                return SqlKeeperSyncState(
+                    public_id=public_id,
+                    org_id=org_id,
+                    resource_type=resource_type.value,
+                    ltd_id=ltd_id,
+                    ltd_slug=ltd_slug,
+                    docverse_id=docverse_id,
+                    date_last_synced=date_last_synced,
+                    date_rebuilt_seen=date_rebuilt_seen,
+                    last_seen_etag=last_seen_etag,
+                    content_hash=content_hash,
+                    annotations=annotations,
+                )
+
+            row = await insert_with_time_ordered_public_id(
+                self._session, _make_row
             )
-            self._session.add(row)
+            await self._session.refresh(row)
+            return KeeperSyncState.model_validate(row)
         else:
             row.ltd_slug = ltd_slug
             if docverse_id is not None:

--- a/src/docverse/storage/keeper_sync_run_store.py
+++ b/src/docverse/storage/keeper_sync_run_store.py
@@ -27,6 +27,7 @@ from docverse.domain.keeper_sync_run import (
 )
 from docverse.domain.queue import JobStatus
 from docverse.exceptions import InvalidJobStateError, JobNotFoundError
+from docverse.storage._public_id import insert_with_time_ordered_public_id
 from docverse.storage.pagination import KeeperSyncRunDateStartedCursor
 
 __all__ = ["KeeperSyncRunStore"]
@@ -56,19 +57,30 @@ class KeeperSyncRunStore:
     ) -> KeeperSyncRun:
         """Insert a new run row in ``pending`` status.
 
+        Mints a time-ordered Base32 ``public_id`` at insert time, re-minting
+        on the (rare) same-millisecond collision.
+
         The DB-side partial unique index on ``(org_id) WHERE status IN
         ('pending', 'in_progress')`` enforces the
-        one-non-terminal-run-per-org invariant. The caller is expected
-        to translate the resulting ``IntegrityError`` into a 409 — the
-        store itself stays low-level and lets the constraint speak.
+        one-non-terminal-run-per-org invariant. A violation of that index is
+        not a ``public_id`` collision, so
+        :func:`insert_with_time_ordered_public_id` re-raises it untouched; the
+        caller is expected to translate the resulting ``IntegrityError`` into
+        a 409 — the store itself stays low-level and lets the constraint
+        speak.
         """
-        row = SqlKeeperSyncRun(
-            org_id=org_id,
-            kind=kind.value,
-            status=KeeperSyncRunStatus.pending.value,
+
+        def _make_row(public_id: int) -> SqlKeeperSyncRun:
+            return SqlKeeperSyncRun(
+                public_id=public_id,
+                org_id=org_id,
+                kind=kind.value,
+                status=KeeperSyncRunStatus.pending.value,
+            )
+
+        row = await insert_with_time_ordered_public_id(
+            self._session, _make_row
         )
-        self._session.add(row)
-        await self._session.flush()
         await self._session.refresh(row)
         return KeeperSyncRun.model_validate(row)
 

--- a/src/docverse/storage/keeper_sync_run_store.py
+++ b/src/docverse/storage/keeper_sync_run_store.py
@@ -94,6 +94,18 @@ class KeeperSyncRunStore:
             return None
         return KeeperSyncRun.model_validate(row)
 
+    async def get_by_public_id(self, public_id: int) -> KeeperSyncRun | None:
+        """Fetch a run by its Base32 ``public_id``."""
+        result = await self._session.execute(
+            select(SqlKeeperSyncRun).where(
+                SqlKeeperSyncRun.public_id == public_id
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return KeeperSyncRun.model_validate(row)
+
     async def list_by_org(
         self,
         *,

--- a/src/docverse/storage/queue_job_store.py
+++ b/src/docverse/storage/queue_job_store.py
@@ -12,13 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
 
 from docverse.dbschema.queue_job import SqlQueueJob
-from docverse.domain.base32id import (
-    generate_base32_id,
-    serialize_base32_id,
-    validate_base32_id,
-)
+from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.queue import JobKind, JobStatus, QueueJob
 from docverse.exceptions import InvalidJobStateError, JobNotFoundError
+from docverse.storage._public_id import insert_with_time_ordered_public_id
 from docverse.storage.pagination import QueueJobDateCreatedCursor
 
 __all__ = ["QueueJobStore"]
@@ -51,25 +48,30 @@ class QueueJobStore:
     ) -> QueueJob:
         """Insert a new QueueJob row with status=queued.
 
-        Generates a Base32 public_id. Calls flush() to get DB defaults.
+        Mints a time-ordered Base32 ``public_id`` at insert time, re-minting
+        on the (rare) same-millisecond collision. Calls flush() to get DB
+        defaults.
         """
-        public_id = validate_base32_id(generate_base32_id())
-        row = SqlQueueJob(
-            public_id=public_id,
-            backend_job_id=backend_job_id,
-            kind=kind.value,
-            status=JobStatus.queued.value,
-            org_id=org_id,
-            project_id=project_id,
-            build_id=build_id,
-            edition_id=edition_id,
-            keeper_sync_run_id=keeper_sync_run_id,
-            lifecycle_eval_run_id=lifecycle_eval_run_id,
-            git_ref_audit_run_id=git_ref_audit_run_id,
-            subject_label=subject_label,
+
+        def _make_row(public_id: int) -> SqlQueueJob:
+            return SqlQueueJob(
+                public_id=public_id,
+                backend_job_id=backend_job_id,
+                kind=kind.value,
+                status=JobStatus.queued.value,
+                org_id=org_id,
+                project_id=project_id,
+                build_id=build_id,
+                edition_id=edition_id,
+                keeper_sync_run_id=keeper_sync_run_id,
+                lifecycle_eval_run_id=lifecycle_eval_run_id,
+                git_ref_audit_run_id=git_ref_audit_run_id,
+                subject_label=subject_label,
+            )
+
+        row = await insert_with_time_ordered_public_id(
+            self._session, _make_row
         )
-        self._session.add(row)
-        await self._session.flush()
         await self._session.refresh(row)
         return QueueJob.model_validate(row, from_attributes=True)
 

--- a/tests/dbschema/keeper_sync_runs_public_id_schema_test.py
+++ b/tests/dbschema/keeper_sync_runs_public_id_schema_test.py
@@ -1,0 +1,232 @@
+"""Test the ``keeper_sync_runs.public_id`` migration (``c7d8e9f0a1b2``).
+
+Mirrors :mod:`tests.dbschema.git_ref_audit_runs_schema_test`: the
+``fresh_engine`` fixture brings the schema up to the revision **before**
+this migration, the test seeds populated ``keeper_sync_runs`` rows, then
+steps forward to the migration under test. The migration adds a
+``public_id`` column and backfills it from each row's ``date_started`` in
+ascending order, so the assertions pin that the backfilled IDs are unique
+and sort in ``date_started`` order regardless of primary-key order. The
+downgrade is exercised to confirm the column and its unique constraint
+drop cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+import structlog
+from alembic.config import Config
+from safir.database import (
+    create_database_engine,
+    drop_database,
+    initialize_database,
+    stamp_database_async,
+)
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from alembic import command
+from docverse.config import config
+from docverse.dbschema import Base
+
+# Revision immediately before this PR's public_id migration.
+PRE_PUBLIC_ID_REVISION = "b6c7d8e9f0a1"
+
+# The migration under test.
+PUBLIC_ID_REVISION = "c7d8e9f0a1b2"
+
+
+@pytest_asyncio.fixture
+async def fresh_engine() -> AsyncGenerator[AsyncEngine]:
+    """Yield an engine pointing at a freshly-dropped DB."""
+    logger = structlog.get_logger("docverse")
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    await drop_database(engine, Base.metadata)
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+    try:
+        yield engine
+    finally:
+        await drop_database(engine, Base.metadata)
+        async with engine.begin() as conn:
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+        await initialize_database(
+            engine, logger, schema=Base.metadata, reset=True
+        )
+        await stamp_database_async(engine)
+        await engine.dispose()
+
+
+def _alembic_config() -> Config:
+    return Config("alembic.ini")
+
+
+async def _alembic_upgrade(target: str) -> None:
+    await asyncio.to_thread(command.upgrade, _alembic_config(), target)
+
+
+async def _alembic_downgrade(target: str) -> None:
+    await asyncio.to_thread(command.downgrade, _alembic_config(), target)
+
+
+async def _seed_runs(engine: AsyncEngine) -> int:
+    """Seed one org and three terminal runs with distinct ``date_started``.
+
+    The ``date_started`` order deliberately differs from primary-key order
+    so the backfill's "order by ``date_started``" behaviour is observable:
+    the earliest-started run is inserted second, and the latest-started run
+    is inserted first. All three are seeded in a terminal status so the
+    one-non-terminal-run-per-org partial unique index tolerates the trio.
+
+    Returns the org id.
+    """
+    async with engine.begin() as conn:
+        org_id: int = (
+            await conn.execute(
+                text(
+                    "INSERT INTO organizations"
+                    " (slug, title, base_domain, url_scheme,"
+                    "  root_path_prefix, purgatory_retention_seconds)"
+                    " VALUES ('ksr-pid-org', 'KSR PID Org',"
+                    "  'ksr.example.com', 'subdomain', '/', 2592000)"
+                    " RETURNING id"
+                )
+            )
+        ).scalar_one()
+        await conn.execute(
+            text(
+                """
+                INSERT INTO keeper_sync_runs (org_id, kind, status,
+                    date_started)
+                VALUES
+                    (:org, 'backfill', 'succeeded',
+                     NOW() - INTERVAL '1 minute'),
+                    (:org, 'backfill', 'succeeded',
+                     NOW() - INTERVAL '3 minutes'),
+                    (:org, 'backfill', 'succeeded',
+                     NOW() - INTERVAL '2 minutes')
+                """
+            ),
+            {"org": org_id},
+        )
+    return org_id
+
+
+@pytest.mark.asyncio
+async def test_migration_backfills_ordered_unique_public_ids(
+    fresh_engine: AsyncEngine,
+) -> None:
+    """Existing rows get unique public IDs sorted in ``date_started`` order."""
+    await _alembic_upgrade(PRE_PUBLIC_ID_REVISION)
+    await _seed_runs(fresh_engine)
+    await _alembic_upgrade(PUBLIC_ID_REVISION)
+
+    async with fresh_engine.connect() as conn:
+        columns = {
+            row.column_name: (row.data_type, row.is_nullable)
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT column_name, data_type, is_nullable"
+                        " FROM information_schema.columns"
+                        " WHERE table_name = 'keeper_sync_runs'"
+                        " AND column_name = 'public_id'"
+                    )
+                )
+            ).all()
+        }
+        assert columns["public_id"] == ("bigint", "NO")
+
+        # Public IDs, read back in date_started order.
+        public_ids = [
+            row.public_id
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT public_id FROM keeper_sync_runs"
+                        " ORDER BY date_started ASC, id ASC"
+                    )
+                )
+            ).all()
+        ]
+
+    assert len(public_ids) == 3
+    # Every ID is populated, unique, and strictly increasing in
+    # date_started order.
+    assert all(pid is not None for pid in public_ids)
+    assert len(set(public_ids)) == 3
+    assert public_ids == sorted(public_ids)
+    assert public_ids[0] < public_ids[1] < public_ids[2]
+
+
+@pytest.mark.asyncio
+async def test_unique_constraint_rejects_duplicate_public_id(
+    fresh_engine: AsyncEngine,
+) -> None:
+    """The backfilled column carries a working unique constraint."""
+    await _alembic_upgrade(PRE_PUBLIC_ID_REVISION)
+    org_id = await _seed_runs(fresh_engine)
+    await _alembic_upgrade(PUBLIC_ID_REVISION)
+
+    async with fresh_engine.connect() as conn:
+        existing = (
+            await conn.execute(
+                text("SELECT public_id FROM keeper_sync_runs LIMIT 1")
+            )
+        ).scalar_one()
+
+    with pytest.raises(IntegrityError):
+        async with fresh_engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO keeper_sync_runs (public_id, org_id, kind,"
+                    " status) VALUES (:pid, :org, 'backfill', 'succeeded')"
+                ),
+                {"pid": existing, "org": org_id},
+            )
+
+
+@pytest.mark.asyncio
+async def test_downgrade_drops_public_id_column(
+    fresh_engine: AsyncEngine,
+) -> None:
+    """The downgrade removes the column and its unique constraint cleanly."""
+    await _alembic_upgrade(PRE_PUBLIC_ID_REVISION)
+    await _seed_runs(fresh_engine)
+    await _alembic_upgrade(PUBLIC_ID_REVISION)
+    await _alembic_downgrade(PRE_PUBLIC_ID_REVISION)
+
+    async with fresh_engine.connect() as conn:
+        columns = {
+            row.column_name
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT column_name"
+                        " FROM information_schema.columns"
+                        " WHERE table_name = 'keeper_sync_runs'"
+                    )
+                )
+            ).all()
+        }
+        assert "public_id" not in columns
+
+        constraints = {
+            row.conname
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT conname FROM pg_constraint"
+                        " WHERE conrelid = 'keeper_sync_runs'::regclass"
+                    )
+                )
+            ).all()
+        }
+        assert "keeper_sync_runs_public_id_key" not in constraints

--- a/tests/dbschema/keeper_sync_state_public_id_schema_test.py
+++ b/tests/dbschema/keeper_sync_state_public_id_schema_test.py
@@ -1,0 +1,250 @@
+"""Test the ``keeper_sync_state.public_id`` migration (``d8e9f0a1b2c3``).
+
+Mirrors :mod:`tests.dbschema.keeper_sync_runs_public_id_schema_test`: the
+``fresh_engine`` fixture brings the schema up to the revision **before**
+this migration, the test seeds populated ``keeper_sync_state`` rows, then
+steps forward to the migration under test. The migration adds a
+``public_id`` column and backfills it from each row's
+``COALESCE(date_tombstoned, date_last_synced, now())`` in ascending
+order, so the assertions pin that the backfilled IDs are unique and sort
+in that order regardless of primary-key order — including rows where
+every timestamp is NULL, which fall back to ``now()`` and order last. The
+downgrade is exercised to confirm the column and its unique constraint
+drop cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+import structlog
+from alembic.config import Config
+from safir.database import (
+    create_database_engine,
+    drop_database,
+    initialize_database,
+    stamp_database_async,
+)
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from alembic import command
+from docverse.config import config
+from docverse.dbschema import Base
+
+# Revision immediately before this PR's public_id migration.
+PRE_PUBLIC_ID_REVISION = "c7d8e9f0a1b2"
+
+# The migration under test.
+PUBLIC_ID_REVISION = "d8e9f0a1b2c3"
+
+
+@pytest_asyncio.fixture
+async def fresh_engine() -> AsyncGenerator[AsyncEngine]:
+    """Yield an engine pointing at a freshly-dropped DB."""
+    logger = structlog.get_logger("docverse")
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    await drop_database(engine, Base.metadata)
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+    try:
+        yield engine
+    finally:
+        await drop_database(engine, Base.metadata)
+        async with engine.begin() as conn:
+            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+        await initialize_database(
+            engine, logger, schema=Base.metadata, reset=True
+        )
+        await stamp_database_async(engine)
+        await engine.dispose()
+
+
+def _alembic_config() -> Config:
+    return Config("alembic.ini")
+
+
+async def _alembic_upgrade(target: str) -> None:
+    await asyncio.to_thread(command.upgrade, _alembic_config(), target)
+
+
+async def _alembic_downgrade(target: str) -> None:
+    await asyncio.to_thread(command.downgrade, _alembic_config(), target)
+
+
+async def _seed_states(engine: AsyncEngine) -> int:
+    """Seed one org and four state rows with mixed timestamp coverage.
+
+    The backfill orders by ``COALESCE(date_tombstoned, date_last_synced,
+    now())``. The seeded rows deliberately exercise every branch of that
+    expression, and their primary-key order differs from their expected
+    backfill order so the "order by the coalesced timestamp" behaviour is
+    observable:
+
+    1. inserted first, coalesces to ``date_tombstoned`` (2 minutes ago) →
+       expected backfill order 2.
+    2. inserted second, coalesces to ``date_last_synced`` (5 minutes ago,
+       no tombstone) → expected backfill order 1 (earliest).
+    3. inserted third, coalesces to ``date_tombstoned`` (1 minute ago) →
+       expected backfill order 3.
+    4. inserted fourth, all timestamps NULL → coalesces to ``now()`` →
+       expected backfill order 4 (latest).
+
+    Returns the org id.
+    """
+    async with engine.begin() as conn:
+        org_id: int = (
+            await conn.execute(
+                text(
+                    "INSERT INTO organizations"
+                    " (slug, title, base_domain, url_scheme,"
+                    "  root_path_prefix, purgatory_retention_seconds)"
+                    " VALUES ('kss-pid-org', 'KSS PID Org',"
+                    "  'kss.example.com', 'subdomain', '/', 2592000)"
+                    " RETURNING id"
+                )
+            )
+        ).scalar_one()
+        await conn.execute(
+            text(
+                """
+                INSERT INTO keeper_sync_state (org_id, resource_type,
+                    ltd_id, ltd_slug, date_last_synced, date_tombstoned)
+                VALUES
+                    (:org, 'edition', 1, 'e-1',
+                     NULL, NOW() - INTERVAL '2 minutes'),
+                    (:org, 'edition', 2, 'e-2',
+                     NOW() - INTERVAL '5 minutes', NULL),
+                    (:org, 'edition', 3, 'e-3',
+                     NULL, NOW() - INTERVAL '1 minute'),
+                    (:org, 'edition', 4, 'e-4',
+                     NULL, NULL)
+                """
+            ),
+            {"org": org_id},
+        )
+    return org_id
+
+
+@pytest.mark.asyncio
+async def test_migration_backfills_ordered_unique_public_ids(
+    fresh_engine: AsyncEngine,
+) -> None:
+    """Existing rows get unique public IDs sorted in coalesced-ts order."""
+    await _alembic_upgrade(PRE_PUBLIC_ID_REVISION)
+    await _seed_states(fresh_engine)
+    await _alembic_upgrade(PUBLIC_ID_REVISION)
+
+    async with fresh_engine.connect() as conn:
+        columns = {
+            row.column_name: (row.data_type, row.is_nullable)
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT column_name, data_type, is_nullable"
+                        " FROM information_schema.columns"
+                        " WHERE table_name = 'keeper_sync_state'"
+                        " AND column_name = 'public_id'"
+                    )
+                )
+            ).all()
+        }
+        assert columns["public_id"] == ("bigint", "NO")
+
+        # Public IDs, read back in the same coalesced-timestamp order the
+        # backfill used, which also places the all-NULL row (row 4) last.
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT ltd_slug, public_id FROM keeper_sync_state"
+                    " ORDER BY"
+                    " COALESCE(date_tombstoned, date_last_synced, now())"
+                    " ASC, id ASC"
+                )
+            )
+        ).all()
+
+    slugs = [row.ltd_slug for row in rows]
+    public_ids = [row.public_id for row in rows]
+
+    assert len(public_ids) == 4
+    # The all-NULL row sorts last (now() beats every past timestamp).
+    assert slugs == ["e-2", "e-1", "e-3", "e-4"]
+    # Every ID is populated, unique, and strictly increasing in order.
+    assert all(pid is not None for pid in public_ids)
+    assert len(set(public_ids)) == 4
+    assert public_ids == sorted(public_ids)
+    assert public_ids[0] < public_ids[1] < public_ids[2] < public_ids[3]
+
+
+@pytest.mark.asyncio
+async def test_unique_constraint_rejects_duplicate_public_id(
+    fresh_engine: AsyncEngine,
+) -> None:
+    """The backfilled column carries a working unique constraint."""
+    await _alembic_upgrade(PRE_PUBLIC_ID_REVISION)
+    org_id = await _seed_states(fresh_engine)
+    await _alembic_upgrade(PUBLIC_ID_REVISION)
+
+    async with fresh_engine.connect() as conn:
+        existing = (
+            await conn.execute(
+                text("SELECT public_id FROM keeper_sync_state LIMIT 1")
+            )
+        ).scalar_one()
+
+    with pytest.raises(IntegrityError):
+        async with fresh_engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO keeper_sync_state (public_id, org_id,"
+                    " resource_type, ltd_id, ltd_slug)"
+                    " VALUES (:pid, :org, 'edition', 99, 'e-99')"
+                ),
+                {"pid": existing, "org": org_id},
+            )
+
+
+@pytest.mark.asyncio
+async def test_downgrade_drops_public_id_column(
+    fresh_engine: AsyncEngine,
+) -> None:
+    """The downgrade removes the column and its unique constraint cleanly."""
+    await _alembic_upgrade(PRE_PUBLIC_ID_REVISION)
+    await _seed_states(fresh_engine)
+    await _alembic_upgrade(PUBLIC_ID_REVISION)
+    await _alembic_downgrade(PRE_PUBLIC_ID_REVISION)
+
+    async with fresh_engine.connect() as conn:
+        columns = {
+            row.column_name
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT column_name"
+                        " FROM information_schema.columns"
+                        " WHERE table_name = 'keeper_sync_state'"
+                    )
+                )
+            ).all()
+        }
+        assert "public_id" not in columns
+
+        constraints = {
+            row.conname
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT conname FROM pg_constraint"
+                        " WHERE conrelid = 'keeper_sync_state'::regclass"
+                    )
+                )
+            ).all()
+        }
+        assert "keeper_sync_state_public_id_key" not in constraints

--- a/tests/domain/base32id_test.py
+++ b/tests/domain/base32id_test.py
@@ -1,0 +1,122 @@
+"""Tests for the Crockford Base32 identifier helpers."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+from itertools import pairwise
+
+import pytest
+
+from docverse.domain.base32id import (
+    RESOURCE_ID_EPOCH,
+    RESOURCE_ID_RANDOM_BITS,
+    RESOURCE_ID_TIMESTAMP_BITS,
+    generate_resource_id,
+    mint_resource_id_for_timestamp,
+    mint_time_ordered_resource_ids,
+    serialize_base32_id,
+    validate_base32_id,
+)
+
+# 12 payload characters plus a 2-character checksum, hyphenated every 4.
+_ENVELOPE_RE = re.compile(
+    r"^[0-9a-hjkmnp-tv-z]{4}(?:-[0-9a-hjkmnp-tv-z]{2,4})+$"
+)
+
+
+def test_bit_layout_sums_to_envelope() -> None:
+    """The timestamp and random bits fill exactly the 60-bit envelope."""
+    assert RESOURCE_ID_TIMESTAMP_BITS + RESOURCE_ID_RANDOM_BITS == 60
+
+
+def test_resource_id_fits_envelope_length_and_format() -> None:
+    """A minted ID serializes to a 12+2 hyphenated Crockford string."""
+    resource_id = mint_resource_id_for_timestamp(datetime.now(tz=UTC))
+    assert resource_id < (1 << 60)
+
+    serialized = serialize_base32_id(resource_id)
+    # 14 payload characters (12 + 2 checksum) plus hyphens.
+    assert len(serialized.replace("-", "")) == 14
+    assert _ENVELOPE_RE.match(serialized)
+
+
+def test_checksum_round_trip() -> None:
+    """Serialize -> validate returns the original integer."""
+    resource_id = mint_resource_id_for_timestamp(datetime.now(tz=UTC))
+    serialized = serialize_base32_id(resource_id)
+    assert validate_base32_id(serialized) == resource_id
+
+
+def test_high_bits_decode_to_milliseconds_since_epoch() -> None:
+    """The high 43 bits decode to milliseconds since 2010-01-01 UTC."""
+    timestamp = datetime(2026, 7, 20, 12, 34, 56, 789000, tzinfo=UTC)
+    resource_id = mint_resource_id_for_timestamp(timestamp)
+
+    milliseconds = resource_id >> RESOURCE_ID_RANDOM_BITS
+    expected_ms = (timestamp - RESOURCE_ID_EPOCH) // timedelta(milliseconds=1)
+    assert milliseconds == expected_ms
+
+    recovered = RESOURCE_ID_EPOCH + timedelta(milliseconds=milliseconds)
+    # Millisecond truncation drops sub-millisecond precision only.
+    assert recovered == timestamp.replace(microsecond=789000)
+
+
+def test_creation_order_monotonicity() -> None:
+    """Later timestamps mint strictly larger IDs."""
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    ids = [
+        mint_resource_id_for_timestamp(base + timedelta(milliseconds=n))
+        for n in range(50)
+    ]
+    assert ids == sorted(ids)
+    assert len(set(ids)) == len(ids)
+
+
+def test_mint_for_timestamp_deterministic_modulo_random_bits() -> None:
+    """A fixed timestamp yields a stable high-bit prefix across calls."""
+    timestamp = datetime(2024, 6, 1, 0, 0, 0, tzinfo=UTC)
+    highs = {
+        mint_resource_id_for_timestamp(timestamp) >> RESOURCE_ID_RANDOM_BITS
+        for _ in range(20)
+    }
+    assert len(highs) == 1
+
+
+def test_mint_time_ordered_strictly_increasing_same_millisecond() -> None:
+    """Identical timestamps still yield a strictly increasing sequence."""
+    timestamp = datetime(2025, 3, 3, 3, 3, 3, tzinfo=UTC)
+    ids = mint_time_ordered_resource_ids([timestamp] * 100)
+    assert all(later > earlier for earlier, later in pairwise(ids))
+
+
+def test_mint_time_ordered_tracks_wall_clock() -> None:
+    """Ascending timestamps produce a strictly increasing sequence."""
+    base = datetime(2025, 3, 3, tzinfo=UTC)
+    timestamps = [base + timedelta(seconds=n) for n in range(10)]
+    ids = mint_time_ordered_resource_ids(timestamps)
+    assert ids == sorted(ids)
+    assert len(set(ids)) == len(ids)
+
+
+def test_generate_resource_id_is_time_ordered() -> None:
+    """generate_resource_id mints within the envelope for the current time."""
+    before = datetime.now(tz=UTC) - timedelta(seconds=1)
+    resource_id = generate_resource_id()
+    after = datetime.now(tz=UTC) + timedelta(seconds=1)
+
+    milliseconds = resource_id >> RESOURCE_ID_RANDOM_BITS
+    minted_at = RESOURCE_ID_EPOCH + timedelta(milliseconds=milliseconds)
+    assert before <= minted_at <= after
+
+
+def test_mint_rejects_naive_timestamp() -> None:
+    """A timezone-naive timestamp is rejected."""
+    with pytest.raises(ValueError, match="timezone-aware"):
+        mint_resource_id_for_timestamp(datetime(2026, 1, 1))  # noqa: DTZ001
+
+
+def test_mint_rejects_pre_epoch_timestamp() -> None:
+    """A timestamp before the epoch is rejected."""
+    with pytest.raises(ValueError, match="epoch"):
+        mint_resource_id_for_timestamp(datetime(2009, 12, 31, tzinfo=UTC))

--- a/tests/handlers/dashboard_template_test.py
+++ b/tests/handlers/dashboard_template_test.py
@@ -1125,7 +1125,7 @@ async def test_org_sync_enqueues_dashboard_sync(client: AsyncClient) -> None:
     )
     assert response.status_code == 202
     body = response.json()
-    assert body["binding_id"] == binding_id
+    assert "binding_id" not in body
     assert body["queue_job_id"]
     assert body["queue_job_url"].endswith(
         f"/queue/jobs/{body['queue_job_id']}"
@@ -1209,7 +1209,7 @@ async def test_project_sync_enqueues_dashboard_sync(
     )
     assert response.status_code == 202
     body = response.json()
-    assert body["binding_id"] == binding_id
+    assert "binding_id" not in body
     assert body["queue_job_id"]
     assert body["queue_job_url"].endswith(
         f"/queue/jobs/{body['queue_job_id']}"

--- a/tests/handlers/keeper_sync_runs_test.py
+++ b/tests/handlers/keeper_sync_runs_test.py
@@ -15,7 +15,11 @@ from sqlalchemy import select
 from docverse.client.models import OrgRole
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.queue_job import SqlQueueJob
-from docverse.domain.base32id import generate_base32_id, validate_base32_id
+from docverse.domain.base32id import (
+    generate_base32_id,
+    serialize_base32_id,
+    validate_base32_id,
+)
 from docverse.domain.queue import JobKind, JobStatus
 from docverse.storage.organization_store import OrganizationStore
 from tests.conftest import seed_member, seed_org_with_admin
@@ -28,6 +32,41 @@ def _make_run(**kwargs: Any) -> SqlKeeperSyncRun:
     """Build a run row with a minted ``public_id`` for seeding tests."""
     kwargs.setdefault("public_id", validate_base32_id(generate_base32_id()))
     return SqlKeeperSyncRun(**kwargs)
+
+
+async def _seed_run(
+    org_id: int, *, kind: str = "backfill", status: str = "pending"
+) -> tuple[int, str]:
+    """Seed a run row directly; return ``(primary_key, public_id_b32)``.
+
+    The primary key is used to attribute seeded ``queue_jobs`` (the FK
+    is the integer PK); the Base32 ``public_id`` is what the public API
+    addresses the run by.
+    """
+    async for session in db_session_dependency():
+        async with session.begin():
+            row = _make_run(org_id=org_id, kind=kind, status=status)
+            session.add(row)
+            await session.flush()
+            pk = row.id
+            public = serialize_base32_id(row.public_id)
+            await session.commit()
+            return pk, public
+    msg = "no session"
+    raise AssertionError(msg)
+
+
+async def _run_pk_for_public_id(public_id_b32: str) -> int:
+    """Resolve a run's primary key from its Base32 ``public_id``."""
+    public_id = validate_base32_id(public_id_b32)
+    async for session in db_session_dependency():
+        async with session.begin():
+            stmt = select(SqlKeeperSyncRun.id).where(
+                SqlKeeperSyncRun.public_id == public_id
+            )
+            return (await session.execute(stmt)).scalar_one()
+    msg = "no session"
+    raise AssertionError(msg)
 
 
 async def _setup_org(client: AsyncClient) -> None:
@@ -124,6 +163,11 @@ async def test_post_run_returns_202_with_run_and_queue_job_link(
     assert body["run"]["failed_count"] == 0
     assert body["run"]["total_count"] == 1
     assert "self_url" in body["run"]
+    # The run id is the Base32 public identifier, not the raw integer PK:
+    # it is a hyphen-grouped string that decodes back to a non-negative int.
+    assert isinstance(body["run"]["id"], str)
+    assert "-" in body["run"]["id"]
+    assert validate_base32_id(body["run"]["id"]) >= 0
     assert body["run"]["jobs_url"] == str(
         client.base_url.join(
             f"/docverse/orgs/{_ORG}/keeper-sync/runs/{body['run']['id']}/jobs"
@@ -182,31 +226,32 @@ async def test_get_run_returns_aggregate_counters(
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert create_response.status_code == 202
-    run_id: int = create_response.json()["run"]["id"]
+    run_b32: str = create_response.json()["run"]["id"]
+    run_pk = await _run_pk_for_public_id(run_b32)
     org_id = await _get_org_id()
 
     # Seed mixed-status queue_jobs attributed to this run.
     await _seed_queue_job(
-        org_id=org_id, run_id=run_id, status=JobStatus.queued
+        org_id=org_id, run_id=run_pk, status=JobStatus.queued
     )
     await _seed_queue_job(
-        org_id=org_id, run_id=run_id, status=JobStatus.in_progress
+        org_id=org_id, run_id=run_pk, status=JobStatus.in_progress
     )
     await _seed_queue_job(
-        org_id=org_id, run_id=run_id, status=JobStatus.completed
+        org_id=org_id, run_id=run_pk, status=JobStatus.completed
     )
     await _seed_queue_job(
-        org_id=org_id, run_id=run_id, status=JobStatus.completed
+        org_id=org_id, run_id=run_pk, status=JobStatus.completed
     )
     await _seed_queue_job(
-        org_id=org_id, run_id=run_id, status=JobStatus.failed
+        org_id=org_id, run_id=run_pk, status=JobStatus.failed
     )
     await _seed_queue_job(
-        org_id=org_id, run_id=run_id, status=JobStatus.cancelled
+        org_id=org_id, run_id=run_pk, status=JobStatus.cancelled
     )
 
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 200
@@ -221,7 +266,7 @@ async def test_get_run_returns_aggregate_counters(
     assert body["date_last_activity"] is not None
     assert body["jobs_url"] == str(
         client.base_url.join(
-            f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs"
+            f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}/jobs"
         )
     )
 
@@ -235,27 +280,19 @@ async def test_get_run_date_last_activity_matches_max_child_event(
     org_id = await _get_org_id()
     # Seed a run directly so the response shape doesn't depend on the
     # discovery queue-job's auto-attributed timestamps.
-    async for session in db_session_dependency():
-        async with session.begin():
-            row = _make_run(
-                org_id=org_id, kind="backfill", status="in_progress"
-            )
-            session.add(row)
-            await session.flush()
-            run_id = row.id
-            await session.commit()
+    run_pk, run_b32 = await _seed_run(org_id, status="in_progress")
 
     # Three children, each completing at successively later instants.
     # The MAX(coalesce(...)) post-condition picks the latest one.
     completed_ids: list[int] = [
         await _seed_queue_job(
-            org_id=org_id, run_id=run_id, status=JobStatus.completed
+            org_id=org_id, run_id=run_pk, status=JobStatus.completed
         )
         for _ in range(3)
     ]
 
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 200
@@ -280,16 +317,10 @@ async def test_get_run_date_last_activity_null_when_no_children(
     """``date_last_activity`` is null on a run with no attributed jobs."""
     await _setup_org(client)
     org_id = await _get_org_id()
-    async for session in db_session_dependency():
-        async with session.begin():
-            row = _make_run(org_id=org_id, kind="backfill", status="pending")
-            session.add(row)
-            await session.flush()
-            run_id = row.id
-            await session.commit()
+    _, run_b32 = await _seed_run(org_id, status="pending")
 
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 200
@@ -311,23 +342,11 @@ async def test_list_runs_surfaces_date_last_activity_per_row(
     """
     await _setup_org(client)
     org_id = await _get_org_id()
-    async for session in db_session_dependency():
-        async with session.begin():
-            with_children = _make_run(
-                org_id=org_id, kind="backfill", status="succeeded"
-            )
-            without_children = _make_run(
-                org_id=org_id, kind="backfill", status="failed"
-            )
-            session.add(with_children)
-            session.add(without_children)
-            await session.flush()
-            with_id = with_children.id
-            without_id = without_children.id
-            await session.commit()
+    with_pk, with_b32 = await _seed_run(org_id, status="succeeded")
+    _, without_b32 = await _seed_run(org_id, status="failed")
 
     await _seed_queue_job(
-        org_id=org_id, run_id=with_id, status=JobStatus.completed
+        org_id=org_id, run_id=with_pk, status=JobStatus.completed
     )
 
     response = await client.get(
@@ -336,18 +355,31 @@ async def test_list_runs_surfaces_date_last_activity_per_row(
     )
     assert response.status_code == 200
     runs = {r["id"]: r for r in response.json()}
-    assert runs[with_id]["date_last_activity"] is not None
-    assert runs[without_id]["date_last_activity"] is None
+    assert runs[with_b32]["date_last_activity"] is not None
+    assert runs[without_b32]["date_last_activity"] is None
 
 
 @pytest.mark.asyncio
 async def test_get_run_404_for_unknown_run(client: AsyncClient) -> None:
+    """A valid Base32 id with no matching run resolves to 404."""
     await _setup_org(client)
+    unknown = serialize_base32_id(999999)
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/999",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{unknown}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_run_422_for_malformed_run_id(client: AsyncClient) -> None:
+    """A malformed (non-Base32) run id is rejected with 422, not 404/500."""
+    await _setup_org(client)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/not-a-valid-id",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio
@@ -368,11 +400,11 @@ async def test_get_run_404_for_run_in_other_org(
             row = _make_run(org_id=other.id, kind="backfill", status="pending")
             session.add(row)
             await session.flush()
-            run_id = row.id
+            run_b32 = serialize_base32_id(row.public_id)
             await session.commit()
 
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 404
@@ -387,27 +419,17 @@ async def test_list_runs_returns_per_run_counters(
     org_id = await _get_org_id()
     # Seed two terminal runs directly — counter aggregation must scope
     # per-run, not bleed across runs in the same org.
-    async for session in db_session_dependency():
-        async with session.begin():
-            row_a = _make_run(
-                org_id=org_id, kind="backfill", status="succeeded"
-            )
-            row_b = _make_run(org_id=org_id, kind="backfill", status="failed")
-            session.add(row_a)
-            session.add(row_b)
-            await session.flush()
-            run_a_id = row_a.id
-            run_b_id = row_b.id
-            await session.commit()
+    run_a_pk, run_a_b32 = await _seed_run(org_id, status="succeeded")
+    run_b_pk, run_b_b32 = await _seed_run(org_id, status="failed")
 
     await _seed_queue_job(
-        org_id=org_id, run_id=run_a_id, status=JobStatus.completed
+        org_id=org_id, run_id=run_a_pk, status=JobStatus.completed
     )
     await _seed_queue_job(
-        org_id=org_id, run_id=run_a_id, status=JobStatus.completed
+        org_id=org_id, run_id=run_a_pk, status=JobStatus.completed
     )
     await _seed_queue_job(
-        org_id=org_id, run_id=run_b_id, status=JobStatus.failed
+        org_id=org_id, run_id=run_b_pk, status=JobStatus.failed
     )
 
     response = await client.get(
@@ -416,20 +438,20 @@ async def test_list_runs_returns_per_run_counters(
     )
     assert response.status_code == 200
     runs = {r["id"]: r for r in response.json()}
-    assert runs[run_a_id]["succeeded_count"] == 2
-    assert runs[run_a_id]["failed_count"] == 0
-    assert runs[run_a_id]["total_count"] == 2
-    assert runs[run_b_id]["succeeded_count"] == 0
-    assert runs[run_b_id]["failed_count"] == 1
-    assert runs[run_b_id]["total_count"] == 1
-    assert runs[run_a_id]["jobs_url"] == str(
+    assert runs[run_a_b32]["succeeded_count"] == 2
+    assert runs[run_a_b32]["failed_count"] == 0
+    assert runs[run_a_b32]["total_count"] == 2
+    assert runs[run_b_b32]["succeeded_count"] == 0
+    assert runs[run_b_b32]["failed_count"] == 1
+    assert runs[run_b_b32]["total_count"] == 1
+    assert runs[run_a_b32]["jobs_url"] == str(
         client.base_url.join(
-            f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_a_id}/jobs"
+            f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_a_b32}/jobs"
         )
     )
-    assert runs[run_b_id]["jobs_url"] == str(
+    assert runs[run_b_b32]["jobs_url"] == str(
         client.base_url.join(
-            f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b_id}/jobs"
+            f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b_b32}/jobs"
         )
     )
 
@@ -550,31 +572,23 @@ async def test_get_run_jobs_returns_subject_label(
     """``GET /runs/{id}/jobs`` round-trips ``subject_label`` per child."""
     await _setup_org(client)
     org_id = await _get_org_id()
-    async for session in db_session_dependency():
-        async with session.begin():
-            run = _make_run(
-                org_id=org_id, kind="backfill", status="in_progress"
-            )
-            session.add(run)
-            await session.flush()
-            run_id = run.id
-            await session.commit()
+    run_pk, run_b32 = await _seed_run(org_id, status="in_progress")
 
     await _seed_queue_job(
         org_id=org_id,
-        run_id=run_id,
+        run_id=run_pk,
         status=JobStatus.completed,
         subject_label="sqr-001",
     )
     await _seed_queue_job(
         org_id=org_id,
-        run_id=run_id,
+        run_id=run_pk,
         status=JobStatus.in_progress,
         subject_label="sqr-002",
     )
 
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}/jobs",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 200
@@ -585,8 +599,8 @@ async def test_get_run_jobs_returns_subject_label(
     # Newest first: in_progress was inserted second.
     assert jobs[0]["subject_label"] == "sqr-002"
     assert response.headers["X-Total-Count"] == "2"
-    # The keeper_sync_run_id field is exposed on the response.
-    assert all(job["keeper_sync_run_id"] == run_id for job in jobs)
+    # keeper_sync_run_id is exposed as the run's Base32 public id, not the PK.
+    assert all(job["keeper_sync_run_id"] == run_b32 for job in jobs)
 
 
 @pytest.mark.asyncio
@@ -594,37 +608,29 @@ async def test_get_run_jobs_filters_by_status(client: AsyncClient) -> None:
     """``?status=failed`` narrows the result set to failed children."""
     await _setup_org(client)
     org_id = await _get_org_id()
-    async for session in db_session_dependency():
-        async with session.begin():
-            run = _make_run(
-                org_id=org_id, kind="backfill", status="in_progress"
-            )
-            session.add(run)
-            await session.flush()
-            run_id = run.id
-            await session.commit()
+    run_pk, run_b32 = await _seed_run(org_id, status="in_progress")
 
     await _seed_queue_job(
         org_id=org_id,
-        run_id=run_id,
+        run_id=run_pk,
         status=JobStatus.completed,
         subject_label="ok-1",
     )
     await _seed_queue_job(
         org_id=org_id,
-        run_id=run_id,
+        run_id=run_pk,
         status=JobStatus.failed,
         subject_label="bad-1",
     )
     await _seed_queue_job(
         org_id=org_id,
-        run_id=run_id,
+        run_id=run_pk,
         status=JobStatus.failed,
         subject_label="bad-2",
     )
 
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs?status=failed",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}/jobs?status=failed",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 200
@@ -642,26 +648,18 @@ async def test_get_run_jobs_paginates_with_cursor(
     """``limit`` + ``cursor`` paginate through child queue jobs."""
     await _setup_org(client)
     org_id = await _get_org_id()
-    async for session in db_session_dependency():
-        async with session.begin():
-            run = _make_run(
-                org_id=org_id, kind="backfill", status="in_progress"
-            )
-            session.add(run)
-            await session.flush()
-            run_id = run.id
-            await session.commit()
+    run_pk, run_b32 = await _seed_run(org_id, status="in_progress")
 
     for index in range(3):
         await _seed_queue_job(
             org_id=org_id,
-            run_id=run_id,
+            run_id=run_pk,
             status=JobStatus.completed,
             subject_label=f"slug-{index}",
         )
 
     first = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs?limit=2",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}/jobs?limit=2",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert first.status_code == 200
@@ -683,12 +681,27 @@ async def test_get_run_jobs_paginates_with_cursor(
 
 @pytest.mark.asyncio
 async def test_get_run_jobs_404_for_unknown_run(client: AsyncClient) -> None:
+    """A valid Base32 id with no matching run resolves to 404."""
     await _setup_org(client)
+    unknown = serialize_base32_id(999999)
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/999/jobs",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{unknown}/jobs",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_run_jobs_422_for_malformed_run_id(
+    client: AsyncClient,
+) -> None:
+    """A malformed (non-Base32) run id is rejected with 422, not 404/500."""
+    await _setup_org(client)
+    response = await client.get(
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/not-a-valid-id/jobs",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio
@@ -708,11 +721,11 @@ async def test_get_run_jobs_404_for_run_in_other_org(
             row = _make_run(org_id=other.id, kind="backfill", status="pending")
             session.add(row)
             await session.flush()
-            run_id = row.id
+            run_b32 = serialize_base32_id(row.public_id)
             await session.commit()
 
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}/jobs",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 404
@@ -723,16 +736,10 @@ async def test_get_run_jobs_403_for_non_admin(client: AsyncClient) -> None:
     await _setup_org(client)
     await seed_member(_ORG, "reader-user", OrgRole.reader)
     org_id = await _get_org_id()
-    async for session in db_session_dependency():
-        async with session.begin():
-            run = _make_run(org_id=org_id, kind="backfill", status="pending")
-            session.add(run)
-            await session.flush()
-            run_id = run.id
-            await session.commit()
+    _, run_b32 = await _seed_run(org_id, status="pending")
 
     response = await client.get(
-        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_id}/jobs",
+        f"/docverse/orgs/{_ORG}/keeper-sync/runs/{run_b32}/jobs",
         headers={"X-Auth-Request-User": "reader-user"},
     )
     assert response.status_code == 403

--- a/tests/handlers/keeper_sync_runs_test.py
+++ b/tests/handlers/keeper_sync_runs_test.py
@@ -24,6 +24,12 @@ _ADMIN = "admin-user"
 _ORG = "ks-org"
 
 
+def _make_run(**kwargs: Any) -> SqlKeeperSyncRun:
+    """Build a run row with a minted ``public_id`` for seeding tests."""
+    kwargs.setdefault("public_id", validate_base32_id(generate_base32_id()))
+    return SqlKeeperSyncRun(**kwargs)
+
+
 async def _setup_org(client: AsyncClient) -> None:
     await seed_org_with_admin(client, _ORG, _ADMIN)
 
@@ -231,7 +237,7 @@ async def test_get_run_date_last_activity_matches_max_child_event(
     # discovery queue-job's auto-attributed timestamps.
     async for session in db_session_dependency():
         async with session.begin():
-            row = SqlKeeperSyncRun(
+            row = _make_run(
                 org_id=org_id, kind="backfill", status="in_progress"
             )
             session.add(row)
@@ -276,9 +282,7 @@ async def test_get_run_date_last_activity_null_when_no_children(
     org_id = await _get_org_id()
     async for session in db_session_dependency():
         async with session.begin():
-            row = SqlKeeperSyncRun(
-                org_id=org_id, kind="backfill", status="pending"
-            )
+            row = _make_run(org_id=org_id, kind="backfill", status="pending")
             session.add(row)
             await session.flush()
             run_id = row.id
@@ -309,10 +313,10 @@ async def test_list_runs_surfaces_date_last_activity_per_row(
     org_id = await _get_org_id()
     async for session in db_session_dependency():
         async with session.begin():
-            with_children = SqlKeeperSyncRun(
+            with_children = _make_run(
                 org_id=org_id, kind="backfill", status="succeeded"
             )
-            without_children = SqlKeeperSyncRun(
+            without_children = _make_run(
                 org_id=org_id, kind="backfill", status="failed"
             )
             session.add(with_children)
@@ -361,9 +365,7 @@ async def test_get_run_404_for_run_in_other_org(
             store = OrganizationStore(session=session, logger=logger)
             other = await store.get_by_slug(other_org)
             assert other is not None
-            row = SqlKeeperSyncRun(
-                org_id=other.id, kind="backfill", status="pending"
-            )
+            row = _make_run(org_id=other.id, kind="backfill", status="pending")
             session.add(row)
             await session.flush()
             run_id = row.id
@@ -387,12 +389,10 @@ async def test_list_runs_returns_per_run_counters(
     # per-run, not bleed across runs in the same org.
     async for session in db_session_dependency():
         async with session.begin():
-            row_a = SqlKeeperSyncRun(
+            row_a = _make_run(
                 org_id=org_id, kind="backfill", status="succeeded"
             )
-            row_b = SqlKeeperSyncRun(
-                org_id=org_id, kind="backfill", status="failed"
-            )
+            row_b = _make_run(org_id=org_id, kind="backfill", status="failed")
             session.add(row_a)
             session.add(row_b)
             await session.flush()
@@ -446,9 +446,7 @@ async def test_list_runs_returns_runs_newest_first(
     async for session in db_session_dependency():
         async with session.begin():
             for status in ("succeeded", "failed", "succeeded"):
-                row = SqlKeeperSyncRun(
-                    org_id=org_id, kind="backfill", status=status
-                )
+                row = _make_run(org_id=org_id, kind="backfill", status=status)
                 session.add(row)
             await session.commit()
 
@@ -473,9 +471,7 @@ async def test_list_runs_filters_by_status(client: AsyncClient) -> None:
         async with session.begin():
             for status in ("succeeded", "failed", "succeeded"):
                 session.add(
-                    SqlKeeperSyncRun(
-                        org_id=org_id, kind="backfill", status=status
-                    )
+                    _make_run(org_id=org_id, kind="backfill", status=status)
                 )
             await session.commit()
 
@@ -498,7 +494,7 @@ async def test_list_runs_paginates_with_cursor(client: AsyncClient) -> None:
         async with session.begin():
             for _ in range(3):
                 session.add(
-                    SqlKeeperSyncRun(
+                    _make_run(
                         org_id=org_id, kind="backfill", status="succeeded"
                     )
                 )
@@ -556,7 +552,7 @@ async def test_get_run_jobs_returns_subject_label(
     org_id = await _get_org_id()
     async for session in db_session_dependency():
         async with session.begin():
-            run = SqlKeeperSyncRun(
+            run = _make_run(
                 org_id=org_id, kind="backfill", status="in_progress"
             )
             session.add(run)
@@ -600,7 +596,7 @@ async def test_get_run_jobs_filters_by_status(client: AsyncClient) -> None:
     org_id = await _get_org_id()
     async for session in db_session_dependency():
         async with session.begin():
-            run = SqlKeeperSyncRun(
+            run = _make_run(
                 org_id=org_id, kind="backfill", status="in_progress"
             )
             session.add(run)
@@ -648,7 +644,7 @@ async def test_get_run_jobs_paginates_with_cursor(
     org_id = await _get_org_id()
     async for session in db_session_dependency():
         async with session.begin():
-            run = SqlKeeperSyncRun(
+            run = _make_run(
                 org_id=org_id, kind="backfill", status="in_progress"
             )
             session.add(run)
@@ -709,9 +705,7 @@ async def test_get_run_jobs_404_for_run_in_other_org(
             store = OrganizationStore(session=session, logger=logger)
             other = await store.get_by_slug(other_org)
             assert other is not None
-            row = SqlKeeperSyncRun(
-                org_id=other.id, kind="backfill", status="pending"
-            )
+            row = _make_run(org_id=other.id, kind="backfill", status="pending")
             session.add(row)
             await session.flush()
             run_id = row.id
@@ -731,9 +725,7 @@ async def test_get_run_jobs_403_for_non_admin(client: AsyncClient) -> None:
     org_id = await _get_org_id()
     async for session in db_session_dependency():
         async with session.begin():
-            run = SqlKeeperSyncRun(
-                org_id=org_id, kind="backfill", status="pending"
-            )
+            run = _make_run(org_id=org_id, kind="backfill", status="pending")
             session.add(run)
             await session.flush()
             run_id = run.id

--- a/tests/handlers/keeper_sync_tombstones_test.py
+++ b/tests/handlers/keeper_sync_tombstones_test.py
@@ -17,6 +17,7 @@ from docverse.client.models import (
     ProjectCreate,
     TrackingMode,
 )
+from docverse.domain.base32id import serialize_base32_id
 from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
 from docverse.storage.edition_store import EditionStore
 from docverse.storage.keeper_sync import (
@@ -58,8 +59,13 @@ async def _record_tombstone(
     ltd_id: int | None = None,
     ltd_slug: str | None = None,
     note: str | None = None,
-) -> int:
-    """Record a tombstone via the service and return the state row id."""
+) -> tuple[int, str]:
+    """Record a tombstone; return ``(state_id, public_id_b32)``.
+
+    ``state_id`` is the internal primary key (for direct store
+    assertions); ``public_id_b32`` is the row's Base32 public id, which
+    is what the tombstone API now addresses and serializes.
+    """
     async for session in db_session_dependency():
         async with session.begin():
             state_store = KeeperSyncStateStore(
@@ -79,7 +85,7 @@ async def _record_tombstone(
                 note=note,
             )
             await session.commit()
-        return state.id
+        return state.id, serialize_base32_id(state.public_id)
     msg = "no session"
     raise AssertionError(msg)
 
@@ -227,7 +233,7 @@ async def test_list_tombstones_returns_recorded_rows(
     """A recorded tombstone appears in the listing with all expected fields."""
     await _setup(client)
     org_id = await _get_org_id()
-    state_id = await _record_tombstone(
+    _state_id, tombstone_id = await _record_tombstone(
         org_id=org_id,
         resource_type=ResourceType.edition,
         reason=TombstoneReason.lifecycle_delete,
@@ -244,7 +250,10 @@ async def test_list_tombstones_returns_recorded_rows(
     body = response.json()
     assert len(body) == 1
     entry = body[0]
-    assert entry["state_id"] == state_id
+    # The API exposes the Base32 public id only; the raw primary key
+    # never appears in the response body.
+    assert entry["id"] == tombstone_id
+    assert "state_id" not in entry
     assert entry["resource_type"] == "edition"
     assert entry["ltd_id"] == 4242
     assert entry["ltd_slug"] == "aged-out"
@@ -253,7 +262,7 @@ async def test_list_tombstones_returns_recorded_rows(
     assert entry["date_tombstoned"] is not None
     assert entry["display_path"] == "aged-out"
     assert entry["self_url"].endswith(
-        f"/orgs/{_ORG}/keeper-sync/tombstones/{state_id}"
+        f"/orgs/{_ORG}/keeper-sync/tombstones/{tombstone_id}"
     )
 
 
@@ -352,7 +361,7 @@ async def test_delete_tombstone_returns_204(client: AsyncClient) -> None:
     """A successful clear returns 204 with no body."""
     await _setup(client)
     org_id = await _get_org_id()
-    state_id = await _record_tombstone(
+    _state_id, tombstone_id = await _record_tombstone(
         org_id=org_id,
         resource_type=ResourceType.edition,
         reason=TombstoneReason.manual_delete,
@@ -360,7 +369,7 @@ async def test_delete_tombstone_returns_204(client: AsyncClient) -> None:
     )
 
     response = await client.delete(
-        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state_id}",
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{tombstone_id}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 204
@@ -372,7 +381,7 @@ async def test_delete_tombstone_clears_state_row(client: AsyncClient) -> None:
     """After DELETE, the state row's tombstone fields are NULL."""
     await _setup(client)
     org_id = await _get_org_id()
-    state_id = await _record_tombstone(
+    state_id, tombstone_id = await _record_tombstone(
         org_id=org_id,
         resource_type=ResourceType.edition,
         reason=TombstoneReason.manual_delete,
@@ -381,7 +390,7 @@ async def test_delete_tombstone_clears_state_row(client: AsyncClient) -> None:
     )
 
     response = await client.delete(
-        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state_id}",
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{tombstone_id}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 204
@@ -430,10 +439,10 @@ async def test_delete_tombstone_revives_soft_deleted_edition(
             )
     assert state is not None
     assert state.date_tombstoned is not None
-    state_id = state.id
+    tombstone_id = serialize_base32_id(state.public_id)
 
     response = await client.delete(
-        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state_id}",
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{tombstone_id}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 204
@@ -451,16 +460,30 @@ async def test_delete_tombstone_revives_soft_deleted_edition(
 
 
 @pytest.mark.asyncio
-async def test_delete_tombstone_404_for_unknown_state_id(
+async def test_delete_tombstone_404_for_unknown_id(
     client: AsyncClient,
 ) -> None:
-    """A non-existent state_id returns 404."""
+    """A valid-but-unknown Base32 id returns 404."""
     await _setup(client)
+    unknown = serialize_base32_id(999999)
     response = await client.delete(
-        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/999999",
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{unknown}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstone_422_for_malformed_id(
+    client: AsyncClient,
+) -> None:
+    """A malformed (non-Base32) tombstone id is rejected with 422."""
+    await _setup(client)
+    response = await client.delete(
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/not-a-valid-id",
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio
@@ -479,7 +502,7 @@ async def test_delete_tombstone_404_for_other_org(
         other_id = other.id
         break
 
-    state_id = await _record_tombstone(
+    _state_id, tombstone_id = await _record_tombstone(
         org_id=other_id,
         resource_type=ResourceType.edition,
         reason=TombstoneReason.manual_delete,
@@ -487,7 +510,7 @@ async def test_delete_tombstone_404_for_other_org(
     )
 
     response = await client.delete(
-        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state_id}",
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{tombstone_id}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 404
@@ -512,8 +535,9 @@ async def test_delete_tombstone_404_when_not_tombstoned(
             await session.commit()
         break
 
+    tombstone_id = serialize_base32_id(state.public_id)
     response = await client.delete(
-        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{state.id}",
+        f"/docverse/orgs/{_ORG}/keeper-sync/tombstones/{tombstone_id}",
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert response.status_code == 404

--- a/tests/services/keeper_sync/scheduler_test.py
+++ b/tests/services/keeper_sync/scheduler_test.py
@@ -58,6 +58,7 @@ def _state(
     """Build a ``KeeperSyncState`` with sane defaults for assertions."""
     return KeeperSyncState(
         id=1,
+        public_id=1,
         org_id=1,
         resource_type=resource_type,
         ltd_id=ltd_id,

--- a/tests/services/keeper_sync_run_test.py
+++ b/tests/services/keeper_sync_run_test.py
@@ -166,7 +166,9 @@ async def test_get_run_returns_aggregate_counters(
 
     async with db_session.begin():
         service = _make_service(db_session=db_session, mock_arq=mock_arq)
-        result = await service.get_run(org_slug=org_slug, run_id=run.id)
+        result = await service.get_run(
+            org_slug=org_slug, public_id=run.public_id
+        )
     # Discovery (queued) + 2 keeper_sync_project (queued) = 3 pending,
     # 1 completed, 0 failed, total 4.
     assert result.activity.pending_count == 3
@@ -185,7 +187,7 @@ async def test_get_run_404_for_unknown_run(
         _, org_slug = await _seed_org(db_session)
         service = _make_service(db_session=db_session, mock_arq=mock_arq)
         with pytest.raises(NotFoundError):
-            await service.get_run(org_slug=org_slug, run_id=9999)
+            await service.get_run(org_slug=org_slug, public_id=9999)
 
 
 @pytest.mark.asyncio

--- a/tests/services/keeper_sync_tombstone_test.py
+++ b/tests/services/keeper_sync_tombstone_test.py
@@ -629,7 +629,9 @@ async def test_clear_un_tombstones_state_row(
         )
 
     async with db_session.begin():
-        cleared = await service.clear(state_id=recorded.id, org_id=org_id)
+        cleared = await service.clear(
+            public_id=recorded.public_id, org_id=org_id
+        )
 
     assert cleared.state.date_tombstoned is None
     assert cleared.state.tombstone_reason is None
@@ -701,7 +703,7 @@ async def test_clear_revives_soft_deleted_edition(
 
     service = _build_service(db_session, logger=logger)
     async with db_session.begin():
-        cleared = await service.clear(state_id=state.id, org_id=org.id)
+        cleared = await service.clear(public_id=state.public_id, org_id=org.id)
 
     assert cleared.revived_docverse_row is True
     # Edition is now visible via the default (date_deleted IS NULL) read.
@@ -763,7 +765,7 @@ async def test_clear_revives_soft_deleted_project(
 
     service = _build_service(db_session, logger=logger)
     async with db_session.begin():
-        cleared = await service.clear(state_id=state.id, org_id=org.id)
+        cleared = await service.clear(public_id=state.public_id, org_id=org.id)
 
     assert cleared.revived_docverse_row is True
     async with db_session.begin():
@@ -776,7 +778,7 @@ async def test_clear_revives_soft_deleted_project(
 async def test_clear_raises_when_state_not_found(
     db_session: AsyncSession,
 ) -> None:
-    """A non-existent state_id raises NotFoundError."""
+    """A non-existent public_id raises NotFoundError."""
     logger = structlog.get_logger("test")
     async with db_session.begin():
         org_id = await _seed_org(db_session, slug="ks-clear-miss")
@@ -784,7 +786,7 @@ async def test_clear_raises_when_state_not_found(
     service = _build_service(db_session, logger=logger)
     with pytest.raises(NotFoundError):
         async with db_session.begin():
-            await service.clear(state_id=999_999, org_id=org_id)
+            await service.clear(public_id=999_999, org_id=org_id)
 
 
 @pytest.mark.asyncio
@@ -807,7 +809,7 @@ async def test_clear_raises_when_row_not_tombstoned(
     service = _build_service(db_session, logger=logger)
     with pytest.raises(NotFoundError):
         async with db_session.begin():
-            await service.clear(state_id=state.id, org_id=org_id)
+            await service.clear(public_id=state.public_id, org_id=org_id)
 
 
 @pytest.mark.asyncio
@@ -831,7 +833,7 @@ async def test_clear_is_org_scoped(
 
     with pytest.raises(NotFoundError):
         async with db_session.begin():
-            await service.clear(state_id=recorded.id, org_id=org_b)
+            await service.clear(public_id=recorded.public_id, org_id=org_b)
 
 
 @pytest.mark.asyncio
@@ -854,7 +856,7 @@ async def test_clear_emits_structured_log(
 
     with capture_logs() as captured:
         async with db_session.begin():
-            await service.clear(state_id=recorded.id, org_id=org_id)
+            await service.clear(public_id=recorded.public_id, org_id=org_id)
 
     events = [
         e for e in captured if e.get("event") == "Sync tombstone cleared"

--- a/tests/services/publish_enqueue_test.py
+++ b/tests/services/publish_enqueue_test.py
@@ -33,7 +33,11 @@ from docverse.client.models import (
 from docverse.client.models.queue_enums import JobKind, PublishStatus
 from docverse.config import Configuration
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
-from docverse.domain.base32id import serialize_base32_id
+from docverse.domain.base32id import (
+    generate_base32_id,
+    serialize_base32_id,
+    validate_base32_id,
+)
 from docverse.domain.queue import JobStatus
 from docverse.services.publish_enqueue import enqueue_publish_for_edition
 from docverse.storage.build_store import BuildStore
@@ -136,7 +140,10 @@ async def test_enqueue_publish_for_edition_records_history_when_missing(
             build_public_id,
         ) = await _seed_org_project_edition_build(db_session)
         run_row = SqlKeeperSyncRun(
-            org_id=org_id, kind="backfill", status="in_progress"
+            public_id=validate_base32_id(generate_base32_id()),
+            org_id=org_id,
+            kind="backfill",
+            status="in_progress",
         )
         db_session.add(run_row)
         await db_session.flush()

--- a/tests/storage/build_store_test.py
+++ b/tests/storage/build_store_test.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Iterator
+
 import pytest
 import structlog
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import (
@@ -12,6 +16,7 @@ from docverse.client.models import (
     OrganizationCreate,
     ProjectCreate,
 )
+from docverse.dbschema.build import SqlBuild
 from docverse.domain.base32id import serialize_base32_id
 from docverse.exceptions import InvalidBuildStateError
 from docverse.storage.build_store import BuildStore
@@ -398,3 +403,92 @@ async def test_get_latest_build_id_for_ref(
             project_id=project_id + 9999, git_ref="main"
         )
         assert missing_project is None
+
+
+@pytest.mark.asyncio
+async def test_public_ids_sort_in_creation_order(
+    db_session: AsyncSession,
+    build_store: BuildStore,
+) -> None:
+    """Two builds created in succession sort by public_id in creation order.
+
+    A short real-time gap guarantees the two mints land in distinct
+    milliseconds so the time-ordered high bits establish the ordering
+    independent of the random low bits.
+    """
+    async with db_session.begin():
+        _, project_id = await _create_org_and_project(db_session)
+        first = await build_store.create(
+            project_id=project_id,
+            project_slug="build-proj",
+            data=_build_data(),
+            uploader="testuser",
+        )
+        await asyncio.sleep(0.005)
+        second = await build_store.create(
+            project_id=project_id,
+            project_slug="build-proj",
+            data=_build_data(),
+            uploader="testuser",
+        )
+        await db_session.commit()
+
+    assert second.public_id > first.public_id
+
+
+@pytest.mark.asyncio
+async def test_create_retries_on_public_id_collision(
+    db_session: AsyncSession,
+    build_store: BuildStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A colliding public_id is re-minted with no error and no merged rows."""
+    collision_id = 424242
+    fresh_id = 999999
+
+    def _fake_ids() -> Iterator[int]:
+        yield from (collision_id, fresh_id)
+
+    ids = _fake_ids()
+    monkeypatch.setattr(
+        "docverse.storage._public_id.generate_resource_id",
+        lambda: next(ids),
+    )
+
+    async with db_session.begin():
+        _, project_id = await _create_org_and_project(db_session)
+        # Pre-insert a build occupying ``collision_id`` and flush it into the
+        # outer transaction so the retried insert races a persistent row.
+        existing = SqlBuild(
+            public_id=collision_id,
+            project_id=project_id,
+            git_ref="pre-existing",
+            content_hash="sha256:0",
+            status=BuildStatus.pending,
+            staging_key="__staging/pre.tar.gz",
+            storage_prefix="build-proj/__builds/pre/",
+            uploader="pre",
+        )
+        db_session.add(existing)
+        await db_session.flush()
+
+        created = await build_store.create(
+            project_id=project_id,
+            project_slug="build-proj",
+            data=_build_data(),
+            uploader="testuser",
+        )
+        await db_session.commit()
+
+    # The retry minted the fresh id, leaving the pre-existing row untouched.
+    assert created.public_id == fresh_id
+
+    async with db_session.begin():
+        total = await db_session.scalar(
+            select(func.count()).select_from(SqlBuild)
+        )
+        preserved = await db_session.scalar(
+            select(SqlBuild.git_ref).where(SqlBuild.public_id == collision_id)
+        )
+    assert total == 2
+    assert preserved == "pre-existing"

--- a/tests/storage/keeper_sync/state_store_test.py
+++ b/tests/storage/keeper_sync/state_store_test.py
@@ -71,6 +71,85 @@ async def test_upsert_inserts_row_first_time(
 
 
 @pytest.mark.asyncio
+async def test_upsert_mints_unique_public_id(
+    db_session: AsyncSession,
+) -> None:
+    """Every newly upserted row gets a distinct time-ordered ``public_id``."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+    store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        first = await store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=1,
+            ltd_slug="1",
+        )
+        second = await store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.edition,
+            ltd_id=2,
+            ltd_slug="2",
+        )
+    async with db_session.begin():
+        public_ids = list(
+            (
+                await db_session.execute(
+                    select(SqlKeeperSyncState.public_id)
+                    .where(SqlKeeperSyncState.org_id == org_id)
+                    .order_by(SqlKeeperSyncState.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert first.id != second.id
+    # Both inserts minted a populated, non-null, unique public_id.
+    assert len(public_ids) == 2
+    assert all(pid is not None and pid > 0 for pid in public_ids)
+    assert len(set(public_ids)) == 2
+
+
+@pytest.mark.asyncio
+async def test_upsert_reuses_public_id_on_update(
+    db_session: AsyncSession,
+) -> None:
+    """A second upsert on the same key does not re-mint ``public_id``."""
+    logger = structlog.get_logger("test")
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+    store = KeeperSyncStateStore(session=db_session, logger=logger)
+    async with db_session.begin():
+        inserted = await store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="pipelines",
+            docverse_id=1,
+        )
+
+    async def _public_id() -> int:
+        async with db_session.begin():
+            return (
+                await db_session.execute(
+                    select(SqlKeeperSyncState.public_id).where(
+                        SqlKeeperSyncState.id == inserted.id
+                    )
+                )
+            ).scalar_one()
+
+    first_public_id = await _public_id()
+    async with db_session.begin():
+        await store.upsert(
+            org_id=org_id,
+            resource_type=ResourceType.project,
+            ltd_slug="pipelines",
+            docverse_id=2,
+        )
+    assert await _public_id() == first_public_id
+
+
+@pytest.mark.asyncio
 async def test_upsert_updates_only_non_none_fields(
     db_session: AsyncSession,
 ) -> None:

--- a/tests/storage/keeper_sync_run_store_test.py
+++ b/tests/storage/keeper_sync_run_store_test.py
@@ -378,3 +378,30 @@ async def test_create_retries_on_public_id_collision(
     # The retry minted the fresh id, leaving the pre-existing row untouched.
     assert created_public_id == fresh_id
     assert total == 2
+
+
+@pytest.mark.asyncio
+async def test_get_by_public_id_round_trips(
+    db_session: AsyncSession,
+) -> None:
+    """``get_by_public_id`` resolves the same row ``create`` minted.
+
+    Locks the public-id addressing path the run endpoints rely on: the
+    domain object round-trips its ``public_id`` and a miss returns
+    ``None`` rather than raising.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        created = await store.create(org_id=org_id)
+        await db_session.commit()
+
+    async with db_session.begin():
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        fetched = await store.get_by_public_id(created.public_id)
+        missing = await store.get_by_public_id(created.public_id + 1)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.public_id == created.public_id
+    assert missing is None

--- a/tests/storage/keeper_sync_run_store_test.py
+++ b/tests/storage/keeper_sync_run_store_test.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 
 import pytest
 import structlog
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import KeeperSyncRunStatus, OrganizationCreate
+from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.queue_job import SqlQueueJob
 from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.domain.queue import JobKind, JobStatus
@@ -260,3 +264,117 @@ async def test_missing_run_raises_job_not_found(
         store = KeeperSyncRunStore(session=db_session, logger=_logger())
         with pytest.raises(JobNotFoundError):
             await _call(store)
+
+
+@pytest.mark.asyncio
+async def test_create_mints_public_id(
+    db_session: AsyncSession,
+) -> None:
+    """A freshly-created run carries a positive time-ordered ``public_id``."""
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        run = await store.create(org_id=org_id)
+        await db_session.commit()
+
+    async with db_session.begin():
+        public_id = await db_session.scalar(
+            select(SqlKeeperSyncRun.public_id).where(
+                SqlKeeperSyncRun.id == run.id
+            )
+        )
+    assert public_id is not None
+    assert public_id > 0
+
+
+@pytest.mark.asyncio
+async def test_public_ids_sort_in_creation_order(
+    db_session: AsyncSession,
+) -> None:
+    """Runs created in succession sort by ``public_id`` in creation order.
+
+    The partial unique index permits only one non-terminal run per org, so
+    the first run is driven to a terminal status before the second is
+    created. A short real-time gap guarantees the two mints land in distinct
+    milliseconds so the time-ordered high bits establish the ordering.
+    """
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        first = await store.create(org_id=org_id)
+        await store.transition_status(
+            run_id=first.id, new_status=KeeperSyncRunStatus.succeeded
+        )
+        await asyncio.sleep(0.005)
+        second = await store.create(org_id=org_id)
+        await db_session.commit()
+
+    async with db_session.begin():
+        first_public_id = await db_session.scalar(
+            select(SqlKeeperSyncRun.public_id).where(
+                SqlKeeperSyncRun.id == first.id
+            )
+        )
+        second_public_id = await db_session.scalar(
+            select(SqlKeeperSyncRun.public_id).where(
+                SqlKeeperSyncRun.id == second.id
+            )
+        )
+    assert first_public_id is not None
+    assert second_public_id is not None
+    assert second_public_id > first_public_id
+
+
+@pytest.mark.asyncio
+async def test_create_retries_on_public_id_collision(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A colliding ``public_id`` is re-minted with no error and no merged rows.
+
+    The pre-existing row occupying ``collision_id`` is inserted in a terminal
+    status so it does not trip the one-non-terminal-run-per-org partial unique
+    index, isolating the collision to ``public_id``.
+    """
+    collision_id = 525252
+    fresh_id = 777777
+
+    def _fake_ids() -> Iterator[int]:
+        yield from (collision_id, fresh_id)
+
+    ids = _fake_ids()
+    monkeypatch.setattr(
+        "docverse.storage._public_id.generate_resource_id",
+        lambda: next(ids),
+    )
+
+    async with db_session.begin():
+        org_id = await _seed_org(db_session)
+        store = KeeperSyncRunStore(session=db_session, logger=_logger())
+        # Pre-insert a terminal run occupying ``collision_id`` and flush it
+        # into the outer transaction so the retried insert races a persistent
+        # row.
+        existing = SqlKeeperSyncRun(
+            public_id=collision_id,
+            org_id=org_id,
+            kind="backfill",
+            status=KeeperSyncRunStatus.succeeded.value,
+        )
+        db_session.add(existing)
+        await db_session.flush()
+
+        created = await store.create(org_id=org_id)
+        await db_session.commit()
+
+    async with db_session.begin():
+        created_public_id = await db_session.scalar(
+            select(SqlKeeperSyncRun.public_id).where(
+                SqlKeeperSyncRun.id == created.id
+            )
+        )
+        total = await db_session.scalar(
+            select(func.count()).select_from(SqlKeeperSyncRun)
+        )
+    # The retry minted the fresh id, leaving the pre-existing row untouched.
+    assert created_public_id == fresh_id
+    assert total == 2

--- a/tests/storage/keeper_sync_test.py
+++ b/tests/storage/keeper_sync_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 import structlog
 from sqlalchemy.exc import IntegrityError
@@ -10,7 +12,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from docverse.client.models import OrganizationCreate
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.keeper_sync_state import SqlKeeperSyncState
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.storage.organization_store import OrganizationStore
+
+
+def _make_run(**kwargs: Any) -> SqlKeeperSyncRun:
+    """Build a run row with a minted ``public_id`` for seeding tests."""
+    kwargs.setdefault("public_id", validate_base32_id(generate_base32_id()))
+    return SqlKeeperSyncRun(**kwargs)
 
 
 async def _seed_org(session: AsyncSession, *, slug: str = "ks-org") -> int:
@@ -34,15 +43,13 @@ async def test_partial_unique_index_blocks_two_pending_runs(
     async with db_session.begin():
         org_id = await _seed_org(db_session)
         db_session.add(
-            SqlKeeperSyncRun(org_id=org_id, kind="backfill", status="pending")
+            _make_run(org_id=org_id, kind="backfill", status="pending")
         )
 
     with pytest.raises(IntegrityError):
         async with db_session.begin():
             db_session.add(
-                SqlKeeperSyncRun(
-                    org_id=org_id, kind="backfill", status="pending"
-                )
+                _make_run(org_id=org_id, kind="backfill", status="pending")
             )
 
 
@@ -54,17 +61,13 @@ async def test_partial_unique_index_blocks_pending_and_in_progress(
     async with db_session.begin():
         org_id = await _seed_org(db_session)
         db_session.add(
-            SqlKeeperSyncRun(
-                org_id=org_id, kind="backfill", status="in_progress"
-            )
+            _make_run(org_id=org_id, kind="backfill", status="in_progress")
         )
 
     with pytest.raises(IntegrityError):
         async with db_session.begin():
             db_session.add(
-                SqlKeeperSyncRun(
-                    org_id=org_id, kind="backfill", status="pending"
-                )
+                _make_run(org_id=org_id, kind="backfill", status="pending")
             )
 
 
@@ -76,22 +79,18 @@ async def test_partial_unique_index_allows_terminal_alongside_pending(
     async with db_session.begin():
         org_id = await _seed_org(db_session)
         db_session.add(
-            SqlKeeperSyncRun(
-                org_id=org_id, kind="backfill", status="succeeded"
-            )
+            _make_run(org_id=org_id, kind="backfill", status="succeeded")
         )
         db_session.add(
-            SqlKeeperSyncRun(org_id=org_id, kind="backfill", status="failed")
+            _make_run(org_id=org_id, kind="backfill", status="failed")
         )
         db_session.add(
-            SqlKeeperSyncRun(
-                org_id=org_id, kind="backfill", status="partial_failure"
-            )
+            _make_run(org_id=org_id, kind="backfill", status="partial_failure")
         )
 
     async with db_session.begin():
         db_session.add(
-            SqlKeeperSyncRun(org_id=org_id, kind="backfill", status="pending")
+            _make_run(org_id=org_id, kind="backfill", status="pending")
         )
 
 
@@ -104,14 +103,10 @@ async def test_partial_unique_index_allows_pending_for_distinct_orgs(
         first_org = await _seed_org(db_session, slug="ks-org-a")
         second_org = await _seed_org(db_session, slug="ks-org-b")
         db_session.add(
-            SqlKeeperSyncRun(
-                org_id=first_org, kind="backfill", status="pending"
-            )
+            _make_run(org_id=first_org, kind="backfill", status="pending")
         )
         db_session.add(
-            SqlKeeperSyncRun(
-                org_id=second_org, kind="backfill", status="pending"
-            )
+            _make_run(org_id=second_org, kind="backfill", status="pending")
         )
 
 
@@ -179,9 +174,7 @@ async def test_keeper_sync_runs_status_check_rejects_invalid(
     with pytest.raises(IntegrityError):
         async with db_session.begin():
             db_session.add(
-                SqlKeeperSyncRun(
-                    org_id=org_id, kind="backfill", status="pendng"
-                )
+                _make_run(org_id=org_id, kind="backfill", status="pendng")
             )
 
 
@@ -196,9 +189,7 @@ async def test_keeper_sync_runs_kind_check_rejects_invalid(
     with pytest.raises(IntegrityError):
         async with db_session.begin():
             db_session.add(
-                SqlKeeperSyncRun(
-                    org_id=org_id, kind="garbage", status="pending"
-                )
+                _make_run(org_id=org_id, kind="garbage", status="pending")
             )
 
 

--- a/tests/storage/keeper_sync_test.py
+++ b/tests/storage/keeper_sync_test.py
@@ -22,6 +22,12 @@ def _make_run(**kwargs: Any) -> SqlKeeperSyncRun:
     return SqlKeeperSyncRun(**kwargs)
 
 
+def _make_state(**kwargs: Any) -> SqlKeeperSyncState:
+    """Build a state row with a minted ``public_id`` for seeding tests."""
+    kwargs.setdefault("public_id", validate_base32_id(generate_base32_id()))
+    return SqlKeeperSyncState(**kwargs)
+
+
 async def _seed_org(session: AsyncSession, *, slug: str = "ks-org") -> int:
     logger = structlog.get_logger("test")
     org_store = OrganizationStore(session=session, logger=logger)
@@ -118,7 +124,7 @@ async def test_keeper_sync_state_unique_constraint(
     async with db_session.begin():
         org_id = await _seed_org(db_session)
         db_session.add(
-            SqlKeeperSyncState(
+            _make_state(
                 org_id=org_id,
                 resource_type="project",
                 ltd_id=42,
@@ -129,7 +135,7 @@ async def test_keeper_sync_state_unique_constraint(
     with pytest.raises(IntegrityError):
         async with db_session.begin():
             db_session.add(
-                SqlKeeperSyncState(
+                _make_state(
                     org_id=org_id,
                     resource_type="project",
                     ltd_id=42,
@@ -146,7 +152,7 @@ async def test_keeper_sync_state_allows_distinct_resource_types_same_id(
     async with db_session.begin():
         org_id = await _seed_org(db_session)
         db_session.add(
-            SqlKeeperSyncState(
+            _make_state(
                 org_id=org_id,
                 resource_type="project",
                 ltd_id=1,
@@ -154,7 +160,7 @@ async def test_keeper_sync_state_allows_distinct_resource_types_same_id(
             )
         )
         db_session.add(
-            SqlKeeperSyncState(
+            _make_state(
                 org_id=org_id,
                 resource_type="edition",
                 ltd_id=1,
@@ -201,7 +207,7 @@ async def test_keeper_sync_state_resource_type_check_rejects_invalid(
     async with db_session.begin():
         org_id = await _seed_org(db_session)
         db_session.add(
-            SqlKeeperSyncState(
+            _make_state(
                 org_id=org_id,
                 resource_type="build",
                 ltd_id=7,
@@ -212,7 +218,7 @@ async def test_keeper_sync_state_resource_type_check_rejects_invalid(
     with pytest.raises(IntegrityError):
         async with db_session.begin():
             db_session.add(
-                SqlKeeperSyncState(
+                _make_state(
                     org_id=org_id,
                     resource_type="garbage",
                     ltd_id=99,
@@ -232,7 +238,7 @@ async def test_keeper_sync_state_tombstone_reason_check_rejects_invalid(
     with pytest.raises(IntegrityError):
         async with db_session.begin():
             db_session.add(
-                SqlKeeperSyncState(
+                _make_state(
                     org_id=org_id,
                     resource_type="edition",
                     ltd_id=1,
@@ -250,7 +256,7 @@ async def test_keeper_sync_state_tombstone_reason_check_allows_null(
     async with db_session.begin():
         org_id = await _seed_org(db_session, slug="ks-tomb-check-null")
         db_session.add(
-            SqlKeeperSyncState(
+            _make_state(
                 org_id=org_id,
                 resource_type="edition",
                 ltd_id=1,

--- a/tests/storage/public_id_test.py
+++ b/tests/storage/public_id_test.py
@@ -1,0 +1,103 @@
+"""Tests for the ``public_id`` collision classifier.
+
+Exercises :func:`docverse.storage._public_id._is_public_id_conflict`, which
+gates the re-mint retry loop: only a Postgres ``unique_violation`` (SQLSTATE
+``23505``) on a ``public_id`` constraint is a re-mintable collision. Any other
+integrity error — even one whose message mentions ``public_id`` — must
+propagate rather than be silently retried and masked as an "exhausted
+attempts" error.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.exc import IntegrityError
+
+from docverse.storage._public_id import _is_public_id_conflict
+
+
+class _FakeOrigError(Exception):
+    """Stand-in for the driver exception wrapped by ``IntegrityError.orig``.
+
+    Mirrors the asyncpg surface: a ``sqlstate`` code and an optional
+    ``constraint_name``, plus a string message for the fallback path.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        sqlstate: str | None = None,
+        constraint_name: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.sqlstate = sqlstate
+        self.constraint_name = constraint_name
+
+
+def _integrity_error(orig: _FakeOrigError) -> IntegrityError:
+    return IntegrityError(statement=None, params=None, orig=orig)
+
+
+_DUP_MSG = 'duplicate key violates unique constraint "builds_public_id_key"'
+
+
+def test_unique_violation_on_public_id_constraint_is_conflict() -> None:
+    """23505 + a public_id constraint name is a re-mintable collision."""
+    exc = _integrity_error(
+        _FakeOrigError(
+            _DUP_MSG,
+            sqlstate="23505",
+            constraint_name="builds_public_id_key",
+        )
+    )
+    assert _is_public_id_conflict(exc) is True
+
+
+def test_unique_violation_on_public_id_via_message_fallback() -> None:
+    """23505 with no constraint_name falls back to the message match."""
+    exc = _integrity_error(
+        _FakeOrigError(_DUP_MSG, sqlstate="23505", constraint_name=None)
+    )
+    assert _is_public_id_conflict(exc) is True
+
+
+def test_unique_violation_on_other_constraint_is_not_conflict() -> None:
+    """A unique violation on a different constraint must propagate."""
+    exc = _integrity_error(
+        _FakeOrigError(
+            'duplicate key value violates unique constraint "builds_slug_key"',
+            sqlstate="23505",
+            constraint_name="builds_slug_key",
+        )
+    )
+    assert _is_public_id_conflict(exc) is False
+
+
+def test_not_null_violation_mentioning_public_id_is_not_conflict() -> None:
+    """A non-unique error mentioning public_id must NOT be retried.
+
+    This is the case the tightened classifier guards against: a NOT NULL
+    violation (SQLSTATE 23502) on public_id would otherwise be swallowed by
+    the retry loop and surfaced as an "exhausted attempts" RuntimeError,
+    masking the real bug.
+    """
+    exc = _integrity_error(
+        _FakeOrigError(
+            'null value in column "public_id" violates not-null constraint',
+            sqlstate="23502",
+            constraint_name=None,
+        )
+    )
+    assert _is_public_id_conflict(exc) is False
+
+
+def test_missing_sqlstate_is_not_conflict() -> None:
+    """Without a 23505 SQLSTATE the error is not classified as a collision."""
+    exc = _integrity_error(
+        _FakeOrigError(
+            "some public_id related error with no sqlstate",
+            sqlstate=None,
+            constraint_name=None,
+        )
+    )
+    assert _is_public_id_conflict(exc) is False

--- a/tests/storage/queue_job_store_test.py
+++ b/tests/storage/queue_job_store_test.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 import pytest
 import structlog
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from docverse.client.models import (
@@ -1891,3 +1894,73 @@ async def test_fail_orphaned_jobs_skips_other_kinds(
         await db_session.commit()
 
     assert failed == []
+
+
+@pytest.mark.asyncio
+async def test_public_ids_are_time_ordered(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+) -> None:
+    """Jobs enqueued in succession carry time-ordered public IDs.
+
+    A short real-time gap guarantees the two mints land in distinct
+    milliseconds so the ordering comes from the time-ordered high bits.
+    """
+    async with db_session.begin():
+        first = await store.create(kind=JobKind.build_processing, org_id=1)
+        await asyncio.sleep(0.005)
+        second = await store.create(kind=JobKind.build_processing, org_id=1)
+        await db_session.commit()
+
+    assert second.public_id > first.public_id
+
+
+@pytest.mark.asyncio
+async def test_create_retries_on_public_id_collision(
+    db_session: AsyncSession,
+    store: QueueJobStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A colliding public_id is re-minted with no error and no merged rows."""
+    collision_id = 313131
+    fresh_id = 888888
+
+    def _fake_ids() -> Iterator[int]:
+        yield from (collision_id, fresh_id)
+
+    ids = _fake_ids()
+    monkeypatch.setattr(
+        "docverse.storage._public_id.generate_resource_id",
+        lambda: next(ids),
+    )
+
+    async with db_session.begin():
+        # Pre-insert a job occupying ``collision_id`` and flush it into the
+        # outer transaction so the retried insert races a persistent row.
+        existing = SqlQueueJob(
+            public_id=collision_id,
+            kind=JobKind.build_processing.value,
+            status=JobStatus.queued.value,
+            org_id=1,
+            subject_label="pre-existing",
+        )
+        db_session.add(existing)
+        await db_session.flush()
+
+        created = await store.create(kind=JobKind.build_processing, org_id=1)
+        await db_session.commit()
+
+    # The retry minted the fresh id, leaving the pre-existing row untouched.
+    assert created.public_id == fresh_id
+
+    async with db_session.begin():
+        total = await db_session.scalar(
+            select(func.count()).select_from(SqlQueueJob)
+        )
+        preserved = await db_session.scalar(
+            select(SqlQueueJob.subject_label).where(
+                SqlQueueJob.public_id == collision_id
+            )
+        )
+    assert total == 2
+    assert preserved == "pre-existing"

--- a/tests/storage/queue_job_store_test.py
+++ b/tests/storage/queue_job_store_test.py
@@ -308,7 +308,12 @@ async def _seed_org_and_run(
             base_domain=f"{slug}.example.com",
         )
     )
-    run = SqlKeeperSyncRun(org_id=org.id, kind="backfill", status="pending")
+    run = SqlKeeperSyncRun(
+        public_id=validate_base32_id(generate_base32_id()),
+        org_id=org.id,
+        kind="backfill",
+        status="pending",
+    )
     db_session.add(run)
     await db_session.flush()
     await db_session.refresh(run)

--- a/tests/worker/keeper_sync_project_test.py
+++ b/tests/worker/keeper_sync_project_test.py
@@ -51,6 +51,7 @@ from docverse.dbschema.edition import SqlEdition
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.organization import SqlOrganization
 from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.domain.queue import JobStatus
 from docverse.factory import Factory
 from docverse.metrics import build_event_manager
@@ -167,7 +168,10 @@ async def _seed_org(
 
 async def _seed_run(db_session: AsyncSession, *, org_id: int) -> int:
     row = SqlKeeperSyncRun(
-        org_id=org_id, kind="backfill", status="in_progress"
+        public_id=validate_base32_id(generate_base32_id()),
+        org_id=org_id,
+        kind="backfill",
+        status="in_progress",
     )
     db_session.add(row)
     await db_session.flush()

--- a/tests/worker/keeper_sync_reaper_test.py
+++ b/tests/worker/keeper_sync_reaper_test.py
@@ -28,6 +28,7 @@ from docverse.client.models import (
 from docverse.config import Configuration
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.domain.queue import JobStatus
 from docverse.metrics import build_event_manager
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
@@ -58,7 +59,12 @@ async def _seed_org(db_session: AsyncSession, *, slug: str) -> int:
 async def _seed_run(
     db_session: AsyncSession, *, org_id: int, status: str = "in_progress"
 ) -> int:
-    row = SqlKeeperSyncRun(org_id=org_id, kind="backfill", status=status)
+    row = SqlKeeperSyncRun(
+        public_id=validate_base32_id(generate_base32_id()),
+        org_id=org_id,
+        kind="backfill",
+        status=status,
+    )
     db_session.add(row)
     await db_session.flush()
     await db_session.refresh(row)

--- a/tests/worker/keeper_sync_run_discovery_test.py
+++ b/tests/worker/keeper_sync_run_discovery_test.py
@@ -23,6 +23,7 @@ from docverse.client.models import (
 )
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.queue_job import SqlQueueJob
+from docverse.domain.base32id import generate_base32_id, validate_base32_id
 from docverse.domain.queue import JobStatus
 from docverse.services.keeper_sync_run import KEEPER_SYNC_QUEUE_NAME
 from docverse.services.keeper_sync_tombstone import KeeperSyncTombstoneService
@@ -68,7 +69,12 @@ async def _seed_org(
 
 
 async def _seed_run(db_session: AsyncSession, *, org_id: int) -> int:
-    row = SqlKeeperSyncRun(org_id=org_id, kind="backfill", status="pending")
+    row = SqlKeeperSyncRun(
+        public_id=validate_base32_id(generate_base32_id()),
+        org_id=org_id,
+        kind="backfill",
+        status="pending",
+    )
     db_session.add(row)
     await db_session.flush()
     await db_session.refresh(row)

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -32,7 +32,11 @@ from docverse.config import Configuration
 from docverse.dbschema.keeper_sync_run import SqlKeeperSyncRun
 from docverse.dbschema.organization import SqlOrganization
 from docverse.dbschema.queue_job import SqlQueueJob
-from docverse.domain.base32id import serialize_base32_id
+from docverse.domain.base32id import (
+    generate_base32_id,
+    serialize_base32_id,
+    validate_base32_id,
+)
 from docverse.domain.build import Build
 from docverse.domain.edition import Edition
 from docverse.domain.edition_build_history import EditionBuildHistory
@@ -247,7 +251,10 @@ async def _seed_keeper_sync_run(
 ) -> int:
     """Seed an ``in_progress`` keeper-sync run to attribute a publish to."""
     row = SqlKeeperSyncRun(
-        org_id=org_id, kind="backfill", status="in_progress"
+        public_id=validate_base32_id(generate_base32_id()),
+        org_id=org_id,
+        kind="backfill",
+        status="in_progress",
     )
     db_session.add(row)
     await db_session.flush()


### PR DESCRIPTION
## Summary

- Groundwork and delivery for time-ordered, Base32-addressed resource IDs (PRD #448): a shared Snowflake-style ID generator anchored at a fixed 2010 epoch, applied so builds and queue jobs mint creation-ordered public IDs.
- Add a unique `public_id` column to `keeper_sync_runs` with a `date_started`-ordered backfill migration and collision-retrying minting in the run store.
- Expose keeper-sync runs by their Base32 public ID everywhere in the API: `KeeperSyncRun.id` and its HATEOAS self/jobs URLs, the `GET /runs/{run}` and `GET /runs/{run}/jobs` routes (resolved via a new `RunIdParam`), and `QueueJob.keeper_sync_run_id`. The raw integer primary key no longer appears in any response body.
- Add a unique `public_id` column to `keeper_sync_state` (the rows that back tombstones) with a backfill migration ordered by `COALESCE(date_tombstoned, date_last_synced, now())`, and mint a time-ordered public ID at every state-row insert site (the state store upsert and the tombstone service's preemptive path).
- Expose keeper-sync tombstones by their Base32 public ID: `KeeperSyncTombstone` renames `state_id` to `id` (Base32) and its `self_url`, the `DELETE /orgs/{org}/keeper-sync/tombstones/{tombstone}` route resolves via a new `TombstoneIdParam`, and the listing serializes Base32 IDs only. The raw `keeper_sync_state` primary key no longer appears in any response body.
- Drop the internal `binding_id` from the dashboard-template sync response envelopes.

## Validation steps

- `GET /orgs/{org}/keeper-sync/runs/{run}` and `.../runs/{run}/jobs` resolve a run by its Base32 public ID; a malformed/non-Base32 id returns 422 (not 404/500) and a valid-but-unknown id returns 404.
- Inspect a keeper-sync run response and a run's queue-job listing: `KeeperSyncRun.id`, its `self_url`/`jobs_url`, and `QueueJob.keeper_sync_run_id` all carry the Base32 public ID; the raw integer PK appears nowhere.
- `DELETE /orgs/{org}/keeper-sync/tombstones/{tombstone}` clears a tombstone addressed by its Base32 public ID; a malformed/non-Base32 tombstone id returns 422 and a valid-but-unknown id returns 404.
- Inspect a tombstone listing response: each entry exposes `id` (Base32) and a `self_url` ending in that Base32 id; no `state_id` / raw primary key appears in any response body.
- Confirm two builds (and two queue jobs) created in succession have public IDs that sort in creation order, and a pre-existing random-format build ID still resolves via `GET .../builds/{build}`.
- Run `alembic upgrade head` against a populated database and confirm `keeper_sync_runs.public_id` is backfilled uniquely in `date_started` order with no FK breakage; `alembic downgrade` drops the column and constraint cleanly.
- Run `alembic upgrade head` against a populated database and confirm `keeper_sync_state.public_id` is backfilled uniquely in `COALESCE(date_tombstoned, date_last_synced, now())` order (including rows with all-NULL timestamps, which order last) with no FK breakage; `alembic downgrade` drops the column and its unique constraint cleanly.
- `POST /orgs/{org}/dashboard-template/sync` and the project-scoped variant return 202 bodies with no `binding_id` key.

## References

- Closes #453
- Closes #454
- Closes #455
- Closes #456
- Closes #457
- Closes #459
- PRD: #448
- Jira: https://rubinobs.atlassian.net/browse/DM-55549