### PR TITLE
DM-55493: cap fastapi below 0.140 (faststream incompatibility)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,11 @@ dependencies = [
     "click>=8",
     "cryptography>=48.0.1",
     "docverse-client",
-    "fastapi>=0.115",
+    # FastAPI 0.140 made Dependant a slots dataclass; FastStream's FastAPI
+    # plugin monkey-patches attributes onto Dependant and now raises
+    # AttributeError at import/startup.
+    # TODO: remove when ag2ai/faststream#2959 is fixed
+    "fastapi>=0.115,<0.140",
     "httpx",
     "jinja2>=3.1",
     "pydantic>=2",

--- a/server-changelog.d/20260727_120000_DM_55493_fastapi_cap.md
+++ b/server-changelog.d/20260727_120000_DM_55493_fastapi_cap.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Capped the `fastapi` requirement at `<0.140`. FastAPI 0.140.0 made `Dependant` a `@dataclass(slots=True)`, which breaks FastStream's FastAPI plugin: it monkey-patches `model`, `custom_fields`, and `flat_params` onto `Dependant` instances and now raises `AttributeError: 'Dependant' object has no attribute 'model' and no __dict__ for setting new attributes`. The upstream bug is [ag2ai/faststream#2959](https://github.com/ag2ai/faststream/issues/2959), unfixed as of faststream 0.7.2. The cap keeps the next dependency refresh from baking a broken FastAPI into the lockfile; remove it once FastStream is fixed.

--- a/uv.lock
+++ b/uv.lock
@@ -770,7 +770,7 @@ requires-dist = [
     { name = "click", specifier = ">=8" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "docverse-client", editable = "client" },
-    { name = "fastapi", specifier = ">=0.115" },
+    { name = "fastapi", specifier = ">=0.115,<0.140" },
     { name = "httpx" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2" },


### PR DESCRIPTION
## Summary

Caps the direct `fastapi` requirement in `pyproject.toml`:
`"fastapi>=0.115"` -> `"fastapi>=0.115,<0.140"`.

## Why

FastAPI 0.140.0 (2026-07-24, fastapi/fastapi#16049 "Reduce memory usage in
dependencies") changed `Dependant` to `@dataclass(slots=True)`. FastStream's
FastAPI plugin monkey-patches `dependant.model`, `.custom_fields`, and
`.flat_params` onto that instance
(`faststream/_internal/fastapi/get_dependant.py:131,135,136`), which now raises:

```
AttributeError: 'Dependant' object has no attribute 'model' and no __dict__ for setting new attributes
```

Upstream bug: https://github.com/ag2ai/faststream/issues/2959 (open, unfixed on
main; note the repo moved from `airtai/` to `ag2ai/`). faststream 0.7.2 is the
latest release and is still broken, and downgrading does not help — 0.6.7 (what
we lock) carries the same monkey-patch.

We reach FastStream through `safir[kafka]`.

This repo's committed `uv.lock` still pins a pre-break FastAPI, so **production
and per-PR CI are green today** — only the scheduled Periodic CI job, which
resolves dependencies unpinned, is red. The cap exists so that the next
`make update` does not silently bake 0.140.x into the lockfile and ship a
broken image.

The pin carries a `# TODO: remove when ag2ai/faststream#2959 is fixed` comment.

## Lockfile impact

Relocked with plain `uv lock` (deliberately **not** `--upgrade`), so no
unrelated packages moved. The entire `uv.lock` diff is the one constraint
metadata line:

```diff
-    { name = "fastapi", specifier = ">=0.115" },
+    { name = "fastapi", specifier = ">=0.115,<0.140" },
```

`fastapi` stays resolved at **0.136.3** (unchanged, below the cap);
`faststream` stays at 0.6.7.

## Validation

- `nox -s typing test` — both sessions pass (mypy clean; 1795 tests passed).
- `pre-commit` hooks pass on commit, including `check-toml` and `uv-lock`.
