### PR TITLE
DM-55493: Refresh vendored ruff-shared.toml for ruff 0.16 CPY001

### DIFF
--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -36,6 +36,7 @@ ignore = [
     "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "CPY001",   # No, every single file doesn't need its own copyright notice
     "D102",     # sometimes we use docstring inheritence
     "D104",     # don't see the point of documenting every package
     "D105",     # our style doesn't require docstrings for magic methods


### PR DESCRIPTION
Jira: https://rubinobs.atlassian.net/browse/DM-55493

## Summary

ruff 0.16.0 (2026-07-23) stabilized `CPY001` (missing-copyright-notice) out
of preview. Because `ruff-shared.toml` uses `select = ["ALL"]`, the rule
armed itself fleet-wide. lsst/templates commit `dd8e4b26` (2026-07-24) added
one line to the `[lint]` ignore list:

```
"CPY001",   # No, every single file doesn't need its own copyright notice
```

This PR overwrites the vendored `ruff-shared.toml` with the current
`fastapi_safir_app` template copy verbatim. Diffed before/after: the only
change is the CPY001 ignore line — docverse's vendored copy was already
current with the template otherwise. `pyproject.toml`'s `[tool.ruff]`
overrides (isort `known-first-party`, per-file-ignores) already matched
what the playbook expects and needed no changes.

## Notes

- `ruff check .` against pinned `ruff==0.15.15` (per `.pre-commit-config.yaml`) passes clean.
- Checked against `ruff>=0.16`: `PLR0917` (too-many-positional-arguments), also stabilized in
  0.16.0, now flags several existing handler/service functions in this repo. That is expected
  and out of scope for this config-only PR — Jonathan is handling PLR0917 fallout as separate
  per-site fixes elsewhere in the fleet; this PR does not add local ignores or refactor source
  to silence it.

## Test plan

- [x] `ruff check .` (pinned 0.15.15) passes
- [x] Diffed `ruff-shared.toml` against `lsst/templates` `fastapi_safir_app` template — single-line CPY001 change only