### PR TITLE
DM-55551: Polish the REST API contract (PRD #450)

### DIFF
--- a/client/changelog.d/20260729_120000_DM_55551_openapi_polish.md
+++ b/client/changelog.d/20260729_120000_DM_55551_openapi_polish.md
@@ -1,0 +1,8 @@
+### Backwards-incompatible changes
+
+- `KeeperSyncTombstone` no longer carries a `docverse_id` field. It exposed an internal Docverse database row id; the entry's Base32 `id` and `display_path` already identify the resource.
+
+### Other changes
+
+- Model fields now declare realistic OpenAPI example values: HATEOAS `*_url` fields show full example URLs and public-ID fields show genuine Crockford Base32 identifiers, drawn from shared constants in `docverse.client.models._examples`.
+- Public enums (`KeeperSyncTombstoneReason`, `KeeperSyncRunKind`, `EditionKind`, `TrackingMode`, `JobKind`, `JobStatus`, `PublishStatus`, `OrgRole`, and others) document each value in their class docstrings, which pydantic surfaces as the enum schema description in generated OpenAPI documents.

--- a/client/src/docverse/client/_client.py
+++ b/client/src/docverse/client/_client.py
@@ -16,6 +16,9 @@ from .models import (
     BuildStatus,
     BuildUpdate,
     OrganizationSummary,
+    OrgMembership,
+    OrgMembershipUpdate,
+    OrgRole,
     QueueJob,
 )
 from .models.builds import BuildAnnotations
@@ -148,6 +151,38 @@ class DocverseClient:
             OrganizationSummary.model_validate(item)
             for item in response.json()
         ]
