### PR TITLE
DM-54684: Repair deploy-worker's npm dependency install

### DIFF
--- a/client/src/docverse/_cli.py
+++ b/client/src/docverse/_cli.py
@@ -151,6 +151,87 @@ def upload(
     )
 
 
+def _stage_worker_source(*, worker_dir: Path, dest_dir: Path) -> None:
+    """Pack the worker source and install it into the deployments repo.
+
+    Parameters
+    ----------
+    worker_dir
+        The monorepo's ``cloudflare-worker/`` directory.
+    dest_dir
+        The ``worker/`` directory inside the deployments repo.
+
+    Raises
+    ------
+    click.ClickException
+        If packing, unpacking, or dependency installation fails.
+    """
+    # Phase 1: npm pack
+    click.echo(f"Packing cloudflare worker from {worker_dir}")
+    try:
+        pack_result = subprocess.run(
+            ["npm", "pack", "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=str(worker_dir),
+        )
+    except subprocess.CalledProcessError as exc:
+        msg = f"npm pack failed: {exc.stderr}"
+        raise click.ClickException(msg) from exc
+    try:
+        tarball_name = json.loads(pack_result.stdout)[0]["filename"]
+    except (json.JSONDecodeError, KeyError, IndexError) as exc:
+        msg = f"Failed to parse npm pack output: {pack_result.stdout!r}"
+        raise click.ClickException(msg) from exc
+
+    # Phase 2: copy and unpack into deployments repo
+    click.echo(f"Unpacking worker into {dest_dir}")
+    shutil.copy2(worker_dir / tarball_name, dest_dir / tarball_name)
+    try:
+        subprocess.run(
+            ["tar", "xzf", tarball_name, "--strip-components=1"],
+            check=True,
+            cwd=str(dest_dir),
+        )
+    except subprocess.CalledProcessError as exc:
+        msg = f"Failed to unpack worker tarball: {exc}"
+        raise click.ClickException(msg) from exc
+    finally:
+        for tgz in dest_dir.glob("*.tgz"):
+            tgz.unlink()
+    (worker_dir / tarball_name).unlink(missing_ok=True)
+
+    # Phase 2a: copy the lockfile alongside the unpacked source. ``npm
+    # pack`` always excludes package-lock.json, so without this the
+    # destination keeps whatever lockfile an earlier deploy left behind.
+    # Once that stale lockfile disagrees with the freshly packed
+    # package.json, npm re-resolves the whole tree and deploys stop being
+    # reproducible.
+    lockfile = worker_dir / "package-lock.json"
+    if not lockfile.is_file():
+        msg = f"package-lock.json not found in {worker_dir}"
+        raise click.ClickException(msg)
+    click.echo("Copying worker lockfile")
+    shutil.copy2(lockfile, dest_dir / "package-lock.json")
+
+    # Phase 2b: install worker runtime dependencies. ``npm ci`` installs
+    # exactly what the lockfile pins and wipes node_modules first, so no
+    # stale packages survive from an earlier deploy.
+    click.echo("Installing worker dependencies")
+    try:
+        subprocess.run(
+            ["npm", "ci", "--omit=dev"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=str(dest_dir),
+        )
+    except subprocess.CalledProcessError as exc:
+        msg = f"npm ci failed: {exc.stderr}"
+        raise click.ClickException(msg) from exc
+
+
 @main.command()
 @click.option(
     "--docverse-repo",
@@ -201,55 +282,8 @@ def deploy_worker(
     dest_dir = deployments_repo / "worker"
     dest_dir.mkdir(exist_ok=True)
 
-    # Phase 1: npm pack
-    click.echo(f"Packing cloudflare worker from {worker_dir}")
-    try:
-        pack_result = subprocess.run(
-            ["npm", "pack", "--json"],
-            check=True,
-            capture_output=True,
-            text=True,
-            cwd=str(worker_dir),
-        )
-    except subprocess.CalledProcessError as exc:
-        msg = f"npm pack failed: {exc.stderr}"
-        raise click.ClickException(msg) from exc
-    try:
-        tarball_name = json.loads(pack_result.stdout)[0]["filename"]
-    except (json.JSONDecodeError, KeyError, IndexError) as exc:
-        msg = f"Failed to parse npm pack output: {pack_result.stdout!r}"
-        raise click.ClickException(msg) from exc
-
-    # Phase 2: copy and unpack into deployments repo
-    click.echo(f"Unpacking worker into {dest_dir}")
-    shutil.copy2(worker_dir / tarball_name, dest_dir / tarball_name)
-    try:
-        subprocess.run(
-            ["tar", "xzf", tarball_name, "--strip-components=1"],
-            check=True,
-            cwd=str(dest_dir),
-        )
-    except subprocess.CalledProcessError as exc:
-        msg = f"Failed to unpack worker tarball: {exc}"
-        raise click.ClickException(msg) from exc
-    finally:
-        for tgz in dest_dir.glob("*.tgz"):
-            tgz.unlink()
-    (worker_dir / tarball_name).unlink(missing_ok=True)
-
-    # Phase 2b: install worker runtime dependencies
-    click.echo("Installing worker dependencies")
-    try:
-        subprocess.run(
-            ["npm", "install", "--production"],
-            check=True,
-            capture_output=True,
-            text=True,
-            cwd=str(dest_dir),
-        )
-    except subprocess.CalledProcessError as exc:
-        msg = f"npm install failed: {exc.stderr}"
-        raise click.ClickException(msg) from exc
+    # Phases 1 and 2: pack the worker and stage it in the deployments repo
+    _stage_worker_source(worker_dir=worker_dir, dest_dir=dest_dir)
 
     # Phase 3: wrangler deploy
     wrangler_cmd = [

--- a/client/tests/deploy_worker_integration_test.py
+++ b/client/tests/deploy_worker_integration_test.py
@@ -61,13 +61,19 @@ PACKAGE_JSON = textwrap.dedent("""\
 
 @pytest.fixture
 def docverse_repo() -> Path:
-    """Find the monorepo root by walking up from this file."""
+    """Find the monorepo root by walking up from this file.
+
+    The root is identified by ``cloudflare-worker/`` rather than by
+    ``pyproject.toml``: the client is its own package, so a walk looking
+    for ``pyproject.toml`` stops at ``client/`` and never reaches the
+    monorepo root.
+    """
     current = Path(__file__).resolve().parent
     while current != current.parent:
-        if (current / "pyproject.toml").is_file():
+        if (current / "cloudflare-worker").is_dir():
             return current
         current = current.parent
-    msg = "Could not find monorepo root (no pyproject.toml found)"
+    msg = "Could not find monorepo root (no cloudflare-worker/ found)"
     raise RuntimeError(msg)
 
 
@@ -120,6 +126,13 @@ def test_deploy_worker_dry_run_integration(
     assert worker_dir.is_dir()
     assert (worker_dir / "src" / "index.ts").is_file()
     assert (worker_dir / "package.json").is_file()
+
+    # ``npm pack`` excludes the lockfile, so the deploy has to place it
+    # explicitly; without it ``npm ci`` cannot install reproducibly.
+    deployed_lock = worker_dir / "package-lock.json"
+    assert deployed_lock.is_file()
+    source_lock = docverse_repo / "cloudflare-worker" / "package-lock.json"
+    assert deployed_lock.read_bytes() == source_lock.read_bytes()
 
     # Verify the tarball was cleaned up
     assert not list(worker_dir.glob("*.tgz"))

--- a/client/tests/deploy_worker_test.py
+++ b/client/tests/deploy_worker_test.py
@@ -21,6 +21,9 @@ def mock_monorepo(tmp_path: Path) -> Path:
     (worker_dir / "package.json").write_text(
         '{"name": "docverse-worker", "version": "0.0.0"}'
     )
+    (worker_dir / "package-lock.json").write_text(
+        '{"name": "docverse-worker", "lockfileVersion": 3}'
+    )
     return monorepo
 
 
@@ -143,7 +146,7 @@ def test_deploy_worker_happy_path(
                 cwd=str(dest_dir),
             ),
             call(
-                ["npm", "install", "--production"],
+                ["npm", "ci", "--omit=dev"],
                 check=True,
                 capture_output=True,
                 text=True,
@@ -157,10 +160,16 @@ def test_deploy_worker_happy_path(
         ]
     )
 
-    mock_copy.assert_called_once_with(
-        worker_dir / "docverse-worker-0.0.0.tgz",
-        dest_dir / "docverse-worker-0.0.0.tgz",
-    )
+    assert mock_copy.call_args_list == [
+        call(
+            worker_dir / "docverse-worker-0.0.0.tgz",
+            dest_dir / "docverse-worker-0.0.0.tgz",
+        ),
+        call(
+            worker_dir / "package-lock.json",
+            dest_dir / "package-lock.json",
+        ),
+    ]
 
 
 @patch("docverse._cli.shutil.copy2")
@@ -301,6 +310,79 @@ def test_deploy_worker_wrangler_deploy_fails(
 
     assert result.exit_code == 1
     assert "wrangler deploy failed" in result.output
+
+
+@patch("docverse._cli.shutil.copy2")
+@patch("docverse._cli.subprocess.run")
+def test_deploy_worker_npm_ci_fails(
+    mock_run: MagicMock,
+    mock_copy: MagicMock,
+    mock_monorepo: Path,
+    mock_deployments_repo: Path,
+) -> None:
+    call_count = 0
+    succeed_count = 2
+
+    def side_effect(*args: object, **kwargs: object) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= succeed_count:
+            return _npm_pack_side_effect(*args)
+        raise subprocess.CalledProcessError(
+            1, "npm ci", stderr="npm ERR! ERESOLVE"
+        )
+
+    mock_run.side_effect = side_effect
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        [
+            "deploy-worker",
+            "--docverse-repo",
+            str(mock_monorepo),
+            "--deployments-repo",
+            str(mock_deployments_repo),
+            "--env",
+            "dev",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "npm ci failed" in result.output
+
+
+@patch("docverse._cli.shutil.copy2")
+@patch("docverse._cli.subprocess.run")
+def test_deploy_worker_missing_lockfile(
+    mock_run: MagicMock,
+    mock_copy: MagicMock,
+    mock_monorepo: Path,
+    mock_deployments_repo: Path,
+) -> None:
+    """A worker without a lockfile cannot be installed reproducibly."""
+    (mock_monorepo / "cloudflare-worker" / "package-lock.json").unlink()
+    mock_run.side_effect = _npm_pack_side_effect
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        [
+            "deploy-worker",
+            "--docverse-repo",
+            str(mock_monorepo),
+            "--deployments-repo",
+            str(mock_deployments_repo),
+            "--env",
+            "dev",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "package-lock.json not found" in result.output
+    # Bailed out before npm ci and wrangler deploy.
+    expected_call_count = 2
+    assert mock_run.call_count == expected_call_count
 
 
 def test_deploy_worker_missing_cloudflare_worker_dir(

--- a/cloudflare-worker/package-lock.json
+++ b/cloudflare-worker/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.18.8",
-        "@cloudflare/workers-types": "^4.20250327.0",
+        "@cloudflare/workers-types": "^5.20260722.1",
         "typescript": "^5.8.0",
         "vitest": "~4.1.0",
         "wrangler": "^4.114.0"
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260617.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260617.1.tgz",
-      "integrity": "sha512-HdbP3CNcdMZBwegitFDjWvzv+6wPkFXvV9gBXMnf6RjV2Cy3W8TJL3IhSEGul0S6F1DHjnucP7lrpIsvkzNEjA==",
+      "version": "5.20260804.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260804.1.tgz",
+      "integrity": "sha512-B1dwxpN6e5RZXZkE5zpZj+ooNeNZ1mwavLIyHDYe10ojhlGTwDfe8sAl7R1mMXc1cyIsbr+jKVdvmMEyVcdTdg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },

--- a/cloudflare-worker/package.json
+++ b/cloudflare-worker/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.18.8",
-    "@cloudflare/workers-types": "^4.20250327.0",
+    "@cloudflare/workers-types": "^5.20260722.1",
     "typescript": "^5.8.0",
     "vitest": "~4.1.0",
     "wrangler": "^4.114.0"


### PR DESCRIPTION
## Summary

- Unblock `docverse deploy-worker`, which failed at its dependency-install step with an npm `ERESOLVE` error. Cloudflare ended the `@cloudflare/workers-types` v4 line at `4.20260702.1` and moved to v5, which `wrangler@^4.114.0` peer-requires, so the pin on `^4.20250327.0` became unsatisfiable. This also broke `npm ci` in `cloudflare-worker/` directly, so CI would have failed on its next run regardless of the deploy path.
- Ship the worker lockfile to the deployments repo and install with `npm ci --omit=dev`. `npm pack` always excludes `package-lock.json`, so `worker/` kept whatever lockfile an earlier deploy left behind; once that disagreed with the freshly packed `package.json`, npm re-resolved the whole tree and picked up the broken peer range. `npm ci` also clears `node_modules` first, so stale packages no longer survive between deploys.
- Unskip the deploy-worker integration test, which is why this went unnoticed. Its fixture walked up for the first `pyproject.toml` — now `client/`'s own — so it never located `cloudflare-worker/` and always hit its skip guard. It is keyed on `cloudflare-worker/` now and asserts the deployed lockfile matches the source.

## Validation steps

- Run `docverse deploy-worker --docverse-repo . --deployments-repo /path/to/docverse-cloudflare-deployments --env dev-jsc-test-20260409 --dry-run` and confirm it completes through `Copying worker lockfile` and `Installing worker dependencies` with no `ERESOLVE`.
- Confirm `worker/package-lock.json` in the deployments repo is byte-identical to `cloudflare-worker/package-lock.json` afterwards.
- Drop a junk package into the deployments repo's `worker/node_modules/`, re-run the deploy, and confirm `npm ci` has removed it.
- Deploy for real (drop `--dry-run`) and confirm the worker uploads and serves traffic.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-54684