### PR TITLE
DM-54684: Cloudflare cache purging on edition publish

### DIFF
--- a/cloudflare-worker/src/resolver.ts
+++ b/cloudflare-worker/src/resolver.ts
@@ -9,14 +9,21 @@
  *   3. Try exact path, then `{path}/index.html` for directory index
  *      resolution.
  *   4. Return the R2 object with `Content-Type` inferred from the file
- *      extension and `Cache-Control: public, max-age=60`.
+ *      extension and `Cache-Control` derived from the KV value's
+ *      `cache_profile` field: `CACHE_CONTROL_LONG` for `"long"`,
+ *      `CACHE_CONTROL_SHORT` for `"short"` or an absent field.
  *   5. Route any 404 (missing KV entry, malformed KV JSON, missing R2
  *      object after the index-html fallback) through `notFoundResponse`.
+ *
+ * Edition responses are the only profile-sensitive responses. Dashboard-family
+ * (dashboard HTML, `switcher.json`, `_docverse.json`) and 404 responses always
+ * emit `CACHE_CONTROL_SHORT` so rebuilds stay visible within a minute without
+ * any purge machinery.
  *
  * - `dashboard` routes delegate to `DashboardStore.getDashboard()`, which
  *   encapsulates the `__`-prefixed R2 key layout. The response body is the
  *   R2 object with `Content-Type: text/html; charset=utf-8` and
- *   `Cache-Control: public, max-age=60`. When the request carries an
+ *   `Cache-Control: CACHE_CONTROL_SHORT`. When the request carries an
  *   `If-None-Match` header whose full value exactly matches the R2 object's
  *   `httpEtag`, the resolver returns a bodiless 304 with the same `ETag` and
  *   `Cache-Control` headers instead.
@@ -38,7 +45,7 @@
  * `notFoundResponse(project, dashboardStore, ctx)`, which serves the
  * project's branded `{project}/__404.html` when present and degrades to
  * plain-text `Not Found` otherwise. Both variants apply the same
- * `Cache-Control: public, max-age=60` so dashboard rebuilds and newly
+ * `CACHE_CONTROL_SHORT` so dashboard rebuilds and newly
  * published editions become visible within one minute and 404s don't get
  * CDN-stuck. Unroutable requests (no extractable project slug) bypass this
  * helper at the worker entry point, since there's no project to fall back
@@ -63,10 +70,47 @@ import mime from "mime";
 import type { DashboardStore } from "./dashboardStore";
 import type { Route, EditionRoute } from "./router";
 
