### PR TITLE
DM-55493: Maintain uv version pins with update-uv-version.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,12 @@
 name: CI
 
+env:
+  # Current supported uv version. The uv documentation recommends pinning
+  # this. The version should match the version used in
+  # .pre-commit-config.yaml and frozen in uv.lock. It is updated by
+  # make update-deps.
+  UV_VERSION: "0.11.33"
+
 "on":
   merge_group: {}
   pull_request: {}
@@ -43,6 +50,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - name: Run linters
         run: uv run --only-group=lint prek run --all-files
@@ -63,6 +72,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - name: Run typing
         run: uv run --only-group=nox nox -s typing
@@ -88,6 +99,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - name: Run client tests
         run: >-
@@ -122,6 +135,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - name: Run deploy-worker integration test
         run: uv run --only-group=nox nox -s deploy_worker_test

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 FROM base-image AS install-image
 
 # Install uv.
-COPY --from=ghcr.io/astral-sh/uv:0.9.21 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.33 /uv /bin/uv
 
 # Install system packages only needed for building dependencies.
 COPY scripts/install-dependency-packages.sh .

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ update: update-deps init
 update-deps:
 	uv lock --upgrade
 	uv run --only-group=lint prek autoupdate
+	./scripts/update-uv-version.sh
 
 .PHONY: lint
 lint:

--- a/scripts/update-uv-version.sh
+++ b/scripts/update-uv-version.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Update uv version references based on the frozen version from uv.lock.
+
+# Bash "strict mode", to help catch problems and bugs in the shell script.
+# Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
+set -euo pipefail
+
+# Expand non-matching globs to the empty list instead of the glob so that
+# packages that don't have one of the affected files can silently skip the
+# uv version rewrite rule that doesn't apply.
+shopt -s nullglob
+
+# Determine the current uv release version.
+uv_version=$(echo uv \
+             | uv pip compile - --quiet --no-header --no-annotate --no-config \
+             | sed -n 's/^uv==//p')
+
+# Replace the version in the env variables in GitHub Actions workflows.
+for f in .github/workflows/*.yaml; do
+    sed "s/UV_VERSION: .*/UV_VERSION: \"$uv_version\"/" "$f" >"$f.n"
+    if ! cmp -s "$f" "${f}.n"; then
+        echo "Updating UV_VERSION to $uv_version in $f"
+        mv "${f}.n" "$f"
+    else
+        rm "${f}.n"
+    fi
+done
+
+# Replace the version in any Dockerfiles. Allow for copying this script into
+# packages that have no Dockerfile.
+for f in Dockerfile*; do
+    sed "s/uv:[0-9][0-9.]*/uv:$uv_version/" "$f" >"${f}.n"
+    if ! cmp -s "$f" "${f}.n"; then
+        echo "Updating uv container version to $uv_version in $f"
+        mv "${f}.n" "$f"
+    else
+        rm "${f}.n"
+    fi
+done


### PR DESCRIPTION
Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

## Summary

Adopts `scripts/update-uv-version.sh` (copied verbatim from the
`lsst/templates` `fastapi_safir_app` example) and wires it into
`make update-deps` as the last step of the target.

docverse had no `UV_VERSION` pin surface yet (step 3b of the migration
playbook), so this PR also:

- Adds an `env: UV_VERSION: "0.0.0"` block to `.github/workflows/ci.yaml`
  (comment copied verbatim from the template).
- Gives all four `astral-sh/setup-uv@v7` steps in `ci.yaml` a
  `version: ${{ env.UV_VERSION }}` input.

Running the script once then resolved the placeholder and the Dockerfile
pin to the current latest uv release:

- **Dockerfile** `uv 0.9.21 -> 0.11.33`
- **ci.yaml** `UV_VERSION (new pin) -> 0.11.33`

Files the script rewrote: `.github/workflows/ci.yaml`, `Dockerfile`.

Ran the script a second time to confirm idempotency — no further changes,
`git status --porcelain` clean. `uv.lock` is untouched; this PR carries no
dependency refresh.

## Test plan

- [x] `uv run --only-group=nox nox -s lint` passes (prek: trailing
      whitespace, yaml, toml, json, ruff check, ruff format, uv-lock all
      pass)
- [x] Second run of `scripts/update-uv-version.sh` is a no-op
- [x] `UV_VERSION` in `ci.yaml` and the `uv:` pin in `Dockerfile` agree
      (`0.11.33`)
- [x] `git status --porcelain` shows no `uv.lock` changes

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