+
+    async def update_member(
+        self, org: str, member: str, *, role: OrgRole
+    ) -> OrgMembership:
+        """Update an organization member's role.
+
+        Only the ``role`` is mutable; a member's ``principal`` and
+        ``principal_type`` are immutable (changing identity is a delete plus
+        re-add).
+
+        Parameters
+        ----------
+        org
+            Organization slug.
+        member
+            Membership identifier in the ``{principal_type}:{principal}``
+            format (e.g. ``user:jdoe``).
+        role
+            The new role to assign.
+
+        Returns
+        -------
+        OrgMembership
+            The updated membership.
+        """
+        update = OrgMembershipUpdate(role=role)
+        url = f"/orgs/{org}/members/{member}"
+        response = await self._client.patch(
+            url, json=update.model_dump(exclude_unset=True)
+        )
+        _raise_for_status(response)
+        return OrgMembership.model_validate(response.json())
 
     async def create_build(
         self,

--- a/client/src/docverse/client/_client.py
+++ b/client/src/docverse/client/_client.py
@@ -11,7 +11,13 @@ import click
 import httpx
 
 from ._exceptions import BuildProcessingError, DocverseClientError
-from .models import Build, BuildStatus, BuildUpdate, QueueJob
+from .models import (
+    Build,
+    BuildStatus,
+    BuildUpdate,
+    OrganizationSummary,
+    QueueJob,
+)
 from .models.builds import BuildAnnotations
 from .models.queue_enums import JobStatus
 
@@ -122,6 +128,26 @@ class DocverseClient:
             msg = "DocverseClient must be used as an async context manager"
             raise RuntimeError(msg)
         return self._http
+
+    async def list_organizations(self) -> list[OrganizationSummary]:
+        """List organizations the caller can access.
+
+        Returns one summary per organization in which the caller holds an
+        effective role (via direct or group membership); a superadmin
+        receives every organization. An empty list is a valid response.
+
+        Returns
+        -------
+        list of OrganizationSummary
+            The accessible organizations, each with the caller's effective
+            role.
+        """
+        response = await self._client.get("/orgs")
+        _raise_for_status(response)
+        return [
+            OrganizationSummary.model_validate(item)
+            for item in response.json()
+        ]
 
     async def create_build(
         self,

--- a/client/src/docverse/client/_client.py
+++ b/client/src/docverse/client/_client.py
@@ -15,6 +15,8 @@ from .models import (
     Build,
     BuildStatus,
     BuildUpdate,
+    KeeperSyncConfig,
+    KeeperSyncConfigUpdate,
     OrganizationSummary,
     OrgMembership,
     OrgMembershipUpdate,
@@ -183,6 +185,35 @@ class DocverseClient:
         )
         _raise_for_status(response)
         return OrgMembership.model_validate(response.json())
+
+    async def update_keeper_sync_config(
+        self, org: str, update: KeeperSyncConfigUpdate
+    ) -> KeeperSyncConfig:
+        """Update an organization's LTD Keeper sync config in part.
+
+        Applies JSON-Merge-Patch semantics: only the fields set on ``update``
+        are changed; omitted fields are left untouched. ``project_slugs``,
+        when provided, replaces the stored list wholesale (no append). Send a
+        full ``KeeperSyncConfig`` via ``PUT`` for a complete replacement.
+
+        Parameters
+        ----------
+        org
+            Organization slug.
+        update
+            The partial update; construct it with only the fields to change.
+
+        Returns
+        -------
+        KeeperSyncConfig
+            The updated configuration.
+        """
+        url = f"/orgs/{org}/keeper-sync"
+        response = await self._client.patch(
+            url, json=update.model_dump(exclude_unset=True, mode="json")
+        )
+        _raise_for_status(response)
+        return KeeperSyncConfig.model_validate(response.json())
 
     async def create_build(
         self,

--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -43,6 +43,7 @@ from .infrastructure import (
 )
 from .keeper_sync import (
     KeeperSyncConfig,
+    KeeperSyncConfigUpdate,
     KeeperSyncEditionDiff,
     KeeperSyncEditionStatus,
     KeeperSyncProjectRefreshAccepted,
@@ -136,6 +137,7 @@ __all__ = [
     "JobKind",
     "JobStatus",
     "KeeperSyncConfig",
+    "KeeperSyncConfigUpdate",
     "KeeperSyncEditionDiff",
     "KeeperSyncEditionStatus",
     "KeeperSyncProjectRefreshAccepted",

--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -71,6 +71,7 @@ from .lifecycle import (
 from .memberships import (
     OrgMembership,
     OrgMembershipCreate,
+    OrgMembershipUpdate,
     OrgRole,
     PrincipalType,
 )
@@ -157,6 +158,7 @@ __all__ = [
     "OrgDashboardRebuildResponse",
     "OrgMembership",
     "OrgMembershipCreate",
+    "OrgMembershipUpdate",
     "OrgRole",
     "Organization",
     "OrganizationCreate",

--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -77,6 +77,7 @@ from .memberships import (
 from .organizations import (
     Organization,
     OrganizationCreate,
+    OrganizationSummary,
     OrganizationUpdate,
     UrlScheme,
 )
@@ -165,6 +166,7 @@ __all__ = [
     "OrganizationServiceCreate",
     "OrganizationServiceSummary",
     "OrganizationServiceUpdate",
+    "OrganizationSummary",
     "OrganizationUpdate",
     "PrincipalType",
     "Project",

--- a/client/src/docverse/client/models/__init__.py
+++ b/client/src/docverse/client/models/__init__.py
@@ -17,7 +17,11 @@ from .credentials import (
     OrganizationCredentialCreate,
     S3Credentials,
 )
-from .dashboard import DashboardRebuildResponse, OrgDashboardRebuildEntry
+from .dashboard import (
+    DashboardRebuildResponse,
+    OrgDashboardRebuildEntry,
+    OrgDashboardRebuildResponse,
+)
 from .dashboard_template import (
     DashboardTemplateBinding,
     DashboardTemplateBindingCreate,
@@ -149,6 +153,7 @@ __all__ = [
     "LifecycleRule",
     "LifecycleRuleSet",
     "OrgDashboardRebuildEntry",
+    "OrgDashboardRebuildResponse",
     "OrgMembership",
     "OrgMembershipCreate",
     "OrgRole",

--- a/client/src/docverse/client/models/_examples.py
+++ b/client/src/docverse/client/models/_examples.py
@@ -1,0 +1,69 @@
+"""Shared example values for OpenAPI schema documentation.
+
+These constants feed the ``examples`` argument of model fields so the
+generated OpenAPI docs show realistic values instead of ``"string"``.
+They share one consistent vocabulary — the ``lsst`` organization's
+``pipelines`` project — so cross-references between examples line up
+(e.g. a build's ``self_url`` uses the same id as the build ``id``
+field). The URLs are anchored on ``https://example.org`` because the
+schema is rendered statically; at runtime every ``*_url`` field carries
+an absolute URL built from the incoming request.
+
+The Base32 identifiers are genuine Crockford Base32 values minted with
+:func:`docverse.domain.base32id.mint_resource_id_for_timestamp` (12
+characters plus a 2-character checksum, hyphenated every 4), so they
+round-trip through the real validators.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "EXAMPLE_API_URL",
+    "EXAMPLE_BUILD_ID",
+    "EXAMPLE_BUILD_URL",
+    "EXAMPLE_EDITION_URL",
+    "EXAMPLE_JOB_ID",
+    "EXAMPLE_JOB_URL",
+    "EXAMPLE_ORG_URL",
+    "EXAMPLE_PROJECT_URL",
+    "EXAMPLE_PUBLISH_JOB_ID",
+    "EXAMPLE_PUBLISH_JOB_URL",
+    "EXAMPLE_RUN_ID",
+    "EXAMPLE_TOMBSTONE_ID",
+]
+
+EXAMPLE_API_URL = "https://example.org/docverse/api"
+"""Base URL of the example Docverse API deployment."""
+
+EXAMPLE_ORG_URL = f"{EXAMPLE_API_URL}/orgs/lsst"
+"""Example organization resource URL."""
+
+EXAMPLE_PROJECT_URL = f"{EXAMPLE_ORG_URL}/projects/pipelines"
+"""Example project resource URL."""
+
+EXAMPLE_EDITION_URL = f"{EXAMPLE_PROJECT_URL}/editions/v1"
+"""Example edition resource URL."""
+
+EXAMPLE_BUILD_ID = "1txq-55pj-1x5m-16"
+"""Example public Base32 identifier for a build."""
+
+EXAMPLE_BUILD_URL = f"{EXAMPLE_PROJECT_URL}/builds/{EXAMPLE_BUILD_ID}"
+"""Example build resource URL."""
+
+EXAMPLE_JOB_ID = "1vg8-zbgy-3rhq-52"
+"""Example public Base32 identifier for a queue job."""
+
+EXAMPLE_JOB_URL = f"{EXAMPLE_ORG_URL}/jobs/{EXAMPLE_JOB_ID}"
+"""Example queue-job resource URL."""
+
+EXAMPLE_PUBLISH_JOB_ID = "1vp1-yvk8-39he-47"
+"""Example public Base32 identifier for a child publish_edition job."""
+
+EXAMPLE_PUBLISH_JOB_URL = f"{EXAMPLE_ORG_URL}/jobs/{EXAMPLE_PUBLISH_JOB_ID}"
+"""Example child publish_edition queue-job resource URL."""
+
+EXAMPLE_RUN_ID = "1vg8-z8f9-18w0-84"
+"""Example public Base32 identifier for a keeper-sync run."""
+
+EXAMPLE_TOMBSTONE_ID = "1v3e-2qhh-39ej-55"
+"""Example public Base32 identifier for a keeper-sync tombstone."""

--- a/client/src/docverse/client/models/builds.py
+++ b/client/src/docverse/client/models/builds.py
@@ -8,6 +8,13 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ._examples import (
+    EXAMPLE_BUILD_ID,
+    EXAMPLE_BUILD_URL,
+    EXAMPLE_JOB_URL,
+    EXAMPLE_PROJECT_URL,
+)
+
 __all__ = [
     "Build",
     "BuildAnnotations",
@@ -27,20 +34,30 @@ class BuildAnnotations(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     commit_sha: str | None = Field(
-        default=None, description="Git commit SHA for the build."
+        default=None,
+        description="Git commit SHA for the build.",
+        examples=["6c8b2f01a5d34e1c9f0b2ad37e8c5d914f6a7b3c"],
     )
 
     github_repository: str | None = Field(
         default=None,
         description="GitHub repository (owner/repo) that produced the build.",
+        examples=["lsst/pipelines_lsst_io"],
     )
 
     github_run_id: str | None = Field(
-        default=None, description="GitHub Actions run ID."
+        default=None,
+        description="GitHub Actions run ID.",
+        examples=["16768139904"],
     )
 
     github_run_url: str | None = Field(
-        default=None, description="Full URL to the GitHub Actions run."
+        default=None,
+        description="Full URL to the GitHub Actions run.",
+        examples=[
+            "https://github.com/lsst/pipelines_lsst_io/actions/runs/"
+            "16768139904"
+        ],
     )
 
     github_run_attempt: str | None = Field(
@@ -69,17 +86,22 @@ class BuildAnnotations(BaseModel):
 
 
 class BuildStatus(StrEnum):
-    """Status of a documentation build."""
+    """Status of a documentation build.
+
+    - ``pending`` — the build row exists and Docverse is waiting for the
+      tarball upload.
+    - ``uploaded`` — signal value used in PATCH requests to indicate
+      upload completion. Never persisted or returned: the server
+      transitions the build directly from ``pending`` to ``processing``
+      when it receives this signal.
+    - ``processing`` — a background job is unpacking the upload and
+      updating tracking editions.
+    - ``completed`` — processing finished successfully.
+    - ``failed`` — processing failed; see the build's job for errors.
+    """
 
     pending = "pending"
     uploaded = "uploaded"
-    """Signal value used in PATCH requests to indicate upload completion.
-
-    This status is never persisted to the database. The server transitions
-    the build directly from ``pending`` to ``processing`` when it receives
-    this signal.
-    """
-
     processing = "processing"
     completed = "completed"
     failed = "failed"
@@ -131,16 +153,24 @@ class Build(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this build resource.")
+    self_url: str = Field(
+        description="URL to this build resource.",
+        examples=[EXAMPLE_BUILD_URL],
+    )
 
-    project_url: str = Field(description="URL to the parent project.")
+    project_url: str = Field(
+        description="URL to the parent project.",
+        examples=[EXAMPLE_PROJECT_URL],
+    )
 
     id: str = Field(
-        description="Public Crockford Base32 identifier for the build."
+        description="Public Crockford Base32 identifier for the build.",
+        examples=[EXAMPLE_BUILD_ID],
     )
 
     git_ref: str = Field(
-        description="Git ref (branch, tag, or SHA) for this build."
+        description="Git ref (branch, tag, or SHA) for this build.",
+        examples=["main"],
     )
 
     alternate_name: str | None = Field(
@@ -151,7 +181,11 @@ class Build(BaseModel):
     )
 
     content_hash: str = Field(
-        description="SHA-256 hash of the uploaded tarball."
+        description="SHA-256 hash of the uploaded tarball.",
+        examples=[
+            "sha256:abcdef0123456789abcdef0123456789abcdef0123456789"
+            "abcdef0123456789"
+        ],
     )
 
     status: BuildStatus = Field(description="Current status of the build.")
@@ -159,11 +193,16 @@ class Build(BaseModel):
     upload_url: str | None = Field(
         default=None,
         description="Pre-signed URL for uploading the build tarball.",
+        examples=[
+            "https://staging-bucket.s3.amazonaws.com/uploads/"
+            "1txq-55pj-1x5m-16.tar.gz?X-Amz-Signature=0ad34c"
+        ],
     )
 
     job_url: str | None = Field(
         default=None,
         description="URL to the job processing this build.",
+        examples=[EXAMPLE_JOB_URL],
     )
 
     object_count: int | None = Field(
@@ -177,7 +216,8 @@ class Build(BaseModel):
     )
 
     uploader: str = Field(
-        description="Username of the person who uploaded the build."
+        description="Username of the person who uploaded the build.",
+        examples=["jdoe"],
     )
 
     annotations: BuildAnnotations | None = Field(

--- a/client/src/docverse/client/models/credentials.py
+++ b/client/src/docverse/client/models/credentials.py
@@ -7,6 +7,7 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag
 
+from ._examples import EXAMPLE_ORG_URL
 from .infrastructure import CredentialProvider
 
 __all__ = [
@@ -112,14 +113,21 @@ class OrganizationCredential(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this credential resource.")
+    self_url: str = Field(
+        description="URL to this credential resource.",
+        examples=[f"{EXAMPLE_ORG_URL}/credentials/aws"],
+    )
 
-    org_url: str = Field(description="URL to the parent organization.")
+    org_url: str = Field(
+        description="URL to the parent organization.",
+        examples=[EXAMPLE_ORG_URL],
+    )
 
     label: str = Field(
         description=(
             "Human-readable label for the credential, unique per organization."
         ),
+        examples=["aws"],
     )
 
     provider: CredentialProvider = Field(

--- a/client/src/docverse/client/models/dashboard.py
+++ b/client/src/docverse/client/models/dashboard.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field
 __all__ = [
     "DashboardRebuildResponse",
     "OrgDashboardRebuildEntry",
+    "OrgDashboardRebuildResponse",
 ]
 
 
@@ -36,3 +37,22 @@ class OrgDashboardRebuildEntry(BaseModel):
     )
 
     job_url: str = Field(description="URL to the enqueued job resource.")
+
+
+class OrgDashboardRebuildResponse(BaseModel):
+    """Response body for the org-wide dashboard rebuild endpoint.
+
+    The enqueued jobs are wrapped in an object envelope (rather than a
+    bare JSON array) so the response can grow additional fields without a
+    breaking change.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    entries: list[OrgDashboardRebuildEntry] = Field(
+        default_factory=list,
+        description=(
+            "One entry per project for which a ``dashboard_build`` job was"
+            " enqueued."
+        ),
+    )

--- a/client/src/docverse/client/models/dashboard.py
+++ b/client/src/docverse/client/models/dashboard.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ._examples import EXAMPLE_JOB_ID, EXAMPLE_JOB_URL
+
 __all__ = [
     "DashboardRebuildResponse",
     "OrgDashboardRebuildEntry",
@@ -17,10 +19,14 @@ class DashboardRebuildResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     job_id: str = Field(
-        description="Public Base32 identifier for the enqueued job."
+        description="Public Base32 identifier for the enqueued job.",
+        examples=[EXAMPLE_JOB_ID],
     )
 
-    job_url: str = Field(description="URL to the enqueued job resource.")
+    job_url: str = Field(
+        description="URL to the enqueued job resource.",
+        examples=[EXAMPLE_JOB_URL],
+    )
 
 
 class OrgDashboardRebuildEntry(BaseModel):
@@ -29,14 +35,19 @@ class OrgDashboardRebuildEntry(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     project_slug: str = Field(
-        description="Slug of the project the job will rebuild."
+        description="Slug of the project the job will rebuild.",
+        examples=["pipelines"],
     )
 
     job_id: str = Field(
-        description="Public Base32 identifier for the enqueued job."
+        description="Public Base32 identifier for the enqueued job.",
+        examples=[EXAMPLE_JOB_ID],
     )
 
-    job_url: str = Field(description="URL to the enqueued job resource.")
+    job_url: str = Field(
+        description="URL to the enqueued job resource.",
+        examples=[EXAMPLE_JOB_URL],
+    )
 
 
 class OrgDashboardRebuildResponse(BaseModel):

--- a/client/src/docverse/client/models/dashboard_template.py
+++ b/client/src/docverse/client/models/dashboard_template.py
@@ -7,6 +7,8 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from ._examples import EXAMPLE_JOB_URL, EXAMPLE_ORG_URL
+
 __all__ = [
     "DashboardTemplateBinding",
     "DashboardTemplateBindingCreate",
@@ -104,7 +106,10 @@ class DashboardTemplateBinding(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this binding resource.")
+    self_url: str = Field(
+        description="URL to this binding resource.",
+        examples=[f"{EXAMPLE_ORG_URL}/dashboard-template"],
+    )
 
     web_url: str = Field(
         description=(
@@ -112,17 +117,28 @@ class DashboardTemplateBinding(BaseModel):
             "Always present once a binding exists; derived from the "
             "binding's source coordinates rather than the synced "
             "content row, so it is meaningful before the first sync."
-        )
+        ),
+        examples=["https://github.com/lsst/templates/tree/main/dashboard"],
     )
 
-    github_owner: str = Field(description="GitHub owner (user or org).")
+    github_owner: str = Field(
+        description="GitHub owner (user or org).",
+        examples=["lsst"],
+    )
 
-    github_repo: str = Field(description="GitHub repository name.")
+    github_repo: str = Field(
+        description="GitHub repository name.",
+        examples=["templates"],
+    )
 
-    github_ref: str = Field(description="Git ref (branch, tag, or SHA).")
+    github_ref: str = Field(
+        description="Git ref (branch, tag, or SHA).",
+        examples=["main"],
+    )
 
     root_path: str = Field(
-        description="Path within the repo where the template lives."
+        description="Path within the repo where the template lives.",
+        examples=["/dashboard"],
     )
 
     commit_sha: str | None = Field(
@@ -131,6 +147,7 @@ class DashboardTemplateBinding(BaseModel):
             "Commit SHA of the most-recently-synced template content. "
             "``None`` until the first successful sync."
         ),
+        examples=["6c8b2f01a5d34e1c9f0b2ad37e8c5d914f6a7b3c"],
     )
 
     last_sync_status: str = Field(
@@ -149,6 +166,7 @@ class DashboardTemplateBinding(BaseModel):
             "job, or ``None`` if no sync has been enqueued for this "
             "binding yet (or the referenced job has been pruned)."
         ),
+        examples=[EXAMPLE_JOB_URL],
     )
 
     github_owner_id: int | None = Field(
@@ -158,6 +176,7 @@ class DashboardTemplateBinding(BaseModel):
             "successful sync; ``None`` for un-synced bindings. Informational "
             "only — the public API remains keyed on ``github_owner``."
         ),
+        examples=[1745714],
     )
 
     github_repo_id: int | None = Field(
@@ -168,6 +187,7 @@ class DashboardTemplateBinding(BaseModel):
             "Informational only — the public API remains keyed on "
             "``github_repo``."
         ),
+        examples=[73902645],
     )
 
     github_installation_id: int | None = Field(
@@ -177,6 +197,7 @@ class DashboardTemplateBinding(BaseModel):
             "first successful sync; ``None`` for un-synced bindings or when "
             "the GitHub App is not installed. Informational only."
         ),
+        examples=[42150081],
     )
 
     date_created: datetime = Field(

--- a/client/src/docverse/client/models/editions.py
+++ b/client/src/docverse/client/models/editions.py
@@ -8,6 +8,12 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ._examples import (
+    EXAMPLE_BUILD_ID,
+    EXAMPLE_BUILD_URL,
+    EXAMPLE_EDITION_URL,
+    EXAMPLE_PROJECT_URL,
+)
 from .builds import BuildAnnotations, BuildStatus
 from .queue_enums import PublishStatus
 
@@ -24,7 +30,20 @@ __all__ = [
 
 
 class EditionKind(StrEnum):
-    """Kind of edition."""
+    """Kind of edition.
+
+    - ``main`` — the project's default edition (slug ``__main``), the
+      one served at the project's root URL.
+    - ``release`` — a pinned release version (e.g. ``v1.0.0``).
+    - ``draft`` — a work-in-progress edition, typically tracking a
+      development branch or ticket branch.
+    - ``major`` — an auto-created rollup for a major version line
+      (e.g. ``v1``), kept at the highest release within that line.
+    - ``minor`` — an auto-created rollup for a minor version line
+      (e.g. ``v1.2``), kept at the highest patch within that line.
+    - ``alternate`` — a deployment-variant edition matched only by
+      builds carrying the same ``alternate_name`` scope.
+    """
 
     main = "main"
     release = "release"
@@ -35,7 +54,27 @@ class EditionKind(StrEnum):
 
 
 class TrackingMode(StrEnum):
-    """How an edition tracks builds for automatic updates."""
+    """How an edition tracks builds for automatic updates.
+
+    - ``git_ref`` — follow builds from one git ref, named in
+      ``tracking_params`` (e.g. ``{"git_ref": "main"}``).
+    - ``lsst_doc`` — follow the highest LSST document version tag
+      (``v<major>.<minor>[.<patch>]``, e.g. ``v1.0``).
+    - ``eups_major_release`` — follow the highest two-component EUPS
+      release tag (``v<major>_<minor>``, e.g. ``v12_0``).
+    - ``eups_weekly_release`` — follow the highest EUPS weekly tag
+      (``w_<year>_<week>``, e.g. ``w_2026_30``).
+    - ``eups_daily_release`` — follow the highest EUPS daily tag
+      (``d_<year>_<month>_<day>``, e.g. ``d_2026_07_29``).
+    - ``semver_release`` — follow the highest semantic-version tag
+      overall (e.g. ``v2.3.0``).
+    - ``semver_major`` — follow the highest release within one major
+      version line (used by auto-created ``major`` editions).
+    - ``semver_minor`` — follow the highest patch within one minor
+      version line (used by auto-created ``minor`` editions).
+    - ``alternate_git_ref`` — like ``git_ref``, but match only builds
+      whose ``alternate_name`` equals the edition's variant scope.
+    """
 
     git_ref = "git_ref"
     lsst_doc = "lsst_doc"
@@ -136,31 +175,47 @@ class Edition(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this edition resource.")
+    self_url: str = Field(
+        description="URL to this edition resource.",
+        examples=[EXAMPLE_EDITION_URL],
+    )
 
-    project_url: str = Field(description="URL to the parent project.")
+    project_url: str = Field(
+        description="URL to the parent project.",
+        examples=[EXAMPLE_PROJECT_URL],
+    )
 
     build_url: str | None = Field(
         default=None,
         description="URL to the currently published build.",
+        examples=[EXAMPLE_BUILD_URL],
     )
 
     published_url: str | None = Field(
         default=None,
         description="Public URL where this edition is served.",
+        examples=["https://pipelines.lsst.io/v/v1"],
     )
 
     history_url: str = Field(
-        description="URL to the build history for this edition."
+        description="URL to the build history for this edition.",
+        examples=[f"{EXAMPLE_EDITION_URL}/history"],
     )
 
     rollback_url: str = Field(
-        description="URL to roll back this edition to a previous build."
+        description="URL to roll back this edition to a previous build.",
+        examples=[f"{EXAMPLE_EDITION_URL}/rollback"],
     )
 
-    slug: str = Field(description="URL-safe identifier for the edition.")
+    slug: str = Field(
+        description="URL-safe identifier for the edition.",
+        examples=["v1"],
+    )
 
-    title: str = Field(description="Display title for the edition.")
+    title: str = Field(
+        description="Display title for the edition.",
+        examples=["v1.0"],
+    )
 
     kind: EditionKind = Field(description="Kind of edition.")
 
@@ -198,9 +253,15 @@ class Edition(BaseModel):
 class EditionBuildHistoryEntry(BaseModel):
     """Response model for an edition build history entry."""
 
-    build_id: str = Field(description="Base32-encoded public ID of the build.")
+    build_id: str = Field(
+        description="Base32-encoded public ID of the build.",
+        examples=[EXAMPLE_BUILD_ID],
+    )
 
-    build_url: str = Field(description="URL to the build resource.")
+    build_url: str = Field(
+        description="URL to the build resource.",
+        examples=[EXAMPLE_BUILD_URL],
+    )
 
     git_ref: str = Field(description="Git reference of the build.")
 
@@ -231,6 +292,7 @@ class EditionRollback(BaseModel):
 
     build: str = Field(
         description="Base32 public ID of the target build.",
+        examples=[EXAMPLE_BUILD_ID],
     )
 
 
@@ -269,4 +331,5 @@ class EditionUpdate(BaseModel):
             "Emergency-override path: unlike rollback, the build does not "
             "have to be in the edition's history."
         ),
+        examples=[EXAMPLE_BUILD_ID],
     )

--- a/client/src/docverse/client/models/infrastructure.py
+++ b/client/src/docverse/client/models/infrastructure.py
@@ -14,39 +14,44 @@ __all__ = [
 
 
 class CredentialProvider(StrEnum):
-    """Cloud provider for authentication credentials."""
+    """Cloud provider for authentication credentials.
+
+    - ``aws`` — Amazon Web Services (S3, Route 53, CloudFront).
+    - ``cloudflare`` — Cloudflare (R2, Workers, DNS).
+    - ``fastly`` — Fastly CDN.
+    - ``gcp`` — Google Cloud Platform (GCS, Cloud CDN).
+    - ``s3`` — generic S3-compatible storage (access key ID + secret
+      access key).
+    """
 
     aws = "aws"
-    """Amazon Web Services (S3, Route 53, CloudFront)."""
-
     cloudflare = "cloudflare"
-    """Cloudflare (R2, Workers, DNS)."""
-
     fastly = "fastly"
-    """Fastly CDN."""
-
     gcp = "gcp"
-    """Google Cloud Platform (GCS, Cloud CDN)."""
-
     s3 = "s3"
-    """Generic S3-compatible (access key ID + secret access key)."""
 
 
 class ServiceCategory(StrEnum):
-    """Category of infrastructure service."""
+    """Category of infrastructure service.
+
+    - ``object_storage`` — object storage for documentation content.
+    - ``cdn`` — content delivery network for cache purging and edge
+      data.
+    - ``dns`` — DNS management for subdomain registration.
+    """
 
     object_storage = "object_storage"
-    """Object storage for documentation content."""
-
     cdn = "cdn"
-    """Content delivery network for cache purging and edge data."""
-
     dns = "dns"
-    """DNS management for subdomain registration."""
 
 
 class ServiceProvider(StrEnum):
-    """Specific infrastructure service provider."""
+    """Specific infrastructure service provider.
+
+    Object storage: ``aws_s3``, ``cloudflare_r2``, ``minio``, ``gcs``.
+    CDN: ``fastly``, ``cloudflare_workers``, ``cloudfront``,
+    ``google_cloud_cdn``. DNS: ``route53``, ``cloudflare_dns``.
+    """
 
     # Object storage
     aws_s3 = "aws_s3"

--- a/client/src/docverse/client/models/keeper_sync.py
+++ b/client/src/docverse/client/models/keeper_sync.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 from .editions import EditionKind
 
@@ -75,6 +75,10 @@ class KeeperSyncConfigUpdate(BaseModel):
     ``"*"`` for every project). ``extra="forbid"`` rejects unknown fields, and
     ``model_dump(exclude_unset=True)`` is what distinguishes "omitted" from an
     explicit value. Use ``PUT`` for a full replacement of the config.
+
+    An explicit JSON ``null`` for any field is rejected with a 422: these
+    config fields are non-nullable, so RFC 7386's null-as-remove semantics
+    have no meaning here. Omit a field to leave it unchanged.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -97,6 +101,24 @@ class KeeperSyncConfigUpdate(BaseModel):
             " stored list wholesale (no append semantics)."
         ),
     )
+
+    @field_validator("enabled", "ltd_base_url", "project_slugs")
+    @classmethod
+    def _reject_explicit_null(cls, value: object) -> object:
+        """Reject an explicit ``null`` for any config field.
+
+        The validator is skipped for unset defaults, so it only fires when
+        a field is explicitly sent as ``null``. These fields are
+        non-nullable in the stored config, so null-as-remove has no
+        meaning; omit a field to leave it unchanged.
+        """
+        if value is None:
+            msg = (
+                "keeper-sync config fields may not be null; omit a field to"
+                " leave it unchanged"
+            )
+            raise ValueError(msg)
+        return value
 
 
 class KeeperSyncRunKind(StrEnum):

--- a/client/src/docverse/client/models/keeper_sync.py
+++ b/client/src/docverse/client/models/keeper_sync.py
@@ -12,6 +12,7 @@ from .editions import EditionKind
 
 __all__ = [
     "KeeperSyncConfig",
+    "KeeperSyncConfigUpdate",
     "KeeperSyncEditionDiff",
     "KeeperSyncEditionStatus",
     "KeeperSyncProjectRefreshAccepted",
@@ -59,6 +60,41 @@ class KeeperSyncConfig(BaseModel):
         description=(
             'LTD project slugs to sync, or ``"*"`` for every project'
             " visible on the LTD instance."
+        ),
+    )
+
+
+class KeeperSyncConfigUpdate(BaseModel):
+    """Partial update for an organization's LTD Keeper sync configuration.
+
+    Request model for ``PATCH /orgs/{org}/keeper-sync``, applied with
+    JSON-Merge-Patch semantics: every field is optional, and only the fields
+    present in the request body are changed — omitted fields are left
+    untouched. ``project_slugs``, when provided, **replaces the stored array
+    wholesale** (there is no append semantics; send the full desired list, or
+    ``"*"`` for every project). ``extra="forbid"`` rejects unknown fields, and
+    ``model_dump(exclude_unset=True)`` is what distinguishes "omitted" from an
+    explicit value. Use ``PUT`` for a full replacement of the config.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool | None = Field(
+        default=None,
+        description="Whether LTD Keeper sync is enabled on the organization.",
+    )
+
+    ltd_base_url: HttpUrl | None = Field(
+        default=None,
+        description="Base URL of the LTD Keeper API (v1 shape).",
+    )
+
+    project_slugs: list[str] | Literal["*"] | None = Field(
+        default=None,
+        description=(
+            'LTD project slugs to sync, or ``"*"`` for every project'
+            " visible on the LTD instance. When provided, replaces the"
+            " stored list wholesale (no append semantics)."
         ),
     )
 

--- a/client/src/docverse/client/models/keeper_sync.py
+++ b/client/src/docverse/client/models/keeper_sync.py
@@ -8,6 +8,15 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
+from ._examples import (
+    EXAMPLE_EDITION_URL,
+    EXAMPLE_JOB_ID,
+    EXAMPLE_JOB_URL,
+    EXAMPLE_ORG_URL,
+    EXAMPLE_PROJECT_URL,
+    EXAMPLE_RUN_ID,
+    EXAMPLE_TOMBSTONE_ID,
+)
 from .editions import EditionKind
 
 __all__ = [
@@ -122,7 +131,16 @@ class KeeperSyncConfigUpdate(BaseModel):
 
 
 class KeeperSyncRunKind(StrEnum):
-    """Kind of LTD Keeper sync run."""
+    """Kind of LTD Keeper sync run.
+
+    - ``backfill`` — full import of the configured LTD projects into
+      Docverse; the kind created by ``POST /orgs/{org}/keeper-sync/
+      runs`` today.
+    - ``resync`` — reserved for a re-import of already-synced projects;
+      not created today.
+    - ``reconcile`` — reserved for a diff-and-repair pass against LTD;
+      not created today.
+    """
 
     backfill = "backfill"
     resync = "resync"
@@ -132,10 +150,14 @@ class KeeperSyncRunKind(StrEnum):
 class KeeperSyncRunStatus(StrEnum):
     """Lifecycle status of a keeper sync run.
 
-    ``pending`` — the discovery job has been enqueued but has not yet
-    fanned out any children. ``in_progress`` — discovery has enqueued
-    at least one child sync job. ``succeeded`` / ``partial_failure`` /
-    ``failed`` are terminal states.
+    - ``pending`` — the discovery job has been enqueued but has not yet
+      fanned out any children.
+    - ``in_progress`` — discovery has enqueued at least one child sync
+      job.
+    - ``succeeded`` — terminal; every child job succeeded.
+    - ``partial_failure`` — terminal; some child jobs failed.
+    - ``failed`` — terminal; the run failed outright (e.g. the
+      discovery job itself failed).
     """
 
     pending = "pending"
@@ -150,7 +172,10 @@ class KeeperSyncRun(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: HttpUrl = Field(description="URL to this run resource.")
+    self_url: HttpUrl = Field(
+        description="URL to this run resource.",
+        examples=[f"{EXAMPLE_ORG_URL}/keeper-sync/runs/{EXAMPLE_RUN_ID}"],
+    )
 
     jobs_url: HttpUrl = Field(
         description=(
@@ -159,11 +184,13 @@ class KeeperSyncRun(BaseModel):
             " ``GET /orgs/{org}/jobs?run={id}``). Always present so"
             " clients can paginate the run's children without"
             " constructing the URL by hand."
-        )
+        ),
+        examples=[f"{EXAMPLE_ORG_URL}/jobs?run={EXAMPLE_RUN_ID}"],
     )
 
     id: str = Field(
-        description="Public Crockford Base32 identifier for the run."
+        description="Public Crockford Base32 identifier for the run.",
+        examples=[EXAMPLE_RUN_ID],
     )
 
     kind: KeeperSyncRunKind = Field(description="Kind of run.")
@@ -226,11 +253,13 @@ class KeeperSyncRunCreated(BaseModel):
         description=(
             "Public Base32 identifier for the enqueued"
             " ``keeper_sync_run_discovery`` queue job."
-        )
+        ),
+        examples=[EXAMPLE_JOB_ID],
     )
 
     job_url: HttpUrl = Field(
-        description="URL of the enqueued discovery job resource."
+        description="URL of the enqueued discovery job resource.",
+        examples=[EXAMPLE_JOB_URL],
     )
 
 
@@ -309,7 +338,10 @@ class KeeperSyncProjectStateSummary(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    ltd_slug: str = Field(description="LTD product slug for this project.")
+    ltd_slug: str = Field(
+        description="LTD product slug for this project.",
+        examples=["pipelines"],
+    )
 
     date_last_synced: datetime | None = Field(
         default=None,
@@ -349,10 +381,14 @@ class KeeperSyncEditionStatus(BaseModel):
         description=(
             "Canonical ``GET /orgs/{org}/projects/{project}/editions/"
             "{edition}`` URL for this edition."
-        )
+        ),
+        examples=[EXAMPLE_EDITION_URL],
     )
 
-    slug: str = Field(description="Docverse edition slug.")
+    slug: str = Field(
+        description="Docverse edition slug.",
+        examples=["v1"],
+    )
 
     kind: EditionKind = Field(
         description="Docverse edition kind (``main``, ``draft``, ...)."
@@ -362,8 +398,11 @@ class KeeperSyncEditionStatus(BaseModel):
         default=None,
         description=(
             "LTD edition id from the linked ``keeper_sync_state`` row,"
-            " or ``null`` when no row links this edition."
+            " or ``null`` when no row links this edition. This is the"
+            " numeric id from the legacy LTD Keeper API, not a Docverse"
+            " identifier."
         ),
+        examples=[4289],
     )
 
     ltd_slug: str | None = Field(
@@ -372,6 +411,7 @@ class KeeperSyncEditionStatus(BaseModel):
             "LTD edition slug from the linked state row, or ``null``"
             " when no row links this edition."
         ),
+        examples=["v1"],
     )
 
     date_last_synced: datetime | None = Field(
@@ -432,14 +472,16 @@ class KeeperSyncProjectStatus(BaseModel):
             " URL for this project's keeper-sync status. Lets clients"
             " paginating the org-wide project listing drill into a"
             " single project without constructing the URL by hand."
-        )
+        ),
+        examples=[f"{EXAMPLE_ORG_URL}/keeper-sync/projects/pipelines"],
     )
 
     org_url: HttpUrl = Field(
         description=(
             "Canonical ``GET /orgs/{org}`` URL for the Docverse"
             " organization this report is scoped to."
-        )
+        ),
+        examples=[EXAMPLE_ORG_URL],
     )
 
     project_url: HttpUrl | None = Field(
@@ -449,6 +491,7 @@ class KeeperSyncProjectStatus(BaseModel):
             " the Docverse project, or ``null`` when no Docverse"
             " project has been imported yet for this LTD slug."
         ),
+        examples=[EXAMPLE_PROJECT_URL],
     )
 
     sync_refresh_url: HttpUrl = Field(
@@ -457,7 +500,8 @@ class KeeperSyncProjectStatus(BaseModel):
             " project (``post_org_keeper_sync_project_refresh``). Always"
             " present so operators can trigger a refresh from the"
             " status response without constructing the URL by hand."
-        )
+        ),
+        examples=[f"{EXAMPLE_ORG_URL}/keeper-sync/projects/pipelines/refresh"],
     )
 
     editions_sync_url: HttpUrl = Field(
@@ -467,11 +511,15 @@ class KeeperSyncProjectStatus(BaseModel):
             " (``get_org_keeper_sync_project_editions``). Always"
             " present so operators can scan the full edition list"
             " without constructing the URL by hand."
-        )
+        ),
+        examples=[
+            f"{EXAMPLE_ORG_URL}/keeper-sync/projects/pipelines/editions"
+        ],
     )
 
     ltd_slug: str = Field(
-        description="LTD product slug the report is scoped to."
+        description="LTD product slug the report is scoped to.",
+        examples=["pipelines"],
     )
 
     project_state: KeeperSyncProjectStateSummary | None = Field(
@@ -526,21 +574,25 @@ class KeeperSyncProjectRefreshAccepted(BaseModel):
         description=(
             "Public Base32 identifier for the enqueued"
             " ``keeper_sync_project`` queue job."
-        )
+        ),
+        examples=[EXAMPLE_JOB_ID],
     )
 
-    job_url: HttpUrl = Field(description="URL of the enqueued job resource.")
+    job_url: HttpUrl = Field(
+        description="URL of the enqueued job resource.",
+        examples=[EXAMPLE_JOB_URL],
+    )
 
 
 class KeeperSyncResourceType(StrEnum):
     """LTD resource types tracked by keeper-sync.
 
-    Mirrors :class:`docverse.storage.keeper_sync.ResourceType` as a
-    public wire value so the admin tombstone API can filter requests
-    and shape responses without leaking the server-side enum's import
-    path. Builds are not tombstoned today, but the value is kept so
-    operator-facing filters do not silently reject a valid resource
-    type the schema otherwise carries.
+    - ``project`` — the tombstone vetoes re-import of the LTD product
+      entirely.
+    - ``edition`` — the tombstone vetoes one specific LTD edition.
+    - ``build`` — reserved; builds are not tombstoned today, but the
+      value is kept so operator-facing filters do not silently reject
+      a valid resource type the schema otherwise carries.
     """
 
     project = "project"
@@ -551,21 +603,20 @@ class KeeperSyncResourceType(StrEnum):
 class KeeperSyncTombstoneReason(StrEnum):
     """Why a ``keeper_sync_state`` row was tombstoned.
 
-    Wire-stable enum surfaced by the admin tombstone API. Mirrors
-    :class:`docverse.storage.keeper_sync.TombstoneReason`.
+    - ``manual_delete`` — an operator soft-deleted the Docverse-side
+      resource; the tombstone stops sync from re-importing it.
+    - ``lifecycle_delete`` — an automated process (``lifecycle_eval``,
+      ``git_ref_audit``, or the ``ref_deleted`` webhook) soft-deleted
+      the Docverse-side resource.
+    - ``lifecycle_preemptive`` — sync itself short-circuited an LTD
+      edition that the lifecycle rules would immediately delete,
+      before the build content was copied. No matching Docverse row
+      exists in this case.
     """
 
     manual_delete = "manual_delete"
-    """Operator-driven soft-delete of the Docverse-side resource."""
-
     lifecycle_delete = "lifecycle_delete"
-    """Automated soft-delete by ``lifecycle_eval`` / ``git_ref_audit`` /
-    the ``ref_deleted`` webhook."""
-
     lifecycle_preemptive = "lifecycle_preemptive"
-    """Sync itself short-circuited an LTD edition that the lifecycle
-    rules would immediately delete, before the build content was
-    copied. No matching Docverse row exists in this case."""
 
 
 class KeeperSyncTombstone(BaseModel):
@@ -587,7 +638,10 @@ class KeeperSyncTombstone(BaseModel):
             " endpoint accepts only ``DELETE``; GET-on-self is not"
             " modelled because the list response already carries every"
             " field a single-tombstone fetch would return."
-        )
+        ),
+        examples=[
+            f"{EXAMPLE_ORG_URL}/keeper-sync/tombstones/{EXAMPLE_TOMBSTONE_ID}"
+        ],
     )
 
     id: str = Field(
@@ -595,7 +649,8 @@ class KeeperSyncTombstone(BaseModel):
             "Public Crockford Base32 identifier for the tombstoned"
             " ``keeper_sync_state`` row. Use this id with the DELETE"
             " endpoint to clear the tombstone."
-        )
+        ),
+        examples=[EXAMPLE_TOMBSTONE_ID],
     )
 
     resource_type: KeeperSyncResourceType = Field(
@@ -612,26 +667,19 @@ class KeeperSyncTombstone(BaseModel):
             "LTD-side slug for the tombstoned resource. For ``project``"
             " rows this is the LTD product slug; for ``edition`` rows"
             " it is the LTD edition slug (e.g. ``main`` or ``v1.0``)."
-        )
+        ),
+        examples=["v1"],
     )
 
     ltd_id: int | None = Field(
         default=None,
         description=(
-            "LTD-side numeric id for the tombstoned resource."
+            "LTD-side numeric id for the tombstoned resource,"
+            " from the legacy LTD Keeper API."
             " Populated for ``edition`` and ``build`` rows; ``null``"
             " for ``project`` rows (LTD products are slug-only)."
         ),
-    )
-
-    docverse_id: int | None = Field(
-        default=None,
-        description=(
-            "Docverse-side row id the tombstone is paired to."
-            " ``null`` for ``lifecycle_preemptive`` rows that veto an"
-            " LTD edition that was never imported (so no Docverse row"
-            " exists)."
-        ),
+        examples=[4289],
     )
 
     date_tombstoned: datetime = Field(
@@ -659,5 +707,6 @@ class KeeperSyncTombstone(BaseModel):
             " Falls back to the LTD slug when no Docverse row is"
             " linked (``lifecycle_preemptive`` rows) or the linked"
             " row has been hard-deleted out from under the tombstone."
-        )
+        ),
+        examples=["pipelines/v1"],
     )

--- a/client/src/docverse/client/models/lifecycle.py
+++ b/client/src/docverse/client/models/lifecycle.py
@@ -153,11 +153,15 @@ class LifecycleRuleSet(RootModel[list[LifecycleRule]]):
 class LifecycleEvalRunStatus(StrEnum):
     """Lifecycle status of a ``lifecycle_eval_runs`` aggregate row.
 
-    ``pending`` — the dispatcher has created the run row but has not yet
-    enqueued any per-org child jobs. ``in_progress`` — at least one
-    per-org child has been enqueued. ``succeeded`` /
-    ``partial_failure`` / ``failed`` are terminal states set by
-    ``maybe_finalise_lifecycle_run`` when every child is terminal.
+    - ``pending`` — the dispatcher has created the run row but has not
+      yet enqueued any per-org child jobs.
+    - ``in_progress`` — at least one per-org child has been enqueued.
+    - ``succeeded`` — terminal; every per-org child succeeded.
+    - ``partial_failure`` — terminal; some per-org children failed.
+    - ``failed`` — terminal; the run failed outright.
+
+    Terminal states are set by ``maybe_finalise_lifecycle_run`` when
+    every child is terminal.
     """
 
     pending = "pending"
@@ -172,11 +176,16 @@ class GitRefAuditRunStatus(StrEnum):
 
     Shape mirrors :class:`LifecycleEvalRunStatus` so the daily
     ``git_ref_audit`` dispatcher / per-org / reaper pattern transfers
-    between the two subsystems without operator re-training. ``pending``
-    — discovery has created the run row but has not yet enqueued any
-    per-org child jobs. ``in_progress`` — at least one per-org child
-    has been enqueued. ``succeeded`` / ``partial_failure`` / ``failed``
-    are terminal states set by ``maybe_finalise_git_ref_audit_run``
+    between the two subsystems without operator re-training.
+
+    - ``pending`` — discovery has created the run row but has not yet
+      enqueued any per-org child jobs.
+    - ``in_progress`` — at least one per-org child has been enqueued.
+    - ``succeeded`` — terminal; every per-org child succeeded.
+    - ``partial_failure`` — terminal; some per-org children failed.
+    - ``failed`` — terminal; the run failed outright.
+
+    Terminal states are set by ``maybe_finalise_git_ref_audit_run``
     when every child is terminal.
     """
 

--- a/client/src/docverse/client/models/memberships.py
+++ b/client/src/docverse/client/models/memberships.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 __all__ = [
     "OrgMembership",
@@ -64,6 +64,21 @@ class OrgMembershipUpdate(BaseModel):
     role: OrgRole | None = Field(
         default=None, description="New role to assign to the member."
     )
+
+    @field_validator("role")
+    @classmethod
+    def _reject_explicit_null(cls, value: OrgRole | None) -> OrgRole | None:
+        """Reject an explicit ``null`` for ``role``.
+
+        The validator is skipped for the unset default, so it only fires
+        when the client sends ``{"role": null}``. The column is
+        non-nullable, so RFC 7386's null-as-remove semantics have no
+        meaning here; omit the field to leave the role unchanged.
+        """
+        if value is None:
+            msg = "role may not be null; omit it to leave the role unchanged"
+            raise ValueError(msg)
+        return value
 
 
 class OrgMembership(BaseModel):

--- a/client/src/docverse/client/models/memberships.py
+++ b/client/src/docverse/client/models/memberships.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 __all__ = [
     "OrgMembership",
     "OrgMembershipCreate",
+    "OrgMembershipUpdate",
     "OrgRole",
     "PrincipalType",
 ]
@@ -46,6 +47,23 @@ class OrgMembershipCreate(BaseModel):
     )
 
     role: OrgRole = Field(description="Role to assign.")
+
+
+class OrgMembershipUpdate(BaseModel):
+    """Request model for updating an organization membership (PATCH).
+
+    Only ``role`` is mutable. ``principal`` and ``principal_type`` identify
+    the membership and are immutable — changing identity is a delete plus a
+    re-add. ``extra="forbid"`` rejects attempts to patch those or any other
+    field. Applied with JSON-Merge-Patch semantics: omitted fields are left
+    untouched.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: OrgRole | None = Field(
+        default=None, description="New role to assign to the member."
+    )
 
 
 class OrgMembership(BaseModel):

--- a/client/src/docverse/client/models/memberships.py
+++ b/client/src/docverse/client/models/memberships.py
@@ -6,6 +6,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from ._examples import EXAMPLE_ORG_URL
+
 __all__ = [
     "OrgMembership",
     "OrgMembershipCreate",
@@ -16,14 +18,30 @@ __all__ = [
 
 
 class PrincipalType(StrEnum):
-    """Type of principal in an organization membership."""
+    """Type of principal in an organization membership.
+
+    - ``user`` — the principal is an individual username.
+    - ``group`` — the principal is a group name; every member of the
+      group holds the membership's role.
+    """
 
     user = "user"
     group = "group"
 
 
 class OrgRole(StrEnum):
-    """Role within an organization."""
+    """Role within an organization.
+
+    Roles are ordered: each level includes the permissions of the
+    levels below it.
+
+    - ``reader`` — read access to the organization's resources.
+    - ``uploader`` — reader plus creating builds and uploading build
+      content.
+    - ``admin`` — full control of the organization, including
+      projects, editions, membership, services, credentials, and
+      configuration.
+    """
 
     reader = "reader"
     uploader = "uploader"
@@ -86,9 +104,15 @@ class OrgMembership(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this membership resource.")
+    self_url: str = Field(
+        description="URL to this membership resource.",
+        examples=[f"{EXAMPLE_ORG_URL}/members/user:jdoe"],
+    )
 
-    org_url: str = Field(description="URL to the parent organization.")
+    org_url: str = Field(
+        description="URL to the parent organization.",
+        examples=[EXAMPLE_ORG_URL],
+    )
 
     id: str = Field(
         description=(
@@ -98,7 +122,10 @@ class OrgMembership(BaseModel):
         examples=["user:jdoe", "group:g_spherex"],
     )
 
-    principal: str = Field(description="Username or group name.")
+    principal: str = Field(
+        description="Username or group name.",
+        examples=["jdoe"],
+    )
 
     principal_type: PrincipalType = Field(
         description="Whether the principal is a user or group."

--- a/client/src/docverse/client/models/organizations.py
+++ b/client/src/docverse/client/models/organizations.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .editions import DefaultEditionConfig
 from .lifecycle import LifecycleRuleSet
-from .memberships import OrgMembershipCreate
+from .memberships import OrgMembershipCreate, OrgRole
 from .services import OrganizationServiceSummary
 
 
@@ -244,6 +244,29 @@ class Organization(BaseModel):
 
     date_updated: datetime = Field(
         description="Timestamp of the most recent update."
+    )
+
+
+class OrganizationSummary(BaseModel):
+    """Summary of an organization the caller can access.
+
+    Returned by the non-admin ``GET /orgs`` listing, one entry per
+    organization in which the caller holds an effective role (via direct
+    membership or a group). It carries only the identifying fields plus
+    the caller's effective ``role`` — the full organization resource is
+    available at ``self_url``.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    self_url: str = Field(description="URL to this organization resource.")
+
+    slug: str = Field(description="URL-safe identifier for the organization.")
+
+    title: str = Field(description="Display title for the organization.")
+
+    role: OrgRole = Field(
+        description="The caller's effective role in the organization."
     )
 
 

--- a/client/src/docverse/client/models/organizations.py
+++ b/client/src/docverse/client/models/organizations.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from ._examples import EXAMPLE_ORG_URL
 from .editions import DefaultEditionConfig
 from .lifecycle import LifecycleRuleSet
 from .memberships import OrgMembershipCreate, OrgRole
@@ -41,13 +42,16 @@ def normalize_base_domain(value: str) -> str:
 
 
 class UrlScheme(StrEnum):
-    """URL scheme for serving documentation within an organization."""
+    """URL scheme for serving documentation within an organization.
+
+    - ``subdomain`` — each project is served on its own subdomain of the
+      organization's base domain (e.g. ``https://pipelines.lsst.io``).
+    - ``path_prefix`` — each project is served under a path prefix on a
+      shared host (e.g. ``https://lsst.io/pipelines``).
+    """
 
     subdomain = "subdomain"
-    """Each project is served on its own subdomain."""
-
     path_prefix = "path_prefix"
-    """Each project is served under a path prefix."""
 
 
 class OrganizationCreate(BaseModel):
@@ -123,21 +127,25 @@ class OrganizationCreate(BaseModel):
     publishing_store_label: str | None = Field(
         default=None,
         description="Label of the object_storage service for publishing.",
+        examples=["docs-bucket"],
     )
 
     staging_store_label: str | None = Field(
         default=None,
         description="Label of the object_storage service for staging.",
+        examples=["staging-bucket"],
     )
 
     cdn_service_label: str | None = Field(
         default=None,
         description="Label of the cdn service.",
+        examples=["cdn"],
     )
 
     dns_service_label: str | None = Field(
         default=None,
         description="Label of the dns service.",
+        examples=["dns"],
     )
 
     default_edition_config: DefaultEditionConfig | None = Field(
@@ -159,26 +167,38 @@ class Organization(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this organization resource.")
+    self_url: str = Field(
+        description="URL to this organization resource.",
+        examples=[EXAMPLE_ORG_URL],
+    )
 
     dashboard_template_url: str = Field(
         description=(
             "URL to the organization's default dashboard-template binding."
         ),
+        examples=[f"{EXAMPLE_ORG_URL}/dashboard-template"],
     )
 
     keeper_sync_url: str = Field(
         description=(
             "URL to the organization's LTD Keeper sync configuration."
         ),
+        examples=[f"{EXAMPLE_ORG_URL}/keeper-sync"],
     )
 
-    slug: str = Field(description="URL-safe identifier for the organization.")
+    slug: str = Field(
+        description="URL-safe identifier for the organization.",
+        examples=["lsst"],
+    )
 
-    title: str = Field(description="Display title for the organization.")
+    title: str = Field(
+        description="Display title for the organization.",
+        examples=["Rubin Observatory"],
+    )
 
     base_domain: str = Field(
-        description="Base domain for documentation sites."
+        description="Base domain for documentation sites.",
+        examples=["lsst.io"],
     )
 
     url_scheme: UrlScheme = Field(
@@ -221,21 +241,53 @@ class Organization(BaseModel):
     publishing_store: OrganizationServiceSummary | None = Field(
         default=None,
         description="Object storage service used for publishing.",
+        examples=[
+            {
+                "self_url": f"{EXAMPLE_ORG_URL}/services/docs-bucket",
+                "label": "docs-bucket",
+                "category": "object_storage",
+                "provider": "aws_s3",
+            }
+        ],
     )
 
     staging_store: OrganizationServiceSummary | None = Field(
         default=None,
         description="Object storage service used for staging uploads.",
+        examples=[
+            {
+                "self_url": f"{EXAMPLE_ORG_URL}/services/staging-bucket",
+                "label": "staging-bucket",
+                "category": "object_storage",
+                "provider": "aws_s3",
+            }
+        ],
     )
 
     cdn_service: OrganizationServiceSummary | None = Field(
         default=None,
         description="CDN service for cache purging and edge data.",
+        examples=[
+            {
+                "self_url": f"{EXAMPLE_ORG_URL}/services/cdn",
+                "label": "cdn",
+                "category": "cdn",
+                "provider": "fastly",
+            }
+        ],
     )
 
     dns_service: OrganizationServiceSummary | None = Field(
         default=None,
         description="DNS service for subdomain registration.",
+        examples=[
+            {
+                "self_url": f"{EXAMPLE_ORG_URL}/services/dns",
+                "label": "dns",
+                "category": "dns",
+                "provider": "route53",
+            }
+        ],
     )
 
     date_created: datetime = Field(
@@ -259,11 +311,20 @@ class OrganizationSummary(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this organization resource.")
+    self_url: str = Field(
+        description="URL to this organization resource.",
+        examples=[EXAMPLE_ORG_URL],
+    )
 
-    slug: str = Field(description="URL-safe identifier for the organization.")
+    slug: str = Field(
+        description="URL-safe identifier for the organization.",
+        examples=["lsst"],
+    )
 
-    title: str = Field(description="Display title for the organization.")
+    title: str = Field(
+        description="Display title for the organization.",
+        examples=["Rubin Observatory"],
+    )
 
     role: OrgRole = Field(
         description="The caller's effective role in the organization."
@@ -323,21 +384,25 @@ class OrganizationUpdate(BaseModel):
     publishing_store_label: str | None = Field(
         default=None,
         description="Label of the object_storage service for publishing.",
+        examples=["docs-bucket"],
     )
 
     staging_store_label: str | None = Field(
         default=None,
         description="Label of the object_storage service for staging.",
+        examples=["staging-bucket"],
     )
 
     cdn_service_label: str | None = Field(
         default=None,
         description="Label of the cdn service.",
+        examples=["cdn"],
     )
 
     dns_service_label: str | None = Field(
         default=None,
         description="Label of the dns service.",
+        examples=["dns"],
     )
 
     default_edition_config: DefaultEditionConfig | None = Field(

--- a/client/src/docverse/client/models/projects.py
+++ b/client/src/docverse/client/models/projects.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from ._examples import EXAMPLE_ORG_URL, EXAMPLE_PROJECT_URL
 from .editions import DefaultEditionConfig
 from .editions import Edition as EditionResponse
 from .lifecycle import LifecycleRuleSet
@@ -65,6 +66,7 @@ _GITHUB_OWNER_FIELD = Field(
     max_length=39,
     pattern=r"^[A-Za-z0-9](?:-?[A-Za-z0-9])*$",
     description="GitHub owner (user or organization login).",
+    examples=["lsst"],
 )
 
 _GITHUB_REPO_FIELD = Field(
@@ -72,6 +74,7 @@ _GITHUB_REPO_FIELD = Field(
     max_length=100,
     pattern=r"^[A-Za-z0-9._-]+$",
     description="GitHub repository name.",
+    examples=["pipelines_lsst_io"],
 )
 
 
@@ -88,11 +91,15 @@ class ProjectGitHubBindingCreate(BaseModel):
 class InstallationStatus(StrEnum):
     """Whether the Docverse GitHub App is installed on a repository.
 
-    Derived per response from the project's GitHub binding. Today only
-    ``not_installed`` and ``installed`` are ever returned;
-    ``suspended`` and ``needs_permissions`` are reserved enum values
-    for a later slice (projects currently have no suspended state — the
-    suspend/unsuspend webhooks only touch dashboard-template bindings).
+    Derived per response from the project's GitHub binding.
+
+    - ``not_installed`` — the App is not installed on the repository (or
+      its installation has not yet been resolved).
+    - ``installed`` — the App is installed on the repository.
+    - ``suspended`` — reserved; not returned today (projects currently
+      have no suspended state — the suspend/unsuspend webhooks only
+      touch dashboard-template bindings).
+    - ``needs_permissions`` — reserved; not returned today.
     """
 
     not_installed = "not_installed"
@@ -116,6 +123,7 @@ class ProjectGitHubBinding(BaseModel):
             "GitHub App installation id for the repository. ``None`` when"
             " the App is not installed or has not yet been resolved."
         ),
+        examples=[42150081],
     )
 
     installation_status: InstallationStatus = Field(
@@ -135,6 +143,7 @@ class ProjectGitHubBinding(BaseModel):
             " GitHub App feature is unconfigured or its credentials"
             " failed startup validation."
         ),
+        examples=["https://github.com/apps/docverse"],
     )
 
 
@@ -248,25 +257,42 @@ class Project(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this project resource.")
-
-    org_url: str = Field(description="URL to the parent organization.")
-
-    editions_url: str = Field(
-        description="URL to list editions for this project."
+    self_url: str = Field(
+        description="URL to this project resource.",
+        examples=[EXAMPLE_PROJECT_URL],
     )
 
-    builds_url: str = Field(description="URL to list builds for this project.")
+    org_url: str = Field(
+        description="URL to the parent organization.",
+        examples=[EXAMPLE_ORG_URL],
+    )
+
+    editions_url: str = Field(
+        description="URL to list editions for this project.",
+        examples=[f"{EXAMPLE_PROJECT_URL}/editions"],
+    )
+
+    builds_url: str = Field(
+        description="URL to list builds for this project.",
+        examples=[f"{EXAMPLE_PROJECT_URL}/builds"],
+    )
 
     dashboard_template_url: str = Field(
         description=(
             "URL to the project's dashboard-template binding override."
         ),
+        examples=[f"{EXAMPLE_PROJECT_URL}/dashboard-template"],
     )
 
-    slug: str = Field(description="URL-safe identifier for the project.")
+    slug: str = Field(
+        description="URL-safe identifier for the project.",
+        examples=["pipelines"],
+    )
 
-    title: str = Field(description="Display title for the project.")
+    title: str = Field(
+        description="Display title for the project.",
+        examples=["LSST Science Pipelines"],
+    )
 
     source_url: str | None = Field(
         default=None,
@@ -276,6 +302,7 @@ class Project(BaseModel):
             " (``https://github.com/{owner}/{repo}``); otherwise the"
             " stored non-GitHub URL. ``None`` when neither is set."
         ),
+        examples=["https://github.com/lsst/pipelines_lsst_io"],
     )
 
     github: ProjectGitHubBinding | None = Field(

--- a/client/src/docverse/client/models/queue.py
+++ b/client/src/docverse/client/models/queue.py
@@ -13,6 +13,15 @@ from pydantic import (
     model_serializer,
 )
 
+from ._examples import (
+    EXAMPLE_BUILD_URL,
+    EXAMPLE_EDITION_URL,
+    EXAMPLE_JOB_ID,
+    EXAMPLE_JOB_URL,
+    EXAMPLE_PUBLISH_JOB_ID,
+    EXAMPLE_PUBLISH_JOB_URL,
+    EXAMPLE_RUN_ID,
+)
 from .queue_enums import JobKind, JobStatus
 
 if TYPE_CHECKING:
@@ -58,6 +67,7 @@ class EditionUpdateRef(BaseModel):
             " follow instead of reconstructing the path). Omitted when the"
             " Docverse API base URL could not be resolved."
         ),
+        examples=[EXAMPLE_EDITION_URL],
     )
 
 
@@ -81,6 +91,7 @@ class PublishJobRef(BaseModel):
         description=(
             "Public Crockford Base32 identifier of the publish_edition job."
         ),
+        examples=[EXAMPLE_PUBLISH_JOB_ID],
     )
 
     job_url: str | None = Field(
@@ -91,6 +102,7 @@ class PublishJobRef(BaseModel):
             " path). Omitted when the Docverse API base URL could not be"
             " resolved."
         ),
+        examples=[EXAMPLE_PUBLISH_JOB_URL],
     )
 
 
@@ -188,10 +200,14 @@ class QueueJob(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this queue job resource.")
+    self_url: str = Field(
+        description="URL to this queue job resource.",
+        examples=[EXAMPLE_JOB_URL],
+    )
 
     id: str = Field(
-        description="Public Crockford Base32 identifier for the job."
+        description="Public Crockford Base32 identifier for the job.",
+        examples=[EXAMPLE_JOB_ID],
     )
 
     kind: JobKind = Field(description="Kind of background job.")
@@ -204,6 +220,7 @@ class QueueJob(BaseModel):
             "Public Crockford Base32 identifier of the keeper-sync run this"
             " job is attributed to, or ``null`` for jobs not part of a run."
         ),
+        examples=[EXAMPLE_RUN_ID],
     )
 
     subject_label: str | None = Field(
@@ -212,6 +229,7 @@ class QueueJob(BaseModel):
             "Human-readable identifier for the resource this job targets"
             " (e.g. an LTD slug for keeper-sync project jobs)."
         ),
+        examples=["pipelines"],
     )
 
     subject_url: str | None = Field(
@@ -223,6 +241,7 @@ class QueueJob(BaseModel):
             " publish jobs. ``null`` when no API resource exists or it could"
             " not be resolved."
         ),
+        examples=[EXAMPLE_BUILD_URL],
     )
 
     build_url: str | None = Field(
@@ -231,6 +250,7 @@ class QueueJob(BaseModel):
             "Absolute URL of the build this job processes, or ``null`` when"
             " the job targets no build or it could not be resolved."
         ),
+        examples=[EXAMPLE_BUILD_URL],
     )
 
     edition_url: str | None = Field(
@@ -239,6 +259,7 @@ class QueueJob(BaseModel):
             "Absolute URL of the edition this job targets, or ``null`` when"
             " the job targets no edition or it could not be resolved."
         ),
+        examples=[EXAMPLE_EDITION_URL],
     )
 
     phase: str | None = Field(
@@ -247,6 +268,7 @@ class QueueJob(BaseModel):
             "Current processing phase (e.g., inventory, tracking,"
             " editions, dashboard)."
         ),
+        examples=["editions"],
     )
 
     progress: BuildProcessingProgress | None = Field(

--- a/client/src/docverse/client/models/queue_enums.py
+++ b/client/src/docverse/client/models/queue_enums.py
@@ -12,7 +12,29 @@ __all__ = [
 
 
 class JobKind(StrEnum):
-    """Kind of background job."""
+    """Kind of background job.
+
+    - ``build_processing`` — unpack an uploaded build tarball, inventory
+      its objects, and evaluate edition tracking.
+    - ``edition_update`` — move an edition's build pointer.
+    - ``publish_edition`` — publish an edition's current build to the
+      CDN / object store serving path.
+    - ``dashboard_build`` — regenerate one project's dashboard from
+      database state.
+    - ``dashboard_sync`` — re-fetch a dashboard template from its bound
+      GitHub repository.
+    - ``lifecycle_eval`` — evaluate an organization's lifecycle rules
+      and soft-delete matching editions and builds.
+    - ``git_ref_audit`` — audit tracked git refs against the source
+      repository (feeds the ``ref_deleted`` lifecycle rule).
+    - ``purgatory_cleanup`` — permanently delete soft-deleted builds
+      whose purgatory retention has elapsed.
+    - ``credential_reencrypt`` — re-encrypt stored credentials after a
+      key rotation.
+    - ``keeper_sync_run_discovery`` — fan out per-project sync jobs for
+      a keeper-sync run.
+    - ``keeper_sync_project`` — sync one LTD product into Docverse.
+    """
 
     build_processing = "build_processing"
     edition_update = "edition_update"
@@ -28,7 +50,16 @@ class JobKind(StrEnum):
 
 
 class JobStatus(StrEnum):
-    """Status of a queue job."""
+    """Status of a queue job.
+
+    - ``queued`` — the job is enqueued and waiting for a worker.
+    - ``in_progress`` — a worker is executing the job.
+    - ``completed`` — the job finished successfully.
+    - ``completed_with_errors`` — the job finished, but some of its
+      work failed; see the job's ``errors`` field.
+    - ``failed`` — the job failed; see the job's ``errors`` field.
+    - ``cancelled`` — the job was cancelled before completing.
+    """
 
     queued = "queued"
     in_progress = "in_progress"
@@ -39,7 +70,15 @@ class JobStatus(StrEnum):
 
 
 class PublishStatus(StrEnum):
-    """CDN publish state for an edition or edition build history entry."""
+    """CDN publish state for an edition or edition build history entry.
+
+    - ``pending`` — the edition points at a build that has not been
+      published yet.
+    - ``publishing`` — a ``publish_edition`` job is copying the build
+      to the serving path.
+    - ``published`` — the build is live at the edition's published URL.
+    - ``failed`` — the most recent publish attempt failed.
+    """
 
     pending = "pending"
     publishing = "publishing"

--- a/client/src/docverse/client/models/services.py
+++ b/client/src/docverse/client/models/services.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag
 
+from ._examples import EXAMPLE_ORG_URL
 from .infrastructure import ServiceCategory, ServiceProvider
 
 __all__ = [
@@ -162,7 +163,7 @@ class OrganizationServiceCreate(BaseModel):
                 "Human-readable label for the service, unique per"
                 " organization."
             ),
-            examples=["docs-bucket", "cdn", "dns"],
+            examples=["docs-bucket", "staging-bucket", "cdn", "dns"],
         ),
     ]
 
@@ -207,8 +208,14 @@ class OrganizationServiceUpdate(BaseModel):
 class OrganizationServiceSummary(BaseModel):
     """Lightweight service reference embedded in Organization responses."""
 
-    self_url: str = Field(description="URL to the full service resource.")
-    label: str = Field(description="Service label.")
+    self_url: str = Field(
+        description="URL to the full service resource.",
+        examples=[f"{EXAMPLE_ORG_URL}/services/docs-bucket"],
+    )
+    label: str = Field(
+        description="Service label.",
+        examples=["docs-bucket", "staging-bucket", "cdn", "dns"],
+    )
     category: ServiceCategory = Field(description="Service category.")
     provider: ServiceProvider = Field(description="Service provider.")
 
@@ -221,18 +228,26 @@ class OrganizationService(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
-    self_url: str = Field(description="URL to this service resource.")
+    self_url: str = Field(
+        description="URL to this service resource.",
+        examples=[f"{EXAMPLE_ORG_URL}/services/docs-bucket"],
+    )
 
-    org_url: str = Field(description="URL to the parent organization.")
+    org_url: str = Field(
+        description="URL to the parent organization.",
+        examples=[EXAMPLE_ORG_URL],
+    )
 
     credential_url: str = Field(
-        description="URL to the credential this service uses."
+        description="URL to the credential this service uses.",
+        examples=[f"{EXAMPLE_ORG_URL}/credentials/aws"],
     )
 
     label: str = Field(
         description=(
             "Human-readable label for the service, unique per organization."
         ),
+        examples=["docs-bucket", "staging-bucket", "cdn", "dns"],
     )
 
     category: ServiceCategory = Field(description="Service category.")
@@ -240,11 +255,19 @@ class OrganizationService(BaseModel):
     provider: ServiceProvider = Field(description="Service provider.")
 
     config: dict[str, Any] = Field(
-        description="Provider-specific non-secret configuration."
+        description="Provider-specific non-secret configuration.",
+        examples=[
+            {
+                "provider": "aws_s3",
+                "bucket": "lsst-the-docs",
+                "region": "us-east-1",
+            }
+        ],
     )
 
     credential_label: str = Field(
-        description="Label of the credential used for authentication."
+        description="Label of the credential used for authentication.",
+        examples=["aws"],
     )
 
     date_created: datetime = Field(

--- a/client/tests/client_test.py
+++ b/client/tests/client_test.py
@@ -17,6 +17,7 @@ from docverse.client._exceptions import (
     BuildProcessingError,
     DocverseClientError,
 )
+from docverse.client.models import OrgRole
 from docverse.client.models.builds import BuildAnnotations, BuildStatus
 from docverse.client.models.queue_enums import JobKind, JobStatus
 
@@ -229,6 +230,48 @@ async def test_wait_for_job_failed(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert exc_info.value.job.status == JobStatus.failed
     assert exc_info.value.job.phase == "inventory"
+
+
+@pytest.mark.asyncio
+async def test_list_organizations() -> None:
+    """GET /orgs returns parsed OrganizationSummary entries."""
+    payload = [
+        {
+            "self_url": "/orgs/org-a",
+            "slug": "org-a",
+            "title": "Org A",
+            "role": "admin",
+        },
+        {
+            "self_url": "/orgs/org-b",
+            "slug": "org-b",
+            "title": "Org B",
+            "role": "reader",
+        },
+    ]
+    async with respx.mock(base_url=BASE_URL) as router:
+        route = router.get("/orgs").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        async with DocverseClient(BASE_URL, TOKEN) as client:
+            orgs = await client.list_organizations()
+
+    assert route.called
+    assert [o.slug for o in orgs] == ["org-a", "org-b"]
+    assert orgs[0].role == OrgRole.admin
+    assert orgs[1].role == OrgRole.reader
+    assert orgs[0].title == "Org A"
+
+
+@pytest.mark.asyncio
+async def test_list_organizations_empty() -> None:
+    """GET /orgs with no memberships returns an empty list."""
+    async with respx.mock(base_url=BASE_URL) as router:
+        router.get("/orgs").mock(return_value=httpx.Response(200, json=[]))
+        async with DocverseClient(BASE_URL, TOKEN) as client:
+            orgs = await client.list_organizations()
+
+    assert orgs == []
 
 
 @pytest.mark.asyncio

--- a/client/tests/client_test.py
+++ b/client/tests/client_test.py
@@ -11,13 +11,14 @@ from unittest.mock import patch
 import httpx
 import pytest
 import respx
+from pydantic import ValidationError
 
 from docverse.client._client import DocverseClient
 from docverse.client._exceptions import (
     BuildProcessingError,
     DocverseClientError,
 )
-from docverse.client.models import OrgRole
+from docverse.client.models import OrgMembershipUpdate, OrgRole
 from docverse.client.models.builds import BuildAnnotations, BuildStatus
 from docverse.client.models.queue_enums import JobKind, JobStatus
 
@@ -272,6 +273,40 @@ async def test_list_organizations_empty() -> None:
             orgs = await client.list_organizations()
 
     assert orgs == []
+
+
+@pytest.mark.asyncio
+async def test_update_member() -> None:
+    """PATCH a member's role returns the updated OrgMembership."""
+    payload = {
+        "self_url": "/orgs/myorg/members/user:jdoe",
+        "org_url": "/orgs/myorg",
+        "id": "user:jdoe",
+        "principal": "jdoe",
+        "principal_type": "user",
+        "role": "admin",
+    }
+    async with respx.mock(base_url=BASE_URL) as router:
+        route = router.patch("/orgs/myorg/members/user:jdoe").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        async with DocverseClient(BASE_URL, TOKEN) as client:
+            member = await client.update_member(
+                "myorg", "user:jdoe", role=OrgRole.admin
+            )
+
+    assert route.called
+    assert json.loads(route.calls[0].request.content) == {"role": "admin"}
+    assert member.role == OrgRole.admin
+    assert member.principal == "jdoe"
+
+
+def test_org_membership_update_forbids_identity_fields() -> None:
+    """OrgMembershipUpdate rejects principal/principal_type fields."""
+    with pytest.raises(ValidationError):
+        OrgMembershipUpdate.model_validate({"principal": "someone-else"})
+    with pytest.raises(ValidationError):
+        OrgMembershipUpdate.model_validate({"principal_type": "group"})
 
 
 @pytest.mark.asyncio

--- a/client/tests/client_test.py
+++ b/client/tests/client_test.py
@@ -18,7 +18,11 @@ from docverse.client._exceptions import (
     BuildProcessingError,
     DocverseClientError,
 )
-from docverse.client.models import OrgMembershipUpdate, OrgRole
+from docverse.client.models import (
+    KeeperSyncConfigUpdate,
+    OrgMembershipUpdate,
+    OrgRole,
+)
 from docverse.client.models.builds import BuildAnnotations, BuildStatus
 from docverse.client.models.queue_enums import JobKind, JobStatus
 
@@ -299,6 +303,29 @@ async def test_update_member() -> None:
     assert json.loads(route.calls[0].request.content) == {"role": "admin"}
     assert member.role == OrgRole.admin
     assert member.principal == "jdoe"
+
+
+@pytest.mark.asyncio
+async def test_update_keeper_sync_config() -> None:
+    """PATCH keeper-sync sends only set fields and returns the config."""
+    payload = {
+        "enabled": False,
+        "ltd_base_url": "https://keeper.lsst.codes/",
+        "project_slugs": ["dmtn-001"],
+    }
+    async with respx.mock(base_url=BASE_URL) as router:
+        route = router.patch("/orgs/myorg/keeper-sync").mock(
+            return_value=httpx.Response(200, json=payload)
+        )
+        async with DocverseClient(BASE_URL, TOKEN) as client:
+            config = await client.update_keeper_sync_config(
+                "myorg", KeeperSyncConfigUpdate(enabled=False)
+            )
+
+    assert route.called
+    assert json.loads(route.calls[0].request.content) == {"enabled": False}
+    assert config.enabled is False
+    assert config.project_slugs == ["dmtn-001"]
 
 
 def test_org_membership_update_forbids_identity_fields() -> None:

--- a/client/tests/dashboard_model_test.py
+++ b/client/tests/dashboard_model_test.py
@@ -1,0 +1,33 @@
+"""Tests for dashboard rebuild client models."""
+
+from __future__ import annotations
+
+from docverse.client.models import (
+    OrgDashboardRebuildEntry,
+    OrgDashboardRebuildResponse,
+)
+
+
+def test_org_dashboard_rebuild_response_wraps_entries() -> None:
+    """The org-wide rebuild response is an object envelope, not an array."""
+    entry = OrgDashboardRebuildEntry(
+        project_slug="alpha",
+        job_id="abc123",
+        job_url="https://example.com/orgs/o/jobs/abc123",
+    )
+    response = OrgDashboardRebuildResponse(entries=[entry])
+    dumped = response.model_dump()
+    assert dumped == {
+        "entries": [
+            {
+                "project_slug": "alpha",
+                "job_id": "abc123",
+                "job_url": "https://example.com/orgs/o/jobs/abc123",
+            }
+        ]
+    }
+
+
+def test_org_dashboard_rebuild_response_defaults_to_empty_list() -> None:
+    """An org with no eligible projects yields an empty ``entries`` list."""
+    assert OrgDashboardRebuildResponse().model_dump() == {"entries": []}

--- a/client/tests/keeper_sync_model_test.py
+++ b/client/tests/keeper_sync_model_test.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from docverse.client.models import (
     KeeperSyncConfig,
+    KeeperSyncConfigUpdate,
     KeeperSyncRun,
     KeeperSyncTombstone,
 )
@@ -62,6 +63,39 @@ def test_rejects_invalid_url() -> None:
             ltd_base_url="not-a-url",  # type: ignore[arg-type]
             project_slugs=[],
         )
+
+
+def test_config_update_all_fields_default_unset() -> None:
+    """An empty update dumps to nothing under ``exclude_unset``."""
+    update = KeeperSyncConfigUpdate()
+    assert update.model_dump(exclude_unset=True) == {}
+
+
+def test_config_update_omits_untouched_fields() -> None:
+    """Only the provided field survives ``model_dump(exclude_unset=True)``."""
+    update = KeeperSyncConfigUpdate(enabled=False)
+    assert update.model_dump(exclude_unset=True) == {"enabled": False}
+
+
+def test_config_update_project_slugs_replaces_wholesale() -> None:
+    """``project_slugs`` carries the full replacement list, or ``"*"``."""
+    update = KeeperSyncConfigUpdate(project_slugs=["alpha", "beta"])
+    assert update.model_dump(exclude_unset=True) == {
+        "project_slugs": ["alpha", "beta"]
+    }
+    wildcard = KeeperSyncConfigUpdate(project_slugs="*")
+    assert wildcard.model_dump(exclude_unset=True) == {"project_slugs": "*"}
+
+
+def test_config_update_forbids_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        KeeperSyncConfigUpdate.model_validate({"unknown": True})
+
+
+def test_config_update_rejects_unknown_string_token() -> None:
+    """Only the literal ``"*"`` is accepted for ``project_slugs``."""
+    with pytest.raises(ValidationError):
+        KeeperSyncConfigUpdate(project_slugs="ALL")  # type: ignore[arg-type]
 
 
 def test_keeper_sync_run_id_is_base32_string() -> None:

--- a/client/tests/organization_model_test.py
+++ b/client/tests/organization_model_test.py
@@ -8,9 +8,27 @@ from pydantic import ValidationError
 from docverse.client.models import (
     LifecycleRuleSet,
     OrganizationCreate,
+    OrganizationSummary,
     OrganizationUpdate,
+    OrgRole,
 )
 from docverse.client.models.organizations import normalize_base_domain
+
+
+def test_organization_summary_round_trip() -> None:
+    """OrganizationSummary parses the listing entry shape."""
+    summary = OrganizationSummary.model_validate(
+        {
+            "self_url": "https://example.com/docverse/orgs/lsst",
+            "slug": "lsst",
+            "title": "Rubin Observatory",
+            "role": "reader",
+        }
+    )
+    assert summary.slug == "lsst"
+    assert summary.title == "Rubin Observatory"
+    assert summary.role is OrgRole.reader
+    assert summary.self_url.endswith("/orgs/lsst")
 
 
 @pytest.mark.parametrize(

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -112,6 +112,17 @@ The choice between `PUT` and `PATCH` follows the nature of the target:
   `{"enabled": false}` leaves `ltd_base_url` and `project_slugs`
   unchanged, while providing `project_slugs` replaces the entire list.
 
+  **Explicit `null` is rejected, not honoured.** RFC 7386 merge-patch gives
+  an explicit `null` remove-the-member semantics, but the fields these PATCH
+  endpoints expose map onto non-nullable storage (a member's `role`, the
+  keeper-sync config's `enabled` / `ltd_base_url` / `project_slugs`), so
+  there is nothing to remove. Sending `null` for such a field is a client
+  error and returns **422 Unprocessable Entity**; it is *not* silently
+  treated as "unset". To leave a field unchanged, omit it from the request
+  body. (The request models distinguish the two with a field validator that
+  fires on an explicit `null` but is skipped for the unset default — see
+  `OrgMembershipUpdate` and `KeeperSyncConfigUpdate` in the client models.)
+
 ## Asynchronous operations: 202 with a `Location` job URL
 
 Operations that enqueue background work return **`202 Accepted`**. The

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -1,0 +1,204 @@
+# Docverse REST API conventions
+
+This document records the conventions the Docverse REST API follows so
+that new endpoints stay consistent with the ones already shipped. It is
+written as a standalone Markdown file because the repository does not yet
+have a documentation build; a future Sphinx/documenteer or mkdocs tree can
+absorb it unchanged.
+
+The conventions below are grounded in the handlers under
+`src/docverse/handlers/`. When adding an endpoint, follow the pattern of
+the closest existing handler and keep this document in sync.
+
+## Async-action verb rule
+
+Endpoints that trigger background work are named with a verb path segment
+chosen by the *source of truth* the action reads from. The three verbs in
+use each mean something specific:
+
+- **`rebuild`** — regenerate a derived artifact from Docverse's own
+  database state. Example:
+  `POST /orgs/{org}/projects/{project}/dashboard/rebuild` and the
+  org-wide `POST /orgs/{org}/dashboard/rebuild` regenerate dashboards from
+  the projects and editions already recorded in Docverse.
+- **`sync`** — pull from an external GitHub source. Example:
+  `POST /orgs/{org}/dashboard-template/sync` and
+  `POST /orgs/{org}/projects/{project}/dashboard-template/sync` re-fetch
+  the bound dashboard template from its GitHub repository.
+- **`refresh`** — re-fetch from LTD (the legacy LTD Keeper system).
+  Example: `POST /orgs/{org}/keeper-sync/projects/{ltd_slug}/refresh`
+  triggers an immediate re-fetch of one LTD product's state.
+
+Pick the verb by asking "where does the fresh data come from?" — Docverse's
+database (`rebuild`), GitHub (`sync`), or LTD (`refresh`). Do not
+introduce a new async verb without a distinct source to justify it.
+
+## Path parameters
+
+Path parameters are **bare nouns** naming the resource at that position,
+not `{noun}_id` or `{noun}_slug`. The parameter's actual type (slug,
+Base32 identifier, label) is documented on the `Path(...)` alias in
+`src/docverse/handlers/params.py`, not encoded in the URL:
+
+```
+/orgs/{org}/projects/{project}/builds/{build}
+/orgs/{org}/members/{member}
+/orgs/{org}/services/{service}
+/orgs/{org}/keeper-sync/runs/{run}
+```
+
+- `{org}`, `{project}`, `{edition}` — resource slugs.
+- `{build}`, `{job}`, `{run}`, `{tombstone}` — Base32-encoded
+  identifiers.
+- `{member}` — composite `{type}:{principal}` identifier (e.g.
+  `user:someuser`).
+- `{credential}`, `{service}` — labels.
+
+**Exception:** `{ltd_slug}` keeps its qualified name. It names a slug
+belonging to a foreign system (LTD), and the descriptive name signals that
+it is not a native Docverse identifier. This exception is deliberate and
+should not be "cleaned up" to a bare noun.
+
+## Hypermedia links
+
+Response bodies carry their own URLs so clients can navigate without
+constructing paths. Every resource representation includes a **`self_url`**
+field pointing at its canonical GET endpoint. Links to related resources
+and sub-collections use a **`{relation}_url`** suffix, for example:
+
+- `org_url`, `project_url`, `edition_url`, `build_url` — links to related
+  resources.
+- `projects_url`, `editions_url`, `members_url`, `services_url`,
+  `credentials_url`, `builds_url`, `history_url` — links to
+  sub-collections.
+- `job_url` — link to the queue job a 202 response enqueued.
+- `published_url`, `web_url` — externally-facing (non-API) URLs.
+
+All `*_url` fields are absolute URLs, built from the incoming request so
+they honour the deployment's scheme and host.
+
+## Timestamp field naming
+
+Timestamp fields are prefixed with **`date_`** and carry timezone-aware
+values, for example `date_created`, `date_updated`, `date_uploaded`,
+`date_completed`. This matches the `date_`-prefixed database columns (see
+the coding conventions in `CLAUDE.md`).
+
+## HTTP methods: PUT for config singletons, PATCH for resources
+
+The choice between `PUT` and `PATCH` follows the nature of the target:
+
+- **`PUT` for config singletons.** A configuration singleton that is
+  naturally set as a whole is replaced with `PUT`. The
+  `dashboard-template` bindings are **PUT-only**
+  (`PUT /orgs/{org}/dashboard-template`,
+  `PUT /orgs/{org}/projects/{project}/dashboard-template`): a binding is
+  an atomic pointer, so full replacement is the only meaningful write.
+  `PUT /orgs/{org}/keeper-sync` performs a full replacement of the
+  keeper-sync configuration.
+
+- **`PATCH` for partial updates with JSON-Merge-Patch semantics.**
+  Resources and configs that support field-level edits expose a `PATCH`
+  alongside (or instead of) `PUT`:
+  - `PATCH /orgs/{org}` — update an organization's mutable fields.
+  - `PATCH /orgs/{org}/members/{member}` — update a member's `role` only;
+    `principal`/`principal_type` are immutable (changing identity is a
+    delete plus re-add).
+  - `PATCH /orgs/{org}/keeper-sync` — partial config update.
+
+  **Merge-patch semantics** (house style): omitted fields are left
+  untouched; a provided array field replaces the whole array (no append
+  semantics). For example, `PATCH /orgs/{org}/keeper-sync` with only
+  `{"enabled": false}` leaves `ltd_base_url` and `project_slugs`
+  unchanged, while providing `project_slugs` replaces the entire list.
+
+## Asynchronous operations: 202 with a `Location` job URL
+
+Operations that enqueue background work return **`202 Accepted`**. The
+work is represented as a queue job, and the response sets a **`Location`**
+header pointing at the job so a client can poll for progress:
+
+- `POST .../dashboard/rebuild` (project-scoped),
+  `POST /orgs/{org}/keeper-sync/runs`,
+  `POST /orgs/{org}/keeper-sync/projects/{ltd_slug}/refresh`,
+  `POST .../dashboard-template/sync` each enqueue a single job and set
+  `Location` to that job's `job_url`.
+- The batch `POST /orgs/{org}/dashboard/rebuild` enqueues one job per
+  project, so there is no single job resource. Per RFC 7231 the 202
+  `Location` names a status monitor for the request; here it points at the
+  org-scoped jobs collection (`GET /orgs/{org}/jobs`). The response body
+  is an object (`{"entries": [...]}`), never a bare array, so it can grow
+  fields later.
+
+## `Location` headers on created and enqueued resources
+
+- **201 Created** responses set `Location` to the new resource's
+  `self_url`. This applies to every create endpoint, e.g.
+  `POST /admin/orgs`, `POST /orgs/{org}/projects`,
+  `POST /orgs/{org}/projects/{project}/builds`, `POST /orgs/{org}/members`,
+  `POST /orgs/{org}/services`, `POST /orgs/{org}/credentials`, and the
+  `PUT` dashboard-template bindings when they create a binding.
+- **202 Accepted** responses set `Location` to the job URL (or status
+  monitor), as described above.
+
+## Documented error responses
+
+Client-error responses are declared with FastAPI's `responses=` argument
+so they appear in the OpenAPI spec with safir's `ErrorModel` body shape,
+rather than being left undocumented. The shared helper
+`error_responses(*status_codes)` in `src/docverse/handlers/responses.py`
+builds these declarations for:
+
+- **403 Forbidden** — the caller lacks the role required for the
+  operation.
+- **404 Not Found** — a resource addressed by the request path does not
+  exist.
+- **409 Conflict** — the request conflicts with the current state of the
+  resource (e.g. a rebuild is already queued).
+
+Each operation declares the subset of these codes it can actually return.
+
+## Pagination: keyset cursors with `Link` and `X-Total-Count`
+
+Unbounded collections are paginated with **keyset (cursor) pagination**,
+never offset/limit. The mechanics (see
+`src/docverse/storage/pagination.py`):
+
+- **Query parameters:** `cursor` (an opaque token copied from a previous
+  response — clients must not construct or parse it) and `limit` (default
+  `25`, maximum `100`).
+- **`Link` response header:** carries `rel="next"` / `rel="prev"` URLs
+  (RFC 8288) that already embed the correct cursor. Clients follow these
+  rather than building their own paginated URLs.
+- **`X-Total-Count` response header:** the total number of matching
+  entries across all pages.
+- Cursors are keyset-based on a stable sort key plus an `id` tiebreaker
+  (e.g. `date_created DESC, id DESC` for builds/projects/jobs, `slug ASC`
+  for project/edition listings), so pages stay stable under concurrent
+  inserts.
+
+Paginated listings include: projects, editions, builds, edition build
+history, queue jobs (`GET /orgs/{org}/jobs`), and the keeper-sync
+projects, editions, runs, and tombstones collections.
+
+## Deliberately unpaginated listings
+
+Some collections are **bounded by nature** and return a plain JSON array
+with no `cursor`/`limit` parameters and no `Link`/`X-Total-Count` headers.
+These are intentionally unpaginated because their size is limited by an
+organization's team or configuration, not by user-generated content:
+
+- **Members** — `GET /orgs/{org}/members` (`list[OrgMembership]`).
+- **Credentials** — `GET /orgs/{org}/credentials`
+  (`list[OrganizationCredentialResponse]`).
+- **Services** — `GET /orgs/{org}/services`
+  (`list[OrganizationServiceResponse]`).
+- **Admin orgs** — `GET /admin/orgs` (`list[AdminOrganization]`).
+- **Non-admin orgs** — `GET /orgs` (`list[OrganizationSummary]`), which
+  lists the organizations where the caller has an effective role. It is
+  bounded by the caller's memberships (a superadmin sees all orgs), so it
+  is unpaginated to match the other bounded listings; an empty list is a
+  valid response.
+
+If one of these collections ever grows unbounded, migrate it to the keyset
+pagination pattern above rather than adding offset paging.

--- a/docs/api-conventions.md
+++ b/docs/api-conventions.md
@@ -77,6 +77,78 @@ and sub-collections use a **`{relation}_url`** suffix, for example:
 All `*_url` fields are absolute URLs, built from the incoming request so
 they honour the deployment's scheme and host.
 
+## Public identifiers: no database IDs on the wire
+
+Response bodies never expose integer database row IDs. Resources that
+need a public identifier carry a **Crockford Base32 public ID** (12
+characters plus a 2-character checksum, hyphenated every 4, e.g.
+`1txq-55pj-1x5m-16`), minted from the `public_id` column via
+`docverse.domain.base32id`. Fields holding these IDs are named `id` on
+the resource itself and `{relation}_id` when referencing another
+resource (`job_id`, `build_id`, `keeper_sync_run_id`).
+
+Numeric IDs from *foreign* systems are allowed but must be clearly
+labelled as such in the field name and description: `ltd_id` (legacy
+LTD Keeper), `github_owner_id` / `github_repo_id` /
+`github_installation_id` (GitHub). When a response needs to point at
+another Docverse resource, prefer a `{relation}_url` HATEOAS link (or
+the resource's Base32 public ID) — never its integer row id.
+
+## Example values in the generated OpenAPI schema
+
+Every `*_url`, public-ID, and slug-like field declares
+`Field(examples=[...])` so the rendered OpenAPI docs show realistic
+values instead of `"string"`. The examples share one vocabulary,
+defined as constants in
+`client/src/docverse/client/models/_examples.py`:
+
+- The example deployment is `https://example.org/docverse/api`.
+- The example organization is `lsst`, its project `pipelines`, and its
+  edition `v1`.
+- Example Base32 IDs are genuine minted values (they round-trip through
+  the real validators), one distinct constant per resource type so
+  cross-references line up — e.g. a build's `self_url` embeds the same
+  id shown in the build's `id` field.
+
+When adding a field that fits this vocabulary, reuse the constants
+rather than inventing new example values inline.
+
+## Documenting enums
+
+Pydantic emits an enum's **class docstring** as the description of the
+enum's component schema in the OpenAPI document, but **member
+docstrings are dropped**. Therefore every public (wire-visible) enum
+documents its values as a bulleted list in the class docstring:
+
+```python
+class KeeperSyncTombstoneReason(StrEnum):
+    """Why a ``keeper_sync_state`` row was tombstoned.
+
+    - ``manual_delete`` — an operator soft-deleted ...
+    - ``lifecycle_delete`` — an automated process ...
+    """
+```
+
+Do not put value semantics only in member docstrings — they are
+invisible to API consumers. The list format renders as Markdown in
+Swagger UI and Redoc.
+
+## OpenAPI tags
+
+Operations are grouped under three tags, declared in
+`src/docverse/main.py` and applied per sub-router in
+`src/docverse/handlers/orgs/__init__.py`:
+
+- **`orgs`** — organization-scoped resources: the org itself, members,
+  credentials, services, keeper-sync, the org dashboard, and the
+  org-scoped jobs collection (`/orgs/{org}/jobs`).
+- **`projects`** — projects and their sub-resources (builds, editions,
+  project dashboards and template overrides).
+- **`admin`** — superuser organization administration.
+
+There is deliberately no separate `jobs` tag: jobs are org-scoped
+resources and document under `orgs`.
+
 ## Timestamp field naming
 
 Timestamp fields are prefixed with **`date_`** and carry timezone-aware

--- a/server-changelog.d/20260729_120000_DM_55551_openapi_polish.md
+++ b/server-changelog.d/20260729_120000_DM_55551_openapi_polish.md
@@ -1,0 +1,10 @@
+### Backwards-incompatible changes
+
+- The tombstone entries returned by `GET /orgs/{org}/keeper-sync/tombstones` no longer carry a `docverse_id` field. It exposed the internal integer database row id of the tombstoned project/edition; the entry's Base32 `id` and `display_path` already identify the resource for operators.
+
+### Other changes
+
+- The OpenAPI schema now shows realistic example values instead of `"string"`: every HATEOAS `*_url` field carries a full example URL (anchored on `https://example.org/docverse/api` with a shared `lsst`/`pipelines` example vocabulary), and public-ID fields (`id`, `job_id`, `build_id`, `keeper_sync_run_id`, …) show genuine Crockford Base32 example identifiers. The shared example constants live in `docverse.client.models._examples`.
+- Wire-visible enums now document what each value means in the generated OpenAPI schema. Pydantic surfaces an enum's class docstring as the schema description (member docstrings are dropped), so every public enum (`KeeperSyncTombstoneReason`, `KeeperSyncRunKind`, `EditionKind`, `TrackingMode`, `JobKind`, `JobStatus`, `PublishStatus`, `OrgRole`, and others) lists its values there.
+- The standalone `jobs` OpenAPI tag is retired: the org-scoped `/orgs/{org}/jobs` endpoints now document under the `orgs` tag.
+- `docs/api-conventions.md` records the new conventions: no database ids on the wire, shared example-value vocabulary, enum documentation placement, and the OpenAPI tag set.

--- a/src/docverse/handlers/admin/endpoints.py
+++ b/src/docverse/handlers/admin/endpoints.py
@@ -13,7 +13,7 @@ from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.exceptions import ConflictError, NotFoundError
 from docverse.handlers.params import OrgSlugParam
 
-from .models import Organization
+from .models import AdminOrganization
 
 router = APIRouter(tags=["admin"], dependencies=[Depends(require_superadmin)])
 
@@ -37,7 +37,7 @@ class SentryTestRequest(BaseModel):
 
 @router.post(
     "/admin/orgs",
-    response_model=Organization,
+    response_model=AdminOrganization,
     status_code=status.HTTP_201_CREATED,
     summary="Create an organization",
     name="admin_post_organization",
@@ -45,7 +45,7 @@ class SentryTestRequest(BaseModel):
 async def post_organization(
     data: OrganizationCreate,
     context: Annotated[RequestContext, Depends(context_dependency)],
-) -> Organization:
+) -> AdminOrganization:
     async with context.session.begin():
         service = context.factory.create_organization_service()
         existing = await service.get_by_slug(data.slug)
@@ -64,41 +64,43 @@ async def post_organization(
                 await membership_store.create(org_id=org.id, data=member)
         await context.session.commit()
     # New org has no services yet, so no need to load them
-    return Organization.from_domain(org, context.request)
+    return AdminOrganization.from_domain(org, context.request)
 
 
 @router.get(
     "/admin/orgs",
-    response_model=list[Organization],
+    response_model=list[AdminOrganization],
     summary="List all organizations",
     name="admin_get_organizations",
 )
 async def get_organizations(
     context: Annotated[RequestContext, Depends(context_dependency)],
-) -> list[Organization]:
+) -> list[AdminOrganization]:
     async with context.session.begin():
         service = context.factory.create_organization_service()
         orgs = await service.list_all()
         service_store = context.factory.create_service_store()
-        results: list[Organization] = []
+        results: list[AdminOrganization] = []
         for o in orgs:
             services = await service_store.list_by_org(o.id)
             results.append(
-                Organization.from_domain(o, context.request, services=services)
+                AdminOrganization.from_domain(
+                    o, context.request, services=services
+                )
             )
     return results
 
 
 @router.get(
     "/admin/orgs/{org}",
-    response_model=Organization,
+    response_model=AdminOrganization,
     summary="Get an organization",
     name="admin_get_organization",
 )
 async def get_organization(
     org_slug: OrgSlugParam,
     context: Annotated[RequestContext, Depends(context_dependency)],
-) -> Organization:
+) -> AdminOrganization:
     async with context.session.begin():
         service = context.factory.create_organization_service()
         org = await service.get_by_slug(org_slug)
@@ -107,7 +109,9 @@ async def get_organization(
             raise NotFoundError(msg)
         service_store = context.factory.create_service_store()
         services = await service_store.list_by_org(org.id)
-    return Organization.from_domain(org, context.request, services=services)
+    return AdminOrganization.from_domain(
+        org, context.request, services=services
+    )
 
 
 @router.post(

--- a/src/docverse/handlers/admin/endpoints.py
+++ b/src/docverse/handlers/admin/endpoints.py
@@ -66,7 +66,9 @@ async def post_organization(
                 await membership_store.create(org_id=org.id, data=member)
         await context.session.commit()
     # New org has no services yet, so no need to load them
-    return AdminOrganization.from_domain(org, context.request)
+    response_model = AdminOrganization.from_domain(org, context.request)
+    context.response.headers["Location"] = response_model.self_url
+    return response_model
 
 
 @router.get(

--- a/src/docverse/handlers/admin/endpoints.py
+++ b/src/docverse/handlers/admin/endpoints.py
@@ -12,6 +12,7 @@ from docverse.dependencies.auth import require_superadmin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.exceptions import ConflictError, NotFoundError
 from docverse.handlers.params import OrgSlugParam
+from docverse.handlers.responses import error_responses
 
 from .models import AdminOrganization
 
@@ -41,6 +42,7 @@ class SentryTestRequest(BaseModel):
     status_code=status.HTTP_201_CREATED,
     summary="Create an organization",
     name="admin_post_organization",
+    responses=error_responses(status.HTTP_409_CONFLICT),
 )
 async def post_organization(
     data: OrganizationCreate,
@@ -96,6 +98,7 @@ async def get_organizations(
     response_model=AdminOrganization,
     summary="Get an organization",
     name="admin_get_organization",
+    responses=error_responses(status.HTTP_404_NOT_FOUND),
 )
 async def get_organization(
     org_slug: OrgSlugParam,
@@ -144,6 +147,7 @@ async def post_sentry_test(
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Delete an organization",
     name="admin_delete_organization",
+    responses=error_responses(status.HTTP_404_NOT_FOUND),
 )
 async def delete_organization(
     org_slug: OrgSlugParam,

--- a/src/docverse/handlers/admin/models.py
+++ b/src/docverse/handlers/admin/models.py
@@ -14,8 +14,13 @@ from docverse.domain.organization_service import (
 )
 
 
-class Organization(_OrganizationBase):
-    """Organization response model with HATEOAS self_url."""
+class AdminOrganization(_OrganizationBase):
+    """Admin organization response model with HATEOAS self_url.
+
+    Distinct from the orgs-scoped ``Organization`` model: the admin
+    shape adds ``org_url`` (a link to the org-scoped endpoint) and omits
+    the orgs sub-collection links, so it registers as its own schema.
+    """
 
     org_url: str
     """URL to the org-scoped API endpoint."""

--- a/src/docverse/handlers/admin/models.py
+++ b/src/docverse/handlers/admin/models.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Self
 
+from pydantic import Field
 from starlette.requests import Request
 
 from docverse.client.models import Organization as _OrganizationBase
 from docverse.client.models import OrganizationServiceSummary
+from docverse.client.models._examples import EXAMPLE_API_URL, EXAMPLE_ORG_URL
 from docverse.domain.organization import Organization as OrganizationDomain
 from docverse.domain.organization_service import (
     OrganizationService as OrganizationServiceDomain,
@@ -22,8 +24,15 @@ class AdminOrganization(_OrganizationBase):
     the orgs sub-collection links, so it registers as its own schema.
     """
 
-    org_url: str
-    """URL to the org-scoped API endpoint."""
+    self_url: str = Field(
+        description="URL to this admin organization resource.",
+        examples=[f"{EXAMPLE_API_URL}/admin/orgs/lsst"],
+    )
+
+    org_url: str = Field(
+        description="URL to the org-scoped API endpoint.",
+        examples=[EXAMPLE_ORG_URL],
+    )
 
     @classmethod
     def from_domain(

--- a/src/docverse/handlers/orgs/__init__.py
+++ b/src/docverse/handlers/orgs/__init__.py
@@ -4,7 +4,8 @@ from fastapi import APIRouter
 
 from .builds import router as builds_router
 from .credentials import router as credentials_router
-from .dashboard import router as dashboard_router
+from .dashboard import org_router as dashboard_org_router
+from .dashboard import project_router as dashboard_project_router
 from .dashboard_template import (
     org_default_router as dashboard_template_org_default_router,
 )
@@ -27,7 +28,8 @@ orgs_router.include_router(editions_router, tags=["projects"])
 orgs_router.include_router(members_router, tags=["orgs"])
 orgs_router.include_router(credentials_router, tags=["orgs"])
 orgs_router.include_router(services_router, tags=["orgs"])
-orgs_router.include_router(dashboard_router, tags=["projects"])
+orgs_router.include_router(dashboard_project_router, tags=["projects"])
+orgs_router.include_router(dashboard_org_router, tags=["orgs"])
 orgs_router.include_router(
     dashboard_template_org_default_router, tags=["orgs"]
 )

--- a/src/docverse/handlers/orgs/__init__.py
+++ b/src/docverse/handlers/orgs/__init__.py
@@ -37,6 +37,6 @@ orgs_router.include_router(
     dashboard_template_project_override_router, tags=["projects"]
 )
 orgs_router.include_router(keeper_sync_router, tags=["orgs"])
-orgs_router.include_router(jobs_router, tags=["jobs"])
+orgs_router.include_router(jobs_router, tags=["orgs"])
 
 __all__ = ["orgs_router"]

--- a/src/docverse/handlers/orgs/builds.py
+++ b/src/docverse/handlers/orgs/builds.py
@@ -129,13 +129,15 @@ async def post_build(
             )
 
         await context.session.commit()
-    return Build.from_domain(
+    response_model = Build.from_domain(
         build,
         context.request,
         org_slug,
         project_slug,
         upload_url=upload_url,
     )
+    context.response.headers["Location"] = response_model.self_url
+    return response_model
 
 
 @router.get(

--- a/src/docverse/handlers/orgs/credentials.py
+++ b/src/docverse/handlers/orgs/credentials.py
@@ -61,9 +61,11 @@ async def post_credential(
             credentials=data.credentials.model_dump(exclude={"provider"}),
         )
         await context.session.commit()
-    return OrganizationCredentialResponse.from_domain(
+    response_model = OrganizationCredentialResponse.from_domain(
         credential, context.request, org_slug
     )
+    context.response.headers["Location"] = response_model.self_url
+    return response_model
 
 
 @router.get(

--- a/src/docverse/handlers/orgs/dashboard.py
+++ b/src/docverse/handlers/orgs/dashboard.py
@@ -10,6 +10,7 @@ from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.exceptions import ConflictError
 from docverse.handlers.params import OrgSlugParam, ProjectSlugParam
+from docverse.handlers.responses import error_responses
 
 from .models import DashboardRebuildResponse, OrgDashboardRebuildEntry
 
@@ -22,6 +23,7 @@ router = APIRouter()
     status_code=status.HTTP_202_ACCEPTED,
     summary="Rebuild a project's dashboard",
     name="post_dashboard_rebuild",
+    responses=error_responses(status.HTTP_409_CONFLICT),
 )
 async def post_dashboard_rebuild(
     org_slug: OrgSlugParam,

--- a/src/docverse/handlers/orgs/dashboard.py
+++ b/src/docverse/handlers/orgs/dashboard.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
+from docverse.client.models import OrgDashboardRebuildResponse
 from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.exceptions import ConflictError
@@ -14,10 +15,15 @@ from docverse.handlers.responses import error_responses
 
 from .models import DashboardRebuildResponse, OrgDashboardRebuildEntry
 
-router = APIRouter()
+# The project-scoped rebuild is a project-level operation (tagged
+# ``projects``); the org-wide rebuild is org-level (tagged ``orgs``). They
+# live on separate routers so ``orgs/__init__.py`` can tag each at the
+# appropriate level.
+project_router = APIRouter()
+org_router = APIRouter()
 
 
-@router.post(
+@project_router.post(
     "/orgs/{org}/projects/{project}/dashboard/rebuild",
     response_model=DashboardRebuildResponse,
     status_code=status.HTTP_202_ACCEPTED,
@@ -48,9 +54,9 @@ async def post_dashboard_rebuild(
     return response_model
 
 
-@router.post(
+@org_router.post(
     "/orgs/{org}/dashboard/rebuild",
-    response_model=list[OrgDashboardRebuildEntry],
+    response_model=OrgDashboardRebuildResponse,
     status_code=status.HTTP_202_ACCEPTED,
     summary="Rebuild every project's dashboard in an organization",
     name="post_org_dashboard_rebuild",
@@ -59,7 +65,7 @@ async def post_org_dashboard_rebuild(
     org_slug: OrgSlugParam,
     context: Annotated[RequestContext, Depends(context_dependency)],
     user: Annotated[AuthenticatedUser, Depends(require_admin)],
-) -> list[OrgDashboardRebuildEntry]:
+) -> OrgDashboardRebuildResponse:
     async with context.session.begin():
         service = context.factory.create_dashboard_build_enqueuer()
         results = await service.enqueue_for_org(org_id=user.org.id)
@@ -72,9 +78,11 @@ async def post_org_dashboard_rebuild(
     context.response.headers["Location"] = str(
         context.request.url_for("get_org_jobs", org=org_slug)
     )
-    return [
-        OrgDashboardRebuildEntry.from_domain(
-            project, queue_job, context.request, org_slug
-        )
-        for project, queue_job in results
-    ]
+    return OrgDashboardRebuildResponse(
+        entries=[
+            OrgDashboardRebuildEntry.from_domain(
+                project, queue_job, context.request, org_slug
+            )
+            for project, queue_job in results
+        ]
+    )

--- a/src/docverse/handlers/orgs/dashboard.py
+++ b/src/docverse/handlers/orgs/dashboard.py
@@ -41,9 +41,11 @@ async def post_dashboard_rebuild(
     if queue_job is None:
         msg = f"dashboard_build already queued for project {project_slug!r}"
         raise ConflictError(msg)
-    return DashboardRebuildResponse.from_queue_job(
+    response_model = DashboardRebuildResponse.from_queue_job(
         queue_job, context.request, org_slug
     )
+    context.response.headers["Location"] = response_model.job_url
+    return response_model
 
 
 @router.post(
@@ -63,6 +65,13 @@ async def post_org_dashboard_rebuild(
         results = await service.enqueue_for_org(org_id=user.org.id)
         await context.session.commit()
 
+    # This batch enqueues one job per project, so there is no single job
+    # resource to point at. Per RFC 7231 the 202 ``Location`` names a status
+    # monitor for the request; the org-scoped jobs collection serves that
+    # role here.
+    context.response.headers["Location"] = str(
+        context.request.url_for("get_org_jobs", org=org_slug)
+    )
     return [
         OrgDashboardRebuildEntry.from_domain(
             project, queue_job, context.request, org_slug

--- a/src/docverse/handlers/orgs/dashboard_template.py
+++ b/src/docverse/handlers/orgs/dashboard_template.py
@@ -104,11 +104,14 @@ async def put_org_dashboard_template(
     response.status_code = (
         status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
     )
-    return DashboardTemplateBindingResponse.from_domain(
+    response_model = DashboardTemplateBindingResponse.from_domain(
         _attach_queue_job(result.binding, queue_job),
         context.request,
         org_slug=org_slug,
     )
+    if result.created:
+        response.headers["Location"] = response_model.self_url
+    return response_model
 
 
 @org_default_router.delete(
@@ -146,9 +149,11 @@ async def sync_org_dashboard_template(
         enqueuer = context.factory.create_dashboard_sync_enqueuer()
         queue_job = await enqueuer.enqueue(binding.id)
         await context.session.commit()
-    return DashboardTemplateSyncEnqueuedResponse.from_queue_job(
+    response_model = DashboardTemplateSyncEnqueuedResponse.from_queue_job(
         queue_job, context.request, org_slug
     )
+    context.response.headers["Location"] = response_model.job_url
+    return response_model
 
 
 # ---------------------------------------------------------------------------
@@ -213,12 +218,15 @@ async def put_project_dashboard_template(
     response.status_code = (
         status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
     )
-    return DashboardTemplateBindingResponse.from_domain(
+    response_model = DashboardTemplateBindingResponse.from_domain(
         _attach_queue_job(result.binding, queue_job),
         context.request,
         org_slug=org_slug,
         project_slug=project_slug,
     )
+    if result.created:
+        response.headers["Location"] = response_model.self_url
+    return response_model
 
 
 @project_override_router.delete(
@@ -262,6 +270,8 @@ async def sync_project_dashboard_template(
         enqueuer = context.factory.create_dashboard_sync_enqueuer()
         queue_job = await enqueuer.enqueue(binding.id)
         await context.session.commit()
-    return DashboardTemplateSyncEnqueuedResponse.from_queue_job(
+    response_model = DashboardTemplateSyncEnqueuedResponse.from_queue_job(
         queue_job, context.request, org_slug
     )
+    context.response.headers["Location"] = response_model.job_url
+    return response_model

--- a/src/docverse/handlers/orgs/editions.py
+++ b/src/docverse/handlers/orgs/editions.py
@@ -156,13 +156,15 @@ async def post_edition(
         project_slug=project_slug,
     )
     project_url = project_published_url(org, project)
-    return edition_from_domain(
+    response_model = edition_from_domain(
         edition,
         context.request,
         org_slug,
         project_slug,
         published_url=edition_published_url(project_url, edition),
     )
+    context.response.headers["Location"] = response_model.self_url
+    return response_model
 
 
 @router.get(

--- a/src/docverse/handlers/orgs/editions.py
+++ b/src/docverse/handlers/orgs/editions.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query, status
 
 from docverse.client.models import (
+    Edition,
     EditionCreate,
     EditionKind,
     EditionRollback,
@@ -45,7 +46,7 @@ from docverse.storage.pagination import (
     EditionSortOrder,
 )
 
-from .models import Edition, EditionBuildHistoryResponse
+from .models import EditionBuildHistoryResponse, edition_from_domain
 
 router = APIRouter()
 
@@ -105,7 +106,7 @@ async def get_editions(
     context.response.headers["X-Total-Count"] = str(result.count)
     project_url = project_published_url(org, project)
     return [
-        Edition.from_domain(
+        edition_from_domain(
             e,
             context.request,
             org_slug,
@@ -155,7 +156,7 @@ async def post_edition(
         project_slug=project_slug,
     )
     project_url = project_published_url(org, project)
-    return Edition.from_domain(
+    return edition_from_domain(
         edition,
         context.request,
         org_slug,
@@ -185,7 +186,7 @@ async def get_edition(
             slug=edition_slug,
         )
     project_url = project_published_url(org, project)
-    return Edition.from_domain(
+    return edition_from_domain(
         edition,
         context.request,
         org_slug,
@@ -298,7 +299,7 @@ async def post_edition_rollback(
         project_slug=project_slug,
     )
     project_url = project_published_url(org, project)
-    return Edition.from_domain(
+    return edition_from_domain(
         edition,
         context.request,
         org_slug,
@@ -350,7 +351,7 @@ async def patch_edition(
         project_slug=project_slug,
     )
     project_url = project_published_url(org, project)
-    return Edition.from_domain(
+    return edition_from_domain(
         edition,
         context.request,
         org_slug,

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -96,9 +96,11 @@ async def post_org_keeper_sync_run(
         run_store = context.factory.create_keeper_sync_run_store()
         activity = await run_store.aggregate_activity(run_id=run.id)
         await context.session.commit()
-    return KeeperSyncRunCreated.from_domain(
+    response_model = KeeperSyncRunCreated.from_domain(
         run, activity, queue_job, context.request, org_slug
     )
+    context.response.headers["Location"] = str(response_model.job_url)
+    return response_model
 
 
 @router.get(
@@ -268,9 +270,11 @@ async def post_org_keeper_sync_project_refresh(
             org_slug=org_slug, ltd_slug=ltd_slug
         )
         await context.session.commit()
-    return KeeperSyncProjectRefreshAccepted.from_domain(
+    response_model = KeeperSyncProjectRefreshAccepted.from_domain(
         queue_job, context.request, org_slug
     )
+    context.response.headers["Location"] = str(response_model.job_url)
+    return response_model
 
 
 @router.get(

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Path, Query, Response, status
 
 from docverse.client.models import (
     KeeperSyncConfig,
+    KeeperSyncConfigUpdate,
     KeeperSyncEditionStatus,
     KeeperSyncResourceType,
     KeeperSyncRun,
@@ -71,6 +72,31 @@ async def put_org_keeper_sync_config(
     async with context.session.begin():
         service = context.factory.create_keeper_sync_config_service()
         result = await service.put(org_slug=org_slug, config=data)
+        await context.session.commit()
+    return result
+
+
+@router.patch(
+    "/orgs/{org}/keeper-sync",
+    response_model=KeeperSyncConfig,
+    summary="Partially update the LTD Keeper sync configuration",
+    name="patch_org_keeper_sync_config",
+)
+async def patch_org_keeper_sync_config(
+    org_slug: OrgSlugParam,
+    data: KeeperSyncConfigUpdate,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],
+) -> KeeperSyncConfig:
+    """Merge-patch the org's keeper-sync config.
+
+    Applies JSON-Merge-Patch semantics: omitted fields are left untouched;
+    ``project_slugs``, when provided, replaces the stored array wholesale (no
+    append). ``PUT`` remains available for a full replacement.
+    """
+    async with context.session.begin():
+        service = context.factory.create_keeper_sync_config_service()
+        result = await service.patch(org_slug=org_slug, update=data)
         await context.session.commit()
     return result
 

--- a/src/docverse/handlers/orgs/keeper_sync.py
+++ b/src/docverse/handlers/orgs/keeper_sync.py
@@ -8,7 +8,9 @@ from fastapi import APIRouter, Depends, Path, Query, Response, status
 
 from docverse.client.models import (
     KeeperSyncConfig,
+    KeeperSyncEditionStatus,
     KeeperSyncResourceType,
+    KeeperSyncRun,
     KeeperSyncRunStatus,
     KeeperSyncTombstoneReason,
 )
@@ -27,12 +29,12 @@ from docverse.storage.pagination import (
 from docverse.validation import parse_base32_id
 
 from .keeper_sync_models import (
-    KeeperSyncEditionStatus,
     KeeperSyncProjectRefreshAccepted,
     KeeperSyncProjectStatus,
-    KeeperSyncRun,
     KeeperSyncRunCreated,
     KeeperSyncTombstone,
+    keeper_sync_edition_status_from_domain,
+    keeper_sync_run_from_domain,
 )
 
 router = APIRouter()
@@ -233,7 +235,7 @@ async def get_org_keeper_sync_project_editions(
     )
     context.response.headers["X-Total-Count"] = str(result.page.count)
     return [
-        KeeperSyncEditionStatus.from_domain(
+        keeper_sync_edition_status_from_domain(
             edition,
             result.state_by_docverse_id.get(edition.id),
             context.request,
@@ -325,7 +327,7 @@ async def get_org_keeper_sync_runs(
     context.response.headers["Link"] = result.link_header(context.request.url)
     context.response.headers["X-Total-Count"] = str(result.count)
     return [
-        KeeperSyncRun.from_domain(
+        keeper_sync_run_from_domain(
             run, activity_by_id[run.id], context.request, org_slug
         )
         for run in result.entries
@@ -348,7 +350,7 @@ async def get_org_keeper_sync_run(
     async with context.session.begin():
         service = context.factory.create_keeper_sync_run_service()
         result = await service.get_run(org_slug=org_slug, public_id=public_id)
-    return KeeperSyncRun.from_domain(
+    return keeper_sync_run_from_domain(
         result.run, result.activity, context.request, org_slug
     )
 

--- a/src/docverse/handlers/orgs/keeper_sync_models.py
+++ b/src/docverse/handlers/orgs/keeper_sync_models.py
@@ -43,56 +43,51 @@ from docverse.services.keeper_sync_project import KeeperSyncProjectStatusResult
 from docverse.storage.keeper_sync import KeeperSyncState
 
 __all__ = [
-    "KeeperSyncEditionStatus",
     "KeeperSyncProjectRefreshAccepted",
     "KeeperSyncProjectStatus",
-    "KeeperSyncRun",
     "KeeperSyncRunCreated",
     "KeeperSyncTombstone",
+    "keeper_sync_edition_status_from_domain",
+    "keeper_sync_run_from_domain",
 ]
 
 
-class KeeperSyncRun(_KeeperSyncRunBase):
-    """Keeper sync run response model with HATEOAS ``self_url``."""
-
-    @classmethod
-    def from_domain(
-        cls,
-        run: KeeperSyncRunDomain,
-        activity: KeeperSyncRunActivityDomain,
-        request: Request,
-        org_slug: str,
-    ) -> Self:
-        """Compose the response from a run plus its derived activity."""
-        run_public_id = serialize_base32_id(run.public_id)
-        return cls(
-            self_url=HttpUrl(
-                str(
-                    request.url_for(
-                        "get_org_keeper_sync_run",
-                        org=org_slug,
-                        run=run_public_id,
-                    )
+def keeper_sync_run_from_domain(
+    run: KeeperSyncRunDomain,
+    activity: KeeperSyncRunActivityDomain,
+    request: Request,
+    org_slug: str,
+) -> _KeeperSyncRunBase:
+    """Compose the client ``KeeperSyncRun`` from a run plus its activity."""
+    run_public_id = serialize_base32_id(run.public_id)
+    return _KeeperSyncRunBase(
+        self_url=HttpUrl(
+            str(
+                request.url_for(
+                    "get_org_keeper_sync_run",
+                    org=org_slug,
+                    run=run_public_id,
                 )
-            ),
-            jobs_url=HttpUrl(
-                str(
-                    request.url_for(
-                        "get_org_jobs", org=org_slug
-                    ).include_query_params(run=run_public_id)
-                )
-            ),
-            id=run_public_id,
-            kind=KeeperSyncRunKind(run.kind),
-            status=KeeperSyncRunStatus(run.status),
-            pending_count=activity.pending_count,
-            succeeded_count=activity.succeeded_count,
-            failed_count=activity.failed_count,
-            total_count=activity.total_count,
-            date_started=run.date_started,
-            date_finished=run.date_finished,
-            date_last_activity=activity.date_last_activity,
-        )
+            )
+        ),
+        jobs_url=HttpUrl(
+            str(
+                request.url_for(
+                    "get_org_jobs", org=org_slug
+                ).include_query_params(run=run_public_id)
+            )
+        ),
+        id=run_public_id,
+        kind=KeeperSyncRunKind(run.kind),
+        status=KeeperSyncRunStatus(run.status),
+        pending_count=activity.pending_count,
+        succeeded_count=activity.succeeded_count,
+        failed_count=activity.failed_count,
+        total_count=activity.total_count,
+        date_started=run.date_started,
+        date_finished=run.date_finished,
+        date_last_activity=activity.date_last_activity,
+    )
 
 
 class KeeperSyncRunCreated(_KeeperSyncRunCreatedBase):
@@ -110,7 +105,7 @@ class KeeperSyncRunCreated(_KeeperSyncRunCreatedBase):
         """Build the 202 envelope from the run + enqueued queue-job."""
         job_id = serialize_base32_id(queue_job.public_id)
         return cls(
-            run=KeeperSyncRun.from_domain(run, activity, request, org_slug),
+            run=keeper_sync_run_from_domain(run, activity, request, org_slug),
             job_id=job_id,
             job_url=HttpUrl(
                 str(request.url_for("get_org_job", org=org_slug, job=job_id))
@@ -118,38 +113,33 @@ class KeeperSyncRunCreated(_KeeperSyncRunCreatedBase):
         )
 
 
-class KeeperSyncEditionStatus(_KeeperSyncEditionStatusBase):
-    """Edition-status entry with HATEOAS ``edition_url``."""
-
-    @classmethod
-    def from_domain(
-        cls,
-        edition: EditionDomain,
-        state: KeeperSyncState | None,
-        request: Request,
-        org_slug: str,
-        project_slug: str,
-    ) -> Self:
-        """Compose the entry from a Docverse edition + optional state row."""
-        return cls(
-            edition_url=HttpUrl(
-                str(
-                    request.url_for(
-                        "get_edition",
-                        org=org_slug,
-                        project=project_slug,
-                        edition=edition.slug,
-                    )
+def keeper_sync_edition_status_from_domain(
+    edition: EditionDomain,
+    state: KeeperSyncState | None,
+    request: Request,
+    org_slug: str,
+    project_slug: str,
+) -> _KeeperSyncEditionStatusBase:
+    """Compose the client edition-status entry with a HATEOAS URL."""
+    return _KeeperSyncEditionStatusBase(
+        edition_url=HttpUrl(
+            str(
+                request.url_for(
+                    "get_edition",
+                    org=org_slug,
+                    project=project_slug,
+                    edition=edition.slug,
                 )
-            ),
-            slug=edition.slug,
-            kind=edition.kind,
-            ltd_id=state.ltd_id if state is not None else None,
-            ltd_slug=state.ltd_slug if state is not None else None,
-            date_last_synced=(
-                state.date_last_synced if state is not None else None
-            ),
-        )
+            )
+        ),
+        slug=edition.slug,
+        kind=edition.kind,
+        ltd_id=state.ltd_id if state is not None else None,
+        ltd_slug=state.ltd_slug if state is not None else None,
+        date_last_synced=(
+            state.date_last_synced if state is not None else None
+        ),
+    )
 
 
 class KeeperSyncProjectRefreshAccepted(_KeeperSyncProjectRefreshAcceptedBase):
@@ -204,7 +194,7 @@ class KeeperSyncProjectStatus(_KeeperSyncProjectStatusBase):
                 )
             )
             if result.main_edition_row is not None:
-                main_edition = KeeperSyncEditionStatus.from_domain(
+                main_edition = keeper_sync_edition_status_from_domain(
                     result.main_edition_row.edition,
                     result.main_edition_row.state,
                     request,

--- a/src/docverse/handlers/orgs/keeper_sync_models.py
+++ b/src/docverse/handlers/orgs/keeper_sync_models.py
@@ -281,7 +281,6 @@ class KeeperSyncTombstone(_KeeperSyncTombstoneBase):
             resource_type=KeeperSyncResourceType(state.resource_type),
             ltd_slug=state.ltd_slug,
             ltd_id=state.ltd_id,
-            docverse_id=state.docverse_id,
             date_tombstoned=state.date_tombstoned,
             tombstone_reason=KeeperSyncTombstoneReason(state.tombstone_reason),
             tombstone_note=state.tombstone_note,

--- a/src/docverse/handlers/orgs/members.py
+++ b/src/docverse/handlers/orgs/members.py
@@ -107,7 +107,11 @@ async def post_member(
             principal=member.principal,
         )
     )
-    return OrgMembership.from_domain(member, context.request, org_slug)
+    response_model = OrgMembership.from_domain(
+        member, context.request, org_slug
+    )
+    context.response.headers["Location"] = response_model.self_url
+    return response_model
 
 
 @router.get(

--- a/src/docverse/handlers/orgs/members.py
+++ b/src/docverse/handlers/orgs/members.py
@@ -166,9 +166,22 @@ async def patch_member(
     """
     principal_type, principal = _parse_member_id(member_id)
     updates = data.model_dump(exclude_unset=True)
+    previous_role = None
     async with context.session.begin():
         store = context.factory.create_membership_store()
+        # Read the current membership first so an in-place role change can
+        # carry the prior role on the remove event, and so not-found is
+        # handled uniformly for both the update and empty-patch paths.
+        current = await store.get_by_principal(
+            org_id=user.org.id,
+            principal_type=principal_type,
+            principal=principal,
+        )
+        if current is None:
+            msg = f"Member {member_id!r} not found"
+            raise NotFoundError(msg)
         if "role" in updates:
+            previous_role = current.role
             member = await store.update_role(
                 org_id=user.org.id,
                 principal_type=principal_type,
@@ -177,15 +190,39 @@ async def patch_member(
             )
         else:
             # Empty merge patch: return the current membership unchanged.
-            member = await store.get_by_principal(
-                org_id=user.org.id,
-                principal_type=principal_type,
-                principal=principal,
-            )
+            member = current
         if member is None:
             msg = f"Member {member_id!r} not found"
             raise NotFoundError(msg)
         await context.session.commit()
+    # An in-place role change is modelled as a remove of the old role plus
+    # an add of the new one (MembershipChangeAction carries no update verb).
+    # Publish after the commit (best-effort; raise_on_error=False) and only
+    # when the role actually changed, so a no-op patch stays silent.
+    if previous_role is not None and previous_role != member.role:
+        metrics_principal_type = MetricsPrincipalType.from_api(
+            member.principal_type
+        )
+        await context.events.membership_changed.publish(
+            MembershipChangedEvent(
+                organization=org_slug,
+                project=None,
+                action=MembershipChangeAction.remove,
+                role=MetricsOrgRole.from_api(previous_role),
+                principal_type=metrics_principal_type,
+                principal=member.principal,
+            )
+        )
+        await context.events.membership_changed.publish(
+            MembershipChangedEvent(
+                organization=org_slug,
+                project=None,
+                action=MembershipChangeAction.add,
+                role=MetricsOrgRole.from_api(member.role),
+                principal_type=metrics_principal_type,
+                principal=member.principal,
+            )
+        )
     return OrgMembership.from_domain(member, context.request, org_slug)
 
 

--- a/src/docverse/handlers/orgs/members.py
+++ b/src/docverse/handlers/orgs/members.py
@@ -6,7 +6,11 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
-from docverse.client.models import OrgMembershipCreate, PrincipalType
+from docverse.client.models import (
+    OrgMembershipCreate,
+    OrgMembershipUpdate,
+    PrincipalType,
+)
 from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.exceptions import ConflictError, NotFoundError
@@ -137,6 +141,51 @@ async def get_member(
         if member is None:
             msg = f"Member {member_id!r} not found"
             raise NotFoundError(msg)
+    return OrgMembership.from_domain(member, context.request, org_slug)
+
+
+@router.patch(
+    "/orgs/{org}/members/{member}",
+    response_model=OrgMembership,
+    summary="Update an organization member",
+    name="patch_member",
+)
+async def patch_member(
+    org_slug: OrgSlugParam,
+    member_id: MemberIdParam,
+    data: OrgMembershipUpdate,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+    user: Annotated[AuthenticatedUser, Depends(require_admin)],
+) -> OrgMembership:
+    """Update a member's role.
+
+    Only ``role`` is mutable; ``principal`` and ``principal_type`` are
+    immutable and rejected by the request model's ``extra="forbid"``.
+    Follows the merge-patch house style: unset fields leave the member
+    unchanged.
+    """
+    principal_type, principal = _parse_member_id(member_id)
+    updates = data.model_dump(exclude_unset=True)
+    async with context.session.begin():
+        store = context.factory.create_membership_store()
+        if "role" in updates:
+            member = await store.update_role(
+                org_id=user.org.id,
+                principal_type=principal_type,
+                principal=principal,
+                role=updates["role"],
+            )
+        else:
+            # Empty merge patch: return the current membership unchanged.
+            member = await store.get_by_principal(
+                org_id=user.org.id,
+                principal_type=principal_type,
+                principal=principal,
+            )
+        if member is None:
+            msg = f"Member {member_id!r} not found"
+            raise NotFoundError(msg)
+        await context.session.commit()
     return OrgMembership.from_domain(member, context.request, org_slug)
 
 

--- a/src/docverse/handlers/orgs/members.py
+++ b/src/docverse/handlers/orgs/members.py
@@ -11,6 +11,7 @@ from docverse.dependencies.auth import AuthenticatedUser, require_admin
 from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.exceptions import ConflictError, NotFoundError
 from docverse.handlers.params import MemberIdParam, OrgSlugParam
+from docverse.handlers.responses import error_responses
 from docverse.metrics import (
     MembershipChangeAction,
     MembershipChangedEvent,
@@ -66,6 +67,7 @@ async def get_members(
     status_code=status.HTTP_201_CREATED,
     summary="Add an organization member",
     name="post_member",
+    responses=error_responses(status.HTTP_409_CONFLICT),
 )
 async def post_member(
     org_slug: OrgSlugParam,

--- a/src/docverse/handlers/orgs/models.py
+++ b/src/docverse/handlers/orgs/models.py
@@ -175,7 +175,7 @@ class Project(_ProjectBase):
         edition_response = None
         if default_edition is not None:
             project_url = project_published_url(org, domain)
-            edition_response = Edition.from_domain(
+            edition_response = edition_from_domain(
                 default_edition,
                 request,
                 org.slug,
@@ -290,75 +290,70 @@ class Build(_BuildBase):
         )
 
 
-class Edition(_EditionBase):
-    """Edition response model with HATEOAS URLs."""
-
-    @classmethod
-    def from_domain(
-        cls,
-        domain: EditionDomain,
-        request: Request,
-        org_slug: str,
-        project_slug: str,
-        *,
-        published_url: str | None = None,
-    ) -> Self:
-        """Create from a domain object, adding HATEOAS URLs."""
-        build_url: str | None = None
-        if domain.current_build_public_id is not None:
-            build_id_str = serialize_base32_id(domain.current_build_public_id)
-            build_url = str(
-                request.url_for(
-                    "get_build",
-                    org=org_slug,
-                    project=project_slug,
-                    build=build_id_str,
-                )
+def edition_from_domain(
+    domain: EditionDomain,
+    request: Request,
+    org_slug: str,
+    project_slug: str,
+    *,
+    published_url: str | None = None,
+) -> _EditionBase:
+    """Build the client ``Edition`` model from a domain object with URLs."""
+    build_url: str | None = None
+    if domain.current_build_public_id is not None:
+        build_id_str = serialize_base32_id(domain.current_build_public_id)
+        build_url = str(
+            request.url_for(
+                "get_build",
+                org=org_slug,
+                project=project_slug,
+                build=build_id_str,
             )
-        return cls(
-            self_url=str(
-                request.url_for(
-                    "get_edition",
-                    org=org_slug,
-                    project=project_slug,
-                    edition=domain.slug,
-                )
-            ),
-            project_url=str(
-                request.url_for(
-                    "get_project",
-                    org=org_slug,
-                    project=project_slug,
-                )
-            ),
-            build_url=build_url,
-            published_url=published_url,
-            history_url=str(
-                request.url_for(
-                    "get_edition_history",
-                    org=org_slug,
-                    project=project_slug,
-                    edition=domain.slug,
-                )
-            ),
-            rollback_url=str(
-                request.url_for(
-                    "post_edition_rollback",
-                    org=org_slug,
-                    project=project_slug,
-                    edition=domain.slug,
-                )
-            ),
-            slug=domain.slug,
-            title=domain.title,
-            kind=domain.kind,
-            tracking_mode=domain.tracking_mode,
-            tracking_params=domain.tracking_params,
-            lifecycle_exempt=domain.lifecycle_exempt,
-            publish_status=domain.publish_status,
-            date_created=domain.date_created,
-            date_updated=domain.date_updated,
         )
+    return _EditionBase(
+        self_url=str(
+            request.url_for(
+                "get_edition",
+                org=org_slug,
+                project=project_slug,
+                edition=domain.slug,
+            )
+        ),
+        project_url=str(
+            request.url_for(
+                "get_project",
+                org=org_slug,
+                project=project_slug,
+            )
+        ),
+        build_url=build_url,
+        published_url=published_url,
+        history_url=str(
+            request.url_for(
+                "get_edition_history",
+                org=org_slug,
+                project=project_slug,
+                edition=domain.slug,
+            )
+        ),
+        rollback_url=str(
+            request.url_for(
+                "post_edition_rollback",
+                org=org_slug,
+                project=project_slug,
+                edition=domain.slug,
+            )
+        ),
+        slug=domain.slug,
+        title=domain.title,
+        kind=domain.kind,
+        tracking_mode=domain.tracking_mode,
+        tracking_params=domain.tracking_params,
+        lifecycle_exempt=domain.lifecycle_exempt,
+        publish_status=domain.publish_status,
+        date_created=domain.date_created,
+        date_updated=domain.date_updated,
+    )
 
 
 class EditionBuildHistoryResponse(_EditionBuildHistoryEntryBase):

--- a/src/docverse/handlers/orgs/models.py
+++ b/src/docverse/handlers/orgs/models.py
@@ -36,6 +36,11 @@ from docverse.client.models import (
 )
 from docverse.client.models import OrgMembership as _OrgMembershipBase
 from docverse.client.models import Project as _ProjectBase
+from docverse.client.models._examples import (
+    EXAMPLE_JOB_ID,
+    EXAMPLE_JOB_URL,
+    EXAMPLE_ORG_URL,
+)
 from docverse.domain.base32id import serialize_base32_id
 from docverse.domain.build import Build as BuildDomain
 from docverse.domain.dashboard_github_template import (
@@ -65,10 +70,22 @@ from docverse.storage.github import build_github_browse_url
 class Organization(_OrganizationBase):
     """Organization response model with HATEOAS URLs."""
 
-    services_url: str
-    credentials_url: str
-    projects_url: str
-    members_url: str
+    services_url: str = Field(
+        description="URL to list services for this organization.",
+        examples=[f"{EXAMPLE_ORG_URL}/services"],
+    )
+    credentials_url: str = Field(
+        description="URL to list credentials for this organization.",
+        examples=[f"{EXAMPLE_ORG_URL}/credentials"],
+    )
+    projects_url: str = Field(
+        description="URL to list projects for this organization.",
+        examples=[f"{EXAMPLE_ORG_URL}/projects"],
+    )
+    members_url: str = Field(
+        description="URL to list members of this organization.",
+        examples=[f"{EXAMPLE_ORG_URL}/members"],
+    )
 
     @classmethod
     def from_domain(
@@ -486,10 +503,12 @@ class DashboardTemplateSyncEnqueuedResponse(BaseModel):
     """Response body for the dashboard-template force-sync endpoints."""
 
     job_id: str = Field(
-        description="Base32 public ID of the enqueued ``dashboard_sync`` job."
+        description="Base32 public ID of the enqueued ``dashboard_sync`` job.",
+        examples=[EXAMPLE_JOB_ID],
     )
     job_url: str = Field(
-        description="URL of the enqueued ``dashboard_sync`` job."
+        description="URL of the enqueued ``dashboard_sync`` job.",
+        examples=[EXAMPLE_JOB_URL],
     )
 
     @classmethod

--- a/src/docverse/handlers/orgs/organizations.py
+++ b/src/docverse/handlers/orgs/organizations.py
@@ -4,21 +4,93 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request, status
 
-from docverse.client.models import OrganizationUpdate
+from docverse.client.models import (
+    OrganizationSummary,
+    OrganizationUpdate,
+    OrgRole,
+)
 from docverse.dependencies.auth import (
     AuthenticatedUser,
     require_admin,
     require_reader,
 )
 from docverse.dependencies.context import RequestContext, context_dependency
-from docverse.exceptions import NotFoundError
+from docverse.domain.organization import Organization as OrganizationDomain
+from docverse.exceptions import NotFoundError, PermissionDeniedError
 from docverse.handlers.params import OrgSlugParam
+from docverse.handlers.responses import error_responses
 
 from .models import Organization
 
 router = APIRouter()
+
+
+def _organization_summary(
+    org: OrganizationDomain, request: Request, *, role: OrgRole
+) -> OrganizationSummary:
+    """Build an ``OrganizationSummary`` for a listing entry."""
+    return OrganizationSummary(
+        self_url=str(request.url_for("get_organization", org=org.slug)),
+        slug=org.slug,
+        title=org.title,
+        role=role,
+    )
+
+
+@router.get(
+    "/orgs",
+    response_model=list[OrganizationSummary],
+    summary="List organizations the caller can access",
+    name="get_organizations",
+    responses=error_responses(status.HTTP_403_FORBIDDEN),
+)
+async def get_organizations(
+    request: Request,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> list[OrganizationSummary]:
+    """List organizations in which the caller holds an effective role.
+
+    Any authenticated user may call this. A caller sees each organization
+    where they have a direct or group membership, along with their
+    effective role; a superadmin sees every organization (role reported as
+    ``admin``). An empty list is a valid response.
+    """
+    username = request.headers.get("X-Auth-Request-User")
+    if not username:
+        msg = "Authentication required"
+        raise PermissionDeniedError(msg)
+    context.rebind_logger(username=username)
+
+    async with context.session.begin():
+        org_service = context.factory.create_organization_service()
+        auth_service = context.factory.create_authorization_service()
+        if auth_service.is_superadmin(username):
+            orgs = await org_service.list_all()
+            summaries = [
+                _organization_summary(org, request, role=OrgRole.admin)
+                for org in orgs
+            ]
+        else:
+            token = request.headers.get("X-Auth-Request-Token", "")
+            user_info_store = context.factory.get_user_info_store()
+            groups = await user_info_store.get_groups(token)
+            membership_store = context.factory.create_membership_store()
+            role_map = await membership_store.list_effective_roles(
+                username=username, groups=groups
+            )
+            org_store = context.factory.create_org_store()
+            summaries = []
+            for org_id, role in role_map.items():
+                org = await org_store.get_by_id(org_id)
+                if org is None:
+                    continue
+                summaries.append(
+                    _organization_summary(org, request, role=role)
+                )
+    summaries.sort(key=lambda summary: summary.slug)
+    return summaries
 
 
 @router.get(

--- a/src/docverse/handlers/orgs/organizations.py
+++ b/src/docverse/handlers/orgs/organizations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request, status
+from fastapi import APIRouter, Depends, Request
 
 from docverse.client.models import (
     OrganizationSummary,
@@ -20,7 +20,6 @@ from docverse.dependencies.context import RequestContext, context_dependency
 from docverse.domain.organization import Organization as OrganizationDomain
 from docverse.exceptions import NotFoundError, PermissionDeniedError
 from docverse.handlers.params import OrgSlugParam
-from docverse.handlers.responses import error_responses
 
 from .models import Organization
 
@@ -44,7 +43,8 @@ def _organization_summary(
     response_model=list[OrganizationSummary],
     summary="List organizations the caller can access",
     name="get_organizations",
-    responses=error_responses(status.HTTP_403_FORBIDDEN),
+    # 403 is already declared at the orgs router level (see main.py), so no
+    # route-level responses= is needed here — matching the sibling routes.
 )
 async def get_organizations(
     request: Request,

--- a/src/docverse/handlers/orgs/projects.py
+++ b/src/docverse/handlers/orgs/projects.py
@@ -150,13 +150,15 @@ async def post_project(
         logger=context.logger,
         project_id=project.id,
     )
-    return Project.from_domain(
+    response_model = Project.from_domain(
         project,
         context.request,
         org,
         default_edition=default_edition,
         app_url=context.factory.github_app_html_url,
     )
+    context.response.headers["Location"] = response_model.self_url
+    return response_model
 
 
 @router.get(

--- a/src/docverse/handlers/orgs/services.py
+++ b/src/docverse/handlers/orgs/services.py
@@ -63,9 +63,11 @@ async def post_service(
             credential_label=data.credential_label,
         )
         await context.session.commit()
-    return OrganizationServiceResponse.from_domain(
+    response_model = OrganizationServiceResponse.from_domain(
         svc, context.request, org_slug
     )
+    context.response.headers["Location"] = response_model.self_url
+    return response_model
 
 
 @router.get(

--- a/src/docverse/handlers/responses.py
+++ b/src/docverse/handlers/responses.py
@@ -1,0 +1,57 @@
+"""Reusable OpenAPI ``responses=`` declarations for client-error codes.
+
+Handlers and routers attach these via the FastAPI ``responses=`` argument so
+the generated OpenAPI spec documents each operation's 403/404/409 error
+contract with safir's :class:`~safir.models.ErrorModel` body shape, instead
+of leaving those responses undocumented or repeating inline literals in every
+handler.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import status
+from safir.models import ErrorModel
+
+__all__ = ["error_responses"]
+
+_ERROR_RESPONSES: dict[int, dict[str, Any]] = {
+    status.HTTP_403_FORBIDDEN: {
+        "model": ErrorModel,
+        "description": (
+            "The caller lacks the role required for this operation."
+        ),
+    },
+    status.HTTP_404_NOT_FOUND: {
+        "model": ErrorModel,
+        "description": (
+            "A resource addressed by the request path does not exist."
+        ),
+    },
+    status.HTTP_409_CONFLICT: {
+        "model": ErrorModel,
+        "description": (
+            "The request conflicts with the current state of the resource."
+        ),
+    },
+}
+
+
+def error_responses(*status_codes: int) -> dict[int | str, dict[str, Any]]:
+    """Build ``responses=`` entries for the given client-error status codes.
+
+    Parameters
+    ----------
+    *status_codes
+        One or more of 403, 404, and 409. Each maps to an OpenAPI response
+        documented with safir's ``ErrorModel`` body schema.
+
+    Returns
+    -------
+    dict
+        A mapping suitable for FastAPI's ``responses=`` argument. A fresh
+        copy of each entry is returned so callers may merge or mutate the
+        result without disturbing the shared templates.
+    """
+    return {code: dict(_ERROR_RESPONSES[code]) for code in status_codes}

--- a/src/docverse/main.py
+++ b/src/docverse/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from importlib.metadata import metadata, version
 
 import structlog
-from fastapi import FastAPI
+from fastapi import FastAPI, status
 from fastapi.routing import APIRoute
 from rubin.gafaelfawr import GafaelfawrClient
 from rubin.repertoire import DiscoveryClient
@@ -26,6 +26,7 @@ from .dependencies.context import context_dependency
 from .handlers.admin import admin_router
 from .handlers.internal import internal_router
 from .handlers.orgs import orgs_router
+from .handlers.responses import error_responses
 from .handlers.webhooks import webhook_router
 from .metrics import build_event_manager
 from .sentry import initialize_sentry
@@ -168,8 +169,23 @@ app = FastAPI(
 
 app.exception_handler(ClientRequestError)(client_request_error_handler)
 app.include_router(internal_router)
-app.include_router(admin_router, prefix=config.path_prefix)
-app.include_router(orgs_router, prefix=config.path_prefix)
+# Every admin operation sits behind the superadmin dependency, so all can
+# return 403; the per-resource 404 and create-conflict 409 are declared on
+# the individual admin routes. Orgs operations are all role-guarded and all
+# address an org (and often a sub-resource) by path, so 403 + 404 apply
+# uniformly; conflict-capable orgs routes add 409 individually.
+app.include_router(
+    admin_router,
+    prefix=config.path_prefix,
+    responses=error_responses(status.HTTP_403_FORBIDDEN),
+)
+app.include_router(
+    orgs_router,
+    prefix=config.path_prefix,
+    responses=error_responses(
+        status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND
+    ),
+)
 app.include_router(webhook_router, prefix=config.path_prefix)
 app.add_middleware(XForwardedMiddleware)
 

--- a/src/docverse/main.py
+++ b/src/docverse/main.py
@@ -8,6 +8,7 @@ from importlib.metadata import metadata, version
 
 import structlog
 from fastapi import FastAPI
+from fastapi.routing import APIRoute
 from rubin.gafaelfawr import GafaelfawrClient
 from rubin.repertoire import DiscoveryClient
 from safir.database import create_database_engine, is_database_current
@@ -126,8 +127,21 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 _metadata = metadata("docverse")
 
+
+def _operation_id_from_route_name(route: APIRoute) -> str:
+    """Use a route's declared ``name`` as its OpenAPI ``operationId``.
+
+    FastAPI's default derives the operationId from the route name *and* its
+    path plus HTTP method, leaking the URL structure into the public contract
+    and producing unwieldy client codegen. Every route declares an explicit
+    ``name``, so returning it yields clean, stable operationIds.
+    """
+    return route.name
+
+
 app = FastAPI(
     title="Docverse",
+    generate_unique_id_function=_operation_id_from_route_name,
     description=_metadata.get("Summary", ""),
     version=version("docverse"),
     openapi_url=f"{config.path_prefix}/openapi.json",

--- a/src/docverse/main.py
+++ b/src/docverse/main.py
@@ -151,13 +151,15 @@ app = FastAPI(
     openapi_tags=[
         {
             "name": "orgs",
-            "description": "Organization and membership management.",
+            "description": (
+                "Organization and membership management, including"
+                " org-scoped background job status."
+            ),
         },
         {
             "name": "projects",
             "description": "Projects, builds, and editions.",
         },
-        {"name": "jobs", "description": "Background job status."},
         {
             "name": "admin",
             "description": "Superuser organization administration.",

--- a/src/docverse/metrics/enums.py
+++ b/src/docverse/metrics/enums.py
@@ -80,7 +80,9 @@ class MembershipChangeAction(StrEnum):
     only ever added or removed (an in-place role change is modelled as a
     remove + add by the API), so this event carries a dedicated
     add/remove verb. The emission site selects the action statically:
-    ``post_member`` emits ``add`` and ``delete_member`` emits ``remove``.
+    ``post_member`` emits ``add``, ``delete_member`` emits ``remove``, and
+    ``patch_member`` emits a ``remove`` of the old role followed by an
+    ``add`` of the new one when a role actually changes.
     """
 
     add = "add"

--- a/src/docverse/services/keeper_sync_config.py
+++ b/src/docverse/services/keeper_sync_config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import structlog
 
-from docverse.client.models import KeeperSyncConfig
+from docverse.client.models import KeeperSyncConfig, KeeperSyncConfigUpdate
 from docverse.exceptions import NotFoundError
 from docverse.storage.organization_store import OrganizationStore
 
@@ -62,3 +62,23 @@ class KeeperSyncConfigService:
             )
             raise RuntimeError(msg)
         return updated.keeper_sync_config
+
+    async def patch(
+        self, org_slug: str, update: KeeperSyncConfigUpdate
+    ) -> KeeperSyncConfig:
+        """Apply a JSON-Merge-Patch to the persisted config.
+
+        Fields left unset on ``update`` are carried over unchanged from the
+        current (or default-disabled) config; ``project_slugs``, when
+        provided, replaces the stored list wholesale. Returns the
+        round-tripped merged value.
+
+        Raises
+        ------
+        NotFoundError
+            If the organization does not exist.
+        """
+        current = await self.get(org_slug=org_slug)
+        changes = update.model_dump(exclude_unset=True)
+        merged = current.model_copy(update=changes)
+        return await self.put(org_slug=org_slug, config=merged)

--- a/src/docverse/storage/membership_store.py
+++ b/src/docverse/storage/membership_store.py
@@ -97,6 +97,59 @@ class OrgMembershipStore:
         await self._session.delete(row)
         return True
 
+    async def list_effective_roles(
+        self,
+        *,
+        username: str,
+        groups: list[str],
+    ) -> dict[int, OrgRole]:
+        """Resolve the caller's effective role in every org they belong to.
+
+        Queries all memberships matching the user (by username) or any of
+        the caller's groups, across every organization, and collapses them
+        to the single highest-ranked role per org.
+
+        Parameters
+        ----------
+        username
+            The authenticated username.
+        groups
+            The caller's group names.
+
+        Returns
+        -------
+        dict
+            Mapping of ``org_id`` to the caller's effective
+            :class:`~docverse.client.models.OrgRole` for that org. Orgs in
+            which the caller holds no membership are absent.
+        """
+        conditions = [
+            # Direct user membership
+            (
+                (SqlOrgMembership.principal_type == PrincipalType.user)
+                & (SqlOrgMembership.principal == username)
+            ),
+        ]
+        if groups:
+            # Group memberships
+            conditions.append(
+                (SqlOrgMembership.principal_type == PrincipalType.group)
+                & (SqlOrgMembership.principal.in_(groups))
+            )
+
+        result = await self._session.execute(
+            select(SqlOrgMembership).where(or_(*conditions))
+        )
+        rows = result.scalars().all()
+
+        best: dict[int, OrgRole] = {}
+        for row in rows:
+            role = OrgRole(row.role)
+            current = best.get(row.org_id)
+            if current is None or ROLE_RANK[role] > ROLE_RANK[current]:
+                best[row.org_id] = role
+        return best
+
     async def resolve_role(
         self,
         *,

--- a/src/docverse/storage/membership_store.py
+++ b/src/docverse/storage/membership_store.py
@@ -57,6 +57,37 @@ class OrgMembershipStore:
             return None
         return OrgMembership.model_validate(row)
 
+    async def update_role(
+        self,
+        *,
+        org_id: int,
+        principal_type: PrincipalType,
+        principal: str,
+        role: OrgRole,
+    ) -> OrgMembership | None:
+        """Update a membership's role in place.
+
+        Returns
+        -------
+        OrgMembership or None
+            The updated membership, or None if no matching membership
+            exists.
+        """
+        result = await self._session.execute(
+            select(SqlOrgMembership).where(
+                SqlOrgMembership.org_id == org_id,
+                SqlOrgMembership.principal_type == principal_type,
+                SqlOrgMembership.principal == principal,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        row.role = role
+        await self._session.flush()
+        await self._session.refresh(row)
+        return OrgMembership.model_validate(row)
+
     async def list_by_org(self, org_id: int) -> list[OrgMembership]:
         """List all memberships for an organization."""
         result = await self._session.execute(

--- a/tests/client/keeper_sync_exports_test.py
+++ b/tests/client/keeper_sync_exports_test.py
@@ -124,11 +124,14 @@ def test_handler_side_subclasses_are_not_exported() -> None:
     consumers.
     """
     exported_names = set(client_models.__all__)
+    # ``KeeperSyncEditionStatus`` and ``KeeperSyncRun`` no longer have
+    # handler-side subclasses: their handlers use the client model
+    # directly as ``response_model`` and build it via module-level
+    # ``*_from_domain`` functions, so only genuinely-distinct subclasses
+    # remain here.
     handler_subclasses = {
-        handler_models.KeeperSyncEditionStatus,
         handler_models.KeeperSyncProjectRefreshAccepted,
         handler_models.KeeperSyncProjectStatus,
-        handler_models.KeeperSyncRun,
         handler_models.KeeperSyncRunCreated,
         queue_handler_models.QueueJob,
     }

--- a/tests/handlers/admin_test.py
+++ b/tests/handlers/admin_test.py
@@ -32,6 +32,7 @@ async def test_create_organization(client: AsyncClient) -> None:
     assert data["date_updated"] is not None
     assert "/admin/orgs/test-org" in data["self_url"]
     assert "/orgs/test-org" in data["org_url"]
+    assert response.headers["Location"] == data["self_url"]
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/builds_test.py
+++ b/tests/handlers/builds_test.py
@@ -46,6 +46,64 @@ async def test_create_build(client: AsyncClient) -> None:
     assert "object store" in data["detail"][0]["msg"].lower()
 
 
+async def _configure_staging_store(client: AsyncClient) -> None:
+    """Give ``build-org`` an aws_s3 staging store so POST build can 201.
+
+    Presigned-URL generation signs locally (no network), so an
+    ``aws_s3`` service with placeholder credentials is enough to drive
+    the create path end-to-end.
+    """
+    headers = {"X-Auth-Request-User": "testuser"}
+    await client.post(
+        "/docverse/orgs/build-org/credentials",
+        json={
+            "label": "aws-cred",
+            "credentials": {
+                "provider": "aws",
+                "access_key_id": "AKIAEXAMPLE",
+                "secret_access_key": "secret",
+            },
+        },
+        headers=headers,
+    )
+    await client.post(
+        "/docverse/orgs/build-org/services",
+        json={
+            "label": "my-s3",
+            "credential_label": "aws-cred",
+            "config": {
+                "provider": "aws_s3",
+                "bucket": "my-bucket",
+                "region": "us-east-1",
+            },
+        },
+        headers=headers,
+    )
+    await client.patch(
+        "/docverse/orgs/build-org",
+        json={"staging_store_label": "my-s3"},
+        headers=headers,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_build_sets_location_header(client: AsyncClient) -> None:
+    """POST build returns 201 with ``Location`` == the build's self_url."""
+    await _setup(client)
+    await _configure_staging_store(client)
+    response = await client.post(
+        "/docverse/orgs/build-org/projects/build-proj/builds",
+        json={
+            "git_ref": "main",
+            "content_hash": CONTENT_HASH,
+        },
+        headers={"X-Auth-Request-User": "testuser"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert response.headers["Location"] == data["self_url"]
+
+
 @pytest.mark.asyncio
 async def test_create_build_with_annotations(client: AsyncClient) -> None:
     """Annotations round-trip via DB seeding + GET (POST needs a store)."""

--- a/tests/handlers/credentials_test.py
+++ b/tests/handlers/credentials_test.py
@@ -36,6 +36,7 @@ async def test_create_credential(client: AsyncClient) -> None:
     assert data["provider"] == "aws"
     assert "self_url" in data
     assert "org_url" in data
+    assert response.headers["Location"] == data["self_url"]
     # Credential payload should NOT be in the response
     assert "credentials" not in data
     assert "encrypted_credentials" not in data

--- a/tests/handlers/dashboard_template_test.py
+++ b/tests/handlers/dashboard_template_test.py
@@ -76,6 +76,8 @@ async def test_org_put_creates_binding(client: AsyncClient) -> None:
     assert "date_created" in body
     assert "date_updated" in body
     assert body["self_url"].endswith(f"/orgs/{_ORG}/dashboard-template")
+    # A create (201) carries a Location header equal to the self_url.
+    assert response.headers["Location"] == body["self_url"]
     # ``web_url`` is derived from the binding source coordinates; ``/``
     # root_path collapses to a bare ``/tree/{ref}`` URL with no trailing
     # path segment.
@@ -320,6 +322,8 @@ async def test_org_put_is_idempotent_no_op(client: AsyncClient) -> None:
         headers={"X-Auth-Request-User": _ADMIN},
     )
     assert second.status_code == 200
+    # A no-op update returns 200, not 201, so no Location header is set.
+    assert "Location" not in second.headers
     second_body = second.json()
 
     assert second_body["date_created"] == first_body["date_created"]
@@ -627,6 +631,7 @@ async def test_project_put_creates_binding(client: AsyncClient) -> None:
     )
     assert response.status_code == 201
     body = response.json()
+    assert response.headers["Location"] == body["self_url"]
     assert body["github_owner"] == "lsst-sqre"
     assert body["root_path"] == "/"
     assert body["last_sync_status"] == "pending"
@@ -1128,6 +1133,7 @@ async def test_org_sync_enqueues_dashboard_sync(client: AsyncClient) -> None:
     assert "binding_id" not in body
     assert body["job_id"]
     assert body["job_url"].endswith(f"/orgs/{_ORG}/jobs/{body['job_id']}")
+    assert response.headers["Location"] == body["job_url"]
     # The job_url resolves via the org-scoped GET.
     job_response = await client.get(
         body["job_url"],
@@ -1217,6 +1223,7 @@ async def test_project_sync_enqueues_dashboard_sync(
     assert "binding_id" not in body
     assert body["job_id"]
     assert body["job_url"].endswith(f"/orgs/{_ORG}/jobs/{body['job_id']}")
+    assert response.headers["Location"] == body["job_url"]
     # The job_url resolves via the org-scoped GET.
     job_response = await client.get(
         body["job_url"],

--- a/tests/handlers/dashboard_test.py
+++ b/tests/handlers/dashboard_test.py
@@ -134,14 +134,16 @@ async def test_org_dashboard_rebuild_returns_one_job_per_project(
     # org-scoped jobs collection rather than a single job.
     assert response.headers["Location"].endswith("/orgs/dash-org/jobs")
     body = response.json()
-    assert isinstance(body, list)
-    assert len(body) == 3
-    by_slug = {entry["project_slug"]: entry for entry in body}
+    assert isinstance(body, dict)
+    entries = body["entries"]
+    assert isinstance(entries, list)
+    assert len(entries) == 3
+    by_slug = {entry["project_slug"]: entry for entry in entries}
     assert set(by_slug) == {"alpha", "beta", "gamma"}
-    job_ids = {entry["job_id"] for entry in body}
+    job_ids = {entry["job_id"] for entry in entries}
     assert len(job_ids) == 3
     assert all(isinstance(jid, str) and jid for jid in job_ids)
-    for entry in body:
+    for entry in entries:
         assert entry["job_url"].endswith(
             f"/orgs/dash-org/jobs/{entry['job_id']}"
         )
@@ -181,8 +183,8 @@ async def test_org_dashboard_rebuild_skips_projects_with_active_jobs(
     )
     assert response.status_code == 202
     body = response.json()
-    assert isinstance(body, list)
-    slugs = {entry["project_slug"] for entry in body}
+    assert isinstance(body, dict)
+    slugs = {entry["project_slug"] for entry in body["entries"]}
     assert slugs == {"alpha", "gamma"}
 
 
@@ -196,7 +198,7 @@ async def test_org_dashboard_rebuild_empty_when_no_projects(
         headers={"X-Auth-Request-User": "admin-user"},
     )
     assert response.status_code == 202
-    assert response.json() == []
+    assert response.json() == {"entries": []}
 
 
 @pytest.mark.asyncio
@@ -219,7 +221,7 @@ async def test_org_dashboard_rebuild_excludes_deleted_projects(
     )
     assert response.status_code == 202
     body = response.json()
-    slugs = {entry["project_slug"] for entry in body}
+    slugs = {entry["project_slug"] for entry in body["entries"]}
     assert slugs == {"keep-one", "keep-two"}
 
 

--- a/tests/handlers/dashboard_test.py
+++ b/tests/handlers/dashboard_test.py
@@ -37,6 +37,7 @@ async def test_dashboard_rebuild_returns_202_with_queue_id(
     assert isinstance(body["job_id"], str)
     assert len(body["job_id"]) > 0
     assert body["job_url"].endswith(f"/orgs/dash-org/jobs/{body['job_id']}")
+    assert response.headers["Location"] == body["job_url"]
     # The job_url resolves via the org-scoped GET.
     job_response = await client.get(
         body["job_url"],
@@ -129,6 +130,9 @@ async def test_org_dashboard_rebuild_returns_one_job_per_project(
         headers={"X-Auth-Request-User": "admin-user"},
     )
     assert response.status_code == 202
+    # The batch enqueues one job per project, so Location points at the
+    # org-scoped jobs collection rather than a single job.
+    assert response.headers["Location"].endswith("/orgs/dash-org/jobs")
     body = response.json()
     assert isinstance(body, list)
     assert len(body) == 3

--- a/tests/handlers/editions_test.py
+++ b/tests/handlers/editions_test.py
@@ -82,6 +82,7 @@ async def test_create_edition(client: AsyncClient) -> None:
     assert data["published_url"] == (
         "https://ed-proj.ed-org.example.com/v/main/"
     )
+    assert response.headers["Location"] == data["self_url"]
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/jobs_test.py
+++ b/tests/handlers/jobs_test.py
@@ -936,16 +936,21 @@ async def test_keeper_sync_run_jobs_endpoint_removed(
 
 
 @pytest.mark.asyncio
-async def test_jobs_tag_replaces_queue(client: AsyncClient) -> None:
-    """The OpenAPI ``jobs`` tag replaces the retired ``queue`` tag."""
+async def test_jobs_routes_carry_orgs_tag(client: AsyncClient) -> None:
+    """The org-scoped jobs routes are folded into the ``orgs`` tag.
+
+    The standalone ``jobs`` tag (and the older ``queue`` tag) are
+    retired: ``/orgs/{org}/jobs`` endpoints are org-scoped, so they
+    document under ``orgs`` alongside the rest of the org surface.
+    """
     spec = (await client.get("/docverse/openapi.json")).json()
     tag_names = {tag["name"] for tag in spec.get("tags", [])}
-    assert "jobs" in tag_names
+    assert "jobs" not in tag_names
     assert "queue" not in tag_names
 
-    # The org-scoped jobs routes carry the ``jobs`` tag.
     op = spec["paths"]["/docverse/orgs/{org}/jobs/{job}"]["get"]
-    assert "jobs" in op["tags"]
+    assert "orgs" in op["tags"]
+    assert "jobs" not in op["tags"]
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/keeper_sync_refresh_test.py
+++ b/tests/handlers/keeper_sync_refresh_test.py
@@ -77,6 +77,7 @@ async def test_post_refresh_returns_202_with_queue_job_link(
     body = response.json()
     assert body["job_id"]
     assert body["job_url"].endswith(f"/orgs/{_ORG}/jobs/{body['job_id']}")
+    assert response.headers["Location"] == body["job_url"]
     # The job_url resolves via the org-scoped GET.
     job_response = await client.get(
         body["job_url"],

--- a/tests/handlers/keeper_sync_runs_test.py
+++ b/tests/handlers/keeper_sync_runs_test.py
@@ -176,6 +176,7 @@ async def test_post_run_returns_202_with_run_and_queue_job_link(
     assert "job_url" in body
     assert body["job_id"]
     assert body["job_url"].endswith(f"/orgs/{_ORG}/jobs/{body['job_id']}")
+    assert response.headers["Location"] == body["job_url"]
     # The job_url resolves via the org-scoped GET.
     job_response = await client.get(
         body["job_url"],

--- a/tests/handlers/keeper_sync_test.py
+++ b/tests/handlers/keeper_sync_test.py
@@ -251,6 +251,24 @@ async def test_patch_rejects_unknown_field(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field",
+    ["enabled", "ltd_base_url", "project_slugs"],
+)
+async def test_patch_rejects_explicit_null(
+    client: AsyncClient, field: str
+) -> None:
+    """An explicit ``null`` for any field is a 422, not a 500 or no-op."""
+    await _setup(client)
+    response = await client.patch(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={field: None},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_patch_403_for_non_admin(client: AsyncClient) -> None:
     await _setup(client)
     await seed_member(_ORG, "reader-user", OrgRole.reader)

--- a/tests/handlers/keeper_sync_test.py
+++ b/tests/handlers/keeper_sync_test.py
@@ -142,6 +142,137 @@ async def test_put_can_disable_without_clearing_other_fields(
 
 
 @pytest.mark.asyncio
+async def test_patch_only_enabled_leaves_other_fields(
+    client: AsyncClient,
+) -> None:
+    """A merge patch of only ``enabled`` leaves the other fields untouched."""
+    await _setup(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={
+            "enabled": True,
+            "ltd_base_url": "https://keeper.example.com/",
+            "project_slugs": ["dmtn-001", "sqr-112"],
+        },
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    response = await client.patch(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={"enabled": False},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is False
+    assert body["ltd_base_url"] == "https://keeper.example.com/"
+    assert body["project_slugs"] == ["dmtn-001", "sqr-112"]
+
+
+@pytest.mark.asyncio
+async def test_patch_project_slugs_replaces_wholesale(
+    client: AsyncClient,
+) -> None:
+    """Providing ``project_slugs`` replaces the whole list (no append)."""
+    await _setup(client)
+    await client.put(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={
+            "enabled": True,
+            "ltd_base_url": "https://keeper.lsst.codes/",
+            "project_slugs": ["alpha", "beta"],
+        },
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    response = await client.patch(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={"project_slugs": ["gamma"]},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["project_slugs"] == ["gamma"]
+    # Untouched fields survive the merge.
+    assert body["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_empty_body_leaves_config_unchanged(
+    client: AsyncClient,
+) -> None:
+    """An empty merge patch is a no-op that returns the current config."""
+    await _setup(client)
+    payload = {
+        "enabled": True,
+        "ltd_base_url": "https://keeper.lsst.codes/",
+        "project_slugs": ["only"],
+    }
+    await client.put(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json=payload,
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    response = await client.patch(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    assert response.json() == {**payload}
+
+
+@pytest.mark.asyncio
+async def test_patch_on_never_set_org_merges_onto_defaults(
+    client: AsyncClient,
+) -> None:
+    """Patching a never-configured org merges onto the default config."""
+    await _setup(client)
+    response = await client.patch(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={"enabled": True},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is True
+    assert body["ltd_base_url"] == "https://keeper.lsst.codes/"
+    assert body["project_slugs"] == []
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_unknown_field(client: AsyncClient) -> None:
+    """An unknown field is rejected with a 422 (``extra=forbid``)."""
+    await _setup(client)
+    response = await client.patch(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={"unknown": True},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_403_for_non_admin(client: AsyncClient) -> None:
+    await _setup(client)
+    await seed_member(_ORG, "reader-user", OrgRole.reader)
+    response = await client.patch(
+        f"/docverse/orgs/{_ORG}/keeper-sync",
+        json={"enabled": False},
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_patch_404_for_unknown_org(client: AsyncClient) -> None:
+    response = await client.patch(
+        "/docverse/orgs/missing-org/keeper-sync",
+        json={"enabled": False},
+        headers={"X-Auth-Request-User": _ADMIN},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_get_403_for_non_admin(client: AsyncClient) -> None:
     await _setup(client)
     await seed_member(_ORG, "reader-user", OrgRole.reader)

--- a/tests/handlers/members_test.py
+++ b/tests/handlers/members_test.py
@@ -37,6 +37,7 @@ async def test_create_member(client: AsyncClient) -> None:
     assert data["principal"] == "jdoe"
     assert data["id"] == "user:jdoe"
     assert data["self_url"].endswith("/orgs/mem-org/members/user:jdoe")
+    assert response.headers["Location"] == data["self_url"]
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/members_test.py
+++ b/tests/handlers/members_test.py
@@ -226,6 +226,112 @@ async def test_patch_member_rejects_principal_change(
 
 
 @pytest.mark.asyncio
+async def test_patch_member_rejects_null_role(client: AsyncClient) -> None:
+    """An explicit ``{"role": null}`` is a 422, not a silent no-op or 500."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/mem-org/members",
+        json={
+            "principal": "null-role-user",
+            "principal_type": "user",
+            "role": "reader",
+        },
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    response = await client.patch(
+        "/docverse/orgs/mem-org/members/user:null-role-user",
+        json={"role": None},
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert response.status_code == 422
+
+    # The role is unchanged (the rejected patch never touched storage).
+    response = await client.get(
+        "/docverse/orgs/mem-org/members/user:null-role-user",
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert response.json()["role"] == "reader"
+
+
+@pytest.mark.asyncio
+async def test_patch_member_role_change_publishes_remove_and_add(
+    client: AsyncClient,
+) -> None:
+    """An in-place role change emits remove(old role) + add(new role)."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/mem-org/members",
+        json={
+            "principal": "role-churn",
+            "principal_type": "user",
+            "role": "reader",
+        },
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.membership_changed
+    assert isinstance(publisher, MockEventPublisher)
+    baseline = len(publisher.published)
+
+    response = await client.patch(
+        "/docverse/orgs/mem-org/members/user:role-churn",
+        json={"role": "admin"},
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert response.status_code == 200
+
+    new_events = publisher.published[baseline:]
+    assert len(new_events) == 2
+    remove_event, add_event = new_events
+    assert remove_event.action == MembershipChangeAction.remove
+    assert remove_event.role == MetricsOrgRole.reader
+    assert remove_event.principal == "role-churn"
+    assert remove_event.principal_type == MetricsPrincipalType.user
+    assert add_event.action == MembershipChangeAction.add
+    assert add_event.role == MetricsOrgRole.admin
+    assert add_event.principal == "role-churn"
+    assert add_event.principal_type == MetricsPrincipalType.user
+
+
+@pytest.mark.asyncio
+async def test_patch_member_no_op_publishes_nothing(
+    client: AsyncClient,
+) -> None:
+    """Patching to the same role (or an empty body) emits no event."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/mem-org/members",
+        json={
+            "principal": "steady",
+            "principal_type": "user",
+            "role": "reader",
+        },
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    events = context_dependency._events
+    assert events is not None
+    publisher = events.membership_changed
+    assert isinstance(publisher, MockEventPublisher)
+    baseline = len(publisher.published)
+
+    same_role = await client.patch(
+        "/docverse/orgs/mem-org/members/user:steady",
+        json={"role": "reader"},
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert same_role.status_code == 200
+    empty = await client.patch(
+        "/docverse/orgs/mem-org/members/user:steady",
+        json={},
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert empty.status_code == 200
+
+    assert len(publisher.published) == baseline
+
+
+@pytest.mark.asyncio
 async def test_patch_member_not_found(client: AsyncClient) -> None:
     """PATCH on a missing member returns 404."""
     await _setup(client)

--- a/tests/handlers/members_test.py
+++ b/tests/handlers/members_test.py
@@ -170,6 +170,95 @@ async def test_delete_member_publishes_membership_changed(
 
 
 @pytest.mark.asyncio
+async def test_patch_member_role(client: AsyncClient) -> None:
+    """PATCH with a new role updates and returns the membership."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/mem-org/members",
+        json={
+            "principal": "promote-me",
+            "principal_type": "user",
+            "role": "reader",
+        },
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    response = await client.patch(
+        "/docverse/orgs/mem-org/members/user:promote-me",
+        json={"role": "admin"},
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["role"] == "admin"
+    assert data["principal"] == "promote-me"
+    assert data["id"] == "user:promote-me"
+
+    # The change is durable.
+    response = await client.get(
+        "/docverse/orgs/mem-org/members/user:promote-me",
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert response.json()["role"] == "admin"
+
+
+@pytest.mark.asyncio
+async def test_patch_member_rejects_principal_change(
+    client: AsyncClient,
+) -> None:
+    """Attempts to change identity fields are rejected by extra=forbid."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/mem-org/members",
+        json={
+            "principal": "immutable-user",
+            "principal_type": "user",
+            "role": "reader",
+        },
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    for body in ({"principal": "someone-else"}, {"principal_type": "group"}):
+        response = await client.patch(
+            "/docverse/orgs/mem-org/members/user:immutable-user",
+            json=body,
+            headers={"X-Auth-Request-User": "admin-user"},
+        )
+        assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_member_not_found(client: AsyncClient) -> None:
+    """PATCH on a missing member returns 404."""
+    await _setup(client)
+    response = await client.patch(
+        "/docverse/orgs/mem-org/members/user:nobody",
+        json={"role": "admin"},
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_member_requires_admin(client: AsyncClient) -> None:
+    """A non-admin member cannot change roles."""
+    await _setup(client)
+    await client.post(
+        "/docverse/orgs/mem-org/members",
+        json={
+            "principal": "reader-user",
+            "principal_type": "user",
+            "role": "reader",
+        },
+        headers={"X-Auth-Request-User": "admin-user"},
+    )
+    response = await client.patch(
+        "/docverse/orgs/mem-org/members/user:reader-user",
+        json={"role": "admin"},
+        headers={"X-Auth-Request-User": "reader-user"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_duplicate_member(client: AsyncClient) -> None:
     await _setup(client)
     await client.post(

--- a/tests/handlers/openapi_test.py
+++ b/tests/handlers/openapi_test.py
@@ -144,6 +144,20 @@ async def test_no_path_derived_operation_ids(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_org_dashboard_rebuild_tagged_orgs(client: AsyncClient) -> None:
+    """The org-wide dashboard rebuild is an org-level op tagged ``orgs``.
+
+    ``POST /orgs/{org}/dashboard/rebuild`` addresses the whole
+    organization (not a single project), so it must carry the ``orgs``
+    tag and must not be mis-filed under ``projects``.
+    """
+    spec = (await client.get("/docverse/openapi.json")).json()
+    operation = spec["paths"]["/docverse/orgs/{org}/dashboard/rebuild"]["post"]
+    tags = set(operation.get("tags", []))
+    assert tags == {"orgs"}
+
+
+@pytest.mark.asyncio
 async def test_operations_document_forbidden_response(
     client: AsyncClient,
 ) -> None:

--- a/tests/handlers/openapi_test.py
+++ b/tests/handlers/openapi_test.py
@@ -1,0 +1,37 @@
+"""Spec-lint tests for the generated OpenAPI schema."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+__all__ = []
+
+
+@pytest.mark.asyncio
+async def test_no_module_mangled_schema_names(client: AsyncClient) -> None:
+    """No component schema name is module-path mangled.
+
+    When two handler/client models share a name, FastAPI disambiguates
+    them by prefixing the full module path (e.g.
+    ``docverse__handlers__orgs__models__Edition``). Those ``__``-laden
+    names leak the server's internal package layout into the public
+    contract and produce ugly client codegen. Convergent models must be
+    collapsed onto a single schema so no such name survives.
+    """
+    spec = (await client.get("/docverse/openapi.json")).json()
+    schemas = spec["components"]["schemas"]
+    mangled = sorted(name for name in schemas if "__" in name)
+    assert mangled == [], (
+        f"module-mangled schema names must not appear in openapi.json: "
+        f"{mangled}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_organization_schema_named(client: AsyncClient) -> None:
+    """Admin serves ``AdminOrganization``; orgs keep ``Organization``."""
+    spec = (await client.get("/docverse/openapi.json")).json()
+    schemas = spec["components"]["schemas"]
+    assert "AdminOrganization" in schemas
+    assert "Organization" in schemas

--- a/tests/handlers/openapi_test.py
+++ b/tests/handlers/openapi_test.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
 from httpx import AsyncClient
 
 __all__ = []
+
+_HTTP_METHODS = frozenset({"get", "post", "put", "patch", "delete"})
 
 
 @pytest.mark.asyncio
@@ -35,3 +39,66 @@ async def test_admin_organization_schema_named(client: AsyncClient) -> None:
     schemas = spec["components"]["schemas"]
     assert "AdminOrganization" in schemas
     assert "Organization" in schemas
+
+
+@pytest.mark.asyncio
+async def test_operation_ids_match_route_names(
+    app: FastAPI, client: AsyncClient
+) -> None:
+    """Every operationId equals its route's declared ``name``.
+
+    FastAPI's default ``operationId`` is derived from the route name *and*
+    its path plus HTTP method (e.g.
+    ``get_build_docverse_orgs__org__projects__project__builds__build__get``),
+    which leaks the URL structure into the public contract and produces
+    unwieldy client codegen. Passing a ``generate_unique_id_function`` that
+    returns ``route.name`` makes each operationId the clean route name.
+    """
+    expected: dict[tuple[str, str], str] = {}
+    for route in app.routes:
+        if not isinstance(route, APIRoute) or not route.include_in_schema:
+            continue
+        for method in route.methods:
+            if method.lower() in _HTTP_METHODS:
+                expected[(route.path, method.lower())] = route.name
+
+    spec = (await client.get("/docverse/openapi.json")).json()
+    mismatches: list[str] = []
+    for path, operations in spec["paths"].items():
+        for method, operation in operations.items():
+            if method.lower() not in _HTTP_METHODS:
+                continue
+            op_id = operation.get("operationId")
+            want = expected.get((path, method.lower()))
+            if op_id != want:
+                mismatches.append(
+                    f"{method.upper()} {path}: operationId={op_id!r} "
+                    f"expected route name={want!r}"
+                )
+    assert mismatches == [], (
+        "operationIds must equal their route names:\n" + "\n".join(mismatches)
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_path_derived_operation_ids(client: AsyncClient) -> None:
+    """No operationId carries a path-derived suffix.
+
+    Route names use single-underscore words (``post_build``); FastAPI's
+    default path-mangled operationIds contain double underscores from the
+    substituted path separators. Asserting no operationId contains ``__``
+    guards against any default-generated id slipping back into the spec.
+    """
+    spec = (await client.get("/docverse/openapi.json")).json()
+    op_ids = [
+        operation["operationId"]
+        for operations in spec["paths"].values()
+        for method, operation in operations.items()
+        if method.lower() in _HTTP_METHODS and "operationId" in operation
+    ]
+    assert op_ids, "spec exposed no operations"
+    path_derived = sorted(op_id for op_id in op_ids if "__" in op_id)
+    assert path_derived == [], (
+        f"default path-derived operationIds must not appear in openapi.json: "
+        f"{path_derived}"
+    )

--- a/tests/handlers/openapi_test.py
+++ b/tests/handlers/openapi_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
@@ -10,6 +12,43 @@ from httpx import AsyncClient
 __all__ = []
 
 _HTTP_METHODS = frozenset({"get", "post", "put", "patch", "delete"})
+
+# Tags identifying the orgs sub-routers and admin router — the operations
+# whose 403/404/409 error contract this spec-lint covers. Internal and
+# webhook routes are deliberately excluded.
+_IN_SCOPE_TAGS = frozenset({"orgs", "projects", "jobs", "admin"})
+
+_ERROR_MODEL_REF = "#/components/schemas/ErrorModel"
+
+
+def _in_scope_operations(
+    spec: dict[str, Any],
+) -> list[tuple[str, str, dict[str, Any]]]:
+    """Return ``(path, method, operation)`` for in-scope operations."""
+    operations: list[tuple[str, str, dict[str, Any]]] = []
+    for path, methods in spec["paths"].items():
+        for method, operation in methods.items():
+            if method.lower() not in _HTTP_METHODS:
+                continue
+            tags = set(operation.get("tags", []))
+            if tags & _IN_SCOPE_TAGS:
+                operations.append((path, method, operation))
+    return operations
+
+
+def _documents_error_model(
+    operation: dict[str, Any], status_code: str
+) -> bool:
+    """Whether an operation documents ``status_code`` with ``ErrorModel``."""
+    response = operation.get("responses", {}).get(status_code)
+    if response is None:
+        return False
+    schema = (
+        response.get("content", {})
+        .get("application/json", {})
+        .get("schema", {})
+    )
+    return bool(schema.get("$ref") == _ERROR_MODEL_REF)
 
 
 @pytest.mark.asyncio
@@ -101,4 +140,81 @@ async def test_no_path_derived_operation_ids(client: AsyncClient) -> None:
     assert path_derived == [], (
         f"default path-derived operationIds must not appear in openapi.json: "
         f"{path_derived}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_operations_document_forbidden_response(
+    client: AsyncClient,
+) -> None:
+    """Every in-scope operation documents a 403 with the error body.
+
+    Orgs and admin operations all sit behind a role dependency, so each
+    can return 403 for an insufficiently-privileged caller. That contract
+    must be documented from the shared error-responses helper with safir's
+    ``ErrorModel`` body schema.
+    """
+    spec = (await client.get("/docverse/openapi.json")).json()
+    missing = [
+        f"{method.upper()} {path}"
+        for path, method, operation in _in_scope_operations(spec)
+        if not _documents_error_model(operation, "403")
+    ]
+    assert missing == [], (
+        "operations must document a 403 ErrorModel response:\n"
+        + "\n".join(missing)
+    )
+
+
+@pytest.mark.asyncio
+async def test_resource_operations_document_not_found_response(
+    client: AsyncClient,
+) -> None:
+    """Every in-scope operation with a path parameter documents 404.
+
+    An operation addressing a resource by a path parameter (e.g.
+    ``/orgs/{org}/...``) can always miss, so it must document a 404 with
+    the shared ``ErrorModel`` body schema. Collection endpoints without a
+    path parameter (e.g. ``POST /admin/orgs``) are exempt.
+    """
+    spec = (await client.get("/docverse/openapi.json")).json()
+    missing = [
+        f"{method.upper()} {path}"
+        for path, method, operation in _in_scope_operations(spec)
+        if "{" in path and not _documents_error_model(operation, "404")
+    ]
+    assert missing == [], (
+        "resource operations must document a 404 ErrorModel response:\n"
+        + "\n".join(missing)
+    )
+
+
+@pytest.mark.asyncio
+async def test_conflict_operations_document_conflict_response(
+    client: AsyncClient,
+) -> None:
+    """Operations that can conflict document a 409 with the error body.
+
+    The create/enqueue operations that raise ``ConflictError`` must
+    surface that in the contract via the shared helper. Keyed by
+    operationId (which equals the route name).
+    """
+    spec = (await client.get("/docverse/openapi.json")).json()
+    by_op_id = {
+        operation["operationId"]: operation
+        for _, _, operation in _in_scope_operations(spec)
+    }
+    conflict_op_ids = [
+        "admin_post_organization",
+        "post_member",
+        "post_dashboard_rebuild",
+    ]
+    missing = [
+        op_id
+        for op_id in conflict_op_ids
+        if not _documents_error_model(by_op_id[op_id], "409")
+    ]
+    assert missing == [], (
+        "conflict operations must document a 409 ErrorModel response: "
+        f"{missing}"
     )

--- a/tests/handlers/openapi_test.py
+++ b/tests/handlers/openapi_test.py
@@ -15,8 +15,9 @@ _HTTP_METHODS = frozenset({"get", "post", "put", "patch", "delete"})
 
 # Tags identifying the orgs sub-routers and admin router — the operations
 # whose 403/404/409 error contract this spec-lint covers. Internal and
-# webhook routes are deliberately excluded.
-_IN_SCOPE_TAGS = frozenset({"orgs", "projects", "jobs", "admin"})
+# webhook routes are deliberately excluded. (Org-scoped jobs routes are
+# tagged ``orgs``.)
+_IN_SCOPE_TAGS = frozenset({"orgs", "projects", "admin"})
 
 _ERROR_MODEL_REF = "#/components/schemas/ErrorModel"
 

--- a/tests/handlers/orgs_listing_test.py
+++ b/tests/handlers/orgs_listing_test.py
@@ -1,0 +1,106 @@
+"""Tests for the non-admin ``GET /orgs`` listing endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from docverse.client.models import OrgRole
+from docverse.dependencies.context import context_dependency
+from docverse.storage.user_info_store import StubUserInfoStore
+from tests.conftest import seed_group_member, seed_member, seed_org_with_admin
+
+
+@pytest.mark.asyncio
+async def test_member_sees_own_orgs_with_roles(client: AsyncClient) -> None:
+    """A member of two orgs sees exactly those two with correct roles."""
+    await seed_org_with_admin(client, "list-org-a", "alice")
+    await seed_org_with_admin(client, "list-org-b", "other-admin")
+    await seed_member("list-org-b", "alice", OrgRole.reader)
+    # An org alice is not a member of.
+    await seed_org_with_admin(client, "list-org-c", "carol")
+
+    response = await client.get(
+        "/docverse/orgs",
+        headers={"X-Auth-Request-User": "alice"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    by_slug = {entry["slug"]: entry for entry in data}
+    assert set(by_slug) == {"list-org-a", "list-org-b"}
+    assert by_slug["list-org-a"]["role"] == "admin"
+    assert by_slug["list-org-b"]["role"] == "reader"
+    assert by_slug["list-org-a"]["title"] == "Test Org list-org-a"
+    assert by_slug["list-org-a"]["self_url"].endswith("/orgs/list-org-a")
+    assert by_slug["list-org-a"]["self_url"].startswith("http")
+
+
+@pytest.mark.asyncio
+async def test_superadmin_sees_all_orgs(client: AsyncClient) -> None:
+    """A superadmin sees every org, each with the admin effective role."""
+    await seed_org_with_admin(client, "sa-org-a", "alice")
+    await seed_org_with_admin(client, "sa-org-b", "bob")
+
+    response = await client.get(
+        "/docverse/orgs",
+        headers={"X-Auth-Request-User": "superadmin"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    by_slug = {entry["slug"]: entry for entry in data}
+    assert {"sa-org-a", "sa-org-b"} <= set(by_slug)
+    assert by_slug["sa-org-a"]["role"] == "admin"
+    assert by_slug["sa-org-b"]["role"] == "admin"
+
+
+@pytest.mark.asyncio
+async def test_non_member_sees_empty_list(client: AsyncClient) -> None:
+    """A user with no memberships receives an empty list (200, not 403)."""
+    await seed_org_with_admin(client, "empty-org", "owner")
+
+    response = await client.get(
+        "/docverse/orgs",
+        headers={"X-Auth-Request-User": "nobody"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_group_membership_grants_visibility(
+    client: AsyncClient,
+) -> None:
+    """A caller sees an org where only their group holds a role."""
+    await seed_org_with_admin(client, "grp-list-org", "owner")
+    await seed_group_member("grp-list-org", "g_team", OrgRole.uploader)
+
+    context_dependency._user_info_store = StubUserInfoStore(groups=["g_team"])
+    response = await client.get(
+        "/docverse/orgs",
+        headers={"X-Auth-Request-User": "group-user"},
+    )
+    assert response.status_code == 200
+    by_slug = {entry["slug"]: entry for entry in response.json()}
+    assert "grp-list-org" in by_slug
+    assert by_slug["grp-list-org"]["role"] == "uploader"
+
+
+@pytest.mark.asyncio
+async def test_highest_role_wins_across_memberships(
+    client: AsyncClient,
+) -> None:
+    """When user and group memberships overlap, the higher role wins."""
+    await seed_org_with_admin(client, "dual-org", "owner")
+    await seed_member("dual-org", "dual-user", OrgRole.reader)
+    await seed_group_member("dual-org", "g_admins", OrgRole.admin)
+
+    context_dependency._user_info_store = StubUserInfoStore(
+        groups=["g_admins"]
+    )
+    response = await client.get(
+        "/docverse/orgs",
+        headers={"X-Auth-Request-User": "dual-user"},
+    )
+    assert response.status_code == 200
+    by_slug = {entry["slug"]: entry for entry in response.json()}
+    assert by_slug["dual-org"]["role"] == "admin"

--- a/tests/handlers/projects_test.py
+++ b/tests/handlers/projects_test.py
@@ -49,6 +49,7 @@ async def test_create_project(client: AsyncClient) -> None:
     assert data["title"] == "My Docs"
     assert "id" not in data
     assert data["self_url"].endswith("/orgs/proj-org/projects/my-docs")
+    assert response.headers["Location"] == data["self_url"]
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/services_test.py
+++ b/tests/handlers/services_test.py
@@ -65,6 +65,7 @@ async def test_create_service(client: AsyncClient) -> None:
     assert data["credential_label"] == "primary-aws"
     assert "self_url" in data
     assert "org_url" in data
+    assert response.headers["Location"] == data["self_url"]
 
 
 @pytest.mark.asyncio

--- a/tests/storage/membership_store_test.py
+++ b/tests/storage/membership_store_test.py
@@ -114,6 +114,50 @@ async def test_list_by_org(
 
 
 @pytest.mark.asyncio
+async def test_update_role(
+    db_session: AsyncSession,
+    membership_store: OrgMembershipStore,
+) -> None:
+    async with db_session.begin():
+        org_id = await _create_org(db_session)
+        await membership_store.create(
+            org_id=org_id,
+            data=OrgMembershipCreate(
+                principal="carol",
+                principal_type=PrincipalType.user,
+                role=OrgRole.reader,
+            ),
+        )
+        updated = await membership_store.update_role(
+            org_id=org_id,
+            principal_type=PrincipalType.user,
+            principal="carol",
+            role=OrgRole.admin,
+        )
+        await db_session.commit()
+    assert updated is not None
+    assert updated.role == OrgRole.admin
+    assert updated.principal == "carol"
+
+
+@pytest.mark.asyncio
+async def test_update_role_not_found(
+    db_session: AsyncSession,
+    membership_store: OrgMembershipStore,
+) -> None:
+    async with db_session.begin():
+        org_id = await _create_org(db_session)
+        updated = await membership_store.update_role(
+            org_id=org_id,
+            principal_type=PrincipalType.user,
+            principal="ghost",
+            role=OrgRole.admin,
+        )
+        await db_session.commit()
+    assert updated is None
+
+
+@pytest.mark.asyncio
 async def test_delete_membership(
     db_session: AsyncSession,
     membership_store: OrgMembershipStore,


### PR DESCRIPTION
## Summary

- Eliminate all module-mangled (`docverse__...`) schema names from `openapi.json` by collapsing the handler-side `Edition`, `KeeperSyncRun`, and `KeeperSyncEditionStatus` response models onto their identical client-package counterparts.
- Rename the admin `Organization` response model to `AdminOrganization` (its shape genuinely differs — it adds `org_url`); the orgs-scoped `Organization` keeps the plain name.
- Convert the three convergent `from_domain` classmethods into module-level `*_from_domain` builder functions that construct the client model; handlers now reference the client class directly as `response_model`.
- Generate clean `operationId`s by passing a `generate_unique_id_function` to the FastAPI app that returns each route's declared `name`, replacing FastAPI's path-mangled defaults so the public contract and client codegen stay clean.
- Document the 403/404/409 error contract across all orgs and admin operations via a shared `responses=` helper (`src/docverse/handlers/responses.py`) built on safir's `ErrorModel` body shape, replacing the spec's previous 422/500-only coverage.
- Add a `Location` header to every 201 create response (the resource's `self_url`) and every 202 enqueue response (the org-scoped job URL); the org-wide dashboard rebuild points at the org jobs collection since it enqueues one job per project.
- Wrap `POST /orgs/{org}/dashboard/rebuild`'s 202 body in an `OrgDashboardRebuildResponse` object envelope (`{"entries": [...]}`) instead of a bare array so it can grow fields, retag the org-level operation from `projects` to `orgs`, and audit the remaining `orgs/__init__.py` tag assignments for level-consistency.
- Add a non-admin `GET /orgs` listing that returns the organizations where the caller holds an effective role (direct or via group) as a summary model (`slug`, `title`, `self_url`, effective `role`); superadmins see all orgs and any authenticated caller with no memberships gets an empty `200`. Exposed on `docverse-client` as `list_organizations()` with an `OrganizationSummary` model.
- Add `PATCH /orgs/{org}/members/{member}` for in-place member role updates (admin-only, returns the updated `OrgMembership`) following the merge-patch house style with an all-optional `OrgMembershipUpdate` model whose `extra="forbid"` rejects attempts to change the immutable `principal`/`principal_type`. Exposed on `docverse-client` as `update_member()`.
- Add `PATCH /orgs/{org}/keeper-sync` for merge-patch updates of the org keeper-sync config via a new all-optional `KeeperSyncConfigUpdate` client model (`extra="forbid"`): omitted fields are left untouched, and `project_slugs`, when provided, replaces the stored array wholesale (documented — no append). `PUT` remains for full replacement and the `dashboard-template` endpoints stay PUT-only. Exposed on `docverse-client` as `update_keeper_sync_config()`.
- Document the REST API conventions in `docs/api-conventions.md` (standalone Markdown, since the repo has no docs build yet): the async verb rule (`rebuild`/`sync`/`refresh`), bare-noun path params (and the `{ltd_slug}` exception), `self_url`/`*_url` hypermedia links, `date_` timestamp prefixes, PUT-for-config-singletons vs PATCH-for-resources merge-patch semantics, the 202-with-`Location` async pattern, keyset pagination with `Link` + `X-Total-Count`, and the deliberately-unpaginated listings (members, credentials, services, admin orgs, non-admin `GET /orgs`).

## Validation steps

- Fetch `GET /docverse/openapi.json` and confirm no `components.schemas` key contains `__`.
- Confirm the admin org endpoints serve a schema named `AdminOrganization` and the orgs endpoints still serve `Organization`.
- Confirm every operation's `operationId` in `openapi.json` equals its route's `name` and no `operationId` carries a path-derived `__` suffix.
- Confirm every orgs/admin operation documents a `403` response with the `ErrorModel` body schema.
- Confirm every path-parameterized orgs/admin operation documents a `404` response with the `ErrorModel` body schema.
- Confirm the conflict operations (admin create org, add member, project dashboard rebuild) each document a `409` response with the `ErrorModel` body schema.
- Create a resource via each POST/PUT create endpoint and confirm the 201 response carries a `Location` header equal to the body's `self_url`.
- Trigger each async-enqueue endpoint and confirm the 202 response carries a `Location` header pointing at the org-scoped job URL.
- `POST /orgs/{org}/dashboard/rebuild` and confirm the 202 body is an object `{"entries": [...]}` (not a bare array), and that in `openapi.json` the operation is tagged `orgs`.
- As a user who is a member of two orgs (with different roles), `GET /docverse/orgs` and confirm exactly those two orgs are returned with the correct effective `role`; as a superadmin confirm all orgs are returned; as a user with no memberships confirm an empty list with status `200`.
- `PATCH /orgs/{org}/members/{member}` with `{"role": "admin"}` as an org admin and confirm the member's role changes and the updated `OrgMembership` is returned; confirm a body with `principal` or `principal_type` is rejected with `422`; confirm a non-admin caller gets `403`.
- `PATCH /orgs/{org}/keeper-sync` with only `{"enabled": false}` after a full `PUT` and confirm `ltd_base_url` and `project_slugs` are unchanged; `PATCH` with `{"project_slugs": [...]}` and confirm the stored list is replaced wholesale; confirm `PUT` still performs a full replacement and a non-admin caller gets `403`.
- Read `docs/api-conventions.md` and confirm it covers the verb rule, path-param naming, hypermedia links, timestamp naming, PUT-vs-PATCH, the 202 async pattern, and pagination, and that it enumerates the deliberately-unpaginated listings.

> Stacking note: this branch was cut from `tickets/DM-55550` (PR #465) and targets it as base; it will be rebased onto `main` before final merge.

## References

- Closes #466
- Closes #467
- Closes #468
- Closes #469
- Closes #470
- Closes #471
- Closes #472
- Closes #473
- Closes #474
- PRD: #450
- Jira: https://rubinobs.atlassian.net/browse/DM-55551
