### PR TITLE
DM-55493: scope PLR0917 for ruff 0.16

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -47,6 +47,12 @@ where = ["src"]
 [tool.ruff]
 extend = "../ruff-shared.toml"
 
+[tool.ruff.lint.extend-per-file-ignores]
+"src/docverse/client/_cli.py" = [
+    "PLR0917", # Too many positional arguments (Click builds the CLI from
+               # the decorated command signature; nothing calls it directly).
+]
+
 [tool.coverage.run]
 parallel = true
 branch = true

--- a/src/docverse/dependencies/context.py
+++ b/src/docverse/dependencies/context.py
@@ -166,6 +166,7 @@ class ContextDependency:
 
     async def initialize(  # noqa: C901
         self,
+        *,
         user_info_store: UserInfoStore | None = None,
         credential_encryptor: CredentialEncryptor | None = None,
         superadmin_usernames: list[str] | None = None,

--- a/src/docverse/factory.py
+++ b/src/docverse/factory.py
@@ -112,6 +112,7 @@ class Factory:
 
     def __init__(
         self,
+        *,
         session: AsyncSession,
         logger: structlog.stdlib.BoundLogger,
         credential_encryptor: CredentialEncryptor | None = None,
@@ -123,7 +124,6 @@ class Factory:
         github_app_private_key: SecretStr | None = None,
         github_webhook_secret: SecretStr | None = None,
         github_app_name: str = "lsst-sqre/docverse",
-        *,
         github_app_validated: bool = True,
         default_queue_name: str,
     ) -> None:
@@ -946,6 +946,7 @@ class HandlerFactory(Factory):
 
     def __init__(
         self,
+        *,
         session: AsyncSession,
         logger: structlog.stdlib.BoundLogger,
         arq_queue: ArqQueue,
@@ -958,7 +959,6 @@ class HandlerFactory(Factory):
         github_app_private_key: SecretStr | None = None,
         github_webhook_secret: SecretStr | None = None,
         github_app_html_url: str | None = None,
-        *,
         github_app_validated: bool = True,
         default_queue_name: str,
     ) -> None:

--- a/src/docverse/services/build.py
+++ b/src/docverse/services/build.py
@@ -25,6 +25,7 @@ class BuildService:
 
     def __init__(
         self,
+        *,
         store: BuildStore,
         org_store: OrganizationStore,
         project_store: ProjectStore,

--- a/src/docverse/services/edition.py
+++ b/src/docverse/services/edition.py
@@ -33,6 +33,7 @@ class EditionService:
 
     def __init__(
         self,
+        *,
         store: EditionStore,
         org_store: OrganizationStore,
         project_store: ProjectStore,


### PR DESCRIPTION
## Background

ruff 0.16.0 stabilizes `PLR0917` (`too-many-positional-arguments`), promoting it out of preview. Because our shared config selects the `PL` ruleset, the rule starts firing across the repo the moment the pinned ruff crosses 0.16. This PR gets ahead of that bump so the upgrade lands clean.

Note the repo's pinned pre-commit ruff is older and does **not** report these — verify locally with:

```
uvx ruff@0.16.0 check --select PLR0917,ISC004 .
```

Baseline on `main` was **18** findings. This PR resolves 6 of them and deliberately leaves 12.

## Disposition

`PLR0917` counts *positional* parameters, so the fix is to make parameters keyword-only with a bare `*,` — not to remove, reorder, or `noqa` them. Each site was triaged on whether the signature is ours to shape or is dictated by a framework.

**Fixed by making parameters keyword-only (5):**

| Site | Was |
|---|---|
| `Factory.__init__` | 11 positional |
| `HandlerFactory.__init__` | 12 positional |
| `ContextDependency.initialize` | 10 positional |
| `BuildService.__init__` | 6 positional |
| `EditionService.__init__` | 8 positional |

All five are internal APIs called only by our own code. Every parameter is a distinct injected collaborator with no natural positional order, so `*,` goes directly after `self` — there is no leading argument that reads better positionally. Both `Factory` and `HandlerFactory` already carried a `*,` partway down the signature; this just moves it up, which is why the diff there is a one-line move rather than an addition.

**Scoped ignore (1):** `client/src/docverse/client/_cli.py` — the `upload` command, 11 positional parameters. Click constructs the CLI from the decorated function's signature and invokes it itself; making the parameters keyword-only would not improve any real call site because there is no internal caller. This is a framework-imposed shape, so it gets a targeted per-file ignore rather than a signature change.

The ignore lives in `client/pyproject.toml`, not the root one: `client/` has its own `[tool.ruff]` that extends `../ruff-shared.toml`, so ruff resolves config for those files against the client's `pyproject.toml` and never consults the root. An entry in the root file would be silently dead config. `ruff-shared.toml` itself is untouched, so the file-matches-source check still passes.

## Expected-remaining (12, intentional)

All under `src/docverse/handlers/orgs/` — `builds.py` (2), `dashboard_template.py` (1), `editions.py` (4), `jobs.py` (1), `keeper_sync.py` (3), `projects.py` (1). These are decorated FastAPI route handlers whose parameter lists *are* the request schema (path params + `Depends(...)` injections). They are not silenced locally; they're being addressed by a separate change in `lsst/templates`.

## Call sites

Checked exhaustively across `src/`, `tests/`, and `client/`, including `super().__init__(...)`: **no caller changes were needed.** All 12 `Factory(...)` / `HandlerFactory(...)` construction sites, all 5 `ContextDependency.initialize(...)` calls, and all `BuildService(...)` / `EditionService(...)` constructions already passed keyword arguments. `HandlerFactory` subclasses `Factory` and its `super().__init__(...)` was already fully keyword too.

No changelog fragment: there is no root `changelog.d`, and the only change under the client package (which does have one) is a lint ignore with no behavior change.

## Validation

- `uvx ruff@0.16.0 check --select PLR0917,ISC004 .` — 18 findings before, 12 after, all 12 the expected `handlers/orgs/` routes. No `ISC004` findings at any point.
- `nox -s typing test` — typing passed; 1795 tests passed. A signature change that broke a caller would surface here.
- pre-commit (`ruff check`, `ruff format`, `check toml`) passed on commit.

One pre-existing, unrelated `RUF036` in `src/docverse/cli.py` is visible under ruff 0.16.0 and left for separate work.