+/**
+ * `Cache-Control` for short-lived responses: edition responses whose KV value
+ * carries `cache_profile: "short"` (or omits it), plus every dashboard-family
+ * and 404 response unconditionally.
+ */
+export const CACHE_CONTROL_SHORT = "public, max-age=60";
+
+/**
+ * `Cache-Control` for edition responses whose KV value carries
+ * `cache_profile: "long"`: 5 minutes in the browser, 1 day at the edge.
+ * Safe because Docverse issues a hostname-wide Cloudflare purge whenever a
+ * long-profile edition is published.
+ */
+export const CACHE_CONTROL_LONG = "public, max-age=300, s-maxage=86400";
+
+/** Edge-caching policy for an edition, as recorded in its KV value. */
+type CacheProfile = "long" | "short";
+
 /** Shape of the JSON value stored in the editions KV namespace. */
 interface EditionMapping {
   build_id: string;
   r2_prefix: string;
+  /**
+   * Edge-caching policy for this edition. Optional: KV values written before
+   * this field existed (or by an older publisher) omit it, in which case the
+   * resolver falls back to the short profile, which is always safe.
+   */
+  cache_profile?: CacheProfile;
+}
+
+/**
+ * Select the `Cache-Control` header for an edition response.
+ *
+ * Anything other than an explicit `"long"` — `"short"`, a missing field, or an
+ * unrecognized value from a future publisher — maps to the short profile so
+ * ambiguous KV state never over-caches.
+ */
+function editionCacheControl(mapping: EditionMapping): string {
+  return mapping.cache_profile === "long"
+    ? CACHE_CONTROL_LONG
+    : CACHE_CONTROL_SHORT;
 }
 
 /**
@@ -153,7 +197,7 @@ async function resolveDashboardFamily(
       status: 304,
       headers: {
         "ETag": object.httpEtag,
-        "Cache-Control": "public, max-age=60",
+        "Cache-Control": CACHE_CONTROL_SHORT,
       },
     });
   }
@@ -162,7 +206,7 @@ async function resolveDashboardFamily(
     headers: {
       "Content-Type": contentType,
       "ETag": object.httpEtag,
-      "Cache-Control": "public, max-age=60",
+      "Cache-Control": CACHE_CONTROL_SHORT,
     },
   });
 }
@@ -231,7 +275,7 @@ async function resolveEdition(
     headers: {
       "Content-Type": contentType,
       "ETag": object.httpEtag,
-      "Cache-Control": "public, max-age=60",
+      "Cache-Control": editionCacheControl(mapping),
     },
   });
 }
@@ -239,8 +283,9 @@ async function resolveEdition(
 /**
  * Build a 404 response for a routable request, preferring the project's
  * branded `__404.html` and degrading to plain text on miss. Both variants
- * apply the same `Cache-Control: public, max-age=60` so CDN behavior is
- * uniform across the `/v/` namespace.
+ * apply the same `CACHE_CONTROL_SHORT` so CDN behavior is
+ * uniform across the `/v/` namespace, regardless of any edition's
+ * `cache_profile`.
  *
  * Consults `caches.default` before calling `get404` so repeated 404s for the
  * same project don't re-hit R2 within the 60-second TTL. The cache key is a
@@ -272,14 +317,14 @@ export async function notFoundResponse(
             "Content-Type": "text/html; charset=utf-8",
             "Content-Length": object.size.toString(),
             "ETag": object.httpEtag,
-            "Cache-Control": "public, max-age=60",
+            "Cache-Control": CACHE_CONTROL_SHORT,
           },
         })
       : new Response("Not Found", {
           status: 404,
           headers: {
             "Content-Type": "text/plain",
-            "Cache-Control": "public, max-age=60",
+            "Cache-Control": CACHE_CONTROL_SHORT,
           },
         });
   ctx.waitUntil(caches.default.put(cacheKey, response.clone()));

--- a/cloudflare-worker/test/resolver.test.ts
+++ b/cloudflare-worker/test/resolver.test.ts
@@ -185,7 +185,7 @@ describe("resolve — edition routes", () => {
     path: "getting-started.html",
   };
 
-  it("returns R2 object with correct Content-Type and Cache-Control", async () => {
+  it("returns R2 object with correct Content-Type and the short Cache-Control when cache_profile is absent", async () => {
     const kv = createMockKV({
       "pipelines/__main": JSON.stringify({
         build_id: "b123",
@@ -210,6 +210,66 @@ describe("resolve — edition routes", () => {
     );
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=60",
+    );
+    expect(await response.text()).toBe("<html>hello</html>");
+  });
+
+  it("emits the long Cache-Control when the KV value carries cache_profile long", async () => {
+    const kv = createMockKV({
+      "pipelines/__main": JSON.stringify({
+        build_id: "b123",
+        r2_prefix: "pipelines/__main/b123/",
+        cache_profile: "long",
+      }),
+    });
+    const r2 = createMockR2({
+      "pipelines/__main/b123/getting-started.html": {
+        body: streamFromString("<html>hello</html>"),
+        size: 18,
+      },
+    });
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request("https://example.com/pipelines/getting-started.html");
+
+    const response = await resolve(route, request, kv, r2, dashboardStore, ctx);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=300, s-maxage=86400",
+    );
+    // ETag and Content-Type are unchanged by the cache profile.
+    expect(response.headers.get("Content-Type")).toBe("text/html");
+    expect(response.headers.get("ETag")).toBe(
+      '"pipelines/__main/b123/getting-started.html-etag"',
+    );
+    expect(await response.text()).toBe("<html>hello</html>");
+  });
+
+  it("emits the short Cache-Control when the KV value carries cache_profile short", async () => {
+    const kv = createMockKV({
+      "pipelines/__main": JSON.stringify({
+        build_id: "b123",
+        r2_prefix: "pipelines/__main/b123/",
+        cache_profile: "short",
+      }),
+    });
+    const r2 = createMockR2({
+      "pipelines/__main/b123/getting-started.html": {
+        body: streamFromString("<html>hello</html>"),
+        size: 18,
+      },
+    });
+    const dashboardStore = createMockDashboardStore();
+    const request = new Request("https://example.com/pipelines/getting-started.html");
+
+    const response = await resolve(route, request, kv, r2, dashboardStore, ctx);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    // ETag and Content-Type are unchanged by the cache profile.
+    expect(response.headers.get("Content-Type")).toBe("text/html");
+    expect(response.headers.get("ETag")).toBe(
+      '"pipelines/__main/b123/getting-started.html-etag"',
     );
     expect(await response.text()).toBe("<html>hello</html>");
   });

--- a/src/docverse_server/domain/cache_profile.py
+++ b/src/docverse_server/domain/cache_profile.py
@@ -14,6 +14,8 @@ docs can name the policy without re-deriving it.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from docverse.models import EditionKind
 
 __all__ = [
@@ -21,13 +23,24 @@ __all__ = [
     "CACHE_CONTROL_SHORT",
     "CACHE_PROFILE_LONG",
     "CACHE_PROFILE_SHORT",
+    "CacheProfile",
     "compute_cache_profile",
 ]
 
-CACHE_PROFILE_LONG = "long"
+CacheProfile = Literal["long", "short"]
+"""Name of an edge cache profile.
+
+Threaded from `compute_cache_profile` through the
+`~docverse_server.storage.editionpublisher.EditionPublisher` protocol
+into the Cloudflare Workers KV pointer payload. Typing it as a literal
+keeps a misspelled profile from silently degrading to the Worker's
+``short`` fallback.
+"""
+
+CACHE_PROFILE_LONG: CacheProfile = "long"
 """Profile for read-heavy editions whose content rarely changes."""
 
-CACHE_PROFILE_SHORT = "short"
+CACHE_PROFILE_SHORT: CacheProfile = "short"
 """Profile for frequently-rebuilt editions (the safe default)."""
 
 CACHE_CONTROL_SHORT = "public, max-age=60"
@@ -58,7 +71,7 @@ hostname.
 """
 
 
-def compute_cache_profile(edition_kind: EditionKind) -> str:
+def compute_cache_profile(edition_kind: EditionKind) -> CacheProfile:
     """Derive the edge cache profile for an edition kind.
 
     Parameters
@@ -68,7 +81,7 @@ def compute_cache_profile(edition_kind: EditionKind) -> str:
 
     Returns
     -------
-    str
+    CacheProfile
         ``"long"`` for ``main``, ``release``, ``major``, and ``minor``
         editions; ``"short"`` for ``draft`` and ``alternate`` editions,
         which are rebuilt often enough that maintainers should see

--- a/src/docverse_server/domain/cache_profile.py
+++ b/src/docverse_server/domain/cache_profile.py
@@ -1,0 +1,79 @@
+"""Edge cache-profile derivation for published editions.
+
+This module is the single Python-side home for the CDN cache policy:
+the profile names written into the Cloudflare Workers KV edition
+pointer, the ``Cache-Control`` header values the Worker emits for each
+profile, and the pure function mapping an edition's kind onto a
+profile.
+
+The ``CACHE_CONTROL_*`` values mirror the constants of the same name in
+``cloudflare-worker/src/resolver.ts``. The Worker — not the server — is
+what actually emits these headers; they live here so logs, metrics, and
+docs can name the policy without re-deriving it.
+"""
+
+from __future__ import annotations
+
+from docverse.models import EditionKind
+
+__all__ = [
+    "CACHE_CONTROL_LONG",
+    "CACHE_CONTROL_SHORT",
+    "CACHE_PROFILE_LONG",
+    "CACHE_PROFILE_SHORT",
+    "compute_cache_profile",
+]
+
+CACHE_PROFILE_LONG = "long"
+"""Profile for read-heavy editions whose content rarely changes."""
+
+CACHE_PROFILE_SHORT = "short"
+"""Profile for frequently-rebuilt editions (the safe default)."""
+
+CACHE_CONTROL_SHORT = "public, max-age=60"
+"""``Cache-Control`` the Worker emits for the ``short`` profile."""
+
+CACHE_CONTROL_LONG = "public, max-age=300, s-maxage=86400"
+"""``Cache-Control`` the Worker emits for the ``long`` profile.
+
+Five minutes in the browser, one day at the edge. Publishes of
+long-profile editions trigger a hostname-wide Cloudflare purge so the
+edge copy is replaced rather than waited out.
+"""
+
+_LONG_PROFILE_KINDS = frozenset(
+    {
+        EditionKind.main,
+        EditionKind.release,
+        EditionKind.major,
+        EditionKind.minor,
+    }
+)
+"""Edition kinds that cache long at the edge.
+
+``main`` and ``release`` are read-heavy and stable. The ``major`` /
+``minor`` rollups are aliases for a release line: they only change when
+a release publish updates them, and that publish already purges the
+hostname.
+"""
+
+
+def compute_cache_profile(edition_kind: EditionKind) -> str:
+    """Derive the edge cache profile for an edition kind.
+
+    Parameters
+    ----------
+    edition_kind
+        Kind of the edition being published.
+
+    Returns
+    -------
+    str
+        ``"long"`` for ``main``, ``release``, ``major``, and ``minor``
+        editions; ``"short"`` for ``draft`` and ``alternate`` editions,
+        which are rebuilt often enough that maintainers should see
+        changes without waiting on a purge.
+    """
+    if edition_kind in _LONG_PROFILE_KINDS:
+        return CACHE_PROFILE_LONG
+    return CACHE_PROFILE_SHORT

--- a/src/docverse_server/domain/published_url.py
+++ b/src/docverse_server/domain/published_url.py
@@ -10,7 +10,42 @@ from .edition import Edition
 from .organization import Organization
 from .project import Project
 
-__all__ = ["edition_published_url", "project_published_url"]
+__all__ = [
+    "compute_project_hostname",
+    "edition_published_url",
+    "project_published_url",
+]
+
+
+def compute_project_hostname(org: Organization, project_slug: str) -> str:
+    """Hostname that serves a project's documentation.
+
+    This is the hostname the Cloudflare Worker answers on for the
+    project, and therefore the scope of a hostname-wide CDN cache purge.
+
+    Parameters
+    ----------
+    org
+        Organization owning the project.
+    project_slug
+        Slug of the project.
+
+    Returns
+    -------
+    str
+        ``{project_slug}.{base_domain}`` for ``subdomain`` orgs, or the
+        normalized ``base_domain`` for ``path_prefix`` orgs (where every
+        project shares one hostname). Never includes a scheme or path.
+
+    Notes
+    -----
+    ``slug_rewrite_rules`` are deliberately not involved: those rules
+    derive *edition* slugs from git refs, not project hostnames.
+    """
+    base_domain = normalize_base_domain(org.base_domain)
+    if org.url_scheme == UrlScheme.subdomain:
+        return f"{project_slug}.{base_domain}"
+    return base_domain
 
 
 def project_published_url(org: Organization, project: Project) -> str:
@@ -20,15 +55,15 @@ def project_published_url(org: Organization, project: Project) -> str:
     path-prefix orgs serve under ``base_domain + root_path_prefix +
     project_slug``. Always returns a trailing slash.
     """
-    base_domain = normalize_base_domain(org.base_domain)
+    hostname = compute_project_hostname(org, project.slug)
     if org.url_scheme == UrlScheme.subdomain:
-        return f"https://{project.slug}.{base_domain}/"
+        return f"https://{hostname}/"
     prefix = org.root_path_prefix or "/"
     if not prefix.endswith("/"):
         prefix = f"{prefix}/"
     if not prefix.startswith("/"):
         prefix = f"/{prefix}"
-    return f"https://{base_domain}{prefix}{project.slug}/"
+    return f"https://{hostname}{prefix}{project.slug}/"
 
 
 def edition_published_url(project_url: str, edition: Edition) -> str:

--- a/src/docverse_server/factory.py
+++ b/src/docverse_server/factory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
+from typing import Any
 
 import httpx
 import structlog
@@ -54,6 +55,7 @@ from .services.project import ProjectService
 from .services.project_github_binding import ProjectGitHubBindingResolver
 from .services.ref_deleted_processor import RefDeletedWebhookProcessor
 from .storage.build_store import BuildStore
+from .storage.cdncachepurger import CdnCachePurger, create_cdn_cache_purger
 from .storage.dashboard_templates.github import (
     DashboardGitHubTemplateBindingStore,
     DashboardGitHubTemplateStore,
@@ -544,6 +546,7 @@ class Factory:
                 session=self._session, logger=self._logger
             ),
             publisher_provider=self.create_edition_publisher_for_org,
+            purger_provider=self.create_cdn_cache_purger_for_org,
             logger=self._logger,
         )
 
@@ -740,7 +743,70 @@ class Factory:
             msg = "HTTP client is required to build an EditionPublisher"
             raise RuntimeError(msg)
 
-        # Step 1: Load the service config
+        provider, config, credentials = await self._resolve_cdn_service(
+            org_id=org_id, service_label=service_label
+        )
+        return create_edition_publisher(
+            provider=provider,
+            config=config,
+            credentials=credentials,
+            logger=self._logger,
+            http_client=self._http_client,
+        )
+
+    async def create_cdn_cache_purger_for_org(
+        self, *, org_id: int, service_label: str
+    ) -> CdnCachePurger:
+        """Resolve an org's CdnCachePurger from its service configuration.
+
+        Shares the org's CDN service row (and therefore its API token)
+        with `create_edition_publisher_for_org`, so operators manage one
+        Cloudflare service rather than two.
+
+        Parameters
+        ----------
+        org_id
+            Organization ID.
+        service_label
+            Service label to use (typically the org's
+            ``cdn_service_label``).
+
+        Returns
+        -------
+        CdnCachePurger
+            An unopened CdnCachePurger. Caller must use as async context
+            manager. Organizations whose service has no ``zone_id`` get a
+            no-op purger rather than an error.
+        """
+        if self._http_client is None:
+            msg = "HTTP client is required to build a CdnCachePurger"
+            raise RuntimeError(msg)
+
+        provider, config, credentials = await self._resolve_cdn_service(
+            org_id=org_id, service_label=service_label
+        )
+        return create_cdn_cache_purger(
+            provider=provider,
+            config=config,
+            credentials=credentials,
+            logger=self._logger,
+            http_client=self._http_client,
+        )
+
+    async def _resolve_cdn_service(
+        self, *, org_id: int, service_label: str
+    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
+        """Load a service row and decrypt its credential.
+
+        Returns the service's provider, its non-secret config, and the
+        decrypted credential payload — the three inputs every CDN
+        storage factory takes.
+
+        Raises
+        ------
+        RuntimeError
+            If no service with ``service_label`` exists for the org.
+        """
         service_store = self.create_service_store()
         svc = await service_store.get_by_label(
             organization_id=org_id, label=service_label
@@ -749,20 +815,11 @@ class Factory:
             msg = f"Service {service_label!r} not found"
             raise RuntimeError(msg)
 
-        # Step 2: Decrypt the credential
         credential_service = self.create_credential_service()
         _cred, cred_payload = await credential_service.get_decrypted(
             org_id=org_id, label=svc.credential_label
         )
-
-        # Step 3: Build the EditionPublisher from config + credentials
-        return create_edition_publisher(
-            provider=svc.provider,
-            config=svc.config,
-            credentials=cred_payload,
-            logger=self._logger,
-            http_client=self._http_client,
-        )
+        return svc.provider, svc.config, cred_payload
 
     async def create_objectstore_for_org(
         self, *, org_id: int, service_label: str

--- a/src/docverse_server/services/edition_publishing.py
+++ b/src/docverse_server/services/edition_publishing.py
@@ -9,9 +9,15 @@ import structlog
 from docverse.models.queue_enums import PublishStatus
 from docverse_server.domain.base32id import serialize_base32_id
 from docverse_server.domain.build import Build
-from docverse_server.domain.cache_profile import compute_cache_profile
+from docverse_server.domain.cache_profile import (
+    CACHE_PROFILE_LONG,
+    compute_cache_profile,
+)
 from docverse_server.domain.edition import Edition
 from docverse_server.domain.edition_build_history import EditionBuildHistory
+from docverse_server.domain.organization import Organization
+from docverse_server.domain.published_url import compute_project_hostname
+from docverse_server.storage.cdncachepurger import CdnCachePurger
 from docverse_server.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
 )
@@ -19,7 +25,11 @@ from docverse_server.storage.edition_store import EditionStore
 from docverse_server.storage.editionpublisher import EditionPublisher
 from docverse_server.storage.organization_store import OrganizationStore
 
-__all__ = ["EditionPublisherProvider", "EditionPublishingService"]
+__all__ = [
+    "CdnCachePurgerProvider",
+    "EditionPublisherProvider",
+    "EditionPublishingService",
+]
 
 
 class EditionPublisherProvider(Protocol):
@@ -29,6 +39,16 @@ class EditionPublisherProvider(Protocol):
         self, *, org_id: int, service_label: str
     ) -> EditionPublisher:
         """Return an unopened ``EditionPublisher`` for the org."""
+        ...
+
+
+class CdnCachePurgerProvider(Protocol):
+    """Callable that resolves a ``CdnCachePurger`` for an org."""
+
+    async def __call__(
+        self, *, org_id: int, service_label: str
+    ) -> CdnCachePurger:
+        """Return an unopened ``CdnCachePurger`` for the org."""
         ...
 
 
@@ -49,12 +69,14 @@ class EditionPublishingService:
         edition_store: EditionStore,
         history_store: EditionBuildHistoryStore,
         publisher_provider: EditionPublisherProvider,
+        purger_provider: CdnCachePurgerProvider,
         logger: structlog.stdlib.BoundLogger,
     ) -> None:
         self._org_store = org_store
         self._edition_store = edition_store
         self._history_store = history_store
         self._publisher_provider = publisher_provider
+        self._purger_provider = purger_provider
         self._logger = logger
 
     async def publish(
@@ -77,6 +99,12 @@ class EditionPublishingService:
         The edge cache profile written with the pointer is derived from
         the edition's ``kind`` (see
         `docverse_server.domain.cache_profile.compute_cache_profile`).
+        Long-profile editions are cached at the CDN edge for far longer
+        than the publish cadence, so after a successful publish this
+        method also purges the project's hostname from the CDN cache.
+        Short-profile editions expire quickly on their own and are never
+        purged. Purge failures are logged and swallowed: a CDN hiccup
+        leaves a stale edge copy rather than failing the publish.
 
         On a successful publish both the edition row and the supplied
         history entry are updated to ``PublishStatus.published``. When
@@ -117,6 +145,14 @@ class EditionPublishingService:
                 build_public_id=serialize_base32_id(build.public_id),
                 object_key_prefix=build.storage_prefix,
                 cache_profile=cache_profile,
+            )
+        if cache_profile == CACHE_PROFILE_LONG:
+            await self._purge_cdn_cache(
+                org=org,
+                service_label=org.cdn_service_label,
+                project_slug=project_slug,
+                edition=edition,
+                build=build,
             )
         await self._mark_published(
             edition_id=edition.id, history_id=history_entry.id
@@ -186,6 +222,42 @@ class EditionPublishingService:
             edition_slug=edition_slug,
             cdn_service_label=org.cdn_service_label,
         )
+
+    async def _purge_cdn_cache(
+        self,
+        *,
+        org: Organization,
+        service_label: str,
+        project_slug: str,
+        edition: Edition,
+        build: Build,
+    ) -> None:
+        """Purge the project's hostname from the CDN edge cache.
+
+        Best-effort: any failure resolving or invoking the purger is
+        logged at ERROR with the full publish context and swallowed, so
+        a CDN outage degrades to a stale edge copy instead of a failed
+        publish. Every attempt is logged, success or failure.
+        """
+        hostname = compute_project_hostname(org, project_slug)
+        logger = self._logger.bind(
+            org_id=org.id,
+            project_slug=project_slug,
+            edition_slug=edition.slug,
+            build_id=build.id,
+            cdn_service_label=service_label,
+            hostname=hostname,
+        )
+        try:
+            purger = await self._purger_provider(
+                org_id=org.id, service_label=service_label
+            )
+            async with purger:
+                await purger.purge_hostname(hostname)
+        except Exception:
+            logger.exception("CDN cache purge failed")
+        else:
+            logger.info("Purged CDN cache")
 
     async def _mark_published(
         self, *, edition_id: int, history_id: int

--- a/src/docverse_server/services/edition_publishing.py
+++ b/src/docverse_server/services/edition_publishing.py
@@ -147,6 +147,16 @@ class EditionPublishingService:
                 cache_profile=cache_profile,
             )
         if cache_profile == CACHE_PROFILE_LONG:
+            # The purge fires as soon as the KV write returns. Workers KV
+            # is eventually consistent, so for a short window afterwards
+            # an edge colo can still read the previous pointer and
+            # re-populate its cache with the old build under the long
+            # profile, where it lives until the next publish purges it.
+            # That window is accepted for now: PRD #183 puts purge
+            # retries and scheduling machinery out of scope, and a
+            # delayed second purge would need a job-queue mechanism this
+            # story does not build. Revisit if the stale window is
+            # observed in practice.
             await self._purge_cdn_cache(
                 org=org,
                 service_label=org.cdn_service_label,

--- a/src/docverse_server/services/edition_publishing.py
+++ b/src/docverse_server/services/edition_publishing.py
@@ -9,6 +9,7 @@ import structlog
 from docverse.models.queue_enums import PublishStatus
 from docverse_server.domain.base32id import serialize_base32_id
 from docverse_server.domain.build import Build
+from docverse_server.domain.cache_profile import compute_cache_profile
 from docverse_server.domain.edition import Edition
 from docverse_server.domain.edition_build_history import EditionBuildHistory
 from docverse_server.storage.edition_build_history_store import (
@@ -73,6 +74,10 @@ class EditionPublishingService:
         ``EditionPublisher`` is resolved via ``publisher_provider`` and
         used as an async context manager to publish the pointer.
 
+        The edge cache profile written with the pointer is derived from
+        the edition's ``kind`` (see
+        `docverse_server.domain.cache_profile.compute_cache_profile`).
+
         On a successful publish both the edition row and the supplied
         history entry are updated to ``PublishStatus.published``. When
         the publisher raises, the exception propagates — the caller is
@@ -101,6 +106,7 @@ class EditionPublishingService:
             )
             return
 
+        cache_profile = compute_cache_profile(edition.kind)
         publisher = await self._publisher_provider(
             org_id=org_id, service_label=org.cdn_service_label
         )
@@ -110,6 +116,7 @@ class EditionPublishingService:
                 edition_slug=edition.slug,
                 build_public_id=serialize_base32_id(build.public_id),
                 object_key_prefix=build.storage_prefix,
+                cache_profile=cache_profile,
             )
         await self._mark_published(
             edition_id=edition.id, history_id=history_entry.id
@@ -121,6 +128,7 @@ class EditionPublishingService:
             edition_slug=edition.slug,
             build_id=build.id,
             cdn_service_label=org.cdn_service_label,
+            cache_profile=cache_profile,
         )
 
     async def unpublish(

--- a/src/docverse_server/storage/cdncachepurger/__init__.py
+++ b/src/docverse_server/storage/cdncachepurger/__init__.py
@@ -1,0 +1,13 @@
+"""CDN cache purger abstractions and implementations."""
+
+from ._cloudflare import CloudflareCachePurger
+from ._factory import create_cdn_cache_purger
+from ._noop import NoopCdnCachePurger
+from ._protocol import CdnCachePurger
+
+__all__ = [
+    "CdnCachePurger",
+    "CloudflareCachePurger",
+    "NoopCdnCachePurger",
+    "create_cdn_cache_purger",
+]

--- a/src/docverse_server/storage/cdncachepurger/__init__.py
+++ b/src/docverse_server/storage/cdncachepurger/__init__.py
@@ -2,12 +2,14 @@
 
 from ._cloudflare import CloudflareCachePurger
 from ._factory import create_cdn_cache_purger
+from ._mock import MockCdnCachePurger
 from ._noop import NoopCdnCachePurger
 from ._protocol import CdnCachePurger
 
 __all__ = [
     "CdnCachePurger",
     "CloudflareCachePurger",
+    "MockCdnCachePurger",
     "NoopCdnCachePurger",
     "create_cdn_cache_purger",
 ]

--- a/src/docverse_server/storage/cdncachepurger/_cloudflare.py
+++ b/src/docverse_server/storage/cdncachepurger/_cloudflare.py
@@ -1,0 +1,84 @@
+"""Cloudflare CDN cache purger."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Self
+
+import httpx
+import structlog
+
+__all__ = ["CloudflareCachePurger"]
+
+
+class CloudflareCachePurger:
+    """CDN cache purger backed by the Cloudflare zone purge API.
+
+    Purges by hostname via ``POST /client/v4/zones/{zone_id}/purge_cache``,
+    the one purge mechanism available on every Cloudflare plan tier
+    (purge by prefix and by cache tag are Enterprise-only).
+    """
+
+    def __init__(
+        self,
+        *,
+        zone_id: str,
+        api_token: str,
+        http_client: httpx.AsyncClient,
+        logger: structlog.stdlib.BoundLogger,
+    ) -> None:
+        self._zone_id = zone_id
+        self._api_token = api_token
+        self._http_client = http_client
+        self._logger = logger
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    async def purge_hostname(self, hostname: str) -> None:
+        """Purge every cached response for a hostname in the zone.
+
+        Parameters
+        ----------
+        hostname
+            Hostname whose cached responses should be invalidated, without
+            a scheme or path (e.g. ``myproject.example.org``).
+
+        Raises
+        ------
+        httpx.HTTPStatusError
+            If Cloudflare returns a 4xx or 5xx response. The failure is
+            logged at ``ERROR`` with full context first; the caller
+            decides whether to swallow it.
+        """
+        url = (
+            "https://api.cloudflare.com/client/v4"
+            f"/zones/{self._zone_id}/purge_cache"
+        )
+        response = await self._http_client.post(
+            url,
+            json={"hosts": [hostname]},
+            headers={"Authorization": f"Bearer {self._api_token}"},
+        )
+        if response.is_error:
+            self._logger.error(
+                "Cloudflare cache purge failed",
+                status_code=response.status_code,
+                response_body=response.text,
+                zone_id=self._zone_id,
+                hostname=hostname,
+            )
+        response.raise_for_status()
+        self._logger.info(
+            "Purged Cloudflare cache for hostname",
+            zone_id=self._zone_id,
+            hostname=hostname,
+        )

--- a/src/docverse_server/storage/cdncachepurger/_factory.py
+++ b/src/docverse_server/storage/cdncachepurger/_factory.py
@@ -1,0 +1,108 @@
+"""Factory for creating CdnCachePurger instances from service config."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import structlog
+
+from ._cloudflare import CloudflareCachePurger
+from ._noop import NoopCdnCachePurger
+from ._protocol import CdnCachePurger
+
+__all__ = ["create_cdn_cache_purger"]
+
+
+_CLOUDFLARE_WORKERS_PROVIDER = "cloudflare_workers"
+
+_REQUIRED_CONFIG_KEYS: dict[str, set[str]] = {
+    _CLOUDFLARE_WORKERS_PROVIDER: set(),
+}
+"""Config keys a purger cannot be built without.
+
+``zone_id`` is deliberately **not** required: organizations served from
+a ``workers.dev`` subdomain have no zone, and they get a
+`NoopCdnCachePurger` rather than a configuration error.
+"""
+
+_REQUIRED_CREDENTIAL_KEYS: dict[str, set[str]] = {
+    _CLOUDFLARE_WORKERS_PROVIDER: {"api_token"},
+}
+
+
+def _validate_keys(
+    provider: str,
+    config: dict[str, Any],
+    credentials: dict[str, Any],
+) -> None:
+    """Raise ``ValueError`` if required keys are missing or empty."""
+    required_config = _REQUIRED_CONFIG_KEYS[provider]
+    required_creds = _REQUIRED_CREDENTIAL_KEYS[provider]
+    missing_config = {k for k in required_config if not config.get(k)}
+    missing_creds = {k for k in required_creds if not credentials.get(k)}
+    errors: list[str] = []
+    if missing_config:
+        errors.append(f"config: {', '.join(sorted(missing_config))}")
+    if missing_creds:
+        errors.append(f"credentials: {', '.join(sorted(missing_creds))}")
+    if errors:
+        msg = (
+            f"Missing required keys for {provider!r} CDN cache purger — "
+            + "; ".join(errors)
+        )
+        raise ValueError(msg)
+
+
+def create_cdn_cache_purger(
+    *,
+    provider: str,
+    config: dict[str, Any],
+    credentials: dict[str, Any],
+    logger: structlog.stdlib.BoundLogger,
+    http_client: httpx.AsyncClient,
+) -> CdnCachePurger:
+    """Create a CdnCachePurger from service config and credentials.
+
+    Parameters
+    ----------
+    provider
+        The service provider (currently only ``cloudflare_workers``).
+    config
+        Non-secret service configuration. ``zone_id`` selects a real
+        purger; without it the organization has no purgeable zone.
+    credentials
+        Decrypted credential payload (api_token, …). The same
+        ``api_token`` as the edition publisher is reused.
+    logger
+        Bound logger for contextual logging.
+    http_client
+        Shared ``httpx.AsyncClient`` used to issue requests.
+
+    Returns
+    -------
+    CdnCachePurger
+        An unopened purger. The caller must use it as an async context
+        manager before calling ``purge_hostname``. A `NoopCdnCachePurger`
+        is returned when the provider is supported but ``zone_id`` is
+        absent, so callers never have to branch on configuration.
+
+    Raises
+    ------
+    ValueError
+        If the provider is not supported or required credential keys are
+        missing.
+    """
+    if provider == _CLOUDFLARE_WORKERS_PROVIDER:
+        _validate_keys(provider, config, credentials)
+        zone_id = config.get("zone_id")
+        if not zone_id:
+            return NoopCdnCachePurger(logger=logger)
+        return CloudflareCachePurger(
+            zone_id=zone_id,
+            api_token=credentials["api_token"],
+            http_client=http_client,
+            logger=logger,
+        )
+    msg = f"Unsupported CDN cache purger provider: {provider!r}"
+    raise ValueError(msg)

--- a/src/docverse_server/storage/cdncachepurger/_mock.py
+++ b/src/docverse_server/storage/cdncachepurger/_mock.py
@@ -1,0 +1,45 @@
+"""In-memory mock CDN cache purger for testing."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Self
+
+import structlog
+
+__all__ = ["MockCdnCachePurger"]
+
+
+class MockCdnCachePurger:
+    """In-memory implementation of the ``CdnCachePurger`` protocol.
+
+    Records every hostname passed to ``purge_hostname`` in order so
+    tests can assert both that a purge happened and what its scope was.
+    """
+
+    def __init__(
+        self,
+        *,
+        logger: structlog.stdlib.BoundLogger | None = None,
+    ) -> None:
+        self._purge_calls: list[str] = []
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    @property
+    def purge_calls(self) -> list[str]:
+        """Hostnames passed to ``purge_hostname``, in call order."""
+        return list(self._purge_calls)
+
+    async def purge_hostname(self, hostname: str) -> None:
+        """Record a hostname purge without contacting any CDN."""
+        self._purge_calls.append(hostname)

--- a/src/docverse_server/storage/cdncachepurger/_mock.py
+++ b/src/docverse_server/storage/cdncachepurger/_mock.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from types import TracebackType
 from typing import Self
 
-import structlog
-
 __all__ = ["MockCdnCachePurger"]
 
 
@@ -17,11 +15,7 @@ class MockCdnCachePurger:
     tests can assert both that a purge happened and what its scope was.
     """
 
-    def __init__(
-        self,
-        *,
-        logger: structlog.stdlib.BoundLogger | None = None,
-    ) -> None:
+    def __init__(self) -> None:
         self._purge_calls: list[str] = []
 
     async def __aenter__(self) -> Self:

--- a/src/docverse_server/storage/cdncachepurger/_noop.py
+++ b/src/docverse_server/storage/cdncachepurger/_noop.py
@@ -1,0 +1,45 @@
+"""No-op CDN cache purger for deployments without a purgeable zone."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Self
+
+import structlog
+
+__all__ = ["NoopCdnCachePurger"]
+
+
+class NoopCdnCachePurger:
+    """CDN cache purger that logs the request and does nothing.
+
+    Used for organizations whose Cloudflare service has no ``zone_id``
+    — typically sandboxes served from a ``workers.dev`` subdomain, which
+    has no zone to purge. Returning this rather than raising lets
+    callers purge unconditionally without branching on configuration.
+    """
+
+    def __init__(
+        self,
+        *,
+        logger: structlog.stdlib.BoundLogger | None = None,
+    ) -> None:
+        self._logger = logger or structlog.get_logger(__name__)
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    async def purge_hostname(self, hostname: str) -> None:
+        """Log the skipped purge without contacting any CDN."""
+        self._logger.info(
+            "Skipping CDN cache purge: no purgeable zone configured",
+            hostname=hostname,
+        )

--- a/src/docverse_server/storage/cdncachepurger/_protocol.py
+++ b/src/docverse_server/storage/cdncachepurger/_protocol.py
@@ -1,0 +1,55 @@
+"""CDN cache purger protocol for invalidating edge caches."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Protocol, Self, runtime_checkable
+
+__all__ = ["CdnCachePurger"]
+
+
+@runtime_checkable
+class CdnCachePurger(Protocol):
+    """Backend-agnostic interface for purging a CDN's edge cache.
+
+    A ``CdnCachePurger`` invalidates content cached at a CDN's edge so
+    readers see a newly-published build without waiting out the edge
+    TTL. It is deliberately separate from
+    `~docverse_server.storage.editionpublisher.EditionPublisher` (which
+    only writes edition pointers) so the CDN and pointer-store concerns
+    can evolve independently.
+
+    Only hostname-scoped purging is exposed because that is the one
+    mechanism available on every Cloudflare plan tier. Narrower
+    mechanisms (purge by URL, prefix, or cache tag) can be added to this
+    protocol later without changing existing callers.
+
+    Implementations must be usable as async context managers.
+    """
+
+    async def __aenter__(self) -> Self: ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None: ...
+
+    async def purge_hostname(self, hostname: str) -> None:
+        """Purge every cached response for a hostname.
+
+        Parameters
+        ----------
+        hostname
+            Hostname whose cached responses should be invalidated, without
+            a scheme or path (e.g. ``myproject.example.org``).
+
+        Raises
+        ------
+        Exception
+            Implementations may raise on a provider-side failure. Callers
+            that treat purging as best-effort are responsible for logging
+            and swallowing the error.
+        """
+        ...

--- a/src/docverse_server/storage/editionpublisher/_cloudflare_kv.py
+++ b/src/docverse_server/storage/editionpublisher/_cloudflare_kv.py
@@ -54,6 +54,7 @@ class CloudflareKvEditionPublisher:
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
+        cache_profile: str,
     ) -> None:
         """Write the edition pointer to the configured KV namespace."""
         url = (
@@ -63,13 +64,16 @@ class CloudflareKvEditionPublisher:
             f"/values/{project_slug}/{edition_slug}"
         )
         # The Cloudflare Worker resolver reads the object-store prefix
-        # from the ``r2_prefix`` KV field; see cloudflare-worker/src/
-        # resolver.ts.
+        # from the ``r2_prefix`` KV field and the edge cache policy from
+        # ``cache_profile``; see cloudflare-worker/src/resolver.ts. The
+        # ``cache_profile`` field is additive — a Worker that predates it
+        # falls back to the short profile.
         response = await self._http_client.put(
             url,
             json={
                 "build_id": build_public_id,
                 "r2_prefix": object_key_prefix,
+                "cache_profile": cache_profile,
             },
             headers={"Authorization": f"Bearer {self._api_token}"},
         )

--- a/src/docverse_server/storage/editionpublisher/_cloudflare_kv.py
+++ b/src/docverse_server/storage/editionpublisher/_cloudflare_kv.py
@@ -8,6 +8,8 @@ from typing import Self
 import httpx
 import structlog
 
+from docverse_server.domain.cache_profile import CacheProfile
+
 __all__ = ["CloudflareKvEditionPublisher"]
 
 _HTTP_NOT_FOUND = 404
@@ -54,7 +56,7 @@ class CloudflareKvEditionPublisher:
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
-        cache_profile: str,
+        cache_profile: CacheProfile,
     ) -> None:
         """Write the edition pointer to the configured KV namespace."""
         url = (

--- a/src/docverse_server/storage/editionpublisher/_mock.py
+++ b/src/docverse_server/storage/editionpublisher/_mock.py
@@ -19,6 +19,7 @@ class PublishCall:
     edition_slug: str
     build_public_id: str
     object_key_prefix: str
+    cache_profile: str
 
 
 @dataclass(frozen=True)
@@ -72,6 +73,7 @@ class MockEditionPublisher:
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
+        cache_profile: str,
     ) -> None:
         """Record a publish call."""
         self._calls.append(
@@ -80,6 +82,7 @@ class MockEditionPublisher:
                 edition_slug=edition_slug,
                 build_public_id=build_public_id,
                 object_key_prefix=object_key_prefix,
+                cache_profile=cache_profile,
             )
         )
 

--- a/src/docverse_server/storage/editionpublisher/_mock.py
+++ b/src/docverse_server/storage/editionpublisher/_mock.py
@@ -8,6 +8,8 @@ from typing import Self
 
 import structlog
 
+from docverse_server.domain.cache_profile import CacheProfile
+
 __all__ = ["MockEditionPublisher", "PublishCall", "UnpublishCall"]
 
 
@@ -19,7 +21,7 @@ class PublishCall:
     edition_slug: str
     build_public_id: str
     object_key_prefix: str
-    cache_profile: str
+    cache_profile: CacheProfile
 
 
 @dataclass(frozen=True)
@@ -73,7 +75,7 @@ class MockEditionPublisher:
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
-        cache_profile: str,
+        cache_profile: CacheProfile,
     ) -> None:
         """Record a publish call."""
         self._calls.append(

--- a/src/docverse_server/storage/editionpublisher/_protocol.py
+++ b/src/docverse_server/storage/editionpublisher/_protocol.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from types import TracebackType
 from typing import Protocol, Self, runtime_checkable
 
+from docverse_server.domain.cache_profile import CacheProfile
+
 __all__ = ["EditionPublisher"]
 
 
@@ -36,7 +38,7 @@ class EditionPublisher(Protocol):
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
-        cache_profile: str,
+        cache_profile: CacheProfile,
     ) -> None:
         """Publish an edition pointer to the backing store.
 

--- a/src/docverse_server/storage/editionpublisher/_protocol.py
+++ b/src/docverse_server/storage/editionpublisher/_protocol.py
@@ -36,6 +36,7 @@ class EditionPublisher(Protocol):
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
+        cache_profile: str,
     ) -> None:
         """Publish an edition pointer to the backing store.
 
@@ -50,6 +51,12 @@ class EditionPublisher(Protocol):
         object_key_prefix
             Object-store key prefix for the build's rendered artifacts
             (e.g. an R2 or S3 prefix).
+        cache_profile
+            Edge cache profile for the edition (``"long"`` or
+            ``"short"``), derived by
+            `docverse_server.domain.cache_profile.compute_cache_profile`.
+            Implementations record it alongside the pointer so the CDN
+            layer can choose a ``Cache-Control`` policy per edition.
         """
         ...
 

--- a/tests/domain/cache_profile_test.py
+++ b/tests/domain/cache_profile_test.py
@@ -1,0 +1,36 @@
+"""Tests for cache-profile derivation."""
+
+from __future__ import annotations
+
+import pytest
+
+from docverse.models import EditionKind
+from docverse_server.domain.cache_profile import (
+    CACHE_PROFILE_LONG,
+    CACHE_PROFILE_SHORT,
+    compute_cache_profile,
+)
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected"),
+    [
+        (EditionKind.main, CACHE_PROFILE_LONG),
+        (EditionKind.release, CACHE_PROFILE_LONG),
+        (EditionKind.major, CACHE_PROFILE_LONG),
+        (EditionKind.minor, CACHE_PROFILE_LONG),
+        (EditionKind.draft, CACHE_PROFILE_SHORT),
+        (EditionKind.alternate, CACHE_PROFILE_SHORT),
+    ],
+)
+def test_compute_cache_profile(kind: EditionKind, expected: str) -> None:
+    assert compute_cache_profile(kind) == expected
+
+
+@pytest.mark.parametrize("kind", list(EditionKind))
+def test_every_kind_maps_to_a_known_profile(kind: EditionKind) -> None:
+    """A newly-added ``EditionKind`` must still get a valid profile."""
+    assert compute_cache_profile(kind) in {
+        CACHE_PROFILE_LONG,
+        CACHE_PROFILE_SHORT,
+    }

--- a/tests/domain/published_url_test.py
+++ b/tests/domain/published_url_test.py
@@ -1,0 +1,53 @@
+"""Tests for the published-URL and hostname helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from docverse.models import UrlScheme
+from docverse_server.domain.organization import Organization
+from docverse_server.domain.published_url import compute_project_hostname
+
+
+def _org(
+    *,
+    base_domain: str = "example.org",
+    url_scheme: UrlScheme = UrlScheme.subdomain,
+    root_path_prefix: str = "/",
+) -> Organization:
+    now = datetime.now(tz=UTC)
+    return Organization(
+        id=1,
+        slug="test-org",
+        title="Test Org",
+        base_domain=base_domain,
+        url_scheme=url_scheme,
+        root_path_prefix=root_path_prefix,
+        slug_rewrite_rules=None,
+        lifecycle_rules=None,
+        purgatory_retention=timedelta(days=30),
+        date_created=now,
+        date_updated=now,
+    )
+
+
+def test_compute_project_hostname_subdomain_scheme() -> None:
+    """Subdomain orgs serve each project on its own hostname."""
+    org = _org(url_scheme=UrlScheme.subdomain)
+    assert compute_project_hostname(org, "my-project") == (
+        "my-project.example.org"
+    )
+
+
+def test_compute_project_hostname_path_prefix_scheme() -> None:
+    """Path-prefix orgs serve every project on the base domain."""
+    org = _org(url_scheme=UrlScheme.path_prefix, root_path_prefix="/docs/")
+    assert compute_project_hostname(org, "my-project") == "example.org"
+
+
+def test_compute_project_hostname_normalizes_base_domain() -> None:
+    """A base domain carrying a scheme or trailing slash is normalized."""
+    org = _org(base_domain="https://example.org/")
+    assert compute_project_hostname(org, "my-project") == (
+        "my-project.example.org"
+    )

--- a/tests/services/edition_publishing_test.py
+++ b/tests/services/edition_publishing_test.py
@@ -8,6 +8,7 @@ from typing import Self
 import pytest
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
 
 from docverse.models import (
     BuildCreate,
@@ -21,12 +22,17 @@ from docverse.models import (
 from docverse.models.queue_enums import PublishStatus
 from docverse_server.domain.base32id import serialize_base32_id
 from docverse_server.domain.build import Build
+from docverse_server.domain.dashboard_context import MAIN_SLUG
 from docverse_server.domain.edition import Edition
 from docverse_server.domain.edition_build_history import EditionBuildHistory
 from docverse_server.services.edition_publishing import (
     EditionPublishingService,
 )
 from docverse_server.storage.build_store import BuildStore
+from docverse_server.storage.cdncachepurger import (
+    CdnCachePurger,
+    MockCdnCachePurger,
+)
 from docverse_server.storage.edition_build_history_store import (
     EditionBuildHistoryStore,
 )
@@ -87,6 +93,28 @@ class _FailingPublisher:
         raise self._exc
 
 
+class _FailingPurger:
+    """A CdnCachePurger whose ``purge_hostname`` raises."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    async def purge_hostname(self, hostname: str) -> None:
+        _ = hostname
+        raise self._exc
+
+
 def _logger() -> structlog.stdlib.BoundLogger:
     return structlog.get_logger("docverse")  # type: ignore[no-any-return]
 
@@ -96,6 +124,7 @@ def _make_service(
     *,
     publisher: EditionPublisher | None = None,
     provider_raises: bool = False,
+    purger: CdnCachePurger | None = None,
 ) -> EditionPublishingService:
     async def provider(*, org_id: int, service_label: str) -> EditionPublisher:
         if provider_raises:
@@ -109,6 +138,14 @@ def _make_service(
             raise AssertionError(msg)
         return publisher
 
+    resolved_purger = purger if purger is not None else MockCdnCachePurger()
+
+    async def purger_provider(
+        *, org_id: int, service_label: str
+    ) -> CdnCachePurger:
+        _ = (org_id, service_label)
+        return resolved_purger
+
     logger = _logger()
     return EditionPublishingService(
         org_store=OrganizationStore(session=db_session, logger=logger),
@@ -117,6 +154,7 @@ def _make_service(
             session=db_session, logger=logger
         ),
         publisher_provider=provider,
+        purger_provider=purger_provider,
         logger=logger,
     )
 
@@ -155,16 +193,30 @@ async def _setup(
             source_url="https://example.com/example/repo",
         ),
     )
-    edition = await edition_store.create(
-        project_id=project.id,
-        data=EditionCreate(
-            slug="main",
+    if edition_kind is EditionKind.main:
+        # The database constrains main-kind editions to the reserved
+        # ``__main`` slug, which ``EditionCreate`` rejects — project
+        # creation seeds it through ``create_internal`` for the same
+        # reason.
+        edition = await edition_store.create_internal(
+            project_id=project.id,
+            slug=MAIN_SLUG,
             title="Latest",
             kind=edition_kind,
             tracking_mode=TrackingMode.git_ref,
             tracking_params={"git_ref": "main"},
-        ),
-    )
+        )
+    else:
+        edition = await edition_store.create(
+            project_id=project.id,
+            data=EditionCreate(
+                slug="main",
+                title="Latest",
+                kind=edition_kind,
+                tracking_mode=TrackingMode.git_ref,
+                tracking_params={"git_ref": "main"},
+            ),
+        )
     build = await build_store.create(
         project_id=project.id,
         data=BuildCreate(git_ref="main", content_hash=_HASH),
@@ -367,3 +419,216 @@ async def test_publish_draft_edition_uses_short_cache_profile(
 
     assert len(mock_publisher.calls) == 1
     assert mock_publisher.calls[0].cache_profile == "short"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("edition_kind", "org_slug"),
+    [
+        (EditionKind.main, "purge-main-org"),
+        (EditionKind.release, "purge-release-org"),
+        (EditionKind.major, "purge-major-org"),
+        (EditionKind.minor, "purge-minor-org"),
+    ],
+)
+async def test_publish_long_profile_purges_project_hostname(
+    db_session: AsyncSession,
+    edition_kind: EditionKind,
+    org_slug: str,
+) -> None:
+    """Long-profile publishes purge the project's hostname exactly once."""
+    mock_purger = MockCdnCachePurger()
+    service = _make_service(
+        db_session,
+        publisher=MockEditionPublisher(),
+        purger=mock_purger,
+    )
+    async with db_session.begin():
+        org_id, edition, build, history_entry = await _setup(
+            db_session,
+            org_slug=org_slug,
+            cdn_service_label="cdn-prod",
+            edition_kind=edition_kind,
+        )
+        await service.publish(
+            org_id=org_id,
+            project_slug=_PROJECT_SLUG,
+            edition=edition,
+            build=build,
+            history_entry=history_entry,
+        )
+        await db_session.commit()
+
+    assert mock_purger.purge_calls == [
+        f"{_PROJECT_SLUG}.{org_slug}.example.com"
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("edition_kind", "org_slug"),
+    [
+        (EditionKind.draft, "nopurge-draft-org"),
+        (EditionKind.alternate, "nopurge-alternate-org"),
+    ],
+)
+async def test_publish_short_profile_does_not_purge(
+    db_session: AsyncSession,
+    edition_kind: EditionKind,
+    org_slug: str,
+) -> None:
+    """Short-profile publishes make no purge call."""
+    mock_purger = MockCdnCachePurger()
+    service = _make_service(
+        db_session,
+        publisher=MockEditionPublisher(),
+        purger=mock_purger,
+    )
+    async with db_session.begin():
+        org_id, edition, build, history_entry = await _setup(
+            db_session,
+            org_slug=org_slug,
+            cdn_service_label="cdn-prod",
+            edition_kind=edition_kind,
+        )
+        await service.publish(
+            org_id=org_id,
+            project_slug=_PROJECT_SLUG,
+            edition=edition,
+            build=build,
+            history_entry=history_entry,
+        )
+        await db_session.commit()
+
+    assert mock_purger.purge_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_without_cdn_service_label_does_not_purge(
+    db_session: AsyncSession,
+) -> None:
+    """Orgs with no cdn_service_label never reach the purge step."""
+    mock_purger = MockCdnCachePurger()
+    service = _make_service(
+        db_session, provider_raises=True, purger=mock_purger
+    )
+    async with db_session.begin():
+        org_id, edition, build, history_entry = await _setup(
+            db_session, org_slug="nopurge-no-cdn-org"
+        )
+        await service.publish(
+            org_id=org_id,
+            project_slug=_PROJECT_SLUG,
+            edition=edition,
+            build=build,
+            history_entry=history_entry,
+        )
+        await db_session.commit()
+
+    assert mock_purger.purge_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publish_logs_successful_purge(
+    db_session: AsyncSession,
+) -> None:
+    """A successful purge emits a structured log with full context."""
+    async with db_session.begin():
+        org_id, edition, build, history_entry = await _setup(
+            db_session,
+            org_slug="purge-log-org",
+            cdn_service_label="cdn-prod",
+            edition_kind=EditionKind.main,
+        )
+        with capture_logs() as logs:
+            service = _make_service(
+                db_session,
+                publisher=MockEditionPublisher(),
+                purger=MockCdnCachePurger(),
+            )
+            await service.publish(
+                org_id=org_id,
+                project_slug=_PROJECT_SLUG,
+                edition=edition,
+                build=build,
+                history_entry=history_entry,
+            )
+        await db_session.commit()
+
+    entries = [e for e in logs if e["event"] == "Purged CDN cache"]
+    assert len(entries) == 1
+    assert (
+        entries[0]["hostname"] == f"{_PROJECT_SLUG}.purge-log-org.example.com"
+    )
+    assert entries[0]["edition_slug"] == edition.slug
+    assert entries[0]["build_id"] == build.id
+
+
+@pytest.mark.asyncio
+async def test_publish_logs_failed_purge(
+    db_session: AsyncSession,
+) -> None:
+    """A failed purge emits a structured error log with full context."""
+    async with db_session.begin():
+        org_id, edition, build, history_entry = await _setup(
+            db_session,
+            org_slug="purge-log-fail-org",
+            cdn_service_label="cdn-prod",
+            edition_kind=EditionKind.main,
+        )
+        with capture_logs() as logs:
+            service = _make_service(
+                db_session,
+                publisher=MockEditionPublisher(),
+                purger=_FailingPurger(RuntimeError("purge exploded")),
+            )
+            await service.publish(
+                org_id=org_id,
+                project_slug=_PROJECT_SLUG,
+                edition=edition,
+                build=build,
+                history_entry=history_entry,
+            )
+        await db_session.commit()
+
+    entries = [e for e in logs if e["event"] == "CDN cache purge failed"]
+    assert len(entries) == 1
+    assert entries[0]["log_level"] == "error"
+    assert entries[0]["hostname"] == (
+        f"{_PROJECT_SLUG}.purge-log-fail-org.example.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_purge_failure_does_not_propagate(
+    db_session: AsyncSession,
+) -> None:
+    """A failing purge still leaves the edition and history published."""
+    service = _make_service(
+        db_session,
+        publisher=MockEditionPublisher(),
+        purger=_FailingPurger(RuntimeError("purge exploded")),
+    )
+    async with db_session.begin():
+        org_id, edition, build, history_entry = await _setup(
+            db_session,
+            org_slug="purge-fail-org",
+            cdn_service_label="cdn-prod",
+            edition_kind=EditionKind.main,
+        )
+        await service.publish(
+            org_id=org_id,
+            project_slug=_PROJECT_SLUG,
+            edition=edition,
+            build=build,
+            history_entry=history_entry,
+        )
+        await db_session.commit()
+
+    async with db_session.begin():
+        refreshed = await _fetch_edition(
+            db_session, edition.id, edition.project_id, edition.slug
+        )
+        assert refreshed.publish_status == PublishStatus.published
+        refreshed_history = await _fetch_history(db_session, edition.id)
+        assert refreshed_history.publish_status == PublishStatus.published

--- a/tests/services/edition_publishing_test.py
+++ b/tests/services/edition_publishing_test.py
@@ -22,6 +22,7 @@ from docverse.models import (
 from docverse.models.queue_enums import PublishStatus
 from docverse_server.domain.base32id import serialize_base32_id
 from docverse_server.domain.build import Build
+from docverse_server.domain.cache_profile import CacheProfile
 from docverse_server.domain.dashboard_context import MAIN_SLUG
 from docverse_server.domain.edition import Edition
 from docverse_server.domain.edition_build_history import EditionBuildHistory
@@ -72,7 +73,7 @@ class _FailingPublisher:
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
-        cache_profile: str,
+        cache_profile: CacheProfile,
     ) -> None:
         _ = (
             project_slug,

--- a/tests/services/edition_publishing_test.py
+++ b/tests/services/edition_publishing_test.py
@@ -66,8 +66,15 @@ class _FailingPublisher:
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
+        cache_profile: str,
     ) -> None:
-        _ = (project_slug, edition_slug, build_public_id, object_key_prefix)
+        _ = (
+            project_slug,
+            edition_slug,
+            build_public_id,
+            object_key_prefix,
+            cache_profile,
+        )
         raise self._exc
 
     async def unpublish(
@@ -119,6 +126,7 @@ async def _setup(
     *,
     org_slug: str,
     cdn_service_label: str | None = None,
+    edition_kind: EditionKind = EditionKind.release,
 ) -> tuple[int, Edition, Build, EditionBuildHistory]:
     logger = _logger()
     org_store = OrganizationStore(session=db_session, logger=logger)
@@ -152,7 +160,7 @@ async def _setup(
         data=EditionCreate(
             slug="main",
             title="Latest",
-            kind=EditionKind.release,
+            kind=edition_kind,
             tracking_mode=TrackingMode.git_ref,
             tracking_params={"git_ref": "main"},
         ),
@@ -323,6 +331,7 @@ async def test_publish_successful_calls_publisher_and_marks_published(
     assert call.edition_slug == edition.slug
     assert call.build_public_id == serialize_base32_id(build.public_id)
     assert call.object_key_prefix == build.storage_prefix
+    assert call.cache_profile == "long"
 
     async with db_session.begin():
         refreshed = await _fetch_edition(
@@ -331,3 +340,30 @@ async def test_publish_successful_calls_publisher_and_marks_published(
         assert refreshed.publish_status == PublishStatus.published
         refreshed_history = await _fetch_history(db_session, edition.id)
         assert refreshed_history.publish_status == PublishStatus.published
+
+
+@pytest.mark.asyncio
+async def test_publish_draft_edition_uses_short_cache_profile(
+    db_session: AsyncSession,
+) -> None:
+    """A draft edition's pointer carries the short cache profile."""
+    mock_publisher = MockEditionPublisher()
+    service = _make_service(db_session, publisher=mock_publisher)
+    async with db_session.begin():
+        org_id, edition, build, history_entry = await _setup(
+            db_session,
+            org_slug="draft-pub-org",
+            cdn_service_label="cdn-prod",
+            edition_kind=EditionKind.draft,
+        )
+        await service.publish(
+            org_id=org_id,
+            project_slug=_PROJECT_SLUG,
+            edition=edition,
+            build=build,
+            history_entry=history_entry,
+        )
+        await db_session.commit()
+
+    assert len(mock_publisher.calls) == 1
+    assert mock_publisher.calls[0].cache_profile == "short"

--- a/tests/storage/cdncachepurger/cloudflare_test.py
+++ b/tests/storage/cdncachepurger/cloudflare_test.py
@@ -1,0 +1,90 @@
+"""Tests for the CloudflareCachePurger."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+from docverse_server.storage.cdncachepurger import CloudflareCachePurger
+
+
+def _make_purger(
+    handler: httpx.MockTransport,
+    *,
+    zone_id: str = "zone-123",
+    api_token: str = "token-789",
+) -> tuple[CloudflareCachePurger, httpx.AsyncClient]:
+    client = httpx.AsyncClient(transport=handler)
+    purger = CloudflareCachePurger(
+        zone_id=zone_id,
+        api_token=api_token,
+        http_client=client,
+        logger=structlog.get_logger("test"),
+    )
+    return purger, client
+
+
+@pytest.mark.asyncio
+async def test_purge_hostname_posts_to_zone_purge_endpoint() -> None:
+    seen: dict[str, httpx.Request] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["request"] = request
+        return httpx.Response(200, json={"success": True})
+
+    purger, client = _make_purger(httpx.MockTransport(handler))
+    async with client, purger as p:
+        await p.purge_hostname("myproject.example.org")
+
+    request = seen["request"]
+    assert request.method == "POST"
+    assert str(request.url) == (
+        "https://api.cloudflare.com/client/v4/zones/zone-123/purge_cache"
+    )
+    assert request.headers["Authorization"] == "Bearer token-789"
+    assert json.loads(request.content) == {"hosts": ["myproject.example.org"]}
+
+
+@pytest.mark.asyncio
+async def test_purge_hostname_raises_on_4xx() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"errors": ["forbidden"]})
+
+    purger, client = _make_purger(httpx.MockTransport(handler))
+    async with client, purger as p:
+        with pytest.raises(httpx.HTTPStatusError):
+            await p.purge_hostname("myproject.example.org")
+
+
+@pytest.mark.asyncio
+async def test_purge_hostname_raises_on_5xx() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"errors": ["boom"]})
+
+    purger, client = _make_purger(httpx.MockTransport(handler))
+    async with client, purger as p:
+        with pytest.raises(httpx.HTTPStatusError):
+            await p.purge_hostname("myproject.example.org")
+
+
+@pytest.mark.asyncio
+async def test_purge_hostname_logs_error_with_context() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"errors": ["boom"]})
+
+    with capture_logs() as logs:
+        purger, client = _make_purger(httpx.MockTransport(handler))
+        async with client, purger as p:
+            with pytest.raises(httpx.HTTPStatusError):
+                await p.purge_hostname("myproject.example.org")
+
+    errors = [entry for entry in logs if entry["log_level"] == "error"]
+    assert len(errors) == 1
+    assert errors[0]["hostname"] == "myproject.example.org"
+    assert errors[0]["zone_id"] == "zone-123"
+    assert errors[0]["status_code"] == 500
+    assert "boom" in errors[0]["response_body"]

--- a/tests/storage/cdncachepurger/factory_test.py
+++ b/tests/storage/cdncachepurger/factory_test.py
@@ -1,0 +1,80 @@
+"""Tests for ``create_cdn_cache_purger``."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import structlog
+
+from docverse_server.storage.cdncachepurger import (
+    CloudflareCachePurger,
+    NoopCdnCachePurger,
+    create_cdn_cache_purger,
+)
+
+
+def _make_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(200, json={})
+        )
+    )
+
+
+def test_creates_cloudflare_purger_when_zone_id_present() -> None:
+    purger = create_cdn_cache_purger(
+        provider="cloudflare_workers",
+        config={
+            "account_id": "acct-123",
+            "kv_namespace_id": "ns-456",
+            "zone_id": "zone-789",
+        },
+        credentials={"api_token": "token-abc"},
+        logger=structlog.get_logger("test"),
+        http_client=_make_client(),
+    )
+    assert isinstance(purger, CloudflareCachePurger)
+
+
+def test_creates_noop_purger_when_zone_id_absent() -> None:
+    purger = create_cdn_cache_purger(
+        provider="cloudflare_workers",
+        config={"account_id": "acct-123", "kv_namespace_id": "ns-456"},
+        credentials={"api_token": "token-abc"},
+        logger=structlog.get_logger("test"),
+        http_client=_make_client(),
+    )
+    assert isinstance(purger, NoopCdnCachePurger)
+
+
+def test_creates_noop_purger_when_zone_id_empty() -> None:
+    purger = create_cdn_cache_purger(
+        provider="cloudflare_workers",
+        config={"zone_id": ""},
+        credentials={"api_token": "token-abc"},
+        logger=structlog.get_logger("test"),
+        http_client=_make_client(),
+    )
+    assert isinstance(purger, NoopCdnCachePurger)
+
+
+def test_missing_api_token_raises() -> None:
+    with pytest.raises(ValueError, match="api_token"):
+        create_cdn_cache_purger(
+            provider="cloudflare_workers",
+            config={"zone_id": "zone-789"},
+            credentials={},
+            logger=structlog.get_logger("test"),
+            http_client=_make_client(),
+        )
+
+
+def test_unsupported_provider_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported CDN cache purger"):
+        create_cdn_cache_purger(
+            provider="fastly",
+            config={"zone_id": "zone-789"},
+            credentials={"api_token": "token-abc"},
+            logger=structlog.get_logger("test"),
+            http_client=_make_client(),
+        )

--- a/tests/storage/cdncachepurger/mock_test.py
+++ b/tests/storage/cdncachepurger/mock_test.py
@@ -1,0 +1,29 @@
+"""Tests for the MockCdnCachePurger."""
+
+from __future__ import annotations
+
+import pytest
+
+from docverse_server.storage.cdncachepurger import (
+    CdnCachePurger,
+    MockCdnCachePurger,
+)
+
+
+@pytest.mark.asyncio
+async def test_records_purge_calls() -> None:
+    purger = MockCdnCachePurger()
+    async with purger as p:
+        await p.purge_hostname("myproject.example.org")
+        await p.purge_hostname("other.example.org")
+
+    assert purger.purge_calls == [
+        "myproject.example.org",
+        "other.example.org",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_implements_protocol() -> None:
+    purger = MockCdnCachePurger()
+    assert isinstance(purger, CdnCachePurger)

--- a/tests/storage/cdncachepurger/noop_test.py
+++ b/tests/storage/cdncachepurger/noop_test.py
@@ -1,0 +1,29 @@
+"""Tests for the NoopCdnCachePurger."""
+
+from __future__ import annotations
+
+import pytest
+from structlog.testing import capture_logs
+
+from docverse_server.storage.cdncachepurger import (
+    CdnCachePurger,
+    NoopCdnCachePurger,
+)
+
+
+@pytest.mark.asyncio
+async def test_purge_hostname_is_a_logged_noop() -> None:
+    """The purge does nothing observable beyond an INFO log."""
+    with capture_logs() as logs:
+        purger = NoopCdnCachePurger()
+        async with purger as p:
+            await p.purge_hostname("myproject.example.org")
+
+    assert [entry["log_level"] for entry in logs] == ["info"]
+    assert logs[0]["hostname"] == "myproject.example.org"
+
+
+@pytest.mark.asyncio
+async def test_implements_protocol() -> None:
+    purger = NoopCdnCachePurger()
+    assert isinstance(purger, CdnCachePurger)

--- a/tests/storage/editionpublisher/cloudflare_kv_test.py
+++ b/tests/storage/editionpublisher/cloudflare_kv_test.py
@@ -46,6 +46,7 @@ async def test_publish_issues_put_to_kv_endpoint() -> None:
             edition_slug="main",
             build_public_id="ABC123",
             object_key_prefix="myproject/__builds/ABC123/",
+            cache_profile="long",
         )
 
     request = seen["request"]
@@ -60,6 +61,32 @@ async def test_publish_issues_put_to_kv_endpoint() -> None:
     assert json.loads(request.content) == {
         "build_id": "ABC123",
         "r2_prefix": "myproject/__builds/ABC123/",
+        "cache_profile": "long",
+    }
+
+
+@pytest.mark.asyncio
+async def test_publish_writes_short_cache_profile() -> None:
+    seen: dict[str, httpx.Request] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["request"] = request
+        return httpx.Response(200, json={"success": True})
+
+    publisher, client = _make_publisher(httpx.MockTransport(handler))
+    async with client, publisher as pub:
+        await pub.publish(
+            project_slug="myproject",
+            edition_slug="tickets-dm-1",
+            build_public_id="ABC123",
+            object_key_prefix="myproject/__builds/ABC123/",
+            cache_profile="short",
+        )
+
+    assert json.loads(seen["request"].content) == {
+        "build_id": "ABC123",
+        "r2_prefix": "myproject/__builds/ABC123/",
+        "cache_profile": "short",
     }
 
 
@@ -76,6 +103,7 @@ async def test_publish_raises_on_4xx() -> None:
                 edition_slug="e",
                 build_public_id="B",
                 object_key_prefix="p/__builds/B/",
+                cache_profile="long",
             )
 
 
@@ -92,6 +120,7 @@ async def test_publish_raises_on_5xx() -> None:
                 edition_slug="e",
                 build_public_id="B",
                 object_key_prefix="p/__builds/B/",
+                cache_profile="long",
             )
 
 

--- a/tests/storage/editionpublisher/mock_test.py
+++ b/tests/storage/editionpublisher/mock_test.py
@@ -20,12 +20,14 @@ async def test_records_publish_calls() -> None:
             edition_slug="main",
             build_public_id="ABC123",
             object_key_prefix="myproject/__builds/ABC123/",
+            cache_profile="long",
         )
         await pub.publish(
             project_slug="myproject",
             edition_slug="v1",
             build_public_id="DEF456",
             object_key_prefix="myproject/__builds/DEF456/",
+            cache_profile="short",
         )
 
     assert publisher.calls == [
@@ -34,12 +36,14 @@ async def test_records_publish_calls() -> None:
             edition_slug="main",
             build_public_id="ABC123",
             object_key_prefix="myproject/__builds/ABC123/",
+            cache_profile="long",
         ),
         PublishCall(
             project_slug="myproject",
             edition_slug="v1",
             build_public_id="DEF456",
             object_key_prefix="myproject/__builds/DEF456/",
+            cache_profile="short",
         ),
     ]
 

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -38,6 +38,7 @@ from docverse_server.domain.base32id import (
     validate_base32_id,
 )
 from docverse_server.domain.build import Build
+from docverse_server.domain.cache_profile import CacheProfile
 from docverse_server.domain.edition import Edition
 from docverse_server.domain.edition_build_history import EditionBuildHistory
 from docverse_server.domain.organization import Organization
@@ -95,7 +96,7 @@ class _FailingPublisher:
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
-        cache_profile: str,
+        cache_profile: CacheProfile,
     ) -> None:
         _ = (
             project_slug,
@@ -872,7 +873,7 @@ class _RecordingMockEditionPublisher(MockEditionPublisher):
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
-        cache_profile: str,
+        cache_profile: CacheProfile,
     ) -> None:
         self._publish_timestamps.append(time.monotonic())
         await super().publish(

--- a/tests/worker/publish_edition_test.py
+++ b/tests/worker/publish_edition_test.py
@@ -95,8 +95,15 @@ class _FailingPublisher:
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
+        cache_profile: str,
     ) -> None:
-        _ = (project_slug, edition_slug, build_public_id, object_key_prefix)
+        _ = (
+            project_slug,
+            edition_slug,
+            build_public_id,
+            object_key_prefix,
+            cache_profile,
+        )
         raise self._exc
 
     async def unpublish(
@@ -865,6 +872,7 @@ class _RecordingMockEditionPublisher(MockEditionPublisher):
         edition_slug: str,
         build_public_id: str,
         object_key_prefix: str,
+        cache_profile: str,
     ) -> None:
         self._publish_timestamps.append(time.monotonic())
         await super().publish(
@@ -872,6 +880,7 @@ class _RecordingMockEditionPublisher(MockEditionPublisher):
             edition_slug=edition_slug,
             build_public_id=build_public_id,
             object_key_prefix=object_key_prefix,
+            cache_profile=cache_profile,
         )
 
 


### PR DESCRIPTION
## Summary

- Teach the Cloudflare worker to derive an edition response's `Cache-Control` from an optional `cache_profile` field on the KV value: `"long"` serves `public, max-age=300, s-maxage=86400` (5 min browser, 1 day edge), while `"short"` or an absent field keeps today's `public, max-age=60`.
- Consolidate the `max-age=60` literals repeated across `resolver.ts` into two named constants (`CACHE_CONTROL_SHORT`, `CACHE_CONTROL_LONG`); dashboard-family 200s/304s and both 404 variants (including the `caches.default` 404 entry) keep the short value unconditionally.
- Start writing `cache_profile` into the KV edition pointer from the Python side: a new `docverse_server.domain.cache_profile` module derives the profile from the edition's kind (`main`/`release`/`major`/`minor` → `"long"`, `draft`/`alternate` → `"short"`) and mirrors the worker's `CACHE_CONTROL_*` strings, and `EditionPublishingService.publish()` threads it through `EditionPublisher.publish()` into the KV JSON payload alongside `build_id`/`r2_prefix`.
- Add a `storage/cdncachepurger/` package mirroring `storage/editionpublisher/`: a `CdnCachePurger` protocol whose async-context-manager `purge_hostname(hostname)` is the only purge mechanism exposed (prefix and cache-tag purges are Cloudflare Enterprise-only), a `CloudflareCachePurger` that POSTs `{"hosts": [hostname]}` to `/client/v4/zones/{zone_id}/purge_cache` with Bearer auth, a `NoopCdnCachePurger` that logs at INFO and does nothing, and a `create_cdn_cache_purger()` factory resolving between them from the `cloudflare_workers` service config.
- Keep `zone_id` an **optional** service-config key: `workers.dev` sandboxes have no zone, so the factory returns the noop purger rather than raising, and callers never branch on configuration. The existing `api_token` credential is reused, so no second per-org token is needed.
- Close the loop by purging on publish: after a successful publish of a long-profile edition, `EditionPublishingService.publish()` resolves a purger through a new `CdnCachePurgerProvider` (mirroring `EditionPublisherProvider`, wired in `factory.py` to a `create_cdn_cache_purger_for_org` that shares the org's CDN service row and token with the publisher) and purges the project's hostname, so readers see a new build without waiting out the one-day edge TTL. Short-profile publishes and orgs with no `cdn_service_label` make no purge call.
- Derive the purge scope from a new pure `compute_project_hostname(org, project_slug)` in `domain/published_url.py` — `{project_slug}.{base_domain}` for subdomain orgs, the base domain for path-prefix orgs — which `project_published_url` now builds on, so the purged hostname and the advertised URL cannot drift.
- Purge failures never fail a publish: the storage layer raises with zone, hostname, status code, and response body logged at ERROR, and the orchestrator logs the failure with the full publish context and swallows it, still marking the edition and its history entry `published`.
- Deploy-first rollout per PRD #183: the KV schema change is additive, so the worker (which defaults safely to short) can ship before the Python side starts writing `cache_profile`.

## Validation steps

- Deploy the worker and request a page from an edition whose KV value carries `cache_profile: "long"`; confirm the response has `Cache-Control: public, max-age=300, s-maxage=86400` and an unchanged `ETag`/`Content-Type`.
- Request a page from an edition whose KV value has `cache_profile: "short"` or no `cache_profile` at all (the current production state); confirm `Cache-Control: public, max-age=60`.
- Request `/v/`, `/v/switcher.json`, and a `_docverse.json` edition-metadata URL; confirm each still returns `public, max-age=60`.
- Request a nonexistent path to trigger both the branded `__404.html` and the plain-text fallback; confirm both still return `public, max-age=60`.
- Publish a build to a project's main (or a release) edition and read the KV key back from Cloudflare; confirm the stored JSON now has `"cache_profile": "long"` next to `build_id` and `r2_prefix`.
- Publish a build to a draft edition and confirm its KV value carries `"cache_profile": "short"`, and that soft-deleting an edition still removes the KV key as before.
- On an org with a `zone_id`, publish to a main/release edition, then check the Cloudflare zone's audit log for a `purge_cache` call scoped to the project's hostname, and confirm a previously-cached page reflects the new build within seconds instead of after the edge TTL.
- Publish to a draft edition on the same org and confirm no purge is recorded.
- Publish on a `workers.dev` sandbox org (no `zone_id`) and confirm the publish succeeds with the noop purger's INFO log and no Cloudflare API call.
- Temporarily point an org's CDN service at a bad `zone_id` (or revoke the token), publish a main edition, and confirm the publish still succeeds, the edition and its history entry are `published`, and a `CDN cache purge failed` ERROR log carries the org, project, edition, build, and hostname.

## References

- Closes #486
- Closes #487
- Closes #488
- Closes #489
- PRD: #183
- Jira: https://rubinobs.atlassian.net/browse/DM-54684
