### PR TITLE
DM-54684: Make the build content hash time-independent

### DIFF
--- a/client/changelog.d/20260807_120000_DM_54684_tarball_hash.md
+++ b/client/changelog.d/20260807_120000_DM_54684_tarball_hash.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- `create_tarball` no longer folds the current time into the digest it reports, so archiving byte-identical content twice now yields the same `content_hash`. The digest covers the compressed bytes, and `tarfile`'s `w:gz` mode stamps `time.time()` into the gzip header's MTIME field, so the hash changed as soon as two calls straddled an integer second. The gzip stream is now built explicitly with `mtime=0`, and with no embedded original filename. Note that the digest is still derived from the tarball rather than from file contents alone, so the same documentation built twice — in separate CI runs, or from a fresh checkout — will still hash differently because each tar member carries its own mtime.

--- a/client/src/docverse/_tar.py
+++ b/client/src/docverse/_tar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gzip
 import hashlib
 import io
 import tarfile
@@ -51,6 +52,14 @@ def create_tarball(source_dir: str | Path) -> tuple[Path, str]:
         ``(tarball_path, content_hash)`` where *content_hash* is formatted
         as ``sha256:<hex>``. The caller is responsible for deleting the
         temporary file.
+
+    Notes
+    -----
+    The digest covers the compressed bytes, so the gzip header has to be
+    stable for identical content to hash identically. ``tarfile``'s own
+    ``w:gz`` mode stamps the current time into that header, which made the
+    digest change every second; the gzip stream is therefore built
+    explicitly with ``mtime=0``.
     """
     source = Path(source_dir).resolve()
     tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115
@@ -59,7 +68,12 @@ def create_tarball(source_dir: str | Path) -> tuple[Path, str]:
     try:
         with Path(tmp.name).open("wb", buffering=0) as raw:
             writer = _HashingWriter(raw)
-            with tarfile.open(mode="w:gz", fileobj=writer) as tar:
+            with (
+                gzip.GzipFile(
+                    filename="", mode="wb", fileobj=writer, mtime=0
+                ) as gz,
+                tarfile.open(mode="w", fileobj=gz) as tar,
+            ):
                 tar.add(str(source), arcname=".")
     except BaseException:
         Path(tmp.name).unlink(missing_ok=True)

--- a/client/tests/tar_test.py
+++ b/client/tests/tar_test.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import re
 import tarfile
+import time
 from pathlib import Path
+
+import pytest
 
 from docverse._tar import create_tarball
 
@@ -40,9 +43,52 @@ def test_create_tarball_hash_determinism(tmp_path: Path) -> None:
     source.mkdir()
     (source / "page.html").write_text("<p>content</p>")
 
-    _, hash1 = create_tarball(source)
+    path1, hash1 = create_tarball(source)
     path2, hash2 = create_tarball(source)
     try:
         assert hash1 == hash2
     finally:
+        path1.unlink(missing_ok=True)
         path2.unlink(missing_ok=True)
+
+
+def test_create_tarball_hash_ignores_wall_clock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Identical content hashes alike however far apart it is archived.
+
+    ``test_create_tarball_hash_determinism`` only catches a time-dependent
+    digest when its two calls happen to straddle an integer second, so it
+    fails intermittently rather than reliably. Move the clock explicitly.
+    """
+    source = tmp_path / "docs"
+    source.mkdir()
+    (source / "page.html").write_text("<p>content</p>")
+
+    monkeypatch.setattr(time, "time", lambda: 1_000_000_000.0)
+    path1, hash1 = create_tarball(source)
+    monkeypatch.setattr(time, "time", lambda: 2_000_000_000.0)
+    path2, hash2 = create_tarball(source)
+    try:
+        assert hash1 == hash2
+    finally:
+        path1.unlink(missing_ok=True)
+        path2.unlink(missing_ok=True)
+
+
+def test_create_tarball_gzip_header_has_no_timestamp(tmp_path: Path) -> None:
+    """The gzip MTIME field is zeroed so the digest stays content-only."""
+    source = tmp_path / "docs"
+    source.mkdir()
+    (source / "page.html").write_text("<p>content</p>")
+
+    tarball_path, _ = create_tarball(source)
+    try:
+        header = tarball_path.read_bytes()[:10]
+        assert header[:2] == b"\x1f\x8b"  # gzip magic
+        # Bytes 4-7 are the little-endian MTIME field.
+        assert header[4:8] == b"\x00\x00\x00\x00"
+        # Bit 3 of FLG would mean an original filename is embedded.
+        assert not header[3] & 0x08
+    finally:
+        tarball_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- Stop `create_tarball`'s content hash from changing with the wall clock. The digest covers the compressed bytes, and `tarfile`'s `w:gz` mode stamps `time.time()` into the gzip header's MTIME field, so byte-identical content hashed differently once the clock crossed an integer second. Build the gzip stream explicitly with `mtime=0` (and `filename=""`, which keeps an embedded name out of the header for the same reason).
- This showed up as an intermittent `client-test` failure in `test_create_tarball_hash_determinism`, which only catches the bug when its two `create_tarball` calls straddle a second boundary — in the run that caught it, the same assertion passed three further times in the same job. The substantive cost is that `content_hash` is stored and indexed on `builds` (`idx_builds_project_id_content_hash`) for dedup lookups, so a time-varying digest makes client-upload hashes useless for matching.
- Add two tests that fail deterministically without the fix: one moves the clock between calls, one asserts the gzip MTIME field is zeroed.

Diagnosis, for the record — the decompressed tar was already identical; only the header differed:

```
gzip header1: 1f8b0800 940a766a 02ff
gzip header2: 1f8b0800 960a766a 02ff
DECOMPRESSED tar identical: True
hash1 == hash2: False
```

## Validation steps

- Upload the same build directory twice more than a second apart and confirm the `Content hash:` line printed by `docverse upload` is identical both times.
- Confirm the resulting tarball is still a readable `.tar.gz` (`tar tzf`) with members at the archive root.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-54684